### PR TITLE
Re-adding json presenter fixture

### DIFF
--- a/grype/presenter/json/test-fixtures/image-simple/Dockerfile
+++ b/grype/presenter/json/test-fixtures/image-simple/Dockerfile
@@ -1,0 +1,6 @@
+# Note: changes to this file will result in updating several test values. Consider making a new image fixture instead of editing this one.
+FROM scratch
+ADD file-1.txt /somefile-1.txt
+ADD file-2.txt /somefile-2.txt
+# note: adding a directory will behave differently on docker engine v18 vs v19
+ADD target /


### PR DESCRIPTION
The json presenter Dockerfile had been missing for some time now --once #257 was merged it became apparent that this fixture was not committed. This implies that we additionally have a cache + fixture image name collision that needs to be adjusted in the way fixture images are built in stereoscope (future PR). This PR only restores the fixture.