### PR TITLE
Add slack links to issue selection

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,11 @@
+contact_links:
+
+  - name: Help & Support Slack Channel ⛑️
+    # link to toolbox-help channel
+    url: https://anchorecommunity.slack.com/archives/C019BUXV7R6
+    about: Ask a questions and get answers
+
+  - name: Developer Slack Channel 💬
+    # link to toolbox-dev channel
+    url: https://anchorecommunity.slack.com/archives/C0190NF9TSM
+    about: Participate in design discussions and feature development


### PR DESCRIPTION
This will add slack channel links as options in the issue template selection box.