### PR TITLE
Change search key json output to a map

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -127,11 +127,6 @@ github.com/anchore/stereoscope v0.0.0-20200520221116-025e07f1c93e h1:QBwtrM0MXi0
 github.com/anchore/stereoscope v0.0.0-20200520221116-025e07f1c93e/go.mod h1:bkyLl5VITnrmgErv4S1vDfVz/TGAZ5il6161IQo7w2g=
 github.com/anchore/stereoscope v0.0.0-20200813152757-548b22c8a0b3 h1:pl+txuYlhK8Mmio4d+4zQI/1xg8X6BtNErTASrx23Wk=
 github.com/anchore/stereoscope v0.0.0-20200813152757-548b22c8a0b3/go.mod h1:WntReQTI/I27FOQ87UgLVVzWgku6+ZsqfOTLxpIZFCs=
-github.com/anchore/syft v0.1.0-beta.4 h1:8gy/0jCDHmL+mjSrk+i2H8EGpRxPqbmk76nnmEiuSnU=
-github.com/anchore/syft v0.1.0-beta.4.0.20200813161205-17b8d44ff52b h1:mDLFT5nITUUxNnai6jCM8itlwmn2NrmB9RPx7H8+WB0=
-github.com/anchore/syft v0.1.0-beta.4.0.20200813161205-17b8d44ff52b/go.mod h1:3jUg8wy5f570Mc3C3nbO00OwRcMaNy++ETL44vXYFBA=
-github.com/anchore/syft v0.1.0-beta.4.0.20200817141227-c5ba8c4a1d7c h1:J+o26rEGNrVasll5KjTGTimKk8pY0mkFsyFkfrEgr4A=
-github.com/anchore/syft v0.1.0-beta.4.0.20200817141227-c5ba8c4a1d7c/go.mod h1:9+y7BAsXbGz8ZZQag9iru52xlEvy0PgDyceQ8pmWtWg=
 github.com/anchore/syft v0.1.0-beta.4.0.20200827121056-d85d0ac418a7 h1:mK3orcgTjK1YPWaYKUDbrDq1CFmBT5dQFq0a0w1zq3s=
 github.com/anchore/syft v0.1.0-beta.4.0.20200827121056-d85d0ac418a7/go.mod h1:zy2x5Z9URqzmLdWHENTGxcsap7HoLisEsekOv5lr0Us=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
@@ -863,8 +858,6 @@ golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 h1:vEg9joUBmeBcK9iSJftGNf3coIG4HqZElCPehJsfAYM=
-golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -965,6 +958,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/grype/match/match.go
+++ b/grype/match/match.go
@@ -14,16 +14,16 @@ type Match struct {
 	Package       *pkg.Package
 	// SearchKey provides an indication of how this match was found.
 	// TODO: is this a good name for what it represents? (which is an audit trail of HOW we got this match from the store)
-	SearchKey       string
+	SearchKey       map[string]interface{}
 	SearchMatches   map[string]interface{}
 	IndirectPackage *pkg.Package
 	Matcher         MatcherType
 }
 
 func (m Match) String() string {
-	return fmt.Sprintf("Match(pkg=%s vuln=%s type='%s' key='%s' foundBy='%s')", m.Package, m.Vulnerability.String(), m.Type, m.SearchKey, m.Matcher)
+	return fmt.Sprintf("Match(pkg=%s vuln=%s type='%s' foundBy='%s')", m.Package, m.Vulnerability.String(), m.Type, m.Matcher)
 }
 
 func (m Match) Summary() string {
-	return fmt.Sprintf("vuln='%s' type='%s' key='%s' foundBy='%s')", m.Vulnerability.ID, m.Type, m.SearchKey, m.Matcher)
+	return fmt.Sprintf("vuln='%s' type='%s' key='%s' foundBy='%s'", m.Vulnerability.ID, m.Type, m.SearchKey, m.Matcher)
 }

--- a/grype/match/match.go
+++ b/grype/match/match.go
@@ -7,23 +7,24 @@ import (
 	"github.com/anchore/syft/syft/pkg"
 )
 
+// Match represents a finding in the vulnerability matching process, pairing a single package and a single vulnerability object.
 type Match struct {
-	Type          Type
-	Confidence    float64
-	Vulnerability vulnerability.Vulnerability
-	Package       *pkg.Package
-	// SearchKey provides an indication of how this match was found.
-	// TODO: is this a good name for what it represents? (which is an audit trail of HOW we got this match from the store)
-	SearchKey       map[string]interface{}
-	SearchMatches   map[string]interface{}
-	IndirectPackage *pkg.Package
-	Matcher         MatcherType
+	Type            Type                        // The kind of match made (an exact match, fuzzy match, indirect vs direct, etc).
+	Confidence      float64                     // The certainty of the match as a ratio (currently unused, reserved for future use).
+	Vulnerability   vulnerability.Vulnerability // The vulnerability details of the match.
+	Package         *pkg.Package                // The package used to search for a match.
+	SearchKey       map[string]interface{}      // The specific attributes that were used to search (other than package name and version) --this indicates "how" the match was made.
+	SearchMatches   map[string]interface{}      // The specific attributes on the vulnerability object that were matched with --this indicates "what" was found in the match.
+	IndirectPackage *pkg.Package                // An optional package which was used to indirectly match the package and vulnerability. This is used when the OS package only matches with the development/source package for vulnerability matching.
+	Matcher         MatcherType                 // The matcher object that discovered the match.
 }
 
+// String is the string representation of select match fields.
 func (m Match) String() string {
 	return fmt.Sprintf("Match(pkg=%s vuln=%s type='%s' foundBy='%s')", m.Package, m.Vulnerability.String(), m.Type, m.Matcher)
 }
 
+// Summary is a short string representation of the match object.
 func (m Match) Summary() string {
 	return fmt.Sprintf("vuln='%s' type='%s' key='%s' foundBy='%s'", m.Vulnerability.ID, m.Type, m.SearchKey, m.Matcher)
 }

--- a/grype/matcher/common/cpe_matchers.go
+++ b/grype/matcher/common/cpe_matchers.go
@@ -54,7 +54,9 @@ func FindMatchesByPackageCPE(store vulnerability.ProviderByCPE, p *pkg.Package, 
 					Vulnerability: *vuln,
 					Package:       p,
 					Matcher:       upstreamMatcher,
-					SearchKey:     cpe.BindToFmtString(),
+					SearchKey: map[string]interface{}{
+						"cpe": cpe.BindToFmtString(),
+					},
 					SearchMatches: map[string]interface{}{
 						"cpes":       cpesToString(vuln.CPEs),
 						"constraint": vuln.Constraint.String(),

--- a/grype/matcher/common/distro_matchers.go
+++ b/grype/matcher/common/distro_matchers.go
@@ -1,4 +1,3 @@
-// nolint:dupl
 package common
 
 import (
@@ -38,7 +37,12 @@ func FindMatchesByPackageDistro(store vulnerability.ProviderByDistro, d distro.D
 				Vulnerability: *vuln,
 				Package:       p,
 				Matcher:       upstreamMatcher,
-				SearchKey:     d.String(),
+				SearchKey: map[string]interface{}{
+					"distro": map[string]string{
+						"type":    d.Type.String(),
+						"version": d.RawVersion,
+					},
+				},
 				SearchMatches: map[string]interface{}{
 					"constraint": vuln.Constraint.String(),
 				},

--- a/grype/matcher/common/language_matchers.go
+++ b/grype/matcher/common/language_matchers.go
@@ -1,4 +1,3 @@
-// nolint:dupl
 package common
 
 import (
@@ -37,7 +36,9 @@ func FindMatchesByPackageLanguage(store vulnerability.ProviderByLanguage, l pkg.
 				Vulnerability: *vuln,
 				Package:       p,
 				Matcher:       upstreamMatcher,
-				SearchKey:     l.String(),
+				SearchKey: map[string]interface{}{
+					"language": l.String(),
+				},
 				SearchMatches: map[string]interface{}{
 					"constraint": vuln.Constraint.String(),
 				},

--- a/grype/presenter/cyclonedx/presenter_dirs_test.go
+++ b/grype/presenter/cyclonedx/presenter_dirs_test.go
@@ -76,9 +76,11 @@ func TestCycloneDxDirsPresenter(t *testing.T) {
 			ID:           "CVE-1999-0002",
 			RecordSource: "source-2",
 		},
-		Package:   &pkg2,
-		Matcher:   match.DpkgMatcher,
-		SearchKey: "a search key...",
+		Package: &pkg2,
+		Matcher: match.DpkgMatcher,
+		SearchKey: map[string]interface{}{
+			"some": "key",
+		},
 	}
 
 	results := result.NewResult()

--- a/grype/presenter/cyclonedx/presenter_imgs_test.go
+++ b/grype/presenter/cyclonedx/presenter_imgs_test.go
@@ -123,9 +123,11 @@ func TestCycloneDxImgsPresenter(t *testing.T) {
 			ID:           "CVE-1999-0002",
 			RecordSource: "source-2",
 		},
-		Package:   &pkg2,
-		Matcher:   match.DpkgMatcher,
-		SearchKey: "a search key...",
+		Package: &pkg2,
+		Matcher: match.DpkgMatcher,
+		SearchKey: map[string]interface{}{
+			"some": "key",
+		},
 	}
 
 	results := result.NewResult()

--- a/grype/presenter/json/presenter.go
+++ b/grype/presenter/json/presenter.go
@@ -40,8 +40,8 @@ type Finding struct {
 // MatchDetails contains all data that indicates how the result match was found
 type MatchDetails struct {
 	Matcher   string                 `json:"matcher"`
-	SearchKey string                 `json:"search-key"`
-	MatchInfo map[string]interface{} `json:"matched-on,omitempty"`
+	SearchKey map[string]interface{} `json:"search-key"`
+	MatchInfo map[string]interface{} `json:"matched-on"`
 }
 
 // Present creates a JSON-based reporting

--- a/grype/presenter/json/presenter_test.go
+++ b/grype/presenter/json/presenter_test.go
@@ -97,6 +97,15 @@ func TestJsonPresenter(t *testing.T) {
 		},
 		Package: &pkg1,
 		Matcher: match.DpkgMatcher,
+		SearchKey: map[string]interface{}{
+			"distro": map[string]string{
+				"type":    "ubuntu",
+				"version": "20.04",
+			},
+		},
+		SearchMatches: map[string]interface{}{
+			"constraint": ">= 20",
+		},
 	}
 
 	var match2 = match.Match{
@@ -107,6 +116,12 @@ func TestJsonPresenter(t *testing.T) {
 		},
 		Package: &pkg1,
 		Matcher: match.DpkgMatcher,
+		SearchKey: map[string]interface{}{
+			"cpe": "somecpe",
+		},
+		SearchMatches: map[string]interface{}{
+			"constraint": "somecpe",
+		},
 	}
 
 	var match3 = match.Match{
@@ -117,6 +132,12 @@ func TestJsonPresenter(t *testing.T) {
 		},
 		Package: &pkg1,
 		Matcher: match.DpkgMatcher,
+		SearchKey: map[string]interface{}{
+			"language": "java",
+		},
+		SearchMatches: map[string]interface{}{
+			"constraint": "< 2.0.0",
+		},
 	}
 
 	results := result.NewResult()

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonPresenter.golden
@@ -10,7 +10,15 @@
   },
   "match-details": {
    "matcher": "dpkg-matcher",
-   "search-key": ""
+   "search-key": {
+    "distro": {
+     "type": "ubuntu",
+     "version": "20.04"
+    }
+   },
+   "matched-on": {
+    "constraint": ">= 20"
+   }
   },
   "artifact": {
    "name": "package-1",
@@ -40,7 +48,12 @@
   },
   "match-details": {
    "matcher": "dpkg-matcher",
-   "search-key": ""
+   "search-key": {
+    "cpe": "somecpe"
+   },
+   "matched-on": {
+    "constraint": "somecpe"
+   }
   },
   "artifact": {
    "name": "package-1",
@@ -64,7 +77,12 @@
   },
   "match-details": {
    "matcher": "dpkg-matcher",
-   "search-key": ""
+   "search-key": {
+    "language": "java"
+   },
+   "matched-on": {
+    "constraint": "< 2.0.0"
+   }
   },
   "artifact": {
    "name": "package-1",

--- a/grype/presenter/table/presenter_test.go
+++ b/grype/presenter/table/presenter_test.go
@@ -91,9 +91,11 @@ func TestTablePresenter(t *testing.T) {
 			ID:           "CVE-1999-0002",
 			RecordSource: "source-2",
 		},
-		Package:   &pkg2,
-		Matcher:   match.DpkgMatcher,
-		SearchKey: "a search key...",
+		Package: &pkg2,
+		Matcher: match.DpkgMatcher,
+		SearchKey: map[string]interface{}{
+			"some": "key",
+		},
 	}
 
 	results := result.NewResult()

--- a/test/integration/match_coverage_test.go
+++ b/test/integration/match_coverage_test.go
@@ -45,7 +45,9 @@ func addAlpineMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, 
 		Confidence:    1.0,
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
-		SearchKey:     "cpe:2.3:*:*:libvncserver:0.9.9:*:*:*:*:*:*:*",
+		SearchKey: map[string]interface{}{
+			"cpe": "cpe:2.3:*:*:libvncserver:0.9.9:*:*:*:*:*:*:*",
+		},
 		SearchMatches: map[string]interface{}{
 			"cpes":       []string{"cpe:2.3:*:*:libvncserver:0.9.9:*:*:*:*:*:*:*"},
 			"constraint": "< 0.9.10 (unknown)",
@@ -72,7 +74,9 @@ func addJavascriptMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catal
 		Confidence:    1.0,
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
-		SearchKey:     "javascript",
+		SearchKey: map[string]interface{}{
+			"language": "javascript",
+		},
 		SearchMatches: map[string]interface{}{
 			"constraint": "< 3.2.1 (unknown)",
 		},
@@ -98,7 +102,9 @@ func addPythonMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, 
 		Confidence:    1.0,
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
-		SearchKey:     "python",
+		SearchKey: map[string]interface{}{
+			"language": "python",
+		},
 		SearchMatches: map[string]interface{}{
 			"constraint": "< 2.6.2 (python)",
 		},
@@ -124,7 +130,9 @@ func addRubyMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, th
 		Confidence:    1.0,
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
-		SearchKey:     "ruby",
+		SearchKey: map[string]interface{}{
+			"language": "ruby",
+		},
 		SearchMatches: map[string]interface{}{
 			"constraint": "> 4.0.0, <= 4.1.1 (semver)",
 		},
@@ -157,7 +165,9 @@ func addJavaMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, th
 		Confidence:    1.0,
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
-		SearchKey:     "java",
+		SearchKey: map[string]interface{}{
+			"language": "java",
+		},
 		SearchMatches: map[string]interface{}{
 			"constraint": ">= 0.0.1, < 1.2.0 (unknown)",
 		},
@@ -184,7 +194,12 @@ func addDpkgMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, th
 		Confidence:    1.0,
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
-		SearchKey:     "debian 8",
+		SearchKey: map[string]interface{}{
+			"distro": map[string]string{
+				"type":    "debian",
+				"version": "8",
+			},
+		},
 		SearchMatches: map[string]interface{}{
 			"constraint": "<= 1.8.2 (deb)",
 		},
@@ -210,7 +225,12 @@ func addRhelMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, th
 		Confidence:    1.0,
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
-		SearchKey:     "centos 8",
+		SearchKey: map[string]interface{}{
+			"distro": map[string]string{
+				"type":    "centos",
+				"version": "8",
+			},
+		},
 		SearchMatches: map[string]interface{}{
 			"constraint": "<= 1.0.42 (rpm)",
 		},


### PR DESCRIPTION
This is a follow up on https://github.com/anchore/grype/pull/137#discussion_r474756009 ; Today the `SearchKey` for a grype Match is an arbitrary string. To allow for more programmatic usefulness of the field, changing the key to a map of items that are used in the search is more useful (as no string parsing is required to interpret the key).

Closes #145 