### PR TITLE
Manually login to docker via cli during release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,10 +94,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('Makefile') }}-${{ hashFiles('**/go.sum') }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.TOOLBOX_DOCKER_USER }}
-          password: ${{ secrets.TOOLBOX_DOCKER_PASS }}
+        run: echo ${{ secrets.TOOLBOX_DOCKER_PASS }} | docker login docker.io -u ${{ secrets.TOOLBOX_DOCKER_USER }} --password-stdin
 
       - name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
The https://github.com/docker/login-action github action is not supported on mac, thus we need to login manually (see https://github.com/anchore/grype/runs/2179331427?check_suite_focus=true)