### PR TITLE
Move docker login after keychain creation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,9 +93,6 @@ jobs:
             ${{ github.workspace }}/.tmp
           key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('Makefile') }}-${{ hashFiles('**/go.sum') }}
 
-      - name: Login to Docker Hub
-        run: echo ${{ secrets.TOOLBOX_DOCKER_PASS }} | docker login docker.io -u ${{ secrets.TOOLBOX_DOCKER_USER }} --password-stdin
-
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v2
@@ -117,6 +114,8 @@ jobs:
       - name: Build snapshot artifacts
         run: make release
         env:
+          DOCKER_USERNAME: ${{ secrets.TOOLBOX_DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.TOOLBOX_DOCKER_PASS }}
           GITHUB_TOKEN: ${{ secrets.ANCHORE_GIT_READ_TOKEN }}
           GPG_PRIVATE_KEY: ${{ secrets.SIGNING_GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.SIGNING_GPG_PASSPHRASE }}

--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,9 @@ release: clean-dist changelog-release ## Build and publish final binaries and pa
 	# Prepare for macOS-specific signing process
 	.github/scripts/mac-prepare-for-signing.sh
 
+	# login to docker
+	@echo $${DOCKER_PASSWORD} | docker login docker.io -u $${DOCKER_USERNAME}  --password-stdin
+
 	# create a config with the dist dir overridden
 	echo "dist: $(DISTDIR)" > $(TEMPDIR)/goreleaser.yaml
 	cat .goreleaser.yaml >> $(TEMPDIR)/goreleaser.yaml


### PR DESCRIPTION
Currently the release step logs into docker, however, this needs to occur after creating the keychain used for mac signing.