### PR TITLE
Add description and cvss metadata to v1 schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/adrg/xdg v0.2.1
 	github.com/anchore/go-testutils v0.0.0-20200624184116-66aa578126db
 	github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b
-	github.com/anchore/grype-db v0.0.0-20200730184339-fc1f236ce8b2
+	github.com/anchore/grype-db v0.0.0-20200806124046-3929ab5bb802
 	github.com/anchore/stereoscope v0.0.0-20200803190343-146f38f8cc19
 	github.com/anchore/syft v0.1.0-beta.2.0.20200804222243-70e673204c0c
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/anchore/go-testutils v0.0.0-20200624184116-66aa578126db h1:LWKezJnFTF
 github.com/anchore/go-testutils v0.0.0-20200624184116-66aa578126db/go.mod h1:D3rc2L/q4Hcp9eeX6AIJH4Q+kPjOtJCFhG9za90j+nU=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZVsCYMrIZBpFxwV26CbsuoEh5muXD5I1Ods=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/grype-db v0.0.0-20200730184339-fc1f236ce8b2 h1:+gImvds0JpqeacmqiStSeteev5X1CxXYCwyCrSy1cWc=
-github.com/anchore/grype-db v0.0.0-20200730184339-fc1f236ce8b2/go.mod h1:LINmipRzG88vnJEWvgMMDVCFH1qZsj7+bjmpERlSyaA=
+github.com/anchore/grype-db v0.0.0-20200806124046-3929ab5bb802 h1:9Ngp0fOUcj7u/ps/Gte8mizVFHbmlTqn+pr1my1Tnkw=
+github.com/anchore/grype-db v0.0.0-20200806124046-3929ab5bb802/go.mod h1:LINmipRzG88vnJEWvgMMDVCFH1qZsj7+bjmpERlSyaA=
 github.com/anchore/stereoscope v0.0.0-20200520221116-025e07f1c93e h1:QBwtrM0MXi0z+GcHk3RoSyzaQ+CLgas0bC/uOd1P+PQ=
 github.com/anchore/stereoscope v0.0.0-20200520221116-025e07f1c93e/go.mod h1:bkyLl5VITnrmgErv4S1vDfVz/TGAZ5il6161IQo7w2g=
 github.com/anchore/stereoscope v0.0.0-20200803190343-146f38f8cc19 h1:iJ6du/cA9KJ0ctP905u2zCcpJubsy6kxLZBvG4XG+uY=


### PR DESCRIPTION
This PR adds the V2 & V3 CVSS NVD data and description fields to the VulnerabilityMetadata table, which are optional fields depending on the feed source. (pulls in https://github.com/anchore/grype-db/pull/8)