### PR TITLE
update go.mod and go.sum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.14
 
 require (
 	github.com/adrg/xdg v0.2.1
-	github.com/anchore/go-testutils v0.0.0-20200917125216-21656fe928a5
+	github.com/anchore/go-testutils v0.0.0-20200923124913-cc3783363628
 	github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca
 	github.com/anchore/grype-db v0.0.0-20200909132108-9474dd8f080f
-	github.com/anchore/stereoscope v0.0.0-20200813152757-548b22c8a0b3
+	github.com/anchore/stereoscope v0.0.0-20200922191919-df2d5de22d9d
 	github.com/anchore/syft v0.1.0-beta.4.0.20200918175440-45b5cab49a8a
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/anchore/go-testutils v0.0.0-20200624184116-66aa578126db h1:LWKezJnFTF
 github.com/anchore/go-testutils v0.0.0-20200624184116-66aa578126db/go.mod h1:D3rc2L/q4Hcp9eeX6AIJH4Q+kPjOtJCFhG9za90j+nU=
 github.com/anchore/go-testutils v0.0.0-20200917125216-21656fe928a5 h1:PTlhfgpfUWDfaflw35A64z9eF+OctprWrnympmRQ7tY=
 github.com/anchore/go-testutils v0.0.0-20200917125216-21656fe928a5/go.mod h1:D3rc2L/q4Hcp9eeX6AIJH4Q+kPjOtJCFhG9za90j+nU=
+github.com/anchore/go-testutils v0.0.0-20200923124913-cc3783363628 h1:caf7eF19+hdk94vtFrBnDmefWWEGY5706gcZdWrnVvQ=
+github.com/anchore/go-testutils v0.0.0-20200923124913-cc3783363628/go.mod h1:utpHUF0ws0l8seM+Dae3moM6S14xH8nqTZVLHAFYBuw=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZVsCYMrIZBpFxwV26CbsuoEh5muXD5I1Ods=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca h1:rLyc7Rih769rYABQe4nBPt3jHJd/snBuVvKKGoy5HEc=
@@ -129,6 +131,8 @@ github.com/anchore/stereoscope v0.0.0-20200520221116-025e07f1c93e h1:QBwtrM0MXi0
 github.com/anchore/stereoscope v0.0.0-20200520221116-025e07f1c93e/go.mod h1:bkyLl5VITnrmgErv4S1vDfVz/TGAZ5il6161IQo7w2g=
 github.com/anchore/stereoscope v0.0.0-20200813152757-548b22c8a0b3 h1:pl+txuYlhK8Mmio4d+4zQI/1xg8X6BtNErTASrx23Wk=
 github.com/anchore/stereoscope v0.0.0-20200813152757-548b22c8a0b3/go.mod h1:WntReQTI/I27FOQ87UgLVVzWgku6+ZsqfOTLxpIZFCs=
+github.com/anchore/stereoscope v0.0.0-20200922191919-df2d5de22d9d h1:5SCC6HUKKXEBADHnpBaraweYVbmQNdY2fIklETxmkmo=
+github.com/anchore/stereoscope v0.0.0-20200922191919-df2d5de22d9d/go.mod h1:W89qUNQ/8ntF5+LY/dynjcvVjWy9ae4TDo48tNK+Cdw=
 github.com/anchore/syft v0.1.0-beta.4.0.20200827121056-d85d0ac418a7 h1:mK3orcgTjK1YPWaYKUDbrDq1CFmBT5dQFq0a0w1zq3s=
 github.com/anchore/syft v0.1.0-beta.4.0.20200827121056-d85d0ac418a7/go.mod h1:zy2x5Z9URqzmLdWHENTGxcsap7HoLisEsekOv5lr0Us=
 github.com/anchore/syft v0.1.0-beta.4.0.20200918175440-45b5cab49a8a h1:iuq3OFYmGlkG7/zaNNLD25vnScCe4jLjeSSTFRZYiyA=


### PR DESCRIPTION
Fixes the currently broken main branch that has go-testutils commits from https://github.com/anchore/grype/pull/154 that had not merged into `main`. 

Those unmerged commits were proposed here: https://github.com/anchore/grype/pull/154

The updates in this PR aren't new, they are just pointing to the same commits as they appear in `main`
