### PR TITLE
Add license validation

### DIFF
--- a/.bouncer.yaml
+++ b/.bouncer.yaml
@@ -1,0 +1,5 @@
+permit:
+  - BSD.*
+  - MIT.*
+  - Apache.*
+  - MPL.*

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ TEMPDIR = ./.tmp
 RESULTSDIR = $(TEMPDIR)/results
 COVER_REPORT = $(RESULTSDIR)/cover.report
 COVER_TOTAL = $(RESULTSDIR)/cover.total
+LICENSES_REPORT = $(RESULTSDIR)/licenses.json
 LINTCMD = $(TEMPDIR)/golangci-lint run --tests=false --config .golangci.yaml
 BOLD := $(shell tput -T linux bold)
 PURPLE := $(shell tput -T linux setaf 5)
@@ -49,6 +50,8 @@ bootstrap: ## Download and install all project dependencies (+ prep tooling in t
 	go get ./...
 	# install golangci-lint
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .tmp/ v1.26.0
+	# install bouncer
+	curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b .tmp/ v0.2.0
 
 lint: ## Run gofmt + golangci lint checks
 	$(call title,Running linters)
@@ -92,3 +95,8 @@ build-release: ## Build final release binary
 				   -X main.commit="$(git describe --dirty --always)" \
 				   -X main.buildTime="$(date --rfc-3339=seconds --utc)"
 				   -o dist/vulnscan
+
+# todo: this should be later used by goreleaser
+check-licenses:
+	$(TEMPDIR)/bouncer list -o json | tee $(LICENSES_REPORT)
+	$(TEMPDIR)/bouncer check


### PR DESCRIPTION
Run make check-licenses to ensure that the licenses from all dependencies meet the constraints as described in .bouncer.yaml. This will be added as a quality gate before cutting a release (when release support has been added).