### PR TITLE
simplify version cmd + add json option

### DIFF
--- a/internal/version/build.go
+++ b/internal/version/build.go
@@ -14,13 +14,13 @@ var buildDate = valueNotProvided
 var platform = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
 
 type Version struct {
-	Version      string
-	GitCommit    string
-	GitTreeState string
-	BuildDate    string
-	GoVersion    string
-	Compiler     string
-	Platform     string
+	Version      string `json:"version"`
+	GitCommit    string `json:"git-commit"`
+	GitTreeState string `json:"git-tree-state"`
+	BuildDate    string `json:"build-date"`
+	GoVersion    string `json:"go-version"`
+	Compiler     string `json:"compiler"`
+	Platform     string `json:"platform"`
 }
 
 func FromBuild() Version {


### PR DESCRIPTION
This PR removes the verbose cmd and adds a machine readable format:

```
$ grype version
Application:          grype
Version:              0.1.0-beta.6
BuildDate:            2020-08-10T23:01:19Z
GitCommit:            cbd60606522186b88e345231c0699cedb53266de
GitTreeState:         clean
Platform:             linux/amd64
GoVersion:            go1.14.6
Compiler:             gc
Supported DB Schema:  1
```

```
$ grype version -o json
{
  "application: "grype",
  "version: "0.1.0-beta.6",
  "build-date: "2020-08-10T23:01:19Z",
  "git-commit: "cbd60606522186b88e345231c0699cedb53266de",
  "git-tree-state: "clean",
  "platform: "linux/amd64",
  "go-version: "go1.14.6",
  "compiler: "gc",
  "supported-db-schema":  1
}
```