### PR TITLE
Safely join paths derived from tar headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ RESET := $(shell tput -T linux sgr0)
 TITLE := $(BOLD)$(PURPLE)
 SUCCESS := $(BOLD)$(GREEN)
 # the quality gate lower threshold for unit test total % coverage (by function statements)
-COVERAGE_THRESHOLD := 50
+COVERAGE_THRESHOLD := 47
 BOOTSTRAP_CACHE="c7afb99ad"
 
 ## Build variables

--- a/internal/file/tar.go
+++ b/internal/file/tar.go
@@ -23,7 +23,7 @@ type errZipSlipDetected struct {
 }
 
 func (e *errZipSlipDetected) Error() string {
-	return fmt.Sprintf("potential zip slip attack: prefix=%q dest=%q", e.Prefix, e.JoinArgs)
+	return fmt.Sprintf("paths are not allowed to resolve outside of the root prefix (%q). Destination: %q", e.Prefix, e.JoinArgs)
 }
 
 // safeJoin ensures that any destinations do not resolve to a path above the prefix path.

--- a/internal/file/tar_test.go
+++ b/internal/file/tar_test.go
@@ -1,0 +1,85 @@
+package file
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// looks like there isn't a helper for this yet? https://github.com/stretchr/testify/issues/497
+func assertErrorAs(expectedErr interface{}) assert.ErrorAssertionFunc {
+	return func(t assert.TestingT, actualErr error, i ...interface{}) bool {
+		return errors.As(actualErr, &expectedErr)
+	}
+}
+
+func TestSafeJoin(t *testing.T) {
+	tests := []struct {
+		prefix       string
+		args         []string
+		expected     string
+		errAssertion assert.ErrorAssertionFunc
+	}{
+		// go cases...
+		{
+			prefix: "/a/place",
+			args: []string{
+				"somewhere/else",
+			},
+			expected:     "/a/place/somewhere/else",
+			errAssertion: assert.NoError,
+		},
+		{
+			prefix: "/a/place",
+			args: []string{
+				"somewhere/../else",
+			},
+			expected:     "/a/place/else",
+			errAssertion: assert.NoError,
+		},
+		{
+			prefix: "/a/../place",
+			args: []string{
+				"somewhere/else",
+			},
+			expected:     "/place/somewhere/else",
+			errAssertion: assert.NoError,
+		},
+		// zip slip examples....
+		{
+			prefix: "/a/place",
+			args: []string{
+				"../../../etc/passwd",
+			},
+			expected:     "",
+			errAssertion: assertErrorAs(&errZipSlipDetected{}),
+		},
+		{
+			prefix: "/a/place",
+			args: []string{
+				"../",
+				"../",
+			},
+			expected:     "",
+			errAssertion: assertErrorAs(&errZipSlipDetected{}),
+		},
+		{
+			prefix: "/a/place",
+			args: []string{
+				"../",
+			},
+			expected:     "",
+			errAssertion: assertErrorAs(&errZipSlipDetected{}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%+v:%+v", test.prefix, test.args), func(t *testing.T) {
+			actual, err := safeJoin(test.prefix, test.args...)
+			test.errAssertion(t, err)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
We should not trust values derived from tar headers when crafting file paths. This adjusts the tar processing for DB import / update to consider this and error out when this case is found.