### PR TITLE
cmd: display help menu when no args are passed in - skip the error

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,7 @@ var rootCmd = &cobra.Command{
 `, map[string]interface{}{
 		"appName": internal.ApplicationName,
 	}),
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if appConfig.Dev.ProfileCPU {
 			f, err := os.Create("cpu.profile")
@@ -49,7 +49,14 @@ var rootCmd = &cobra.Command{
 				}
 			}
 		}
-
+		if len(args) == 0 {
+			err := cmd.Help()
+			if err != nil {
+				log.Errorf(err.Error())
+				os.Exit(1)
+			}
+			os.Exit(1)
+		}
 		err := runDefaultCmd(cmd, args)
 
 		if appConfig.Dev.ProfileCPU {


### PR DESCRIPTION
This might be a bit controversial, but I think that displaying the help menu in addition to an error message is not necessary:

<img width="811" alt="Screen Shot 2020-08-03 at 12 05 16 PM" src="https://user-images.githubusercontent.com/317847/89202874-9aa19680-d581-11ea-82b9-fd8305b3d241.png">

This change checks manually (as in without Cobra's API) if the number of args is 0 so that the help menu is displayed, which in turn has the information that a user needs in order to run it like needing an argument to do anything.

Up for discussion could be the exit status code. Some tools like `grep` will set it to non-zero when no args are passed in.