### PR TITLE
Run checks on PRs from forks

### DIFF
--- a/.github/workflows/static-unit-integration.yaml
+++ b/.github/workflows/static-unit-integration.yaml
@@ -2,6 +2,7 @@ name: 'Static Analysis + Unit + Integration'
 on:
   workflow_dispatch:
   push:
+  pull_request:
 jobs:
 
   Static-Analysis:


### PR DESCRIPTION
Today we are triggering the static analysis and test workflow from push events, which forks for members of the repo, but not for PRs from a fork. This PR adds the `pull_request` trigger to the static analysis and test workflow. Note: this will cause what appears to be duplicate checks for PRs originating from members of the repo, which happens on simultaneous push and PR events. This is somewhat undesirable behavior but the refs being checked are technically different --one running against the typical git `ref` while the other is running against `refs/pull/<prnum>/merge`, as seen from the `GITHUB_REF`.