### PR TITLE
Tweak table summary

### DIFF
--- a/grype/presenter/presenter.go
+++ b/grype/presenter/presenter.go
@@ -23,7 +23,7 @@ func GetPresenter(option Option, results result.Result, catalog *pkg.Catalog, th
 	case JSONPresenter:
 		return json.NewPresenter(results, catalog, theScope, metadataProvider)
 	case TablePresenter:
-		return table.NewPresenter(results, catalog)
+		return table.NewPresenter(results, catalog, metadataProvider)
 	default:
 		return nil
 	}

--- a/grype/presenter/table/test-fixtures/snapshot/TestTablePresenter.golden
+++ b/grype/presenter/table/test-fixtures/snapshot/TestTablePresenter.golden
@@ -1,3 +1,3 @@
-NAME       INSTALLED  VULNERABILITY  FOUND-BY        
-package-1  1.0.1      CVE-1999-0001                   
-package-2  2.0.1      CVE-1999-0002  a search key...  
+NAME       INSTALLED  VULNERABILITY  SEVERITY 
+package-1  1.0.1      CVE-1999-0001  Low       
+package-2  2.0.1      CVE-1999-0002  Critical  


### PR DESCRIPTION
The summary table should be concerned with the "whats" of a result and allow other presenters to show "how" in more detail. For this reason the "search-key" column (showing how a match is made) is being replaced with "severity" (from the recently added metadata provider). 