### PR TITLE
Fix distroNamespace mapping to only use major version for select distros

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.4
+	github.com/scylladb/go-set v1.0.2
 	github.com/sergi/go-diff v1.1.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/afero v1.3.2

--- a/grype/vulnerability/namespace.go
+++ b/grype/vulnerability/namespace.go
@@ -37,22 +37,27 @@ func githubJavaNamer(p *pkg.Package) []string {
 // TODO: expand with namer mapping to be more generic?
 func distroNamespace(d distro.Distro) string {
 	// TODO: can we drive this from information from grype-db? that would be ideal...
-	var distroStr string
-	switch d.Type {
-	case distro.CentOS, distro.RedHat:
-		distroStr = "rhel"
-	case distro.AmazonLinux:
-		distroStr = "amzn"
-	case distro.OracleLinux:
-		distroStr = "ol"
-	case distro.Alpine:
-		// XXX this assumes that a major and minor versions will always exist in Segments
-		segments := d.Version.Segments()
-		return fmt.Sprintf("%s:%d.%d", d.Type.String(), segments[0], segments[1])
-	default:
-		distroStr = d.Type.String()
+	var versionSegments []int
+	if d.Version != nil {
+		versionSegments = d.Version.Segments()
 	}
-	return fmt.Sprintf("%s:%s", strings.ToLower(distroStr), d.FullVersion())
+
+	if len(versionSegments) > 0 {
+		switch d.Type {
+		// derived from https://github.com/anchore/anchore-engine/blob/5bbbe6b9744f2fb806198ae5d6f0cfe3b367fd9d/anchore_engine/services/policy_engine/__init__.py#L149-L159
+		case distro.CentOS, distro.RedHat, distro.Fedora:
+			// TODO: there is no mapping of fedora version to RHEL latest version (only the name)
+			return fmt.Sprintf("rhel:%d", versionSegments[0])
+		case distro.AmazonLinux:
+			return fmt.Sprintf("amzn:%d", versionSegments[0])
+		case distro.OracleLinux:
+			return fmt.Sprintf("ol:%d", versionSegments[0])
+		case distro.Alpine:
+			// XXX this assumes that a major and minor versions will always exist in Segments
+			return fmt.Sprintf("alpine:%d.%d", versionSegments[0], versionSegments[1])
+		}
+	}
+	return fmt.Sprintf("%s:%s", strings.ToLower(d.Type.String()), d.FullVersion())
 }
 
 func languageNamespaces(l pkg.Language) map[string]namer {

--- a/grype/vulnerability/namespace_test.go
+++ b/grype/vulnerability/namespace_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/scylladb/go-set/strset"
+
 	"github.com/anchore/syft/syft/distro"
 )
 
@@ -14,6 +16,34 @@ func TestDistroNamespace_AllDistros(t *testing.T) {
 		version  string
 		expected string
 	}{
+		// regression: https://github.com/anchore/grype/issues/221
+		{
+			dist:     distro.RedHat,
+			version:  "8.3",
+			expected: "rhel:8",
+		},
+		{
+			dist:     distro.CentOS,
+			version:  "8.3",
+			expected: "rhel:8",
+		},
+		{
+			dist:     distro.AmazonLinux,
+			version:  "8.3",
+			expected: "amzn:8",
+		},
+		{
+			dist:     distro.OracleLinux,
+			version:  "8.3",
+			expected: "ol:8",
+		},
+		{
+			dist:    distro.Fedora,
+			version: "31.1",
+			// TODO: this is incorrect and will be solved in a future issue (to map the fedora version to the rhel latest version)
+			expected: "rhel:31",
+		},
+		// end of regression #221
 		{
 			dist:     distro.RedHat,
 			version:  "8",
@@ -42,7 +72,7 @@ func TestDistroNamespace_AllDistros(t *testing.T) {
 		{
 			dist:     distro.Fedora,
 			version:  "31",
-			expected: "fedora:31",
+			expected: "rhel:31",
 		},
 		{
 			dist:     distro.Busybox,
@@ -60,15 +90,24 @@ func TestDistroNamespace_AllDistros(t *testing.T) {
 			expected: "ubuntu:18.04",
 		},
 		{
+			// TODO: this is not correct. This should be mapped to a feed source.
 			dist:     distro.ArchLinux,
 			version:  "", // ArchLinux doesn't expose a version
 			expected: "archlinux:",
 		},
 		{
+			// TODO: this is not correct. This should be mapped to a feed source.
 			dist:     distro.OpenSuseLeap,
 			version:  "15.2",
 			expected: "opensuseleap:15.2",
 		},
+	}
+
+	observedDistros := strset.New()
+	actualDistros := strset.New()
+
+	for _, d := range distro.All {
+		actualDistros.Add(d.String())
 	}
 
 	for _, test := range tests {
@@ -79,6 +118,8 @@ func TestDistroNamespace_AllDistros(t *testing.T) {
 				t.Errorf("could not create distro='%+v:%+v': %+v", test.dist, test.version, err)
 			}
 
+			observedDistros.Add(d.Type.String())
+
 			actual := distroNamespace(d)
 			if actual != test.expected {
 				t.Errorf("mismatched distro namespace: '%s'!='%s'", actual, test.expected)
@@ -86,8 +127,8 @@ func TestDistroNamespace_AllDistros(t *testing.T) {
 		})
 	}
 
-	if len(tests) != len(distro.All) {
-		t.Errorf("probably excluded a distro in namespace name testing")
+	for _, d := range strset.SymmetricDifference(observedDistros, actualDistros).List() {
+		t.Errorf("missed/extra distro in testing: %s", d)
 	}
 
 }


### PR DESCRIPTION
The RedHat, CentOS, AmazonLinux, and OracleLinux distros should be using a namespace with explicitly only the major version. Today there are cases where we also use the minor version if the raw data surfaces it (e.g. `rhel:8.3` should really be `rhel:8`). This PR fixes this behavior.

Additionally this corrects the mapping for fedora, which should map to `rhel` as well. A future PR will additionally fix the version mapping for this case (captured in https://github.com/anchore/grype/issues/223).

Closes #221  