### PR TITLE
Refactor constraint expression parser to allow for quoted versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/anchore/grype-db v0.0.0-20200929200644-6d1c82acc95e
 	github.com/anchore/stereoscope v0.0.0-20210105001222-7beea73cb7e5
 	github.com/anchore/syft v0.12.4
-	github.com/bmatcuk/doublestar v1.3.3 // indirect
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/dustin/go-humanize v1.0.0
 	github.com/facebookincubator/nvdtools v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alicebob/sqlittle v1.4.0 h1:vgYt0nAjhdf/hg52MjKJ84g/uTzBPfrvI+VUBrIghxA=
 github.com/alicebob/sqlittle v1.4.0/go.mod h1:Co1L1qxHqCwf41puWhk2HOodojR0mcsAV4BIt8byZh8=
-github.com/anchore/client-go v0.0.0-20201210022459-59e7a0749c74 h1:9kkKTIyXJC+/syUcY6KWxFoJZJ+GWwrIscF+gBY067k=
-github.com/anchore/client-go v0.0.0-20201210022459-59e7a0749c74/go.mod h1:FaODhIA06mxO1E6R32JE0TL1JWZZkmjRIAd4ULvHUKk=
 github.com/anchore/client-go v0.0.0-20201216213038-a486b838e238 h1:/iI+1cj1a27ow0wj378pPJIm8sCSy6I21Tz6oLbLDQY=
 github.com/anchore/client-go v0.0.0-20201216213038-a486b838e238/go.mod h1:FaODhIA06mxO1E6R32JE0TL1JWZZkmjRIAd4ULvHUKk=
 github.com/anchore/go-rpmdb v0.0.0-20201106153645-0043963c2e12 h1:xbeIbn5F52JVx3RUIajxCj8b0y+9lywspql4sFhcxWQ=
@@ -128,18 +126,8 @@ github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca h1:rLyc7Rih76
 github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/grype-db v0.0.0-20200929200644-6d1c82acc95e h1:s0HmxxDuJyvgGBXmNBZwuXLLFSUfBmS9+/Rz1L58Bz0=
 github.com/anchore/grype-db v0.0.0-20200929200644-6d1c82acc95e/go.mod h1:LINmipRzG88vnJEWvgMMDVCFH1qZsj7+bjmpERlSyaA=
-github.com/anchore/stereoscope v0.0.0-20201203153145-3f9a05a624d7 h1:G3LnRqHL/IIeQZTAMtDOJNYfSYsXLNCZX4DCiS0R0FY=
-github.com/anchore/stereoscope v0.0.0-20201203153145-3f9a05a624d7/go.mod h1:2Jja/4l0zYggW52og+nn0rut4i+OYjCf9vTyrM8RT4E=
-github.com/anchore/stereoscope v0.0.0-20201210022249-091f9bddb42e h1:vHUqHTvH9/oxdDDh1fxS9Ls9gWGytKO7XbbzcQ9MBwI=
-github.com/anchore/stereoscope v0.0.0-20201210022249-091f9bddb42e/go.mod h1:/dHAFjYflH/1tzhdHAcnMCjprMch+YzHJKi59m/1KCM=
 github.com/anchore/stereoscope v0.0.0-20210105001222-7beea73cb7e5 h1:NGRfS6BZKElgiMbqdoH9iQn+6oxT7CJdZYrqgwvGkWY=
 github.com/anchore/stereoscope v0.0.0-20210105001222-7beea73cb7e5/go.mod h1:BMdPL0QEIYfpjQ3M7sHYZvuh6+vcomqF3TMHL8gr6Vw=
-github.com/anchore/syft v0.9.2 h1:kRmquh8qOqH+/84S3/kOzj0cnGiqtW4f38Iz3TGrzXQ=
-github.com/anchore/syft v0.9.2/go.mod h1:1vZpPrvAhEnpUsi4/+V3c9W0eGgSZLesStiKt/ujf6E=
-github.com/anchore/syft v0.9.3-0.20201204184855-2d0c127419a3 h1:kJFcZZlhP5spei7uRon+2QzFTABjmzcJfeYh2Hje8KQ=
-github.com/anchore/syft v0.9.3-0.20201204184855-2d0c127419a3/go.mod h1:1vZpPrvAhEnpUsi4/+V3c9W0eGgSZLesStiKt/ujf6E=
-github.com/anchore/syft v0.10.0 h1:fN7wUauj560M6rjaRYBobpTDxciYQT9f1JQTJvyBRuQ=
-github.com/anchore/syft v0.10.0/go.mod h1:U+cGFs4UkMRxkVgiJ1OtQHfemdDkk2Mpaq5Rw3rqHnI=
 github.com/anchore/syft v0.12.4 h1:fP1AyeDv85A2K/W0xoeBxYyMVWz+QXJVgGyaa1Q6/w4=
 github.com/anchore/syft v0.12.4/go.mod h1:dxcpTsSz1lxSbmq2hrNQA3Ngma1RcYo80s/tpMrVT90=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
@@ -177,8 +165,6 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/bmatcuk/doublestar v1.3.3 h1:pVP1d49CcQQaNOl+PI6sPybIrIOD/6sux31PFdmhTH0=
-github.com/bmatcuk/doublestar v1.3.3/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bmatcuk/doublestar/v2 v2.0.4 h1:6I6oUiT/sU27eE2OFcWqBhL1SwjyvQuOssxT4a1yidI=
 github.com/bmatcuk/doublestar/v2 v2.0.4/go.mod h1:QMmcs3H2AUQICWhfzLXz+IYln8lRQmTZRptLie8RgRw=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
@@ -806,6 +792,7 @@ github.com/tetafro/godot v0.3.7/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQx
 github.com/tetafro/godot v0.4.2/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
+github.com/tj/assert v0.0.0-20171129193455-018094318fb0 h1:Rw8kxzWo1mr6FSaYXjQELRe88y2KdfynXdnK72rdjtA=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
 github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=

--- a/grype/version/constraint_expression.go
+++ b/grype/version/constraint_expression.go
@@ -1,8 +1,10 @@
 package version
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
+	"text/scanner"
 )
 
 type constraintExpression struct {
@@ -11,34 +13,42 @@ type constraintExpression struct {
 }
 
 func newConstraintExpression(phrase string, genFn comparatorGenerator) (constraintExpression, error) {
-	rootExpression := constraintExpression{
-		units:       make([][]constraintUnit, 0),
-		comparators: make([][]Comparator, 0),
+	orParts, err := scanExpression(phrase)
+	if err != nil {
+		return constraintExpression{}, fmt.Errorf("unable to create constraint expression from=%q : %w", phrase, err)
 	}
 
-	if strings.Contains(phrase, "(") || strings.Contains(phrase, ")") {
-		return constraintExpression{}, fmt.Errorf("version constraint expression groups are unsupported (use of parentheses)")
-	}
+	orUnits := make([][]constraintUnit, len(orParts))
+	orComparators := make([][]Comparator, len(orParts))
 
-	orParts := strings.Split(phrase, string(OR))
-	for _, part := range orParts {
-		units, err := splitConstraintPhrase(part)
-		if err != nil {
-			return constraintExpression{}, err
-		}
-		rootExpression.units = append(rootExpression.units, units)
-		comparators := make([]Comparator, len(units))
-		for idx, unit := range units {
-			theComparator, err := genFn(unit)
+	for orIdx, andParts := range orParts {
+		andUnits := make([]constraintUnit, len(andParts))
+		andComparators := make([]Comparator, len(andParts))
+		for andIdx, part := range andParts {
+			unit, err := parseUnit(part)
+			if err != nil {
+				return constraintExpression{}, err
+			}
+			if unit == nil {
+				return constraintExpression{}, fmt.Errorf("unable to parse unit: %q", part)
+			}
+			andUnits[andIdx] = *unit
+
+			comparator, err := genFn(*unit)
 			if err != nil {
 				return constraintExpression{}, fmt.Errorf("failed to create comparator for '%s': %w", unit, err)
 			}
-			comparators[idx] = theComparator
+			andComparators[andIdx] = comparator
 		}
-		rootExpression.comparators = append(rootExpression.comparators, comparators)
+
+		orUnits[orIdx] = andUnits
+		orComparators[orIdx] = andComparators
 	}
 
-	return rootExpression, nil
+	return constraintExpression{
+		units:       orUnits,
+		comparators: orComparators,
+	}, nil
 }
 
 func (c *constraintExpression) satisfied(other *Version) (bool, error) {
@@ -50,9 +60,9 @@ func (c *constraintExpression) satisfied(other *Version) (bool, error) {
 			if err != nil {
 				return false, fmt.Errorf("uncomparable %+v %+v: %w", andUnit, other, err)
 			}
-			constraintUnit := c.units[i][j]
+			unit := c.units[i][j]
 
-			if !constraintUnit.Satisfied(result) {
+			if !unit.Satisfied(result) {
 				allSatisfied = false
 			}
 		}
@@ -60,4 +70,50 @@ func (c *constraintExpression) satisfied(other *Version) (bool, error) {
 		oneSatisfied = oneSatisfied || allSatisfied
 	}
 	return oneSatisfied, nil
+}
+
+func scanExpression(phrase string) ([][]string, error) {
+	var scnr scanner.Scanner
+	var orGroups [][]string // all versions a group of and'd groups or'd together
+	var andGroup []string   // most current group of and'd versions
+	var buf bytes.Buffer    // most current single version value
+	var lastToken string
+
+	captureVersionOperatorPair := func() {
+		if buf.Len() > 0 {
+			ver := buf.String()
+			andGroup = append(andGroup, ver)
+			buf.Reset()
+		}
+	}
+
+	captureAndGroup := func() {
+		if len(andGroup) > 0 {
+			orGroups = append(orGroups, andGroup)
+			andGroup = nil
+		}
+	}
+
+	scnr.Init(strings.NewReader(phrase))
+	tokenRune := scnr.Scan()
+	for tokenRune != scanner.EOF {
+		currentToken := scnr.TokenText()
+		switch {
+		case currentToken == ",":
+			captureVersionOperatorPair()
+		case currentToken == "|" && lastToken == "|":
+			captureVersionOperatorPair()
+			captureAndGroup()
+		case currentToken == "(" || currentToken == ")":
+			return nil, fmt.Errorf("parenthetical expressions are not supported yet")
+		case currentToken != "|":
+			buf.Write([]byte(currentToken))
+		}
+		lastToken = currentToken
+		tokenRune = scnr.Scan()
+	}
+	captureVersionOperatorPair()
+	captureAndGroup()
+
+	return orGroups, nil
 }

--- a/grype/version/constraint_expression_test.go
+++ b/grype/version/constraint_expression_test.go
@@ -1,0 +1,88 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestScanExpression(t *testing.T) {
+	tests := []struct {
+		phrase   string
+		expected [][]string
+		err      bool
+	}{
+		{
+			phrase: "x,y||z",
+			expected: [][]string{
+				{
+					"x",
+					"y",
+				},
+				{
+					"z",
+				},
+			},
+		},
+		{
+			phrase: "<1.0, >=2.0|| 3.0 || =4.0",
+			expected: [][]string{
+				{
+					"<1.0",
+					">=2.0",
+				},
+				{
+					"3.0",
+				},
+				{
+					"=4.0",
+				},
+			},
+		},
+		{
+			// parenthetical expression are not supported yet
+			phrase: "(<1.0, >=2.0|| 3.0) || =4.0",
+			err:    true,
+		},
+		{
+			phrase: ` > 1.0,  <=   2.0,,,    || = 3.0 `,
+			expected: [][]string{
+				{
+					">1.0",
+					"<=2.0",
+				},
+				{
+					"=3.0",
+				},
+			},
+		},
+		{
+			phrase: ` > 1.0,  <= "  (2.0||),,, ",   || = 3.0 `,
+			expected: [][]string{
+				{
+					">1.0",
+					`<="  (2.0||),,, "`,
+				},
+				{
+					"=3.0",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.phrase, func(t *testing.T) {
+			actual, err := scanExpression(test.phrase)
+			if err != nil && test.err == false {
+				t.Fatalf("expected no error, got %+v", err)
+			} else if err == nil && test.err {
+				t.Fatalf("expected an error but did not get one")
+			}
+
+			for _, d := range deep.Equal(test.expected, actual) {
+				t.Errorf("difference: %+v", d)
+			}
+
+		})
+	}
+}

--- a/grype/version/constraint_unit_test.go
+++ b/grype/version/constraint_unit_test.go
@@ -8,126 +8,110 @@ import (
 func TestSplitFuzzyPhrase(t *testing.T) {
 	tests := []struct {
 		phrase   string
-		expected []constraintUnit
+		expected *constraintUnit
 		err      bool
 	}{
 		{
-			phrase:   "",
-			expected: []constraintUnit{},
+			phrase: "",
+		},
+		{
+			phrase: `="in<(b e t w e e n)>quotes<=||>=not!="`,
+			expected: &constraintUnit{
+				rangeOperator: EQ,
+				version:       "in<(b e t w e e n)>quotes<=||>=not!=",
+			},
+		},
+		{
+			phrase: ` >= "in<(b e t w e e n)>quotes<=||>=not!=" `,
+			expected: &constraintUnit{
+				rangeOperator: GTE,
+				version:       "in<(b e t w e e n)>quotes<=||>=not!=",
+			},
+		},
+		{
+			phrase: `="something"`,
+			expected: &constraintUnit{
+				rangeOperator: EQ,
+				version:       "something",
+			},
+		},
+		{
+			phrase: "=something",
+			expected: &constraintUnit{
+				rangeOperator: EQ,
+				version:       "something",
+			},
 		},
 		{
 			phrase: "= something",
-			expected: []constraintUnit{
-				{
-					rangeOperator: EQ,
-					version:       "something",
-				},
+			expected: &constraintUnit{
+				rangeOperator: EQ,
+				version:       "something",
 			},
 		},
 		{
 			phrase: "something",
-			expected: []constraintUnit{
-				{
-					rangeOperator: EQ,
-					version:       "something",
-				},
+			expected: &constraintUnit{
+
+				rangeOperator: EQ,
+				version:       "something",
 			},
 		},
 		{
 			phrase: "> something",
-			expected: []constraintUnit{
-				{
-					rangeOperator: GT,
-					version:       "something",
-				},
+			expected: &constraintUnit{
+
+				rangeOperator: GT,
+				version:       "something",
 			},
 		},
 		{
 			phrase: ">= 2.3",
-			expected: []constraintUnit{
-				{
-					rangeOperator: GTE,
-					version:       "2.3",
-				},
+			expected: &constraintUnit{
+
+				rangeOperator: GTE,
+				version:       "2.3",
 			},
 		},
 		{
 			phrase: "< 2.3",
-			expected: []constraintUnit{
-				{
-					rangeOperator: LT,
-					version:       "2.3",
-				},
+			expected: &constraintUnit{
+
+				rangeOperator: LT,
+				version:       "2.3",
 			},
 		},
 		{
-			phrase: "<= 2.3",
-			expected: []constraintUnit{
-				{
-					rangeOperator: LTE,
-					version:       "2.3",
-				},
+			phrase: "<=2.3",
+			expected: &constraintUnit{
+
+				rangeOperator: LTE,
+				version:       "2.3",
 			},
 		},
 		{
-			phrase: ">= 1.0, <= 2.3",
-			expected: []constraintUnit{
-				{
-					rangeOperator: GTE,
-					version:       "1.0",
-				},
-				{
-					rangeOperator: LTE,
-					version:       "2.3",
-				},
-			},
-		},
-		{
-			phrase: "  >=   1.0 ,   <=   2.3  ",
-			expected: []constraintUnit{
-				{
-					rangeOperator: GTE,
-					version:       "1.0",
-				},
-				{
-					rangeOperator: LTE,
-					version:       "2.3",
-				},
-			},
-		},
-		{
-			phrase: ">1.0,<2.3",
-			expected: []constraintUnit{
-				{
-					rangeOperator: GT,
-					version:       "1.0",
-				},
-				{
-					rangeOperator: LT,
-					version:       "2.3",
-				},
+			phrase: "  >=   1.0 ",
+			expected: &constraintUnit{
+
+				rangeOperator: GTE,
+				version:       "1.0",
 			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.phrase, func(t *testing.T) {
-			actuals, err := splitConstraintPhrase(test.phrase)
+			actual, err := parseUnit(test.phrase)
 			if err != nil && test.err == false {
 				t.Fatalf("expected no error, got %+v", err)
 			} else if err == nil && test.err {
 				t.Fatalf("expected an error but did not get one")
 			}
 
-			if len(actuals) != len(test.expected) {
-				t.Fatalf("unexpected length: %d!=%d", len(actuals), len(test.expected))
+			if !reflect.DeepEqual(test.expected, actual) {
+				t.Errorf("expected: '%+v' got: '%+v'", test.expected, actual)
 			}
 
-			for idx, actual := range actuals {
-				if !reflect.DeepEqual(test.expected[idx], actual) {
-					t.Errorf("expected: '%+v' got: '%+v'", test.expected[idx], actual)
-				}
-			}
 		})
 	}
 }

--- a/grype/version/constraint_unit_test.go
+++ b/grype/version/constraint_unit_test.go
@@ -29,6 +29,14 @@ func TestSplitFuzzyPhrase(t *testing.T) {
 			},
 		},
 		{
+			// to cover a version that has quotes within it, but not necessarily surrounding the entire version
+			phrase: ` >= inbet"ween)>quotes" with trailing words `,
+			expected: &constraintUnit{
+				rangeOperator: GTE,
+				version:       `inbet"ween)>quotes" with trailing words`,
+			},
+		},
+		{
 			phrase: `="something"`,
 			expected: &constraintUnit{
 				rangeOperator: EQ,

--- a/internal/parse.go
+++ b/internal/parse.go
@@ -1,0 +1,15 @@
+package internal
+
+import "regexp"
+
+// MatchCaptureGroups takes a regular expression and string and returns all of the named capture group results in a map.
+func MatchCaptureGroups(regEx *regexp.Regexp, str string) map[string]string {
+	match := regEx.FindStringSubmatch(str)
+	results := make(map[string]string)
+	for i, name := range regEx.SubexpNames() {
+		if i > 0 && i <= len(match) {
+			results[name] = match[i]
+		}
+	}
+	return results
+}


### PR DESCRIPTION
The existing constraint expression parsing assumed that splitting an expression by `||` is good enough to split OR'd expressions, however versions may have these delimiters within quoted text --the same goes for parenthetical statements. This PR rectifies fortifies the existing parser and allows for quoted versions to have arbitrary characters.