### PR TITLE
fix panic on top-level log

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -54,7 +54,7 @@ func setGlobalCliOptions() {
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		log.Errorf(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Currently if you supply a bad CLI switch there is a panic since the logger is not setup yet. This PR makes this case an exception and prints to stderr instead.