### PR TITLE
Add CPE matching to java matcher

### DIFF
--- a/vulnscan/matcher/java/matcher.go
+++ b/vulnscan/matcher/java/matcher.go
@@ -20,5 +20,17 @@ func (m *Matcher) Name() string {
 }
 
 func (m *Matcher) Match(store vulnerability.Provider, _ distro.Distro, p *pkg.Package) ([]match.Match, error) {
-	return common.FindMatchesByPackageLanguage(store, p.Language, p, m.Name())
+	var matches = make([]match.Match, 0)
+	langMatches, err := common.FindMatchesByPackageLanguage(store, p.Language, p, m.Name())
+	if err != nil {
+		return nil, err
+	}
+	matches = append(matches, langMatches...)
+
+	cpeMatches, err := common.FindMatchesByPackageCPE(store, p, m.Name())
+	if err != nil {
+		return nil, err
+	}
+	matches = append(matches, cpeMatches...)
+	return matches, nil
 }


### PR DESCRIPTION
The existing unit tests for both the common language matcher and the common CPE matcher covers testing here. Additionally future integration tests will cover this further (but is outside of the scope of this PR)