### PR TITLE
Add positional argument validation for DB commands

### DIFF
--- a/cmd/db_check.go
+++ b/cmd/db_check.go
@@ -11,6 +11,7 @@ import (
 var dbCheckCmd = &cobra.Command{
 	Use:   "check",
 	Short: "check to see if there is a database update available",
+	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		ret := runDbCheckCmd(cmd, args)
 		if ret != 0 {

--- a/cmd/db_delete.go
+++ b/cmd/db_delete.go
@@ -11,6 +11,7 @@ import (
 var dbDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "delete the vulnerability database",
+	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		ret := runDbDeleteCmd(cmd, args)
 		if ret != 0 {

--- a/cmd/db_import.go
+++ b/cmd/db_import.go
@@ -11,6 +11,7 @@ import (
 var dbImportCmd = &cobra.Command{
 	Use:   "import",
 	Short: "import a vulnerability database archive",
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ret := runDbImportCmd(cmd, args)
 		if ret != 0 {

--- a/cmd/db_status.go
+++ b/cmd/db_status.go
@@ -14,6 +14,7 @@ var showSupportedDbSchema bool
 var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "display database status",
+	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		err := runDbStatusCmd(cmd, args)
 		if err != nil {

--- a/cmd/db_update.go
+++ b/cmd/db_update.go
@@ -11,6 +11,7 @@ import (
 var dbUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "download the latest vulnerability database",
+	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		ret := runDbUpdateCmd(cmd, args)
 		if ret != 0 {


### PR DESCRIPTION
Fixes a crash when no archive is given for db import and additionally is more explicit about positional arguments on remaining db commands.