### PR TITLE
Ensure docker is auth'd during entire release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,6 +75,10 @@ jobs:
     steps:
       - uses: docker-practice/actions-setup-docker@v1
 
+      # note, it is important to always be auth'd into docker.io to prevent rate limiting issues
+      - name: Login to Docker Hub
+        run: echo ${{ secrets.TOOLBOX_DOCKER_PASS }} | docker login docker.io -u ${{ secrets.TOOLBOX_DOCKER_USER }} --password-stdin
+
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -85,13 +89,17 @@ jobs:
 
       # We are expecting this cache to have been created during the "Build-Snapshot-Artifacts" job in the "Acceptance" workflow.
       - name: Restore bootstrap cache
-        id: cache
+        id: bootstrap-cache
         uses: actions/cache@v2
         with:
           path: |
             ~/go/pkg/mod
             ${{ github.workspace }}/.tmp
           key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('Makefile') }}-${{ hashFiles('**/go.sum') }}
+
+      - name: Bootstrap project dependencies
+        if: steps.bootstrap-cache.outputs.cache-hit != 'true'
+        run: make bootstrap
 
       - name: Import GPG key
         id: import_gpg
@@ -100,10 +108,6 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.SIGNING_GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.SIGNING_GPG_PASSPHRASE }}
 
-      - name: Bootstrap project dependencies
-        if: steps.bootstrap-cache.outputs.cache-hit != 'true'
-        run: make bootstrap
-
       - name: GPG signing info
         run: |
           echo "fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}"
@@ -111,7 +115,7 @@ jobs:
           echo "name:        ${{ steps.import_gpg.outputs.name }}"
           echo "email:       ${{ steps.import_gpg.outputs.email }}"
 
-      - name: Build snapshot artifacts
+      - name: Build release artifacts
         run: make release
         env:
           DOCKER_USERNAME: ${{ secrets.TOOLBOX_DOCKER_USER }}

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,7 @@ release: clean-dist changelog-release ## Build and publish final binaries and pa
 	.github/scripts/mac-prepare-for-signing.sh
 
 	# login to docker
+	# note: the previous step creates a new keychain, so it is important to reauth into docker.io
 	@echo $${DOCKER_PASSWORD} | docker login docker.io -u $${DOCKER_USERNAME}  --password-stdin
 
 	# create a config with the dist dir overridden


### PR DESCRIPTION
- Now that docker is rate limiting anonymous pulls, it is useful to be authenticated against docker.io for steps that require docker pull
- Noticed the bootstrap cache step referenced the wrong step name, fixed
- Noticed the release title referenced "snapshot" artifacts, fixed