### PR TITLE
Rename Result object to Matches

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -167,11 +167,11 @@ func startWorker(userInput string) <-chan error {
 			return
 		}
 
-		results := grype.FindVulnerabilitiesForCatalog(provider, *theDistro, catalog)
+		matches := grype.FindVulnerabilitiesForCatalog(provider, *theDistro, catalog)
 
 		bus.Publish(partybus.Event{
 			Type:  event.VulnerabilityScanningFinished,
-			Value: presenter.GetPresenter(appConfig.PresenterOpt, results, catalog, *theScope, metadataProvider),
+			Value: presenter.GetPresenter(appConfig.PresenterOpt, matches, catalog, *theScope, metadataProvider),
 		})
 	}()
 	return errs

--- a/grype/cpe/cpe.go
+++ b/grype/cpe/cpe.go
@@ -129,12 +129,12 @@ func candidateProducts(p *pkg.Package) []string {
 }
 
 func MatchWithoutVersion(c CPE, candidates []CPE) []CPE {
-	results := make([]CPE, 0)
+	matches := make([]CPE, 0)
 	for _, candidate := range candidates {
 		canCopy := candidate
 		if c.MatchWithoutVersion(&canCopy) {
-			results = append(results, candidate)
+			matches = append(matches, candidate)
 		}
 	}
-	return results
+	return matches
 }

--- a/grype/lib.go
+++ b/grype/lib.go
@@ -1,6 +1,7 @@
 package grype
 
 import (
+	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/internal/bus"
 	"github.com/wagoodman/go-partybus"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/anchore/grype/grype/logger"
 
 	"github.com/anchore/grype/grype/matcher"
-	"github.com/anchore/grype/grype/result"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal/log"
 	"github.com/anchore/syft/syft"
@@ -18,16 +18,16 @@ import (
 	"github.com/anchore/syft/syft/scope"
 )
 
-func FindVulnerabilities(provider vulnerability.Provider, userImageStr string, scopeOpt scope.Option) (result.Result, *pkg.Catalog, *scope.Scope, error) {
+func FindVulnerabilities(provider vulnerability.Provider, userImageStr string, scopeOpt scope.Option) (match.Matches, *pkg.Catalog, *scope.Scope, error) {
 	catalog, theScope, theDistro, err := syft.Catalog(userImageStr, scopeOpt)
 	if err != nil {
-		return result.Result{}, nil, nil, err
+		return match.Matches{}, nil, nil, err
 	}
 
 	return FindVulnerabilitiesForCatalog(provider, *theDistro, catalog), catalog, theScope, nil
 }
 
-func FindVulnerabilitiesForCatalog(provider vulnerability.Provider, d distro.Distro, catalog *pkg.Catalog) result.Result {
+func FindVulnerabilitiesForCatalog(provider vulnerability.Provider, d distro.Distro, catalog *pkg.Catalog) match.Matches {
 	packages := make([]*pkg.Package, 0)
 	for p := range catalog.Enumerate() {
 		packages = append(packages, p)
@@ -35,7 +35,7 @@ func FindVulnerabilitiesForCatalog(provider vulnerability.Provider, d distro.Dis
 	return FindVulnerabilitiesForPackage(provider, d, packages...)
 }
 
-func FindVulnerabilitiesForPackage(provider vulnerability.Provider, d distro.Distro, packages ...*pkg.Package) result.Result {
+func FindVulnerabilitiesForPackage(provider vulnerability.Provider, d distro.Distro, packages ...*pkg.Package) match.Matches {
 	return matcher.FindMatches(provider, d, packages...)
 }
 

--- a/grype/match/matches.go
+++ b/grype/match/matches.go
@@ -1,26 +1,21 @@
-package result
+package match
 
 import (
-	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/syft/syft/pkg"
 )
 
-// TODO: consider moving this to the pkg/match under matches.go
-
-// TODO: consider renaming to Matches
-
-type Result struct {
-	byPackage map[pkg.ID][]match.Match
+type Matches struct {
+	byPackage map[pkg.ID][]Match
 }
 
-func NewResult() Result {
-	return Result{
-		byPackage: make(map[pkg.ID][]match.Match),
+func NewResult() Matches {
+	return Matches{
+		byPackage: make(map[pkg.ID][]Match),
 	}
 }
 
 // GetByPkgID returns a slice of potential matches from an ID
-func (r *Result) GetByPkgID(id pkg.ID) []match.Match {
+func (r *Matches) GetByPkgID(id pkg.ID) []Match {
 	matches, ok := r.byPackage[id]
 	if !ok {
 		return nil
@@ -28,30 +23,30 @@ func (r *Result) GetByPkgID(id pkg.ID) []match.Match {
 	return matches
 }
 
-func (r *Result) Merge(other Result) {
+func (r *Matches) Merge(other Matches) {
 	// note: de-duplication of matches is an upstream concern (not here)
 	for pkgID, matches := range other.byPackage {
 		r.add(pkgID, matches...)
 	}
 }
 
-func (r *Result) add(id pkg.ID, matches ...match.Match) {
+func (r *Matches) add(id pkg.ID, matches ...Match) {
 	if len(matches) == 0 {
 		// only packages with matches should be added
 		return
 	}
 	if _, ok := r.byPackage[id]; !ok {
-		r.byPackage[id] = make([]match.Match, 0)
+		r.byPackage[id] = make([]Match, 0)
 	}
 	r.byPackage[id] = append(r.byPackage[id], matches...)
 }
 
-func (r *Result) Add(p *pkg.Package, matches ...match.Match) {
+func (r *Matches) Add(p *pkg.Package, matches ...Match) {
 	r.add(p.ID(), matches...)
 }
 
-func (r *Result) Enumerate() <-chan match.Match {
-	channel := make(chan match.Match)
+func (r *Matches) Enumerate() <-chan Match {
+	channel := make(chan Match)
 	go func() {
 		defer close(channel)
 		for _, matches := range r.byPackage {
@@ -64,6 +59,6 @@ func (r *Result) Enumerate() <-chan match.Match {
 }
 
 // Count returns the total number of matches in a result
-func (r *Result) Count() int {
+func (r *Matches) Count() int {
 	return len(r.byPackage)
 }

--- a/grype/match/matches.go
+++ b/grype/match/matches.go
@@ -8,7 +8,7 @@ type Matches struct {
 	byPackage map[pkg.ID][]Match
 }
 
-func NewResult() Matches {
+func NewMatches() Matches {
 	return Matches{
 		byPackage: make(map[pkg.ID][]Match),
 	}

--- a/grype/matcher/controller.go
+++ b/grype/matcher/controller.go
@@ -76,7 +76,7 @@ func (c *controller) trackMatcher() (*progress.Manual, *progress.Manual) {
 }
 
 func (c *controller) findMatches(provider vulnerability.Provider, d distro.Distro, packages ...*pkg.Package) match.Matches {
-	res := match.NewResult()
+	res := match.NewMatches()
 
 	packagesProcessed, vulnerabilitiesDiscovered := c.trackMatcher()
 

--- a/grype/matcher/controller.go
+++ b/grype/matcher/controller.go
@@ -10,7 +10,6 @@ import (
 	"github.com/anchore/grype/grype/matcher/javascript"
 	"github.com/anchore/grype/grype/matcher/python"
 	"github.com/anchore/grype/grype/matcher/rpmdb"
-	"github.com/anchore/grype/grype/result"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal/bus"
 	"github.com/anchore/grype/internal/log"
@@ -76,8 +75,8 @@ func (c *controller) trackMatcher() (*progress.Manual, *progress.Manual) {
 	return &packagesProcessed, &vulnerabilitiesDiscovered
 }
 
-func (c *controller) findMatches(provider vulnerability.Provider, d distro.Distro, packages ...*pkg.Package) result.Result {
-	res := result.NewResult()
+func (c *controller) findMatches(provider vulnerability.Provider, d distro.Distro, packages ...*pkg.Package) match.Matches {
+	res := match.NewResult()
 
 	packagesProcessed, vulnerabilitiesDiscovered := c.trackMatcher()
 
@@ -107,7 +106,7 @@ func (c *controller) findMatches(provider vulnerability.Provider, d distro.Distr
 	return res
 }
 
-func FindMatches(provider vulnerability.Provider, d distro.Distro, packages ...*pkg.Package) result.Result {
+func FindMatches(provider vulnerability.Provider, d distro.Distro, packages ...*pkg.Package) match.Matches {
 	return controllerInstance.findMatches(provider, d, packages...)
 }
 

--- a/grype/presenter/cyclonedx/document.go
+++ b/grype/presenter/cyclonedx/document.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/anchore/grype/grype/match"
-	"github.com/anchore/grype/grype/result"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/syft/syft/pkg"
 	syftCDX "github.com/anchore/syft/syft/presenter/cyclonedx"
@@ -90,7 +89,7 @@ func NewVulnerability(m match.Match, p vulnerability.MetadataProvider) (Vulnerab
 }
 
 // NewDocumentFromCatalog returns a CycloneDX Document object populated with the vulnerability contents.
-func NewDocumentFromCatalog(catalog *pkg.Catalog, matches result.Result, provider vulnerability.MetadataProvider) Document {
+func NewDocumentFromCatalog(catalog *pkg.Catalog, matches match.Matches, provider vulnerability.MetadataProvider) Document {
 	bom := NewDocument()
 	for p := range catalog.Enumerate() {
 		// make a new compoent (by value)

--- a/grype/presenter/cyclonedx/presenter.go
+++ b/grype/presenter/cyclonedx/presenter.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/anchore/grype/grype/result"
+	"github.com/anchore/grype/grype/match"
+
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/syft/syft/pkg"
 	syftCDX "github.com/anchore/syft/syft/presenter/cyclonedx"
@@ -14,14 +15,14 @@ import (
 
 // Presenter writes a CycloneDX report from the given Catalog and Scope contents
 type Presenter struct {
-	results          result.Result
+	results          match.Matches
 	catalog          *pkg.Catalog
 	scope            scope.Scope
 	metadataProvider vulnerability.MetadataProvider
 }
 
 // NewPresenter is a *Presenter constructor
-func NewPresenter(results result.Result, catalog *pkg.Catalog, theScope scope.Scope, metadataProvider vulnerability.MetadataProvider) *Presenter {
+func NewPresenter(results match.Matches, catalog *pkg.Catalog, theScope scope.Scope, metadataProvider vulnerability.MetadataProvider) *Presenter {
 	return &Presenter{
 		results:          results,
 		catalog:          catalog,

--- a/grype/presenter/cyclonedx/presenter_dirs_test.go
+++ b/grype/presenter/cyclonedx/presenter_dirs_test.go
@@ -82,11 +82,11 @@ func TestCycloneDxDirsPresenter(t *testing.T) {
 		},
 	}
 
-	results := match.NewResult()
+	matches := match.NewMatches()
 
-	results.Add(&pkg1, match1, match2)
+	matches.Add(&pkg1, match1, match2)
 
-	pres := NewPresenter(results, catalog, s, newMetadataMock())
+	pres := NewPresenter(matches, catalog, s, newMetadataMock())
 
 	// run presenter
 	err = pres.Present(&buffer)

--- a/grype/presenter/cyclonedx/presenter_dirs_test.go
+++ b/grype/presenter/cyclonedx/presenter_dirs_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/anchore/go-testutils"
 	"github.com/anchore/grype/grype/match"
-	"github.com/anchore/grype/grype/result"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/syft/syft/pkg"
@@ -83,7 +82,7 @@ func TestCycloneDxDirsPresenter(t *testing.T) {
 		},
 	}
 
-	results := result.NewResult()
+	results := match.NewResult()
 
 	results.Add(&pkg1, match1, match2)
 

--- a/grype/presenter/cyclonedx/presenter_imgs_test.go
+++ b/grype/presenter/cyclonedx/presenter_imgs_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/anchore/go-testutils"
 	"github.com/anchore/grype/grype/match"
-	"github.com/anchore/grype/grype/result"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/syft/syft/pkg"
@@ -130,7 +129,7 @@ func TestCycloneDxImgsPresenter(t *testing.T) {
 		},
 	}
 
-	results := result.NewResult()
+	results := match.NewResult()
 
 	results.Add(&pkg1, match1, match2)
 

--- a/grype/presenter/cyclonedx/presenter_imgs_test.go
+++ b/grype/presenter/cyclonedx/presenter_imgs_test.go
@@ -129,11 +129,11 @@ func TestCycloneDxImgsPresenter(t *testing.T) {
 		},
 	}
 
-	results := match.NewResult()
+	matches := match.NewMatches()
 
-	results.Add(&pkg1, match1, match2)
+	matches.Add(&pkg1, match1, match2)
 
-	pres := NewPresenter(results, catalog, s, newMetadataMock())
+	pres := NewPresenter(matches, catalog, s, newMetadataMock())
 
 	// run presenter
 	err = pres.Present(&buffer)

--- a/grype/presenter/json/presenter.go
+++ b/grype/presenter/json/presenter.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/anchore/grype/grype/result"
+	"github.com/anchore/grype/grype/match"
+
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/syft/syft/pkg"
 	syftJson "github.com/anchore/syft/syft/presenter/json"
@@ -14,14 +15,14 @@ import (
 
 // Presenter is a generic struct for holding fields needed for reporting
 type Presenter struct {
-	results          result.Result
+	results          match.Matches
 	catalog          *pkg.Catalog
 	scope            scope.Scope
 	metadataProvider vulnerability.MetadataProvider
 }
 
 // NewPresenter is a *Presenter constructor
-func NewPresenter(results result.Result, catalog *pkg.Catalog, theScope scope.Scope, metadataProvider vulnerability.MetadataProvider) *Presenter {
+func NewPresenter(results match.Matches, catalog *pkg.Catalog, theScope scope.Scope, metadataProvider vulnerability.MetadataProvider) *Presenter {
 	return &Presenter{
 		results:          results,
 		catalog:          catalog,

--- a/grype/presenter/json/presenter_test.go
+++ b/grype/presenter/json/presenter_test.go
@@ -141,8 +141,8 @@ func TestJsonPresenter(t *testing.T) {
 		},
 	}
 
-	results := match.NewResult()
-	results.Add(&pkg1, match1, match2, match3)
+	matches := match.NewMatches()
+	matches.Add(&pkg1, match1, match2, match3)
 
 	catalog := pkg.NewCatalog()
 	catalog.Add(pkg1)
@@ -150,7 +150,7 @@ func TestJsonPresenter(t *testing.T) {
 
 	theScope, err := scope.NewScopeFromImage(img, scope.AllLayersScope)
 
-	pres := NewPresenter(results, catalog, theScope, newMetadataMock())
+	pres := NewPresenter(matches, catalog, theScope, newMetadataMock())
 
 	// TODO: add a constructor for a match.Match when the data is better shaped
 
@@ -179,11 +179,11 @@ func TestEmptyJsonPresenter(t *testing.T) {
 	// Expected to have an empty JSON array back
 	var buffer bytes.Buffer
 
-	results := match.NewResult()
+	matches := match.NewMatches()
 
 	catalog := pkg.NewCatalog()
 
-	pres := NewPresenter(results, catalog, scope.Scope{}, nil)
+	pres := NewPresenter(matches, catalog, scope.Scope{}, nil)
 
 	// run presenter
 	err := pres.Present(&buffer)

--- a/grype/presenter/json/presenter_test.go
+++ b/grype/presenter/json/presenter_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/anchore/go-testutils"
 	"github.com/anchore/grype/grype/match"
-	"github.com/anchore/grype/grype/result"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/sergi/go-diff/diffmatchpatch"
@@ -142,7 +141,7 @@ func TestJsonPresenter(t *testing.T) {
 		},
 	}
 
-	results := result.NewResult()
+	results := match.NewResult()
 	results.Add(&pkg1, match1, match2, match3)
 
 	catalog := pkg.NewCatalog()
@@ -180,7 +179,7 @@ func TestEmptyJsonPresenter(t *testing.T) {
 	// Expected to have an empty JSON array back
 	var buffer bytes.Buffer
 
-	results := result.NewResult()
+	results := match.NewResult()
 
 	catalog := pkg.NewCatalog()
 

--- a/grype/presenter/presenter.go
+++ b/grype/presenter/presenter.go
@@ -3,13 +3,14 @@ package presenter
 import (
 	"io"
 
+	"github.com/anchore/grype/grype/match"
+
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/syft/syft/scope"
 
 	"github.com/anchore/grype/grype/presenter/cyclonedx"
 	"github.com/anchore/grype/grype/presenter/json"
 	"github.com/anchore/grype/grype/presenter/table"
-	"github.com/anchore/grype/grype/result"
 	"github.com/anchore/syft/syft/pkg"
 )
 
@@ -19,7 +20,7 @@ type Presenter interface {
 }
 
 // GetPresenter retrieves a Presenter that matches a CLI option
-func GetPresenter(option Option, results result.Result, catalog *pkg.Catalog, theScope scope.Scope, metadataProvider vulnerability.MetadataProvider) Presenter {
+func GetPresenter(option Option, results match.Matches, catalog *pkg.Catalog, theScope scope.Scope, metadataProvider vulnerability.MetadataProvider) Presenter {
 	switch option {
 	case JSONPresenter:
 		return json.NewPresenter(results, catalog, theScope, metadataProvider)

--- a/grype/presenter/table/presenter.go
+++ b/grype/presenter/table/presenter.go
@@ -5,7 +5,8 @@ import (
 	"io"
 	"sort"
 
-	"github.com/anchore/grype/grype/result"
+	"github.com/anchore/grype/grype/match"
+
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/olekukonko/tablewriter"
@@ -13,13 +14,13 @@ import (
 
 // Presenter is a generic struct for holding fields needed for reporting
 type Presenter struct {
-	results          result.Result
+	results          match.Matches
 	catalog          *pkg.Catalog
 	metadataProvider vulnerability.MetadataProvider
 }
 
 // NewPresenter is a *Presenter constructor
-func NewPresenter(results result.Result, catalog *pkg.Catalog, metadataProvider vulnerability.MetadataProvider) *Presenter {
+func NewPresenter(results match.Matches, catalog *pkg.Catalog, metadataProvider vulnerability.MetadataProvider) *Presenter {
 	return &Presenter{
 		results:          results,
 		catalog:          catalog,

--- a/grype/presenter/table/presenter_test.go
+++ b/grype/presenter/table/presenter_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/anchore/go-testutils"
 	"github.com/anchore/grype/grype/match"
-	"github.com/anchore/grype/grype/result"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/sergi/go-diff/diffmatchpatch"
@@ -99,7 +98,7 @@ func TestTablePresenter(t *testing.T) {
 		},
 	}
 
-	results := result.NewResult()
+	results := match.NewResult()
 
 	results.Add(&pkg1, match1, match2)
 
@@ -140,7 +139,7 @@ func TestEmptyTablePresenter(t *testing.T) {
 
 	var buffer bytes.Buffer
 
-	results := result.NewResult()
+	results := match.NewResult()
 	catalog := pkg.NewCatalog()
 
 	pres := NewPresenter(results, catalog, newMetadataMock())

--- a/grype/presenter/table/presenter_test.go
+++ b/grype/presenter/table/presenter_test.go
@@ -98,9 +98,9 @@ func TestTablePresenter(t *testing.T) {
 		},
 	}
 
-	results := match.NewResult()
+	matches := match.NewMatches()
 
-	results.Add(&pkg1, match1, match2)
+	matches.Add(&pkg1, match1, match2)
 
 	catalog := pkg.NewCatalog()
 
@@ -108,7 +108,7 @@ func TestTablePresenter(t *testing.T) {
 	catalog.Add(pkg1)
 	catalog.Add(pkg2)
 
-	pres := NewPresenter(results, catalog, newMetadataMock())
+	pres := NewPresenter(matches, catalog, newMetadataMock())
 
 	// TODO: add a constructor for a match.Match when the data is better shaped
 
@@ -139,10 +139,10 @@ func TestEmptyTablePresenter(t *testing.T) {
 
 	var buffer bytes.Buffer
 
-	results := match.NewResult()
+	matches := match.NewMatches()
 	catalog := pkg.NewCatalog()
 
-	pres := NewPresenter(results, catalog, newMetadataMock())
+	pres := NewPresenter(matches, catalog, newMetadataMock())
 
 	// run presenter
 	err := pres.Present(&buffer)

--- a/test/integration/corner_cases_test.go
+++ b/test/integration/corner_cases_test.go
@@ -1,3 +1,5 @@
+//+build integration
+
 package integration
 
 import (

--- a/test/integration/db_mock_test.go
+++ b/test/integration/db_mock_test.go
@@ -1,3 +1,5 @@
+//+build integration
+
 package integration
 
 import (

--- a/test/integration/match_coverage_test.go
+++ b/test/integration/match_coverage_test.go
@@ -253,29 +253,29 @@ func TestPkgCoverageImage(t *testing.T) {
 		{
 			fixtureImage: "image-debian-match-coverage",
 			expectedFn: func(theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore) match.Matches {
-				expectedResults := match.NewResult()
-				addPythonMatches(t, theScope, catalog, theStore, &expectedResults)
-				addRubyMatches(t, theScope, catalog, theStore, &expectedResults)
-				addJavaMatches(t, theScope, catalog, theStore, &expectedResults)
-				addDpkgMatches(t, theScope, catalog, theStore, &expectedResults)
-				addJavascriptMatches(t, theScope, catalog, theStore, &expectedResults)
-				return expectedResults
+				expectedMatches := match.NewMatches()
+				addPythonMatches(t, theScope, catalog, theStore, &expectedMatches)
+				addRubyMatches(t, theScope, catalog, theStore, &expectedMatches)
+				addJavaMatches(t, theScope, catalog, theStore, &expectedMatches)
+				addDpkgMatches(t, theScope, catalog, theStore, &expectedMatches)
+				addJavascriptMatches(t, theScope, catalog, theStore, &expectedMatches)
+				return expectedMatches
 			},
 		},
 		{
 			fixtureImage: "image-centos-match-coverage",
 			expectedFn: func(theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore) match.Matches {
-				expectedResults := match.NewResult()
-				addRhelMatches(t, theScope, catalog, theStore, &expectedResults)
-				return expectedResults
+				expectedMatches := match.NewMatches()
+				addRhelMatches(t, theScope, catalog, theStore, &expectedMatches)
+				return expectedMatches
 			},
 		},
 		{
 			fixtureImage: "image-alpine-match-coverage",
 			expectedFn: func(theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore) match.Matches {
-				expectedResults := match.NewResult()
-				addAlpineMatches(t, theScope, catalog, theStore, &expectedResults)
-				return expectedResults
+				expectedMatches := match.NewMatches()
+				addAlpineMatches(t, theScope, catalog, theStore, &expectedMatches)
+				return expectedMatches
 			},
 		},
 	}
@@ -298,23 +298,23 @@ func TestPkgCoverageImage(t *testing.T) {
 			}
 
 			// build expected matches from what's discovered from the catalog
-			expectedResults := test.expectedFn(*theScope, catalog, theStore)
+			expectedMatches := test.expectedFn(*theScope, catalog, theStore)
 
 			// build expected match set...
-			expectedMatches := map[string]string{}
-			for eMatch := range expectedResults.Enumerate() {
+			expectedMatchSet := map[string]string{}
+			for eMatch := range expectedMatches.Enumerate() {
 				// NOTE: this does not include all fields...
-				expectedMatches[eMatch.Package.Name] = eMatch.String()
+				expectedMatchSet[eMatch.Package.Name] = eMatch.String()
 			}
 
-			expectedCount := len(expectedMatches)
+			expectedCount := len(expectedMatchSet)
 
 			// ensure that all matches are covered
 			actualCount := 0
 			for aMatch := range actualResults.Enumerate() {
 				actualCount++
 				observedMatchers.Add(aMatch.Matcher.String())
-				value, ok := expectedMatches[aMatch.Package.Name]
+				value, ok := expectedMatchSet[aMatch.Package.Name]
 				if !ok {
 					t.Errorf("Package: %s was expected but not found", aMatch.Package.Name)
 				}

--- a/test/integration/match_coverage_test.go
+++ b/test/integration/match_coverage_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/anchore/go-testutils"
 	"github.com/anchore/grype/grype"
 	"github.com/anchore/grype/grype/match"
-	"github.com/anchore/grype/grype/result"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal"
 	"github.com/anchore/syft/syft/pkg"
@@ -28,7 +27,7 @@ func getPackagesByPath(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog,
 	return catalog.PackagesByFile(refs[0])
 }
 
-func addAlpineMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *result.Result) {
+func addAlpineMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
 	packages := getPackagesByPath(t, theScope, catalog, "/lib/apk/db/installed")
 	if len(packages) != 1 {
 		t.Logf("Alpine Packages: %+v", packages)
@@ -57,7 +56,7 @@ func addAlpineMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, 
 	})
 }
 
-func addJavascriptMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *result.Result) {
+func addJavascriptMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
 	packages := getPackagesByPath(t, theScope, catalog, "/javascript/pkg-lock/package-lock.json")
 	if len(packages) != 1 {
 		t.Logf("Javascript Packages: %+v", packages)
@@ -85,7 +84,7 @@ func addJavascriptMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catal
 	})
 }
 
-func addPythonMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *result.Result) {
+func addPythonMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
 	packages := getPackagesByPath(t, theScope, catalog, "/python/dist-info/METADATA")
 	if len(packages) != 1 {
 		t.Logf("Python Packages: %+v", packages)
@@ -113,7 +112,7 @@ func addPythonMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, 
 	})
 }
 
-func addRubyMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *result.Result) {
+func addRubyMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
 	packages := getPackagesByPath(t, theScope, catalog, "/ruby/Gemfile.lock")
 	if len(packages) != 1 {
 		t.Logf("Ruby Packages: %+v", packages)
@@ -141,7 +140,7 @@ func addRubyMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, th
 	})
 }
 
-func addJavaMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *result.Result) {
+func addJavaMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
 	packages := make([]*pkg.Package, 0)
 	for p := range catalog.Enumerate(pkg.JavaPkg) {
 		packages = append(packages, p)
@@ -176,7 +175,7 @@ func addJavaMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, th
 	})
 }
 
-func addDpkgMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *result.Result) {
+func addDpkgMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
 	packages := getPackagesByPath(t, theScope, catalog, "/var/lib/dpkg/status")
 	if len(packages) != 1 {
 		t.Logf("Dpkg Packages: %+v", packages)
@@ -208,7 +207,7 @@ func addDpkgMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, th
 	})
 }
 
-func addRhelMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *result.Result) {
+func addRhelMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
 	packages := getPackagesByPath(t, theScope, catalog, "/var/lib/rpm/Packages")
 	if len(packages) != 1 {
 		t.Logf("RPMDB Packages: %+v", packages)
@@ -249,12 +248,12 @@ func TestPkgCoverageImage(t *testing.T) {
 
 	tests := []struct {
 		fixtureImage string
-		expectedFn   func(scope.Scope, *pkg.Catalog, *mockStore) result.Result
+		expectedFn   func(scope.Scope, *pkg.Catalog, *mockStore) match.Matches
 	}{
 		{
 			fixtureImage: "image-debian-match-coverage",
-			expectedFn: func(theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore) result.Result {
-				expectedResults := result.NewResult()
+			expectedFn: func(theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore) match.Matches {
+				expectedResults := match.NewResult()
 				addPythonMatches(t, theScope, catalog, theStore, &expectedResults)
 				addRubyMatches(t, theScope, catalog, theStore, &expectedResults)
 				addJavaMatches(t, theScope, catalog, theStore, &expectedResults)
@@ -265,16 +264,16 @@ func TestPkgCoverageImage(t *testing.T) {
 		},
 		{
 			fixtureImage: "image-centos-match-coverage",
-			expectedFn: func(theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore) result.Result {
-				expectedResults := result.NewResult()
+			expectedFn: func(theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore) match.Matches {
+				expectedResults := match.NewResult()
 				addRhelMatches(t, theScope, catalog, theStore, &expectedResults)
 				return expectedResults
 			},
 		},
 		{
 			fixtureImage: "image-alpine-match-coverage",
-			expectedFn: func(theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore) result.Result {
-				expectedResults := result.NewResult()
+			expectedFn: func(theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore) match.Matches {
+				expectedResults := match.NewResult()
 				addAlpineMatches(t, theScope, catalog, theStore, &expectedResults)
 				return expectedResults
 			},


### PR DESCRIPTION
Polishing before release --the "Results" object was never meant to be the final name. This PR finalizes a couple of the TODOs by renaming `Result` -> `Matches` and migrating to the `match` package.