### PR TITLE
Add application update check on startup

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -45,7 +45,7 @@ func init() {
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		log.Errorf("could not start application: %+v", err)
+		log.Errorf(err.Error())
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/anchore/imgbom/imgbom/scope"
 	"github.com/anchore/vulnscan/internal"
 	"github.com/anchore/vulnscan/internal/format"
+	"github.com/anchore/vulnscan/internal/version"
 	"github.com/anchore/vulnscan/vulnscan"
 	"github.com/anchore/vulnscan/vulnscan/db"
 	"github.com/anchore/vulnscan/vulnscan/presenter"
@@ -79,6 +80,18 @@ func init() {
 
 // nolint:funlen
 func runDefaultCmd(_ *cobra.Command, args []string) int {
+	if appConfig.CheckForAppUpdate {
+		isAvailable, newVersion, err := version.IsUpdateAvailable()
+		if err != nil {
+			log.Errorf(err.Error())
+		}
+		if isAvailable {
+			log.Infof("New version of %s is available: %s", internal.ApplicationName, newVersion)
+		} else {
+			log.Debugf("No new %s update available", internal.ApplicationName)
+		}
+	}
+
 	userImageStr := args[0]
 	scope, cleanup, err := imgbom.NewScope(userImageStr, appConfig.ScopeOpt)
 	if err != nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -4,31 +4,36 @@ import (
 	"fmt"
 
 	"github.com/anchore/vulnscan/internal"
+	"github.com/anchore/vulnscan/internal/version"
 	"github.com/spf13/cobra"
 )
 
-type Version struct {
-	Version   string
-	Commit    string
-	BuildTime string
-}
-
-var version *Version
+var showVerboseVersionInfo bool
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "show the version",
-	Run:   runVersionCmd,
+	Run:   printVersion,
 }
 
 func init() {
+	versionCmd.Flags().BoolVarP(&showVerboseVersionInfo, "verbose", "v", false, "show additional version information")
+
 	rootCmd.AddCommand(versionCmd)
 }
 
-func SetVersion(v *Version) {
-	version = v
-}
-
-func runVersionCmd(cmd *cobra.Command, args []string) {
-	fmt.Printf("%s %s\n", internal.ApplicationName, version.Version)
+func printVersion(_ *cobra.Command, _ []string) {
+	versionInfo := version.FromBuild()
+	if showVerboseVersionInfo {
+		fmt.Println("Application:  ", internal.ApplicationName)
+		fmt.Println("Version:      ", versionInfo.Version)
+		fmt.Println("BuildDate:    ", versionInfo.BuildDate)
+		fmt.Println("GitCommit:    ", versionInfo.GitCommit)
+		fmt.Println("GitTreeState: ", versionInfo.GitTreeState)
+		fmt.Println("Platform:     ", versionInfo.Platform)
+		fmt.Println("GoVersion:    ", versionInfo.GoVersion)
+		fmt.Println("Compiler:     ", versionInfo.Compiler)
+	} else {
+		fmt.Printf("%s %s\n", internal.ApplicationName, versionInfo.Version)
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,14 +20,15 @@ type CliOnlyOptions struct {
 }
 
 type Application struct {
-	ConfigPath string
-	ScopeOpt   scope.Option
-	Scope      string  `mapstructure:"scope"`
-	Quiet      bool    `mapstructure:"quiet"`
-	Log        Logging `mapstructure:"log"`
-	CliOptions CliOnlyOptions
-	Db         Database    `mapstructure:"db"`
-	Dev        Development `mapstructure:"dev"`
+	ConfigPath        string
+	ScopeOpt          scope.Option
+	Scope             string  `mapstructure:"scope"`
+	Quiet             bool    `mapstructure:"quiet"`
+	Log               Logging `mapstructure:"log"`
+	CliOptions        CliOnlyOptions
+	Db                Database    `mapstructure:"db"`
+	Dev               Development `mapstructure:"dev"`
+	CheckForAppUpdate bool        `mapstructure:"check-for-app-update"`
 }
 
 type Logging struct {
@@ -65,6 +66,7 @@ func setNonCliDefaultValues(v *viper.Viper) {
 	// TODO: set this to true before release
 	v.SetDefault("db.update-on-startup", false)
 	v.SetDefault("dev.profile-cpu", false)
+	v.SetDefault("check-for-app-update", true)
 }
 
 func LoadConfigFromFile(v *viper.Viper, cliOpts *CliOnlyOptions) (*Application, error) {

--- a/internal/version/build.go
+++ b/internal/version/build.go
@@ -1,0 +1,36 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+const valueNotProvided = "[not provided]"
+
+var version = valueNotProvided
+var gitCommit = valueNotProvided
+var gitTreeState = valueNotProvided
+var buildDate = valueNotProvided
+var platform = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+
+type Version struct {
+	Version      string
+	GitCommit    string
+	GitTreeState string
+	BuildDate    string
+	GoVersion    string
+	Compiler     string
+	Platform     string
+}
+
+func FromBuild() Version {
+	return Version{
+		Version:      version,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     platform,
+	}
+}

--- a/internal/version/update.go
+++ b/internal/version/update.go
@@ -1,0 +1,68 @@
+package version
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	hashiVersion "github.com/anchore/go-version"
+)
+
+var latestAppVersionURL = struct {
+	host string
+	path string
+}{
+	// TODO: set me to release host/path before release
+	host: "https://anchore.io",
+	path: "/vulnscan/releases/latest/VERSION",
+}
+
+func IsUpdateAvailable() (bool, string, error) {
+	currentVersionStr := FromBuild().Version
+	currentVersion, err := hashiVersion.NewVersion(currentVersionStr)
+	if err != nil {
+		if currentVersionStr == valueNotProvided {
+			// this is the default build arg and should be ignored (this is not an error case)
+			return false, "", nil
+		}
+		return false, "", fmt.Errorf("failed to parse current application version: %w", err)
+	}
+
+	latestVersion, err := fetchLatestApplicationVersion()
+	if err != nil {
+		return false, "", err
+	}
+
+	if latestVersion.GreaterThan(currentVersion) {
+		return true, latestVersion.String(), nil
+	}
+
+	return false, "", nil
+}
+
+func fetchLatestApplicationVersion() (*hashiVersion.Version, error) {
+	req, err := http.NewRequest(http.MethodGet, latestAppVersionURL.host+latestAppVersionURL.path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for latest version: %w", err)
+	}
+
+	client := http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch latest version: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d on fetching latest version: %s", resp.StatusCode, resp.Status)
+	}
+
+	versionBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read latest version: %w", err)
+	}
+
+	versionStr := strings.TrimSuffix(string(versionBytes), "\n")
+	return hashiVersion.NewVersion(versionStr)
+}

--- a/internal/version/update_test.go
+++ b/internal/version/update_test.go
@@ -1,0 +1,202 @@
+package version
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	hashiVersion "github.com/anchore/go-version"
+)
+
+func TestIsUpdateAvailable(t *testing.T) {
+	tests := []struct {
+		name          string
+		buildVersion  string
+		latestVersion string
+		code          int
+		isAvailable   bool
+		newVersion    string
+		err           bool
+	}{
+		{
+			name:          "equal",
+			buildVersion:  "1.0.0",
+			latestVersion: "1.0.0",
+			code:          200,
+			isAvailable:   false,
+			newVersion:    "",
+			err:           false,
+		},
+		{
+			name:          "hasUpdate",
+			buildVersion:  "1.0.0",
+			latestVersion: "1.2.0",
+			code:          200,
+			isAvailable:   true,
+			newVersion:    "1.2.0",
+			err:           false,
+		},
+		{
+			name:          "aheadOfLatest",
+			buildVersion:  "1.2.0",
+			latestVersion: "1.0.0",
+			code:          200,
+			isAvailable:   false,
+			newVersion:    "",
+			err:           false,
+		},
+		{
+			name:          "EmptyUpdate",
+			buildVersion:  "1.0.0",
+			latestVersion: "",
+			code:          200,
+			isAvailable:   false,
+			newVersion:    "",
+			err:           true,
+		},
+		{
+			name:          "GarbageUpdate",
+			buildVersion:  "1.0.0",
+			latestVersion: "hdfjksdhfhkj",
+			code:          200,
+			isAvailable:   false,
+			newVersion:    "",
+			err:           true,
+		},
+		{
+			name:          "BadUpdate",
+			buildVersion:  "1.0.0",
+			latestVersion: "1.0.",
+			code:          500,
+			isAvailable:   false,
+			newVersion:    "",
+			err:           true,
+		},
+		{
+			name:          "NoBuildVersion",
+			buildVersion:  valueNotProvided,
+			latestVersion: "1.0.0",
+			code:          200,
+			isAvailable:   false,
+			newVersion:    "",
+			err:           false,
+		},
+		{
+			name:          "BadUpdateValidVersion",
+			buildVersion:  "1.0.0",
+			latestVersion: "2.0.0",
+			code:          404,
+			isAvailable:   false,
+			newVersion:    "",
+			err:           true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// setup mocks
+			// local...
+			version = test.buildVersion
+			// remote...
+			handler := http.NewServeMux()
+			handler.HandleFunc(latestAppVersionURL.path, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(test.code)
+				_, _ = w.Write([]byte(test.latestVersion))
+			})
+			mockSrv := httptest.NewServer(handler)
+			latestAppVersionURL.host = mockSrv.URL
+			defer mockSrv.Close()
+
+			isAvailable, newVersion, err := IsUpdateAvailable()
+			if err != nil && !test.err {
+				t.Fatalf("got error but expected none: %+v", err)
+			} else if err == nil && test.err {
+				t.Fatalf("expected error but got none")
+			}
+
+			if newVersion != test.newVersion {
+				t.Errorf("unexpected NEW version: %+v", newVersion)
+			}
+
+			if isAvailable != test.isAvailable {
+				t.Errorf("unexpected result: %+v", isAvailable)
+			}
+		})
+	}
+
+}
+
+func TestFetchLatestApplicationVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		code     int
+		err      bool
+		expected *hashiVersion.Version
+	}{
+		{
+			name:     "gocase",
+			response: "1.0.0",
+			code:     200,
+			expected: hashiVersion.Must(hashiVersion.NewVersion("1.0.0")),
+		},
+		{
+			name:     "garbage",
+			response: "garbage",
+			code:     200,
+			expected: nil,
+			err:      true,
+		},
+		{
+			name:     "http 500",
+			response: "1.0.0",
+			code:     500,
+			expected: nil,
+			err:      true,
+		},
+		{
+			name:     "http 404",
+			response: "1.0.0",
+			code:     404,
+			expected: nil,
+			err:      true,
+		},
+		{
+			name:     "empty",
+			response: "",
+			code:     200,
+			expected: nil,
+			err:      true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// setup mock
+			handler := http.NewServeMux()
+			handler.HandleFunc(latestAppVersionURL.path, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(test.code)
+				_, _ = w.Write([]byte(test.response))
+			})
+			mockSrv := httptest.NewServer(handler)
+			latestAppVersionURL.host = mockSrv.URL
+			defer mockSrv.Close()
+
+			actual, err := fetchLatestApplicationVersion()
+			if err != nil && !test.err {
+				t.Fatalf("got error but expected none: %+v", err)
+			} else if err == nil && test.err {
+				t.Fatalf("expected error but got none")
+			}
+
+			if err != nil {
+				return
+			}
+
+			if actual.String() != test.expected.String() {
+				t.Errorf("unexpected version: %+v", actual.String())
+			}
+		})
+	}
+
+}

--- a/main.go
+++ b/main.go
@@ -4,18 +4,6 @@ import (
 	"github.com/anchore/vulnscan/cmd"
 )
 
-var (
-	version   = "No version provided"
-	commit    = "No commit provided"
-	buildTime = "No build timestamp provided"
-)
-
 func main() {
-	cmd.SetVersion(&cmd.Version{
-		Version:   version,
-		Commit:    commit,
-		BuildTime: buildTime,
-	})
-
 	cmd.Execute()
 }


### PR DESCRIPTION
Sister PR to https://github.com/anchore/imgbom/pull/88 , adds:
- application update check on startup, which is configurable to be toggled either off or on (but not change the URL)
- refactors the version to be internally accessible and adds more build information (to be later filled in by goreleaser)

Closes #22 