### PR TITLE
Remove darwin target from primary build entry

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,7 +20,6 @@ builds:
       # windows not supported yet (due to jotframe)
       # - windows
       - linux
-      - darwin
     goarch:
       - amd64
     # Set the modified timestamp on the output binary to the git timestamp (to ensure a reproducible build)


### PR DESCRIPTION
This is a super small follow-up to https://github.com/anchore/grype/pull/194. I left one line in by mistake... a darwin target in the first build entry within `goreleaser.yaml`.

![missed it by that much](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fmedia.giphy.com%2Fmedia%2FxTiN0DvoDyWQey2B8I%2Fgiphy.gif)

**Note:** This does **not** warrant an immediate release, since I was able to manually remove the darwin `.tar.gz` from the asset list for v0.3.0.
