### PR TITLE
Add signed and notarized ZIP release asset

### DIFF
--- a/.github/scripts/mac-sign-and-notarize.sh
+++ b/.github/scripts/mac-sign-and-notarize.sh
@@ -8,9 +8,12 @@ if [[ "${IS_SNAPSHOT}" == "true" ]]; then
   exit 0
 fi
 
-GON_CONFIG="$2"                         # e.g. "gon.hcl"
-NEW_DMG_NAME="$3"                       # e.g. "./dist/syft-0.1.0.dmg"
-ORIGINAL_DMG_NAME="./dist/output.dmg"   # This should match dmg output_path in the gon config file.
+GON_CONFIG="$2"                                       # e.g. "gon.hcl"
+NEW_NAME_WITHOUT_EXTENSION="$3"                       # e.g. "./dist/syft-0.1.0"
+ORIGINAL_NAME_WITHOUT_EXTENSION="./dist/output"       # This should match dmg and zip output_path in the gon config file, without the extension.
 
 gon "${GON_CONFIG}"
-mv -v "${ORIGINAL_DMG_NAME}" "${NEW_DMG_NAME}"
+
+# Rename outputs with specified desired name
+mv -v "${ORIGINAL_NAME_WITHOUT_EXTENSION}.dmg" "${NEW_NAME_WITHOUT_EXTENSION}.dmg"
+mv -v "${ORIGINAL_NAME_WITHOUT_EXTENSION}.zip" "${NEW_NAME_WITHOUT_EXTENSION}.zip"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,10 +7,6 @@ release:
   # If set to true, will not auto-publish the release. This is done to allow us to review the changelog before publishing.
   draft: true
 
-  # This ensures any macOS signed artifacts get included with the release.
-  extra_files:
-    - glob: "./dist/*.dmg"
-
 builds:
   - binary: grype
     id: grype
@@ -51,12 +47,34 @@ builds:
       -X github.com/anchore/grype/internal/version.gitCommit={{.Commit}}
       -X github.com/anchore/grype/internal/version.buildDate={{.Date}}
       -X github.com/anchore/grype/internal/version.gitTreeState={{.Env.BUILD_GIT_TREE_STATE}}
-    hooks:
-      post: ./.github/scripts/mac-sign-and-notarize.sh "{{.IsSnapshot}}" "gon.hcl" "./dist/grype_{{.Version}}_{{.Target}}.dmg"
+
+archives:
+  - format: tar.gz
+    builds:
+      - grype # i.e. Linux only
+  - format: zip # This is a hack! We don't actually intend to use _this_ ZIP file, we just need goreleaser to consider the ZIP file produced by gon (which will have the same file name) to be an artifact so we can use it downstream in publishing (e.g. to a homebrew tap)
+    id: grype-zip
+    builds:
+      - grype-macos
 
 signs:
   - artifacts: checksum
-    args: ["--output", "${signature}", "--detach-sign", "${artifact}"]
+    cmd: sh
+    args:
+      - '-c'
+      # we should not include the zip artifact, as the artifact is mutated throughout the next macOS notarization step
+      # note: sed -i is not portable
+      - 'sed "/.*\.zip/d" ${artifact} > tmpfile && mv tmpfile ${artifact} && gpg --output ${signature} --detach-sign ${artifact}'
+  - id: grype-macos-signing
+    ids:
+      - grype-macos
+    cmd: ./.github/scripts/mac-sign-and-notarize.sh
+    signature: "grype_${VERSION}_darwin_amd64.dmg" # This is somewhat unintuitive. This gets the DMG file recognized as an artifact. In fact, both a DMG and a ZIP file are being produced by this signing step.
+    args:
+      - "{{ .IsSnapshot }}"
+      - "gon.hcl"
+      - "./dist/grype_{{ .Version }}_darwin_amd64"
+    artifacts: all
 
 nfpms:
   - license: "Apache 2.0"
@@ -73,11 +91,3 @@ brews:
       name: homebrew-grype
     homepage: *website
     description: *description
-
-archives:
-  - format: tar.gz
-    builds:
-      - grype # i.e. Linux only
-    format_overrides:
-      - goos: windows
-        format: zip

--- a/Makefile
+++ b/Makefile
@@ -218,11 +218,14 @@ release: clean-dist ci-bootstrap-mac changelog-release ## Build and publish fina
 	echo "dist: $(DISTDIR)" > $(TEMPDIR)/goreleaser.yaml
 	cat .goreleaser.yaml >> $(TEMPDIR)/goreleaser.yaml
 
-	# release
-	bash -c "BUILD_GIT_TREE_STATE=$(GITTREESTATE) $(TEMPDIR)/goreleaser \
-		--rm-dist \
-		--config $(TEMPDIR)/goreleaser.yaml \
-		--release-notes <(cat CHANGELOG.md)"
+	# release (note the version transformation from v0.7.0 --> 0.7.0)
+	bash -c "\
+		BUILD_GIT_TREE_STATE=$(GITTREESTATE) \
+		VERSION=$(VERSION:v%=%) \
+		$(TEMPDIR)/goreleaser \
+			--rm-dist \
+			--config $(TEMPDIR)/goreleaser.yaml \
+			--release-notes <(cat CHANGELOG.md)"
 
 	# verify checksum signatures
 	.github/scripts/verify-signature.sh "$(DISTDIR)"

--- a/gon.hcl
+++ b/gon.hcl
@@ -9,3 +9,7 @@ dmg {
   output_path = "./dist/output.dmg"
   volume_name = "Grype"
 }
+
+zip {
+  output_path = "./dist/output.zip"
+}

--- a/install.sh
+++ b/install.sh
@@ -243,7 +243,7 @@ unpack() {
 extract_from_dmg() {
   dmg_file=$1
   mount_point="/Volumes/tmp-dmg"
-  hdiutil attach -quiet -mountpoint "${mount_point}" "${dmg_file}"
+  hdiutil attach -quiet -nobrowse -mountpoint "${mount_point}" "${dmg_file}"
   cp -fR "${mount_point}/" ./
   hdiutil detach -quiet -force "${mount_point}"
 }


### PR DESCRIPTION
- Adds "zip" as a `gon` output
- Ensures that ZIP file is a goreleaser artifact and is thus included in the GitHub release assets as well as used for the homebrew installation path
- Removes the "flash" of a Finder window during the execution of `install.sh`

This is also intended to address #203, in that homebrew will now use the `.zip` file (which has been correctly signed and notarized to the standards of macOS) rather than the `.tar.gz` file (which doesn't support notarization).