### PR TITLE
Prevent duplicates, expand on matching information

### DIFF
--- a/grype/match/match.go
+++ b/grype/match/match.go
@@ -15,6 +15,7 @@ type Match struct {
 	// SearchKey provides an indication of how this match was found.
 	// TODO: is this a good name for what it represents? (which is an audit trail of HOW we got this match from the store)
 	SearchKey       string
+	SearchMatches   map[string]interface{}
 	IndirectPackage *pkg.Package
 	Matcher         MatcherType
 }

--- a/grype/matcher/common/cpe_matchers.go
+++ b/grype/matcher/common/cpe_matchers.go
@@ -43,7 +43,13 @@ func FindMatchesByPackageCPE(store vulnerability.ProviderByCPE, p *pkg.Package, 
 					Vulnerability: *vuln,
 					Package:       p,
 					Matcher:       upstreamMatcher,
-					SearchKey:     fmt.Sprintf("cpe[%s] constraint[%s]", cpe.BindToFmtString(), vuln.Constraint.String()),
+					SearchKey:     map[string]interface{}{
+						"cpe": cpe.BindToFmtString(),
+					},
+					SearchMatches: map[string]interface{}{
+						"cpe": vuln.CPEs,
+						"constraint": vuln.Constraint.String(),
+					},
 				})
 			}
 		}

--- a/grype/matcher/common/cpe_matchers_test.go
+++ b/grype/matcher/common/cpe_matchers_test.go
@@ -1,13 +1,14 @@
 package common
 
 import (
+	"testing"
+
 	"github.com/anchore/grype/grype/cpe"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/version"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal"
 	"github.com/anchore/syft/syft/pkg"
-	"testing"
 )
 
 func must(c cpe.CPE, e error) cpe.CPE {
@@ -44,6 +45,13 @@ func (pr *mockCPEProvider) stub() {
 				ID:         "CVE-2017-fake-2",
 				CPEs: []cpe.CPE{
 					must(cpe.New("cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:ruby:*:*")),
+				},
+			},
+			{
+				Constraint: version.MustGetConstraint("= 4.0.1", version.SemanticFormat),
+				ID:         "CVE-2017-fake-3",
+				CPEs: []cpe.CPE{
+					must(cpe.New("cpe:2.3:*:couldntgetthisrightcouldyou:activerecord:4.0.1:*:*:*:*:*:*:*")),
 				},
 			},
 			{

--- a/grype/matcher/common/distro_matchers.go
+++ b/grype/matcher/common/distro_matchers.go
@@ -38,7 +38,12 @@ func FindMatchesByPackageDistro(store vulnerability.ProviderByDistro, d distro.D
 				Vulnerability: *vuln,
 				Package:       p,
 				Matcher:       upstreamMatcher,
-				SearchKey:     fmt.Sprintf("distro[%s] constraint[%s]", d, vuln.Constraint.String()),
+				SearchKey:     map[string]interface{}{
+					"distro": d.String(),
+				},
+				SearchMatches: map[string]interface{}{
+					"constraint": vuln.Constraint.String(),
+				},
 			})
 		}
 	}

--- a/grype/matcher/common/distro_matchers.go
+++ b/grype/matcher/common/distro_matchers.go
@@ -38,9 +38,7 @@ func FindMatchesByPackageDistro(store vulnerability.ProviderByDistro, d distro.D
 				Vulnerability: *vuln,
 				Package:       p,
 				Matcher:       upstreamMatcher,
-				SearchKey:     map[string]interface{}{
-					"distro": d.String(),
-				},
+				SearchKey:     d.String(),
 				SearchMatches: map[string]interface{}{
 					"constraint": vuln.Constraint.String(),
 				},

--- a/grype/matcher/common/language_matchers.go
+++ b/grype/matcher/common/language_matchers.go
@@ -37,9 +37,7 @@ func FindMatchesByPackageLanguage(store vulnerability.ProviderByLanguage, l pkg.
 				Vulnerability: *vuln,
 				Package:       p,
 				Matcher:       upstreamMatcher,
-				SearchKey:     map[string]interface{}{
-					"language": l.String(),
-				},
+				SearchKey:     l.String(),
 				SearchMatches: map[string]interface{}{
 					"constraint": vuln.Constraint.String(),
 				},

--- a/grype/matcher/common/language_matchers.go
+++ b/grype/matcher/common/language_matchers.go
@@ -37,7 +37,12 @@ func FindMatchesByPackageLanguage(store vulnerability.ProviderByLanguage, l pkg.
 				Vulnerability: *vuln,
 				Package:       p,
 				Matcher:       upstreamMatcher,
-				SearchKey:     fmt.Sprintf("language[%s] constraint[%s]", l, vuln.Constraint.String()),
+				SearchKey:     map[string]interface{}{
+					"language": l.String(),
+				},
+				SearchMatches: map[string]interface{}{
+					"constraint": vuln.Constraint.String(),
+				},
 			})
 		}
 	}

--- a/grype/presenter/json/presenter.go
+++ b/grype/presenter/json/presenter.go
@@ -39,9 +39,9 @@ type Finding struct {
 
 // MatchDetails contains all data that indicates how the result match was found
 type MatchDetails struct {
-	Matcher   string `json:"matcher"`
-	SearchKey map[string]interface{} `json:"search-key"`
-	MatchInfo map[string]interface{} `json:"matched-on"`
+	Matcher   string                 `json:"matcher"`
+	SearchKey string                 `json:"search-key"`
+	MatchInfo map[string]interface{} `json:"matched-on,omitempty"`
 }
 
 // Present creates a JSON-based reporting

--- a/grype/presenter/json/presenter.go
+++ b/grype/presenter/json/presenter.go
@@ -33,14 +33,15 @@ func NewPresenter(results result.Result, catalog *pkg.Catalog, theScope scope.Sc
 // Finding is a single item for the JSON array reported
 type Finding struct {
 	Vulnerability Vulnerability     `json:"vulnerability"`
-	MatchDetails  MatchDetails      `json:"matched-by"`
+	MatchDetails  MatchDetails      `json:"match-details"`
 	Artifact      syftJson.Artifact `json:"artifact"`
 }
 
 // MatchDetails contains all data that indicates how the result match was found
 type MatchDetails struct {
 	Matcher   string `json:"matcher"`
-	SearchKey string `json:"search-key"`
+	SearchKey map[string]interface{} `json:"search-key"`
+	MatchInfo map[string]interface{} `json:"matched-on"`
 }
 
 // Present creates a JSON-based reporting
@@ -68,6 +69,7 @@ func (pres *Presenter) Present(output io.Writer) error {
 				MatchDetails: MatchDetails{
 					Matcher:   m.Matcher.String(),
 					SearchKey: m.SearchKey,
+					MatchInfo: m.SearchMatches,
 				},
 			},
 		)

--- a/grype/presenter/json/presenter_test.go
+++ b/grype/presenter/json/presenter_test.go
@@ -3,9 +3,10 @@ package json
 import (
 	"bytes"
 	"flag"
+	"testing"
+
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/syft/syft/scope"
-	"testing"
 
 	"github.com/anchore/go-testutils"
 	"github.com/anchore/grype/grype/match"

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonPresenter.golden
@@ -8,7 +8,7 @@
     "vector": "another vector"
    }
   },
-  "matched-by": {
+  "match-details": {
    "matcher": "dpkg-matcher",
    "search-key": ""
   },
@@ -38,7 +38,7 @@
     "vector": "vector"
    }
   },
-  "matched-by": {
+  "match-details": {
    "matcher": "dpkg-matcher",
    "search-key": ""
   },
@@ -62,7 +62,7 @@
    "id": "CVE-1999-0003",
    "description": "1999-03 description"
   },
-  "matched-by": {
+  "match-details": {
    "matcher": "dpkg-matcher",
    "search-key": ""
   },

--- a/test/integration/match_coverage_test.go
+++ b/test/integration/match_coverage_test.go
@@ -41,11 +41,15 @@ func addAlpineMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, 
 		t.Fatalf("failed to create vuln obj: %+v", err)
 	}
 	theResult.Add(thePkg, match.Match{
-		Type:            match.FuzzyMatch,
-		Confidence:      1.0,
-		Vulnerability:   *vulnObj,
-		Package:         thePkg,
-		SearchKey:       "cpe[cpe:2.3:*:*:libvncserver:0.9.9:*:*:*:*:*:*:*] constraint[< 0.9.10 (unknown)]",
+		Type:          match.FuzzyMatch,
+		Confidence:    1.0,
+		Vulnerability: *vulnObj,
+		Package:       thePkg,
+		SearchKey:     "cpe:2.3:*:*:libvncserver:0.9.9:*:*:*:*:*:*:*",
+		SearchMatches: map[string]interface{}{
+			"cpes":       []string{"cpe:2.3:*:*:libvncserver:0.9.9:*:*:*:*:*:*:*"},
+			"constraint": "< 0.9.10 (unknown)",
+		},
 		IndirectPackage: nil,
 		Matcher:         match.ApkMatcher,
 	})
@@ -64,11 +68,14 @@ func addJavascriptMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catal
 		t.Fatalf("failed to create vuln obj: %+v", err)
 	}
 	theResult.Add(thePkg, match.Match{
-		Type:            match.ExactDirectMatch,
-		Confidence:      1.0,
-		Vulnerability:   *vulnObj,
-		Package:         thePkg,
-		SearchKey:       "language[javascript] constraint[< 3.2.1 (unknown)]",
+		Type:          match.ExactDirectMatch,
+		Confidence:    1.0,
+		Vulnerability: *vulnObj,
+		Package:       thePkg,
+		SearchKey:     "javascript",
+		SearchMatches: map[string]interface{}{
+			"constraint": "< 3.2.1 (unknown)",
+		},
 		IndirectPackage: nil,
 		Matcher:         match.JavascriptMatcher,
 	})
@@ -87,11 +94,14 @@ func addPythonMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, 
 		t.Fatalf("failed to create vuln obj: %+v", err)
 	}
 	theResult.Add(thePkg, match.Match{
-		Type:            match.ExactDirectMatch,
-		Confidence:      1.0,
-		Vulnerability:   *vulnObj,
-		Package:         thePkg,
-		SearchKey:       "language[python] constraint[< 2.6.2 (python)]",
+		Type:          match.ExactDirectMatch,
+		Confidence:    1.0,
+		Vulnerability: *vulnObj,
+		Package:       thePkg,
+		SearchKey:     "python",
+		SearchMatches: map[string]interface{}{
+			"constraint": "< 2.6.2 (python)",
+		},
 		IndirectPackage: nil,
 		Matcher:         match.PythonMatcher,
 	})
@@ -110,11 +120,14 @@ func addRubyMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, th
 		t.Fatalf("failed to create vuln obj: %+v", err)
 	}
 	theResult.Add(thePkg, match.Match{
-		Type:            match.ExactDirectMatch,
-		Confidence:      1.0,
-		Vulnerability:   *vulnObj,
-		Package:         thePkg,
-		SearchKey:       "language[ruby] constraint[> 4.0.0, <= 4.1.1 (semver)]",
+		Type:          match.ExactDirectMatch,
+		Confidence:    1.0,
+		Vulnerability: *vulnObj,
+		Package:       thePkg,
+		SearchKey:     "ruby",
+		SearchMatches: map[string]interface{}{
+			"constraint": "> 4.0.0, <= 4.1.1 (semver)",
+		},
 		IndirectPackage: nil,
 		Matcher:         match.RubyBundleMatcher,
 	})
@@ -140,11 +153,14 @@ func addJavaMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, th
 		t.Fatalf("failed to create vuln obj: %+v", err)
 	}
 	theResult.Add(thePkg, match.Match{
-		Type:            match.ExactDirectMatch,
-		Confidence:      1.0,
-		Vulnerability:   *vulnObj,
-		Package:         thePkg,
-		SearchKey:       "language[java] constraint[>= 0.0.1, < 1.2.0 (unknown)]",
+		Type:          match.ExactDirectMatch,
+		Confidence:    1.0,
+		Vulnerability: *vulnObj,
+		Package:       thePkg,
+		SearchKey:     "java",
+		SearchMatches: map[string]interface{}{
+			"constraint": ">= 0.0.1, < 1.2.0 (unknown)",
+		},
 		IndirectPackage: nil,
 		Matcher:         match.JavaMatcher,
 	})
@@ -164,11 +180,14 @@ func addDpkgMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, th
 		t.Fatalf("failed to create vuln obj: %+v", err)
 	}
 	theResult.Add(thePkg, match.Match{
-		Type:            match.ExactIndirectMatch,
-		Confidence:      1.0,
-		Vulnerability:   *vulnObj,
-		Package:         thePkg,
-		SearchKey:       "distro[debian 8] constraint[<= 1.8.2 (deb)]",
+		Type:          match.ExactIndirectMatch,
+		Confidence:    1.0,
+		Vulnerability: *vulnObj,
+		Package:       thePkg,
+		SearchKey:     "debian 8",
+		SearchMatches: map[string]interface{}{
+			"constraint": "<= 1.8.2 (deb)",
+		},
 		IndirectPackage: nil,
 		Matcher:         match.DpkgMatcher,
 	})
@@ -187,11 +206,14 @@ func addRhelMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, th
 		t.Fatalf("failed to create vuln obj: %+v", err)
 	}
 	theResult.Add(thePkg, match.Match{
-		Type:            match.ExactDirectMatch,
-		Confidence:      1.0,
-		Vulnerability:   *vulnObj,
-		Package:         thePkg,
-		SearchKey:       "distro[centos 8] constraint[<= 1.0.42 (rpm)]",
+		Type:          match.ExactDirectMatch,
+		Confidence:    1.0,
+		Vulnerability: *vulnObj,
+		Package:       thePkg,
+		SearchKey:     "centos 8",
+		SearchMatches: map[string]interface{}{
+			"constraint": "<= 1.0.42 (rpm)",
+		},
 		IndirectPackage: nil,
 		Matcher:         match.RpmDBMatcher,
 	})


### PR DESCRIPTION
Closes #94 

This PR addresses a problem with CPE matching, where previously (exact) matches were not accounted for, allowing for duplicates to get in.

Additionally, it expands the information on what exactly was matched (via `SearchMatches`), and simplifies the `SearchKey` to include only what was searched on (vs. a string built on the fly).

