### PR TITLE
Fix auto-changelog in release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,6 +64,8 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Restore bootstrap cache
         id: cache


### PR DESCRIPTION
Currently goreleaser builds the changelog from the commit history, however, we are only cloning the last commit by default. This PR changes the depth to pull all history, allowing goreleaser to find the last tag and build the changelog accordingly.