### PR TITLE
Remove powershell description from completion command

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -8,7 +8,7 @@ import (
 
 // completionCmd represents the completion command
 var completionCmd = &cobra.Command{
-	Use:   "completion [bash|zsh|fish|powershell]",
+	Use:   "completion [bash|zsh|fish]",
 	Short: "Generate a shell completion for Grype (listing local docker images)",
 	Long: `To load completions (docker image list):
 


### PR DESCRIPTION
## What
I've removed the `powershell` completion command because it is not supported.