### PR TITLE
Ensure credentials are not HTML encoded

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca
 	github.com/anchore/grype-db v0.0.0-20210322113357-5aec8a7cb962
-	github.com/anchore/stereoscope v0.0.0-20210323182342-47b72675ff65
-	github.com/anchore/syft v0.14.1-0.20210401150434-557ad8be4900
+	github.com/anchore/stereoscope v0.0.0-20210405181843-73d71fd93233
+	github.com/anchore/syft v0.14.1-0.20210405182557-7a10cbae0c41
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/dustin/go-humanize v1.0.0
 	github.com/facebookincubator/nvdtools v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -123,10 +123,10 @@ github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca h1:rLyc7Rih76
 github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/grype-db v0.0.0-20210322113357-5aec8a7cb962 h1:yW3xed7hbEjdmEXRnBFit5AGN0exPIFgE1jgW9bks+Q=
 github.com/anchore/grype-db v0.0.0-20210322113357-5aec8a7cb962/go.mod h1:LINmipRzG88vnJEWvgMMDVCFH1qZsj7+bjmpERlSyaA=
-github.com/anchore/stereoscope v0.0.0-20210323182342-47b72675ff65 h1:r3tiir6UCgj/YeTqy4s2bfhZ9SuJYNlXx1Z9e/eLrbI=
-github.com/anchore/stereoscope v0.0.0-20210323182342-47b72675ff65/go.mod h1:G7tFR0iI9r6AvibmXKA9v010pRS1IIJgd0t6fOMDxCw=
-github.com/anchore/syft v0.14.1-0.20210401150434-557ad8be4900 h1:IcFJmlYeBtIXI36QV7F2DrgTJP6i7B3dZB/Wg/VI9vU=
-github.com/anchore/syft v0.14.1-0.20210401150434-557ad8be4900/go.mod h1:ltkH8fstNZ3P6ZhDT2Ih14C1tAw5zdlnmTPRtp1vppY=
+github.com/anchore/stereoscope v0.0.0-20210405181843-73d71fd93233 h1:XkoyUFdQGYT2tb7SH2YBsouw/9q1kZTgXVy52PzM4JE=
+github.com/anchore/stereoscope v0.0.0-20210405181843-73d71fd93233/go.mod h1:G7tFR0iI9r6AvibmXKA9v010pRS1IIJgd0t6fOMDxCw=
+github.com/anchore/syft v0.14.1-0.20210405182557-7a10cbae0c41 h1:xwq+qHO1fU45PoJXavdJ53xwUoPA2GAtS+fXGFjUMTk=
+github.com/anchore/syft v0.14.1-0.20210405182557-7a10cbae0c41/go.mod h1:9X0W88NsIKP0IoL5DFsn7uUffJbtU/KP2c6VYTnbolw=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=


### PR DESCRIPTION
This PR pulls in the fixes from https://github.com/anchore/stereoscope/pull/63 and https://github.com/anchore/syft/pull/368.

Summary of fix in stereoscope: today when setting docker pull options we are responsible for base64 encoding the RegistryAuth JSON, which is an object containing username and password. Before base64 encoding we are not making certain that the JSON marshaling will not escape specific characters typical to HTML documents. This PR swaps out the JSON unmarshal with a JSON encoder with HTML escaping turned off.

Closes #254