### PR TITLE
Limit update version string length

### DIFF
--- a/internal/version/update.go
+++ b/internal/version/update.go
@@ -64,5 +64,9 @@ func fetchLatestApplicationVersion() (*hashiVersion.Version, error) {
 	}
 
 	versionStr := strings.TrimSuffix(string(versionBytes), "\n")
+	if len(versionStr) > 50 {
+		return nil, fmt.Errorf("version too long: %q", versionStr[:50])
+	}
+
 	return hashiVersion.NewVersion(versionStr)
 }

--- a/internal/version/update_test.go
+++ b/internal/version/update_test.go
@@ -168,6 +168,13 @@ func TestFetchLatestApplicationVersion(t *testing.T) {
 			expected: nil,
 			err:      true,
 		},
+		{
+			name:     "too long",
+			response: "this is really long this is really long this is really long this is really long this is really long this is really long this is really long this is really long ",
+			code:     200,
+			expected: nil,
+			err:      true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Currently there is no update file, so the entire anchore.io contents are being parsed in the version check. This limits the version string from the update URL to 50. Longer than we need, but not MBs in length either.