### PR TITLE
simplify schema checks and update grype-db

### DIFF
--- a/cmd/db_status.go
+++ b/cmd/db_status.go
@@ -31,8 +31,8 @@ func runDbStatusCmd(_ *cobra.Command, _ []string) int {
 	status := dbCurator.Status()
 	fmt.Println("Location: ", status.Location)
 	fmt.Println("Built: ", status.Age.String())
-	fmt.Println("Version: ", status.SchemaVersion)
-	fmt.Println("Constraint: ", status.SchemaConstraint)
+	fmt.Println("Current DB Version: ", status.CurrentSchemaVersion)
+	fmt.Println("Require DB Version: ", status.RequiredSchemeVersion)
 	if status.Err != nil {
 		fmt.Printf("Status: INVALID [%+v]\n", status.Err)
 	} else {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/adrg/xdg v0.2.1
 	github.com/anchore/go-testutils v0.0.0-20200624184116-66aa578126db
 	github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b
-	github.com/anchore/grype-db v0.0.0-20200724105409-0ddbeb65f5a3
+	github.com/anchore/grype-db v0.0.0-20200725230023-ff38124c1f49
 	github.com/anchore/syft v0.0.0-20200724122256-9ec5da24dd28
 	github.com/facebookincubator/nvdtools v0.1.4-0.20200622182922-aed862a62ae6
 	github.com/go-test/deep v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZV
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/grype-db v0.0.0-20200724105409-0ddbeb65f5a3 h1:otpVUWQ2HXmL7nX5+t3W94qMqJCaSOW+Myen783WJs8=
 github.com/anchore/grype-db v0.0.0-20200724105409-0ddbeb65f5a3/go.mod h1:LINmipRzG88vnJEWvgMMDVCFH1qZsj7+bjmpERlSyaA=
+github.com/anchore/grype-db v0.0.0-20200725230023-ff38124c1f49 h1:nPrHsCcS0kdqfMhEcHx2TVazthM1j2P+UtkZeSLEnz0=
+github.com/anchore/grype-db v0.0.0-20200725230023-ff38124c1f49/go.mod h1:LINmipRzG88vnJEWvgMMDVCFH1qZsj7+bjmpERlSyaA=
 github.com/anchore/siren-db v0.0.0-20200721170640-64923624e7b2 h1:j3MwtIO1HBgGYD7pG0RVl+jXwkgpTfTk1EoT/QFIYhY=
 github.com/anchore/siren-db v0.0.0-20200721170640-64923624e7b2/go.mod h1:/n1sNOhAfvg5CrlhjWOinKEWpeLYYm9H8gv+afWtpOk=
 github.com/anchore/stereoscope v0.0.0-20200520221116-025e07f1c93e h1:QBwtrM0MXi0z+GcHk3RoSyzaQ+CLgas0bC/uOd1P+PQ=

--- a/grype/db/schema_constraint.go
+++ b/grype/db/schema_constraint.go
@@ -1,3 +1,0 @@
-package db
-
-const DbSchemaConstraint = ">= 1.0.0, < 2.0.0"

--- a/grype/db/status.go
+++ b/grype/db/status.go
@@ -3,9 +3,9 @@ package db
 import "time"
 
 type Status struct {
-	Age              time.Time
-	SchemaVersion    string
-	SchemaConstraint string
-	Location         string
-	Err              error
+	Age                   time.Time
+	CurrentSchemaVersion  int
+	RequiredSchemeVersion int
+	Location              string
+	Err                   error
 }

--- a/grype/db/test-fixtures/curator-validate/bad-checksum/metadata.json
+++ b/grype/db/test-fixtures/curator-validate/bad-checksum/metadata.json
@@ -1,5 +1,5 @@
 {
     "built": "2020-06-15T14:02:36Z",
-    "version": "1.1.0",
+    "version": 1,
     "checksum": "sha256:deadbeefcafe"
 }

--- a/grype/db/test-fixtures/curator-validate/good-checksum/metadata.json
+++ b/grype/db/test-fixtures/curator-validate/good-checksum/metadata.json
@@ -1,5 +1,5 @@
 {
     "built": "2020-06-15T14:02:36Z",
-    "version": "1.1.0",
+    "version": 1,
     "checksum": "sha256:3baf9c50c94e7f1e65bafac2e6a6d559fb177461dd25bf8fca7e6e9e9c266cb4"
 }

--- a/grype/lib.go
+++ b/grype/lib.go
@@ -55,14 +55,17 @@ func LoadVulnerabilityDb(cfg db.Config, update bool) (vulnerability.Provider, er
 	if update {
 		updateAvailable, updateEntry, err := dbCurator.IsUpdateAvailable()
 		if err != nil {
-			// TODO: should this be so fatal? we can certainly continue with a warning...
-			return nil, fmt.Errorf("unable to check for vulnerability database update: %w", err)
+			// we want to continue if possible even if we can't check for an update
+			log.Errorf("unable to check for vulnerability database update")
+			log.Debugf("check for vulnerability update failed: %+v", err)
 		}
 		if updateAvailable {
+			log.Infof("Downloading new vulnerability DB")
 			err = dbCurator.UpdateTo(updateEntry)
 			if err != nil {
 				return nil, fmt.Errorf("unable to update vulnerability database: %w", err)
 			}
+			log.Infof("Updated vulnerability DB to version=%d built=%q", updateEntry.Version, updateEntry.Built.String())
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,8 +67,7 @@ func setNonCliDefaultValues(v *viper.Viper) {
 	v.SetDefault("db.cache-dir", path.Join(xdg.CacheHome, internal.ApplicationName, "db"))
 	// TODO: change me to the production URL before release
 	v.SetDefault("db.update-url", "http://localhost:5000/listing.json")
-	// TODO: set this to true before release
-	v.SetDefault("db.auto-update", false)
+	v.SetDefault("db.auto-update", true)
 	v.SetDefault("dev.profile-cpu", false)
 	v.SetDefault("check-for-app-update", true)
 }


### PR DESCRIPTION
- uses new simplified schema
- removes all schema constraint definitions (which now live only in the grype-db lib)