### PR TITLE
Suppress version constraint token scanner errors

### DIFF
--- a/grype/version/constraint_expression.go
+++ b/grype/version/constraint_expression.go
@@ -95,6 +95,20 @@ func scanExpression(phrase string) ([][]string, error) {
 	}
 
 	scnr.Init(strings.NewReader(phrase))
+
+	scnr.Error = func(*scanner.Scanner, string) {
+		// scanner has the ability to invoke a callback upon tokenization errors. By default, if no handler is provided
+		// then errors are printed to stdout. This handler is provided to suppress this output.
+
+		// Suppressing these errors is not a problem in this case since the scanExpression function should see all tokens
+		// and accumulate them as part of a version value if it is not a token of interest. The text/scanner splits on
+		// a pre-configured set of "common" tokens (which we cannot provide). We are only interested in a sub-set of
+		// these tokens, thus allow for input that would seemingly be invalid for this common set of tokens.
+		// For example, the scanner finding `3.e` would interpret this as a float with no valid exponent. However,
+		// this function accumulates all tokens into the version component (and versions are not guaranteed to have
+		// valid tokens).
+	}
+
 	tokenRune := scnr.Scan()
 	for tokenRune != scanner.EOF {
 		currentToken := scnr.TokenText()


### PR DESCRIPTION
The `text/scanner` is used for constraint expression tokenization. If no error handler is provided to the scanner then errors are reported to stdout by default. This PR adds a handler which ignores all scanner tokenization errors, which is safe under the current context (see the added comments for details). 

Closes #241 