### PR TITLE
Bump syft from v0.5.1 to v0.7.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca
 	github.com/anchore/grype-db v0.0.0-20200929200644-6d1c82acc95e
-	github.com/anchore/stereoscope v0.0.0-20200925184903-c82da54e98fe
-	github.com/anchore/syft v0.5.1
+	github.com/anchore/stereoscope v0.0.0-20201106140100-12e75c48f409
+	github.com/anchore/syft v0.7.1
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/dustin/go-humanize v1.0.0
 	github.com/facebookincubator/nvdtools v0.1.4-0.20200622182922-aed862a62ae6

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alicebob/sqlittle v1.4.0 h1:vgYt0nAjhdf/hg52MjKJ84g/uTzBPfrvI+VUBrIghxA=
 github.com/alicebob/sqlittle v1.4.0/go.mod h1:Co1L1qxHqCwf41puWhk2HOodojR0mcsAV4BIt8byZh8=
-github.com/anchore/go-rpmdb v0.0.0-20200811175839-cbc751c28e8e h1:kty6r0R2JeaNPeWKSYDC+HW3hkqwFh4PP5TQ8pUPYFw=
-github.com/anchore/go-rpmdb v0.0.0-20200811175839-cbc751c28e8e/go.mod h1:iYuIG0Nai8dR0ri3LhZQKUyO1loxUWAGvoWhXDmjy1A=
+github.com/anchore/go-rpmdb v0.0.0-20201106153645-0043963c2e12 h1:xbeIbn5F52JVx3RUIajxCj8b0y+9lywspql4sFhcxWQ=
+github.com/anchore/go-rpmdb v0.0.0-20201106153645-0043963c2e12/go.mod h1:juoyWXIj7sJ1IDl4E/KIfyLtovbs5XQVSIdaQifFQT8=
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0vW0nnNKJfJieyH/TZ9UYAnTZs5/gHTdAe8=
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZVsCYMrIZBpFxwV26CbsuoEh5muXD5I1Ods=
@@ -123,12 +123,10 @@ github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca h1:rLyc7Rih76
 github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/grype-db v0.0.0-20200929200644-6d1c82acc95e h1:s0HmxxDuJyvgGBXmNBZwuXLLFSUfBmS9+/Rz1L58Bz0=
 github.com/anchore/grype-db v0.0.0-20200929200644-6d1c82acc95e/go.mod h1:LINmipRzG88vnJEWvgMMDVCFH1qZsj7+bjmpERlSyaA=
-github.com/anchore/stereoscope v0.0.0-20200925184903-c82da54e98fe h1:m4NSyTo2fVUoUHAV/ZVqE/PFMr/y8oz9HRrhWLk9It0=
-github.com/anchore/stereoscope v0.0.0-20200925184903-c82da54e98fe/go.mod h1:2Jja/4l0zYggW52og+nn0rut4i+OYjCf9vTyrM8RT4E=
-github.com/anchore/syft v0.4.0 h1:Qt9il5QBkFeMAkxEnaIV0VjDtnHP1DdTcA39TfSlZWs=
-github.com/anchore/syft v0.4.0/go.mod h1:fxzECHyEWfAZ06gJVyrKK+DEkLJeJ4PrK7eyPAwqJR0=
-github.com/anchore/syft v0.5.1 h1:yQmAojroms/UpylaAlFAAKmzuKlTLy8U6YljI324PwU=
-github.com/anchore/syft v0.5.1/go.mod h1:yvflCO2nhspj6+I2BP25HqLWn1MM6aQ6EROGbmPxjIU=
+github.com/anchore/stereoscope v0.0.0-20201106140100-12e75c48f409 h1:xKSpDRjmYrEFrdMeDh4AuSUAFc99pdro6YFBKxy2um0=
+github.com/anchore/stereoscope v0.0.0-20201106140100-12e75c48f409/go.mod h1:2Jja/4l0zYggW52og+nn0rut4i+OYjCf9vTyrM8RT4E=
+github.com/anchore/syft v0.7.1 h1:xP5EI8r1WbnrhI71AaEk5e/OSTXJKFleV+J03TTOSv8=
+github.com/anchore/syft v0.7.1/go.mod h1:Uf1lxsZSo/y3HjQ0U94p3aQpHy8Ac6wLyDwYLT0dcYw=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
@@ -161,8 +159,6 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/bmatcuk/doublestar v1.3.1 h1:rT8rxDPsavp9G+4ZULzqhhUSaI/OPsTZNG88Z3i0xvY=
-github.com/bmatcuk/doublestar v1.3.1/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bmatcuk/doublestar v1.3.3 h1:pVP1d49CcQQaNOl+PI6sPybIrIOD/6sux31PFdmhTH0=
 github.com/bmatcuk/doublestar v1.3.3/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
@@ -296,7 +292,6 @@ github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-test/deep v1.0.6/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
 github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/go-toolsmith/astcast v1.0.0/go.mod h1:mt2OdQTeAQcY4DQgPSArJjHCcOwlX+Wl/kwN+LbLGQ4=

--- a/grype/logger/logger.go
+++ b/grype/logger/logger.go
@@ -2,7 +2,9 @@ package logger
 
 type Logger interface {
 	Errorf(format string, args ...interface{})
+	Error(args ...interface{})
 	Warnf(format string, args ...interface{})
+	Warn(args ...interface{})
 	Infof(format string, args ...interface{})
 	Info(args ...interface{})
 	Debugf(format string, args ...interface{})

--- a/grype/matcher/apk/matcher_test.go
+++ b/grype/matcher/apk/matcher_test.go
@@ -53,7 +53,7 @@ func TestNoSecDBMatch(t *testing.T) {
 	provider := vulnerability.NewProviderFromStore(&store)
 
 	m := Matcher{}
-	d, err := distro.NewDistro(distro.Alpine, "3.12.0")
+	d, err := distro.NewDistro(distro.Alpine, "3.12.0", "")
 	if err != nil {
 		t.Fatalf("failed to create a new distro: %+v", err)
 	}
@@ -105,7 +105,7 @@ func TestMatches(t *testing.T) {
 	provider := vulnerability.NewProviderFromStore(&store)
 
 	m := Matcher{}
-	d, err := distro.NewDistro(distro.Alpine, "3.12.0")
+	d, err := distro.NewDistro(distro.Alpine, "3.12.0", "")
 	if err != nil {
 		t.Fatalf("failed to create a new distro: %+v", err)
 	}

--- a/grype/matcher/common/distro_matchers_test.go
+++ b/grype/matcher/common/distro_matchers_test.go
@@ -67,7 +67,7 @@ func TestFindMatchesByPackageDistro(t *testing.T) {
 		},
 	}
 
-	d, err := distro.NewDistro(distro.Debian, "8")
+	d, err := distro.NewDistro(distro.Debian, "8", "")
 	if err != nil {
 		t.Fatal("could not create distro: ", err)
 	}

--- a/grype/matcher/dpkg/matcher_test.go
+++ b/grype/matcher/dpkg/matcher_test.go
@@ -20,7 +20,7 @@ func TestMatcherDpkg_matchBySourceIndirection(t *testing.T) {
 		},
 	}
 
-	d, err := distro.NewDistro(distro.Debian, "8")
+	d, err := distro.NewDistro(distro.Debian, "8", "")
 	if err != nil {
 		t.Fatal("could not create distro: ", err)
 	}

--- a/grype/matcher/rpmdb/matcher_test.go
+++ b/grype/matcher/rpmdb/matcher_test.go
@@ -21,7 +21,7 @@ func TestMatcherDpkg_matchBySourceIndirection(t *testing.T) {
 		},
 	}
 
-	d, err := distro.NewDistro(distro.CentOS, "8")
+	d, err := distro.NewDistro(distro.CentOS, "8", "")
 	if err != nil {
 		t.Fatal("could not create distro: ", err)
 	}
@@ -81,7 +81,7 @@ func TestMatcherDpkg_matchBySourceIndirection_ignoreSource(t *testing.T) {
 		},
 	}
 
-	d, err := distro.NewDistro(distro.CentOS, "8")
+	d, err := distro.NewDistro(distro.CentOS, "8", "")
 	if err != nil {
 		t.Fatal("could not create distro: ", err)
 	}

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
@@ -31,7 +31,8 @@
     ],
     "locations": [
      "/some/path/pkg1"
-    ]
+    ],
+    "licenses": null
    }
   },
   {
@@ -63,7 +64,8 @@
     ],
     "locations": [
      "/some/path/pkg1"
-    ]
+    ],
+    "licenses": null
    }
   },
   {
@@ -90,7 +92,8 @@
     ],
     "locations": [
      "/some/path/pkg1"
-    ]
+    ],
+    "licenses": null
    }
   }
  ],

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
@@ -34,7 +34,8 @@
       "path": "/somefile-1.txt",
       "layerIndex": 0
      }
-    ]
+    ],
+    "licenses": null
    }
   },
   {
@@ -69,7 +70,8 @@
       "path": "/somefile-1.txt",
       "layerIndex": 0
      }
-    ]
+    ],
+    "licenses": null
    }
   },
   {
@@ -99,7 +101,8 @@
       "path": "/somefile-1.txt",
       "layerIndex": 0
      }
-    ]
+    ],
+    "licenses": null
    }
   }
  ],

--- a/grype/vulnerability/namespace_test.go
+++ b/grype/vulnerability/namespace_test.go
@@ -74,7 +74,7 @@ func TestDistroNamespace_AllDistros(t *testing.T) {
 	for _, test := range tests {
 		name := fmt.Sprintf("%s:%s", test.dist, test.version)
 		t.Run(name, func(t *testing.T) {
-			d, err := distro.NewDistro(test.dist, test.version)
+			d, err := distro.NewDistro(test.dist, test.version, "")
 			if err != nil {
 				t.Errorf("could not create distro='%+v:%+v': %+v", test.dist, test.version, err)
 			}
@@ -119,7 +119,7 @@ func TestDistroNamespace_VersionHandeling(t *testing.T) {
 	for _, test := range tests {
 		name := fmt.Sprintf("%s:%s", test.dist, test.version)
 		t.Run(name, func(t *testing.T) {
-			d, err := distro.NewDistro(test.dist, test.version)
+			d, err := distro.NewDistro(test.dist, test.version, "")
 			if err != nil {
 				t.Errorf("could not create distro='%+v:%+v': %+v", test.dist, test.version, err)
 			}

--- a/grype/vulnerability/store_adapter_test.go
+++ b/grype/vulnerability/store_adapter_test.go
@@ -1,9 +1,10 @@
 package vulnerability
 
 import (
+	"testing"
+
 	"github.com/anchore/grype/grype/cpe"
 	"github.com/go-test/deep"
-	"testing"
 
 	"github.com/anchore/grype/grype/version"
 	"github.com/anchore/syft/syft/distro"
@@ -13,7 +14,7 @@ import (
 func TestGetByDistro(t *testing.T) {
 	provider := NewProviderFromStore(newMockStore())
 
-	d, err := distro.NewDistro(distro.Debian, "8")
+	d, err := distro.NewDistro(distro.Debian, "8", "")
 	if err != nil {
 		t.Fatalf("failed to create distro: %+v", err)
 	}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -8,8 +8,16 @@ func Errorf(format string, args ...interface{}) {
 	Log.Errorf(format, args...)
 }
 
+func Error(args ...interface{}) {
+	Log.Error(args...)
+}
+
 func Warnf(format string, args ...interface{}) {
 	Log.Warnf(format, args...)
+}
+
+func Warn(args ...interface{}) {
+	Log.Warn(args...)
 }
 
 func Infof(format string, args ...interface{}) {

--- a/internal/log/nop.go
+++ b/internal/log/nop.go
@@ -3,7 +3,9 @@ package log
 type nopLogger struct{}
 
 func (l *nopLogger) Errorf(format string, args ...interface{}) {}
+func (l *nopLogger) Error(args ...interface{})                 {}
 func (l *nopLogger) Warnf(format string, args ...interface{})  {}
+func (l *nopLogger) Warn(args ...interface{})                  {}
 func (l *nopLogger) Infof(format string, args ...interface{})  {}
 func (l *nopLogger) Info(args ...interface{})                  {}
 func (l *nopLogger) Debugf(format string, args ...interface{}) {}

--- a/internal/logger/logrus.go
+++ b/internal/logger/logrus.go
@@ -82,6 +82,14 @@ func (l *LogrusLogger) Infof(format string, args ...interface{}) {
 	l.Logger.Infof(format, args...)
 }
 
+func (l *LogrusLogger) Warnf(format string, args ...interface{}) {
+	l.Logger.Warnf(format, args...)
+}
+
+func (l *LogrusLogger) Errorf(format string, args ...interface{}) {
+	l.Logger.Errorf(format, args...)
+}
+
 func (l *LogrusLogger) Debug(args ...interface{}) {
 	l.Logger.Debug(args...)
 }
@@ -90,12 +98,12 @@ func (l *LogrusLogger) Info(args ...interface{}) {
 	l.Logger.Info(args...)
 }
 
-func (l *LogrusLogger) Warnf(format string, args ...interface{}) {
-	l.Logger.Warnf(format, args...)
+func (l *LogrusLogger) Warn(args ...interface{}) {
+	l.Logger.Warn(args...)
 }
 
-func (l *LogrusLogger) Errorf(format string, args ...interface{}) {
-	l.Logger.Errorf(format, args...)
+func (l *LogrusLogger) Error(args ...interface{}) {
+	l.Logger.Error(args...)
 }
 
 func (l *LogrusNestedLogger) Debugf(format string, args ...interface{}) {
@@ -106,6 +114,14 @@ func (l *LogrusNestedLogger) Infof(format string, args ...interface{}) {
 	l.Logger.Infof(format, args...)
 }
 
+func (l *LogrusNestedLogger) Warnf(format string, args ...interface{}) {
+	l.Logger.Warnf(format, args...)
+}
+
+func (l *LogrusNestedLogger) Errorf(format string, args ...interface{}) {
+	l.Logger.Errorf(format, args...)
+}
+
 func (l *LogrusNestedLogger) Debug(args ...interface{}) {
 	l.Logger.Debug(args...)
 }
@@ -114,10 +130,10 @@ func (l *LogrusNestedLogger) Info(args ...interface{}) {
 	l.Logger.Info(args...)
 }
 
-func (l *LogrusNestedLogger) Warnf(format string, args ...interface{}) {
-	l.Logger.Warnf(format, args...)
+func (l *LogrusNestedLogger) Warn(args ...interface{}) {
+	l.Logger.Warn(args...)
 }
 
-func (l *LogrusNestedLogger) Errorf(format string, args ...interface{}) {
-	l.Logger.Errorf(format, args...)
+func (l *LogrusNestedLogger) Error(args ...interface{}) {
+	l.Logger.Error(args...)
 }

--- a/test/integration/match_coverage_test.go
+++ b/test/integration/match_coverage_test.go
@@ -339,6 +339,12 @@ func TestPkgCoverageImage(t *testing.T) {
 
 	if len(observedMatchers) != len(definedMatchers) {
 		t.Errorf("matcher coverage incomplete (matchers=%d, coverage=%d)", len(definedMatchers), len(observedMatchers))
+		for _, m := range definedMatchers.ToSlice() {
+			t.Logf("  defined: %+v\n", m)
+		}
+		for _, m := range observedMatchers.ToSlice() {
+			t.Logf("  found: %+v\n", m)
+		}
 	}
 
 }


### PR DESCRIPTION
- Adds warn log level (in parity with syft)
- Bumps syft to v0.7.1