### PR TITLE
Move snapshot builds to linux

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
   Build-Snapshot-Artifacts:
-    runs-on: macos-latest # We're creating these snapshot builds on macOS to be consistent with our release workflow's build process, which also takes place on macOS (due to code signing requirements).
+    runs-on: ubuntu-20.04
     steps:
 
       - uses: actions/setup-go@v2


### PR DESCRIPTION
Now that docker is required for snapshot builds it is more convenient to build on a linux box.