### PR TITLE
Add JSON document import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca
 	github.com/anchore/grype-db v0.0.0-20200929200644-6d1c82acc95e
 	github.com/anchore/stereoscope v0.0.0-20201106140100-12e75c48f409
-	github.com/anchore/syft v0.7.1
+	github.com/anchore/syft v0.8.0
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/dustin/go-humanize v1.0.0
 	github.com/facebookincubator/nvdtools v0.1.4-0.20200622182922-aed862a62ae6

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/anchore/grype-db v0.0.0-20200929200644-6d1c82acc95e h1:s0HmxxDuJyvgGB
 github.com/anchore/grype-db v0.0.0-20200929200644-6d1c82acc95e/go.mod h1:LINmipRzG88vnJEWvgMMDVCFH1qZsj7+bjmpERlSyaA=
 github.com/anchore/stereoscope v0.0.0-20201106140100-12e75c48f409 h1:xKSpDRjmYrEFrdMeDh4AuSUAFc99pdro6YFBKxy2um0=
 github.com/anchore/stereoscope v0.0.0-20201106140100-12e75c48f409/go.mod h1:2Jja/4l0zYggW52og+nn0rut4i+OYjCf9vTyrM8RT4E=
-github.com/anchore/syft v0.7.1 h1:xP5EI8r1WbnrhI71AaEk5e/OSTXJKFleV+J03TTOSv8=
-github.com/anchore/syft v0.7.1/go.mod h1:Uf1lxsZSo/y3HjQ0U94p3aQpHy8Ac6wLyDwYLT0dcYw=
+github.com/anchore/syft v0.8.0 h1:Jq9yja9rwx6oIrPjwSpmB2VWRbrOTLtC06GJnAUz03A=
+github.com/anchore/syft v0.8.0/go.mod h1:Uf1lxsZSo/y3HjQ0U94p3aQpHy8Ac6wLyDwYLT0dcYw=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=

--- a/grype/lib.go
+++ b/grype/lib.go
@@ -1,30 +1,64 @@
 package grype
 
 import (
-	"github.com/anchore/grype/grype/match"
-	"github.com/anchore/grype/internal/bus"
-	"github.com/wagoodman/go-partybus"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/anchore/grype/internal"
 
 	"github.com/anchore/grype/grype/db"
-
 	"github.com/anchore/grype/grype/logger"
-
+	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/matcher"
 	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/grype/internal/bus"
 	"github.com/anchore/grype/internal/log"
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/distro"
 	"github.com/anchore/syft/syft/pkg"
-	"github.com/anchore/syft/syft/scope"
+	"github.com/anchore/syft/syft/source"
+	"github.com/wagoodman/go-partybus"
 )
 
-func FindVulnerabilities(provider vulnerability.Provider, userImageStr string, scopeOpt scope.Option) (match.Matches, *pkg.Catalog, *scope.Scope, error) {
-	catalog, theScope, theDistro, err := syft.Catalog(userImageStr, scopeOpt)
-	if err != nil {
-		return match.Matches{}, nil, nil, err
+func Catalog(userImageStr string, scopeOpt source.Scope) (source.Metadata, *pkg.Catalog, distro.Distro, error) {
+	// handle explicit sbom input first
+	if strings.HasPrefix(userImageStr, "sbom:") {
+		// the user has explicitly hinted this is an sbom, if there is an issue return the error
+		filepath := strings.TrimPrefix(userImageStr, "sbom:")
+		sbomReader, err := os.Open(filepath)
+		if err != nil {
+			return source.Metadata{}, nil, distro.Distro{}, fmt.Errorf("unable to read sbom: %w", err)
+		}
+		return syft.CatalogFromJSON(sbomReader)
+	} else if internal.IsPipedInput() && userImageStr == "" {
+		// the user has not provided an image and stdin is a pipe, assume this to be an explicit sbom case
+		return syft.CatalogFromJSON(os.Stdin)
 	}
 
-	return FindVulnerabilitiesForCatalog(provider, *theDistro, catalog), catalog, theScope, nil
+	// the user has not hinted that this may be a sbom, but lets try that first... ignore failures and fallback to syft
+	if sbomReader, err := os.Open(userImageStr); err == nil {
+		sourceMetadata, catalog, theDistro, err := syft.CatalogFromJSON(sbomReader)
+		if err == nil {
+			return sourceMetadata, catalog, theDistro, nil
+		}
+	}
+
+	// attempt to parse as an image (left syft handle this)
+	theSource, catalog, theDistro, err := syft.Catalog(userImageStr, scopeOpt)
+	if err != nil {
+		return source.Metadata{}, nil, distro.Distro{}, err
+	}
+	return theSource.Metadata, catalog, theDistro, nil
+}
+
+func FindVulnerabilities(provider vulnerability.Provider, userImageStr string, scopeOpt source.Scope) (match.Matches, source.Metadata, *pkg.Catalog, error) {
+	sourceMetadata, catalog, theDistro, err := Catalog(userImageStr, scopeOpt)
+	if err != nil {
+		return match.Matches{}, source.Metadata{}, nil, err
+	}
+
+	return FindVulnerabilitiesForCatalog(provider, theDistro, catalog), sourceMetadata, catalog, nil
 }
 
 func FindVulnerabilitiesForCatalog(provider vulnerability.Provider, d distro.Distro, catalog *pkg.Catalog) match.Matches {

--- a/grype/presenter/cyclonedx/presenter.go
+++ b/grype/presenter/cyclonedx/presenter.go
@@ -2,70 +2,38 @@ package cyclonedx
 
 import (
 	"encoding/xml"
-	"fmt"
 	"io"
 
 	"github.com/anchore/grype/grype/match"
 
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/syft/syft/pkg"
-	syftCDX "github.com/anchore/syft/syft/presenter/cyclonedx"
-	"github.com/anchore/syft/syft/scope"
+	"github.com/anchore/syft/syft/source"
 )
 
 // Presenter writes a CycloneDX report from the given Catalog and Scope contents
 type Presenter struct {
 	results          match.Matches
 	catalog          *pkg.Catalog
-	scope            scope.Scope
+	srcMetadata      source.Metadata
 	metadataProvider vulnerability.MetadataProvider
 }
 
 // NewPresenter is a *Presenter constructor
-func NewPresenter(results match.Matches, catalog *pkg.Catalog, theScope scope.Scope, metadataProvider vulnerability.MetadataProvider) *Presenter {
+func NewPresenter(results match.Matches, catalog *pkg.Catalog, srcMetadata source.Metadata, metadataProvider vulnerability.MetadataProvider) *Presenter {
 	return &Presenter{
 		results:          results,
 		catalog:          catalog,
 		metadataProvider: metadataProvider,
-		scope:            theScope,
+		srcMetadata:      srcMetadata,
 	}
 }
 
 // Present creates a CycloneDX-based reporting
 func (pres *Presenter) Present(output io.Writer) error {
-	bom, err := NewDocumentFromCatalog(pres.catalog, pres.results, pres.metadataProvider)
+	bom, err := NewDocument(pres.catalog, pres.results, pres.srcMetadata, pres.metadataProvider)
 	if err != nil {
 		return err
-	}
-
-	switch src := pres.scope.Source.(type) {
-	case scope.DirSource:
-		bom.BomDescriptor.Component = &syftCDX.BdComponent{
-			Component: syftCDX.Component{
-				Type:    "file",
-				Name:    src.Path,
-				Version: "",
-			},
-		}
-	case scope.ImageSource:
-		var imageID string
-		var versionStr string
-		if len(src.Img.Metadata.Tags) > 0 {
-			imageID = src.Img.Metadata.Tags[0].Context().Name()
-			versionStr = src.Img.Metadata.Tags[0].TagStr()
-		} else {
-			imageID = src.Img.Metadata.Digest
-		}
-		src.Img.Metadata.Tags[0].TagStr()
-		bom.BomDescriptor.Component = &syftCDX.BdComponent{
-			Component: syftCDX.Component{
-				Type:    "container",
-				Name:    imageID,
-				Version: versionStr,
-			},
-		}
-	default:
-		return fmt.Errorf("unsupported source: %T", src)
 	}
 
 	encoder := xml.NewEncoder(output)

--- a/grype/presenter/cyclonedx/presenter_test.go
+++ b/grype/presenter/cyclonedx/presenter_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/stereoscope/pkg/imagetest"
 	"github.com/anchore/syft/syft/pkg"
-	"github.com/anchore/syft/syft/scope"
+	"github.com/anchore/syft/syft/source"
 	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
@@ -144,8 +144,17 @@ func TestCycloneDxPresenter(t *testing.T) {
 				matches.Add(&pkg1, match1, match2)
 				img, cleanup := imagetest.GetFixtureImage(t, "docker-archive", "image-simple")
 				defer cleanup()
-				s, err := scope.NewScopeFromImage(img, scope.AllLayersScope)
-				pres := NewPresenter(matches, catalog, s, newMetadataMock())
+				s, err := source.NewFromImage(img, source.AllLayersScope, "user-input")
+
+				// This accounts for the non-deterministic digest value that we end up with when
+				// we build a container image dynamically during testing. Ultimately, we should
+				// use a golden image as a test fixture in place of building this image during
+				// testing. At that time, this line will no longer be necessary.
+				//
+				// This value is sourced from the "version" node in "./test-fixtures/snapshot/TestCycloneDxImgsPresenter.golden"
+				s.Metadata.ImageMetadata.Digest = "sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368"
+
+				pres := NewPresenter(matches, catalog, s.Metadata, newMetadataMock())
 				// run presenter
 				err = pres.Present(&buffer)
 				if err != nil {
@@ -153,7 +162,7 @@ func TestCycloneDxPresenter(t *testing.T) {
 				}
 
 			} else {
-				s, err := scope.NewScopeFromDir("/some/path")
+				s, err := source.NewFromDirectory("/some/path")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -161,7 +170,7 @@ func TestCycloneDxPresenter(t *testing.T) {
 
 				matches.Add(&pkg1, match1, match2)
 
-				pres := NewPresenter(matches, catalog, s, newMetadataMock())
+				pres := NewPresenter(matches, catalog, s.Metadata, newMetadataMock())
 
 				// run presenter
 				err = pres.Present(&buffer)

--- a/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenter_CycloneDX_Directory_Presenter.golden
+++ b/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenter_CycloneDX_Directory_Presenter.golden
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.2" xmlns:bd="http://cyclonedx.org/schema/ext/bom-descriptor/1.0" xmlns:v="http://cyclonedx.org/schema/ext/vulnerability/1.0" version="1" serialNumber="urn:uuid:7f9d9544-4a3c-4816-9974-2fc76549bd83">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.2" xmlns:bd="http://cyclonedx.org/schema/ext/bom-descriptor/1.0" xmlns:v="http://cyclonedx.org/schema/ext/vulnerability/1.0" version="1" serialNumber="urn:uuid:fb34f36c-9e1e-498e-920f-87b93d11c80a">
   <components>
     <component type="library">
       <name>package-1</name>
       <version>1.0.1</version>
       <v:vulnerabilities>
-        <v:vulnerability ref="urn:uuid:74e83b32-6e0e-4ec0-b480-364ffab1d686">
+        <v:vulnerability ref="urn:uuid:46a01c04-1a43-49ac-b2f6-0aeb0f707da2">
           <v:id>CVE-1999-0001</v:id>
           <v:source name="source-1">
             <v:url>http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0001</v:url>
@@ -25,7 +25,7 @@
           <v:description>1999-01 description</v:description>
           <v:advisories></v:advisories>
         </v:vulnerability>
-        <v:vulnerability ref="urn:uuid:aa67380f-ac2e-4463-83ef-9daeb868e150">
+        <v:vulnerability ref="urn:uuid:a2a52b9c-92be-4b42-a56f-109ae0bab1b5">
           <v:id>CVE-1999-0002</v:id>
           <v:source name="source-2">
             <v:url>http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0002</v:url>
@@ -61,7 +61,7 @@
     </component>
   </components>
   <bd:metadata>
-    <bd:timestamp>2020-09-24T08:43:43-04:00</bd:timestamp>
+    <bd:timestamp>2020-11-17T14:03:05-05:00</bd:timestamp>
     <bd:tool>
       <bd:vendor>anchore</bd:vendor>
       <bd:name>grype</bd:name>

--- a/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenter_CycloneDX_Image_Presenter.golden
+++ b/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenter_CycloneDX_Image_Presenter.golden
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.2" xmlns:bd="http://cyclonedx.org/schema/ext/bom-descriptor/1.0" xmlns:v="http://cyclonedx.org/schema/ext/vulnerability/1.0" version="1" serialNumber="urn:uuid:7f9d9544-4a3c-4816-9974-2fc76549bd83">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.2" xmlns:bd="http://cyclonedx.org/schema/ext/bom-descriptor/1.0" xmlns:v="http://cyclonedx.org/schema/ext/vulnerability/1.0" version="1" serialNumber="urn:uuid:fb34f36c-9e1e-498e-920f-87b93d11c80a">
   <components>
     <component type="library">
       <name>package-1</name>
       <version>1.0.1</version>
       <v:vulnerabilities>
-        <v:vulnerability ref="urn:uuid:74e83b32-6e0e-4ec0-b480-364ffab1d686">
+        <v:vulnerability ref="urn:uuid:46a01c04-1a43-49ac-b2f6-0aeb0f707da2">
           <v:id>CVE-1999-0001</v:id>
           <v:source name="source-1">
             <v:url>http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0001</v:url>
@@ -25,7 +25,7 @@
           <v:description>1999-01 description</v:description>
           <v:advisories></v:advisories>
         </v:vulnerability>
-        <v:vulnerability ref="urn:uuid:aa67380f-ac2e-4463-83ef-9daeb868e150">
+        <v:vulnerability ref="urn:uuid:a2a52b9c-92be-4b42-a56f-109ae0bab1b5">
           <v:id>CVE-1999-0002</v:id>
           <v:source name="source-2">
             <v:url>http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0002</v:url>
@@ -61,7 +61,7 @@
     </component>
   </components>
   <bd:metadata>
-    <bd:timestamp>2020-09-24T08:43:43-04:00</bd:timestamp>
+    <bd:timestamp>2020-11-17T14:03:05-05:00</bd:timestamp>
     <bd:tool>
       <bd:vendor>anchore</bd:vendor>
       <bd:name>grype</bd:name>
@@ -73,13 +73,13 @@
     </bd:component>
   </bd:metadata>
 </bom><?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.2" xmlns:bd="http://cyclonedx.org/schema/ext/bom-descriptor/1.0" xmlns:v="http://cyclonedx.org/schema/ext/vulnerability/1.0" version="1" serialNumber="urn:uuid:29dfd0be-5bc5-4e5a-ba25-07ba4708dd29">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.2" xmlns:bd="http://cyclonedx.org/schema/ext/bom-descriptor/1.0" xmlns:v="http://cyclonedx.org/schema/ext/vulnerability/1.0" version="1" serialNumber="urn:uuid:c1066aac-1c8d-4d82-bca8-774723747bea">
   <components>
     <component type="library">
       <name>package-1</name>
       <version>1.0.1</version>
       <v:vulnerabilities>
-        <v:vulnerability ref="urn:uuid:11f3afe7-3438-41db-9955-aa1f2616e2ca">
+        <v:vulnerability ref="urn:uuid:a7a25280-06c9-45f2-bb78-4be83dbbb213">
           <v:id>CVE-1999-0001</v:id>
           <v:source name="source-1">
             <v:url>http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0001</v:url>
@@ -99,7 +99,7 @@
           <v:description>1999-01 description</v:description>
           <v:advisories></v:advisories>
         </v:vulnerability>
-        <v:vulnerability ref="urn:uuid:424ae84d-2456-4597-bb26-e72152ece9a1">
+        <v:vulnerability ref="urn:uuid:31daf17d-2422-4861-b19b-ef16fe112f38">
           <v:id>CVE-1999-0002</v:id>
           <v:source name="source-2">
             <v:url>http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0002</v:url>
@@ -135,15 +135,15 @@
     </component>
   </components>
   <bd:metadata>
-    <bd:timestamp>2020-09-24T08:43:43-04:00</bd:timestamp>
+    <bd:timestamp>2020-11-17T14:03:05-05:00</bd:timestamp>
     <bd:tool>
       <bd:vendor>anchore</bd:vendor>
       <bd:name>grype</bd:name>
       <bd:version>[not provided]</bd:version>
     </bd:tool>
     <bd:component type="container">
-      <name>index.docker.io/library/stereoscope-fixture-image-simple</name>
-      <version>04e16e44161c8888a1a963720fd0443cbf7eef8101434c431de8725cd98cc9f7</version>
+      <name>user-input</name>
+      <version>sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368</version>
     </bd:component>
   </bd:metadata>
 </bom>

--- a/grype/presenter/cyclonedx/vuln-extension.go
+++ b/grype/presenter/cyclonedx/vuln-extension.go
@@ -1,15 +1,36 @@
 package cyclonedx
 
 import (
-	"encoding/xml"
-	"time"
+	"fmt"
+	"strings"
 
-	"github.com/anchore/grype/internal"
-	"github.com/anchore/grype/internal/version"
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/vulnerability"
 	syftCDX "github.com/anchore/syft/syft/presenter/cyclonedx"
+	"github.com/google/uuid"
 )
 
 // Source: https://cyclonedx.org/ext/vulnerability/
+
+// Vulnerability is the actual description of a vulnerable artifact
+type Vulnerability struct {
+	Ref     string   `xml:"ref,attr"`
+	ID      string   `xml:"v:id"`
+	Source  Source   `xml:"v:source"`
+	Ratings []Rating `xml:"v:ratings>v:rating"`
+	// We do not capture Common Weakness Enumeration
+	//Cwes            Cwes             `xml:"v:cwes"`
+	Description string `xml:"v:description,omitempty"`
+	// We don't have recommendations (e.g. "upgrade")
+	//Recommendations *Recommendations `xml:"v:recommendations"`
+	Advisories *Advisories `xml:"v:advisories,omitempty"`
+}
+
+// Component represents the a single software/package that has vulnerabilities.
+type Component struct {
+	syftCDX.Component
+	Vulnerabilities *[]Vulnerability `xml:"v:vulnerabilities>v:vulnerability,omitempty"`
+}
 
 // Source is the origin of the vulnerability, like Github Advisories or NVD, along
 // with a URL constructed with the vulnerability ID
@@ -38,36 +59,75 @@ type Advisories struct {
 	Advisory []string `xml:"v:advisory"`
 }
 
-// Vulnerability is the actual description of a vulnerable artifact
-type Vulnerability struct {
-	Ref     string   `xml:"ref,attr"`
-	ID      string   `xml:"v:id"`
-	Source  Source   `xml:"v:source"`
-	Ratings []Rating `xml:"v:ratings>v:rating"`
-	// We do not capture Common Weakness Enumeration
-	//Cwes            Cwes             `xml:"v:cwes"`
-	Description string `xml:"v:description,omitempty"`
-	// We don't have recommendations (e.g. "upgrade")
-	//Recommendations *Recommendations `xml:"v:recommendations"`
-	Advisories *Advisories `xml:"v:advisories,omitempty"`
-}
+// NewVulnerability creates a Vulnerability document from a match and the metadata provider
+func NewVulnerability(m match.Match, p vulnerability.MetadataProvider) (Vulnerability, error) {
+	metadata, err := p.GetMetadata(m.Vulnerability.ID, m.Vulnerability.RecordSource)
+	if err != nil {
+		return Vulnerability{}, fmt.Errorf("unable to fetch vuln=%q metadata: %+v", m.Vulnerability.ID, err)
+	}
 
-// Component represents the a single software/package that has vulnerabilities.
-type Component struct {
-	syftCDX.Component
-	Vulnerabilities *[]Vulnerability `xml:"v:vulnerabilities>v:vulnerability,omitempty"`
-}
+	// The spec allows many ratings, but we only have 1
+	var rating Rating
+	var score Score
 
-// NewBomDescriptor returns a new BomDescriptor tailored for the current time and "syft" tool details.
-func NewBomDescriptor() *syftCDX.BomDescriptor {
-	versionInfo := version.FromBuild()
-	return &syftCDX.BomDescriptor{
-		XMLName:   xml.Name{},
-		Timestamp: time.Now().Format(time.RFC3339),
-		Tool: &syftCDX.BdTool{
-			Vendor:  "anchore",
-			Name:    internal.ApplicationName,
-			Version: versionInfo.Version,
+	if metadata.CvssV2 != nil {
+		if metadata.CvssV2.ExploitabilityScore > 0 {
+			score.Exploitability = metadata.CvssV2.ExploitabilityScore
+		}
+		if metadata.CvssV2.ImpactScore > 0 {
+			score.Impact = metadata.CvssV2.ImpactScore
+		}
+		score.Base = metadata.CvssV2.BaseScore
+		rating.Method = "CVSSv2"
+		rating.Vector = metadata.CvssV2.Vector
+	}
+
+	if metadata.CvssV3 != nil {
+		if metadata.CvssV3.ExploitabilityScore > 0 {
+			score.Exploitability = metadata.CvssV3.ExploitabilityScore
+		}
+		if metadata.CvssV3.ImpactScore > 0 {
+			score.Impact = metadata.CvssV3.ImpactScore
+		}
+		score.Base = metadata.CvssV3.BaseScore
+		rating.Method = "CVSSv3"
+		rating.Vector = metadata.CvssV3.Vector
+	}
+
+	rating.Score = score
+
+	// The schema does not allow "Negligible", only allowing the following:
+	// 'None', 'Low', 'Medium', 'High', 'Critical', 'Unknown'
+	severity := metadata.Severity
+	if metadata.Severity == "Negligible" {
+		severity = "Low"
+	}
+
+	rating.Severity = severity
+
+	v := Vulnerability{
+		Ref: uuid.New().URN(),
+		ID:  m.Vulnerability.ID,
+		Source: Source{
+			Name: m.Vulnerability.RecordSource,
+			URL:  makeVulnerabilityURL(m.Vulnerability.ID),
+		},
+		Ratings:     []Rating{rating},
+		Description: metadata.Description,
+		Advisories: &Advisories{
+			Advisory: metadata.Links,
 		},
 	}
+
+	return v, nil
+}
+
+func makeVulnerabilityURL(id string) string {
+	if strings.HasPrefix(id, "CVE-") {
+		return fmt.Sprintf("http://cve.mitre.org/cgi-bin/cvename.cgi?name=%s", id)
+	}
+	if strings.HasPrefix(id, "GHSA") {
+		return fmt.Sprintf("https://github.com/advisories/%s", id)
+	}
+	return id
 }

--- a/grype/presenter/json/descriptor.go
+++ b/grype/presenter/json/descriptor.go
@@ -1,0 +1,7 @@
+package json
+
+// Descriptor describes what created the document as well as surrounding metadata
+type Descriptor struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}

--- a/grype/presenter/json/presenter.go
+++ b/grype/presenter/json/presenter.go
@@ -4,34 +4,38 @@ import (
 	"encoding/json"
 	"io"
 
+	"github.com/anchore/syft/syft/distro"
+
 	"github.com/anchore/grype/grype/match"
 
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/syft/syft/pkg"
-	"github.com/anchore/syft/syft/scope"
+	"github.com/anchore/syft/syft/source"
 )
 
 // Presenter is a generic struct for holding fields needed for reporting
 type Presenter struct {
 	matches          match.Matches
 	catalog          *pkg.Catalog
-	scope            scope.Scope
+	distro           distro.Distro
+	srcMetadata      source.Metadata
 	metadataProvider vulnerability.MetadataProvider
 }
 
 // NewPresenter is a *Presenter constructor
-func NewPresenter(matches match.Matches, catalog *pkg.Catalog, theScope scope.Scope, metadataProvider vulnerability.MetadataProvider) *Presenter {
+func NewPresenter(matches match.Matches, catalog *pkg.Catalog, d distro.Distro, srcMetadata source.Metadata, metadataProvider vulnerability.MetadataProvider) *Presenter {
 	return &Presenter{
 		matches:          matches,
 		catalog:          catalog,
+		distro:           d,
 		metadataProvider: metadataProvider,
-		scope:            theScope,
+		srcMetadata:      srcMetadata,
 	}
 }
 
 // Present creates a JSON-based reporting
 func (pres *Presenter) Present(output io.Writer) error {
-	doc, err := NewDocument(pres.catalog, pres.scope, pres.matches, pres.metadataProvider)
+	doc, err := NewDocument(pres.catalog, pres.distro, pres.srcMetadata, pres.matches, pres.metadataProvider)
 	if err != nil {
 		return err
 	}

--- a/grype/presenter/json/test-fixtures/snapshot/TestEmptyJsonPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestEmptyJsonPresenter.golden
@@ -1,28 +1,42 @@
 {
  "matches": [],
- "image": {
-  "layers": [
-   {
-    "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-    "digest": "sha256:e158b57d6f5a96ef5fd22f2fe76c70b5ba6ff5b2619f9d83125b2aad0492ac7b",
-    "size": 22
-   },
-   {
-    "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-    "digest": "sha256:da21056e7bf4308ecea0c0836848a7fe92f38fdcf35bc09ee6d98e7ab7beeebf",
-    "size": 16
-   },
-   {
-    "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-    "digest": "sha256:f0e18aa6032c24659a9c741fc36ca56f589782ea132061ccf6f52b952403da94",
-    "size": 27
-   }
-  ],
-  "size": 65,
-  "digest": "sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368",
-  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-  "tags": [
-   "stereoscope-fixture-image-simple:04e16e44161c8888a1a963720fd0443cbf7eef8101434c431de8725cd98cc9f7"
-  ]
+ "source": {
+  "type": "image",
+  "target": {
+   "userInput": "user-input",
+   "scope": "AllLayers",
+   "layers": [
+    {
+     "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+     "digest": "sha256:e158b57d6f5a96ef5fd22f2fe76c70b5ba6ff5b2619f9d83125b2aad0492ac7b",
+     "size": 22
+    },
+    {
+     "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+     "digest": "sha256:da21056e7bf4308ecea0c0836848a7fe92f38fdcf35bc09ee6d98e7ab7beeebf",
+     "size": 16
+    },
+    {
+     "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+     "digest": "sha256:f0e18aa6032c24659a9c741fc36ca56f589782ea132061ccf6f52b952403da94",
+     "size": 27
+    }
+   ],
+   "size": 65,
+   "digest": "sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368",
+   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+   "tags": [
+    "stereoscope-fixture-image-simple:04e16e44161c8888a1a963720fd0443cbf7eef8101434c431de8725cd98cc9f7"
+   ]
+  }
+ },
+ "distro": {
+  "name": "centos",
+  "version": "8.0",
+  "idLike": "rhel"
+ },
+ "descriptor": {
+  "name": "grype",
+  "version": "[not provided]"
  }
 }

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
@@ -26,13 +26,15 @@
     "name": "package-1",
     "version": "1.0.1",
     "type": "deb",
-    "foundBy": [
-     "the-cataloger-1"
-    ],
+    "foundBy": "the-cataloger-1",
     "locations": [
-     "/some/path/pkg1"
+     {
+      "path": "/some/path/pkg1"
+     }
     ],
-    "licenses": null
+    "licenses": null,
+    "language": "",
+    "metadataType": ""
    }
   },
   {
@@ -59,13 +61,15 @@
     "name": "package-1",
     "version": "1.0.1",
     "type": "deb",
-    "foundBy": [
-     "the-cataloger-1"
-    ],
+    "foundBy": "the-cataloger-1",
     "locations": [
-     "/some/path/pkg1"
+     {
+      "path": "/some/path/pkg1"
+     }
     ],
-    "licenses": null
+    "licenses": null,
+    "language": "",
+    "metadataType": ""
    }
   },
   {
@@ -87,15 +91,29 @@
     "name": "package-1",
     "version": "1.0.1",
     "type": "deb",
-    "foundBy": [
-     "the-cataloger-1"
-    ],
+    "foundBy": "the-cataloger-1",
     "locations": [
-     "/some/path/pkg1"
+     {
+      "path": "/some/path/pkg1"
+     }
     ],
-    "licenses": null
+    "licenses": null,
+    "language": "",
+    "metadataType": ""
    }
   }
  ],
- "directory": "/some/path"
+ "source": {
+  "type": "directory",
+  "target": "/some/path"
+ },
+ "distro": {
+  "name": "centos",
+  "version": "8.0",
+  "idLike": "rhel"
+ },
+ "descriptor": {
+  "name": "grype",
+  "version": "[not provided]"
+ }
 }

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
@@ -26,16 +26,16 @@
     "name": "package-1",
     "version": "1.1.1",
     "type": "deb",
-    "foundBy": [
-     "the-cataloger-1"
-    ],
+    "foundBy": "the-cataloger-1",
     "locations": [
      {
       "path": "/somefile-1.txt",
-      "layerIndex": 0
+      "layerID": "sha256:e158b57d6f5a96ef5fd22f2fe76c70b5ba6ff5b2619f9d83125b2aad0492ac7b"
      }
     ],
-    "licenses": null
+    "licenses": null,
+    "language": "",
+    "metadataType": ""
    }
   },
   {
@@ -62,16 +62,16 @@
     "name": "package-1",
     "version": "1.1.1",
     "type": "deb",
-    "foundBy": [
-     "the-cataloger-1"
-    ],
+    "foundBy": "the-cataloger-1",
     "locations": [
      {
       "path": "/somefile-1.txt",
-      "layerIndex": 0
+      "layerID": "sha256:e158b57d6f5a96ef5fd22f2fe76c70b5ba6ff5b2619f9d83125b2aad0492ac7b"
      }
     ],
-    "licenses": null
+    "licenses": null,
+    "language": "",
+    "metadataType": ""
    }
   },
   {
@@ -93,42 +93,56 @@
     "name": "package-1",
     "version": "1.1.1",
     "type": "deb",
-    "foundBy": [
-     "the-cataloger-1"
-    ],
+    "foundBy": "the-cataloger-1",
     "locations": [
      {
       "path": "/somefile-1.txt",
-      "layerIndex": 0
+      "layerID": "sha256:e158b57d6f5a96ef5fd22f2fe76c70b5ba6ff5b2619f9d83125b2aad0492ac7b"
      }
     ],
-    "licenses": null
+    "licenses": null,
+    "language": "",
+    "metadataType": ""
    }
   }
  ],
- "image": {
-  "layers": [
-   {
-    "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-    "digest": "sha256:e158b57d6f5a96ef5fd22f2fe76c70b5ba6ff5b2619f9d83125b2aad0492ac7b",
-    "size": 22
-   },
-   {
-    "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-    "digest": "sha256:da21056e7bf4308ecea0c0836848a7fe92f38fdcf35bc09ee6d98e7ab7beeebf",
-    "size": 16
-   },
-   {
-    "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-    "digest": "sha256:f0e18aa6032c24659a9c741fc36ca56f589782ea132061ccf6f52b952403da94",
-    "size": 27
-   }
-  ],
-  "size": 65,
-  "digest": "sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368",
-  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-  "tags": [
-   "stereoscope-fixture-image-simple:04e16e44161c8888a1a963720fd0443cbf7eef8101434c431de8725cd98cc9f7"
-  ]
+ "source": {
+  "type": "image",
+  "target": {
+   "userInput": "user-input",
+   "scope": "AllLayers",
+   "layers": [
+    {
+     "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+     "digest": "sha256:e158b57d6f5a96ef5fd22f2fe76c70b5ba6ff5b2619f9d83125b2aad0492ac7b",
+     "size": 22
+    },
+    {
+     "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+     "digest": "sha256:da21056e7bf4308ecea0c0836848a7fe92f38fdcf35bc09ee6d98e7ab7beeebf",
+     "size": 16
+    },
+    {
+     "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+     "digest": "sha256:f0e18aa6032c24659a9c741fc36ca56f589782ea132061ccf6f52b952403da94",
+     "size": 27
+    }
+   ],
+   "size": 65,
+   "digest": "sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368",
+   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+   "tags": [
+    "stereoscope-fixture-image-simple:04e16e44161c8888a1a963720fd0443cbf7eef8101434c431de8725cd98cc9f7"
+   ]
+  }
+ },
+ "distro": {
+  "name": "centos",
+  "version": "8.0",
+  "idLike": "rhel"
+ },
+ "descriptor": {
+  "name": "grype",
+  "version": "[not provided]"
  }
 }

--- a/grype/presenter/presenter.go
+++ b/grype/presenter/presenter.go
@@ -3,15 +3,17 @@ package presenter
 import (
 	"io"
 
+	"github.com/anchore/syft/syft/distro"
+
 	"github.com/anchore/grype/grype/match"
 
 	"github.com/anchore/grype/grype/vulnerability"
-	"github.com/anchore/syft/syft/scope"
 
 	"github.com/anchore/grype/grype/presenter/cyclonedx"
 	"github.com/anchore/grype/grype/presenter/json"
 	"github.com/anchore/grype/grype/presenter/table"
 	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/source"
 )
 
 // Presenter is the main interface other Presenters need to implement
@@ -20,14 +22,14 @@ type Presenter interface {
 }
 
 // GetPresenter retrieves a Presenter that matches a CLI option
-func GetPresenter(option Option, results match.Matches, catalog *pkg.Catalog, theScope scope.Scope, metadataProvider vulnerability.MetadataProvider) Presenter {
+func GetPresenter(option Option, matches match.Matches, catalog *pkg.Catalog, d distro.Distro, srcMetadata source.Metadata, metadataProvider vulnerability.MetadataProvider) Presenter {
 	switch option {
 	case JSONPresenter:
-		return json.NewPresenter(results, catalog, theScope, metadataProvider)
+		return json.NewPresenter(matches, catalog, d, srcMetadata, metadataProvider)
 	case TablePresenter:
-		return table.NewPresenter(results, catalog, metadataProvider)
+		return table.NewPresenter(matches, catalog, metadataProvider)
 	case CycloneDxPresenter:
-		return cyclonedx.NewPresenter(results, catalog, theScope, metadataProvider)
+		return cyclonedx.NewPresenter(matches, catalog, srcMetadata, metadataProvider)
 	default:
 		return nil
 	}

--- a/grype/vulnerability/namespace_test.go
+++ b/grype/vulnerability/namespace_test.go
@@ -67,7 +67,7 @@ func TestDistroNamespace_AllDistros(t *testing.T) {
 		{
 			dist:     distro.OpenSuseLeap,
 			version:  "15.2",
-			expected: "opensuse-leap:15.2",
+			expected: "opensuseleap:15.2",
 		},
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/anchore/grype/grype/presenter"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal"
-	"github.com/anchore/syft/syft/scope"
+	"github.com/anchore/syft/syft/source"
 	"github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -25,7 +25,7 @@ type Application struct {
 	ConfigPath        string
 	PresenterOpt      presenter.Option
 	Output            string `mapstructure:"output"`
-	ScopeOpt          scope.Option
+	ScopeOpt          source.Scope
 	Scope             string  `mapstructure:"scope"`
 	Quiet             bool    `mapstructure:"quiet"`
 	Log               Logging `mapstructure:"log"`
@@ -108,8 +108,8 @@ func (cfg *Application) Build() error {
 	cfg.PresenterOpt = presenterOption
 
 	// set the scope
-	scopeOption := scope.ParseOption(cfg.Scope)
-	if scopeOption == scope.UnknownScope {
+	scopeOption := source.ParseScope(cfg.Scope)
+	if scopeOption == source.UnknownScope {
 		return fmt.Errorf("bad --scope value '%s'", cfg.Scope)
 	}
 	cfg.ScopeOpt = scopeOption

--- a/internal/input.go
+++ b/internal/input.go
@@ -1,0 +1,10 @@
+package internal
+
+import "os"
+
+// IsPipedInput returns true if there is no input device, which means the user **may** be providing input via a pipe.
+func IsPipedInput() bool {
+	fi, _ := os.Stdin.Stat()
+
+	return fi.Mode()&os.ModeNamedPipe != 0
+}

--- a/internal/ui/select.go
+++ b/internal/ui/select.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/anchore/grype/internal"
+
 	"github.com/anchore/grype/internal/ui/etui"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -13,12 +15,13 @@ import (
 func Select(verbose, quiet bool) UI {
 	var ui UI
 
+	isStdinPiped := internal.IsPipedInput()
 	isStdoutATty := terminal.IsTerminal(int(os.Stdout.Fd()))
 	isStderrATty := terminal.IsTerminal(int(os.Stderr.Fd()))
 	notATerminal := !isStderrATty && !isStdoutATty
 
 	switch {
-	case runtime.GOOS == "windows" || verbose || quiet || notATerminal || !isStderrATty:
+	case runtime.GOOS == "windows" || verbose || quiet || notATerminal || !isStderrATty || isStdinPiped:
 		ui = LoggerUI
 	default:
 		ui = etui.OutputToEphemeralTUI

--- a/test/integration/corner_cases_test.go
+++ b/test/integration/corner_cases_test.go
@@ -3,10 +3,11 @@ package integration
 import (
 	"testing"
 
+	"github.com/anchore/syft/syft/source"
+
 	v1 "github.com/anchore/grype-db/pkg/db/v1"
 	"github.com/anchore/grype/grype"
 	"github.com/anchore/grype/grype/vulnerability"
-	"github.com/anchore/syft/syft/scope"
 )
 
 func TestApkMatch(t *testing.T) {
@@ -48,7 +49,7 @@ func TestApkMatch(t *testing.T) {
 	results, _, _, err := grype.FindVulnerabilities(
 		vulnerability.NewProviderFromStore(&store),
 		"dir:test-fixtures/corner-cases/apk/vnc",
-		scope.AllLayersScope,
+		source.AllLayersScope,
 	)
 	if err != nil {
 		t.Fatalf("failed to find vulnerabilities: %+v", err)

--- a/test/integration/match_coverage_test.go
+++ b/test/integration/match_coverage_test.go
@@ -8,14 +8,15 @@ import (
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal"
 	"github.com/anchore/stereoscope/pkg/imagetest"
+	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/pkg"
-	"github.com/anchore/syft/syft/scope"
+	"github.com/anchore/syft/syft/source"
 	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
-func getPackagesByPath(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, thePath string) []*pkg.Package {
+func getPackagesByPath(t *testing.T, theSource source.Source, catalog *pkg.Catalog, thePath string) []*pkg.Package {
 	t.Helper()
-	refs, err := theScope.Resolver.FilesByGlob(thePath)
+	refs, err := theSource.Resolver.FilesByGlob(thePath)
 	if err != nil {
 		t.Fatalf("could not get ref by path %q: %+v", thePath, err)
 	}
@@ -25,8 +26,8 @@ func getPackagesByPath(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog,
 	return catalog.PackagesByFile(refs[0])
 }
 
-func addAlpineMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
-	packages := getPackagesByPath(t, theScope, catalog, "/lib/apk/db/installed")
+func addAlpineMatches(t *testing.T, theSource source.Source, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
+	packages := getPackagesByPath(t, theSource, catalog, "/lib/apk/db/installed")
 	if len(packages) != 1 {
 		t.Logf("Alpine Packages: %+v", packages)
 		t.Fatalf("problem with upstream syft cataloger (alpine)")
@@ -54,8 +55,8 @@ func addAlpineMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, 
 	})
 }
 
-func addJavascriptMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
-	packages := getPackagesByPath(t, theScope, catalog, "/javascript/pkg-json/package.json")
+func addJavascriptMatches(t *testing.T, theSource source.Source, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
+	packages := getPackagesByPath(t, theSource, catalog, "/javascript/pkg-json/package.json")
 	if len(packages) != 1 {
 		t.Logf("Javascript Packages: %+v", packages)
 		t.Fatalf("problem with upstream syft cataloger (javascript)")
@@ -82,8 +83,8 @@ func addJavascriptMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catal
 	})
 }
 
-func addPythonMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
-	packages := getPackagesByPath(t, theScope, catalog, "/python/dist-info/METADATA")
+func addPythonMatches(t *testing.T, theSource source.Source, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
+	packages := getPackagesByPath(t, theSource, catalog, "/python/dist-info/METADATA")
 	if len(packages) != 1 {
 		t.Logf("Python Packages: %+v", packages)
 		t.Fatalf("problem with upstream syft cataloger (python)")
@@ -110,8 +111,8 @@ func addPythonMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, 
 	})
 }
 
-func addRubyMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
-	packages := getPackagesByPath(t, theScope, catalog, "/ruby/specifications/bundler.gemspec")
+func addRubyMatches(t *testing.T, theSource source.Source, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
+	packages := getPackagesByPath(t, theSource, catalog, "/ruby/specifications/bundler.gemspec")
 	if len(packages) != 1 {
 		t.Logf("Ruby Packages: %+v", packages)
 		t.Fatalf("problem with upstream syft cataloger (ruby)")
@@ -138,7 +139,7 @@ func addRubyMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, th
 	})
 }
 
-func addJavaMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
+func addJavaMatches(t *testing.T, theSource source.Source, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
 	packages := make([]*pkg.Package, 0)
 	for p := range catalog.Enumerate(pkg.JavaPkg) {
 		packages = append(packages, p)
@@ -173,8 +174,8 @@ func addJavaMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, th
 	})
 }
 
-func addDpkgMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
-	packages := getPackagesByPath(t, theScope, catalog, "/var/lib/dpkg/status")
+func addDpkgMatches(t *testing.T, theSource source.Source, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
+	packages := getPackagesByPath(t, theSource, catalog, "/var/lib/dpkg/status")
 	if len(packages) != 1 {
 		t.Logf("Dpkg Packages: %+v", packages)
 		t.Fatalf("problem with upstream syft cataloger (dpkg)")
@@ -205,8 +206,8 @@ func addDpkgMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, th
 	})
 }
 
-func addRhelMatches(t *testing.T, theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
-	packages := getPackagesByPath(t, theScope, catalog, "/var/lib/rpm/Packages")
+func addRhelMatches(t *testing.T, theSource source.Source, catalog *pkg.Catalog, theStore *mockStore, theResult *match.Matches) {
+	packages := getPackagesByPath(t, theSource, catalog, "/var/lib/rpm/Packages")
 	if len(packages) != 1 {
 		t.Logf("RPMDB Packages: %+v", packages)
 		t.Fatalf("problem with upstream syft cataloger (RPMDB)")
@@ -246,33 +247,33 @@ func TestPkgCoverageImage(t *testing.T) {
 
 	tests := []struct {
 		fixtureImage string
-		expectedFn   func(scope.Scope, *pkg.Catalog, *mockStore) match.Matches
+		expectedFn   func(source.Source, *pkg.Catalog, *mockStore) match.Matches
 	}{
 		{
 			fixtureImage: "image-debian-match-coverage",
-			expectedFn: func(theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore) match.Matches {
+			expectedFn: func(theSource source.Source, catalog *pkg.Catalog, theStore *mockStore) match.Matches {
 				expectedMatches := match.NewMatches()
-				addPythonMatches(t, theScope, catalog, theStore, &expectedMatches)
-				addRubyMatches(t, theScope, catalog, theStore, &expectedMatches)
-				addJavaMatches(t, theScope, catalog, theStore, &expectedMatches)
-				addDpkgMatches(t, theScope, catalog, theStore, &expectedMatches)
-				addJavascriptMatches(t, theScope, catalog, theStore, &expectedMatches)
+				addPythonMatches(t, theSource, catalog, theStore, &expectedMatches)
+				addRubyMatches(t, theSource, catalog, theStore, &expectedMatches)
+				addJavaMatches(t, theSource, catalog, theStore, &expectedMatches)
+				addDpkgMatches(t, theSource, catalog, theStore, &expectedMatches)
+				addJavascriptMatches(t, theSource, catalog, theStore, &expectedMatches)
 				return expectedMatches
 			},
 		},
 		{
 			fixtureImage: "image-centos-match-coverage",
-			expectedFn: func(theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore) match.Matches {
+			expectedFn: func(theSource source.Source, catalog *pkg.Catalog, theStore *mockStore) match.Matches {
 				expectedMatches := match.NewMatches()
-				addRhelMatches(t, theScope, catalog, theStore, &expectedMatches)
+				addRhelMatches(t, theSource, catalog, theStore, &expectedMatches)
 				return expectedMatches
 			},
 		},
 		{
 			fixtureImage: "image-alpine-match-coverage",
-			expectedFn: func(theScope scope.Scope, catalog *pkg.Catalog, theStore *mockStore) match.Matches {
+			expectedFn: func(theSource source.Source, catalog *pkg.Catalog, theStore *mockStore) match.Matches {
 				expectedMatches := match.NewMatches()
-				addAlpineMatches(t, theScope, catalog, theStore, &expectedMatches)
+				addAlpineMatches(t, theSource, catalog, theStore, &expectedMatches)
 				return expectedMatches
 			},
 		},
@@ -286,17 +287,23 @@ func TestPkgCoverageImage(t *testing.T) {
 			tarPath := imagetest.GetFixtureImageTarPath(t, test.fixtureImage)
 			defer cleanup()
 
-			actualResults, catalog, theScope, err := grype.FindVulnerabilities(
-				vulnerability.NewProviderFromStore(theStore),
-				"docker-archive:"+tarPath,
-				scope.AllLayersScope,
-			)
+			userImage := "docker-archive:" + tarPath
+			scopeOption := source.AllLayersScope
+
+			// this is purely done to help setup mocks
+			theSource, theCatalog, theDistro, err := syft.Catalog(userImage, scopeOption)
 			if err != nil {
-				t.Fatalf("failed to find vulnerabilities: %+v", err)
+				t.Fatalf("could not get the source obj: %+v", err)
 			}
 
+			actualResults := grype.FindVulnerabilitiesForCatalog(
+				vulnerability.NewProviderFromStore(theStore),
+				theDistro,
+				theCatalog,
+			)
+
 			// build expected matches from what's discovered from the catalog
-			expectedMatches := test.expectedFn(*theScope, catalog, theStore)
+			expectedMatches := test.expectedFn(theSource, theCatalog, theStore)
 
 			// build expected match set...
 			expectedMatchSet := map[string]string{}


### PR DESCRIPTION
- Adds a new `sbom:` scheme where a user can specify a syft json document as input, skipping the need to parse and catalog an image.
- Adds ability to pipe SBOM json document contents into grype via stdin.
- Incorporates changes from https://github.com/anchore/syft/pull/266

Closes #196 