### PR TITLE
Add grype db namespace indication in match details

### DIFF
--- a/grype/match/match.go
+++ b/grype/match/match.go
@@ -14,7 +14,7 @@ type Match struct {
 	Vulnerability vulnerability.Vulnerability // The vulnerability details of the match.
 	Package       pkg.Package                 // The package used to search for a match.
 	SearchKey     map[string]interface{}      // The specific attributes that were used to search (other than package name and version) --this indicates "how" the match was made.
-	SearchMatches map[string]interface{}      // The specific attributes on the vulnerability object that were matched with --this indicates "what" was found in the match.
+	SearchMatches map[string]interface{}      // The specific attributes on the vulnerability object that were matched with --this indicates "what" was matched on / within.
 	Matcher       MatcherType                 // The matcher object that discovered the match.
 }
 

--- a/grype/matcher/common/cpe_matchers.go
+++ b/grype/matcher/common/cpe_matchers.go
@@ -58,8 +58,9 @@ func FindMatchesByPackageCPE(store vulnerability.ProviderByCPE, p pkg.Package, u
 						"cpe": cpe.BindToFmtString(),
 					},
 					SearchMatches: map[string]interface{}{
-						"cpes":       cpesToString(vuln.CPEs),
-						"constraint": vuln.Constraint.String(),
+						"grypeDbNamespace":  vuln.Namespace,
+						"cpes":              cpesToString(vuln.CPEs),
+						"versionConstraint": vuln.Constraint.String(),
 					},
 				})
 			}

--- a/grype/matcher/common/cpe_matchers.go
+++ b/grype/matcher/common/cpe_matchers.go
@@ -58,7 +58,7 @@ func FindMatchesByPackageCPE(store vulnerability.ProviderByCPE, p pkg.Package, u
 						"cpe": cpe.BindToFmtString(),
 					},
 					SearchMatches: map[string]interface{}{
-						"grypeDbNamespace":  vuln.Namespace,
+						"namespace":         vuln.Namespace,
 						"cpes":              cpesToString(vuln.CPEs),
 						"versionConstraint": vuln.Constraint.String(),
 					},

--- a/grype/matcher/common/cpe_matchers_test.go
+++ b/grype/matcher/common/cpe_matchers_test.go
@@ -291,7 +291,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 			store := newMockProviderByCPE()
 			actual, err := FindMatchesByPackageCPE(store, test.p, matcher)
 			assert.NoError(t, err)
-			assertMatchesWithoutVulnData(t, test.expected, actual)
+			assertMatchesUsingIDsForVulnerabilities(t, test.expected, actual)
 		})
 	}
 }

--- a/grype/matcher/common/cpe_matchers_test.go
+++ b/grype/matcher/common/cpe_matchers_test.go
@@ -123,7 +123,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 						"cpe": "cpe:2.3:*:activerecord:activerecord:3.7.5:rando1:*:rando2:*:ruby:*:*",
 					},
 					SearchMatches: map[string]interface{}{
-						"grypeDbNamespace":  "nvd",
+						"namespace":         "nvd",
 						"cpes":              []string{"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*"},
 						"versionConstraint": "< 3.7.6 (semver)",
 					},
@@ -164,7 +164,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 						"cpe": "cpe:2.3:*:activerecord:activerecord:3.7.3:rando1:*:rando2:*:ruby:*:*",
 					},
 					SearchMatches: map[string]interface{}{
-						"grypeDbNamespace":  "nvd",
+						"namespace":         "nvd",
 						"cpes":              []string{"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*"},
 						"versionConstraint": "< 3.7.6 (semver)",
 					},
@@ -190,7 +190,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 						"cpe": "cpe:2.3:*:activerecord:activerecord:3.7.3:rando1:*:rando2:*:ruby:*:*",
 					},
 					SearchMatches: map[string]interface{}{
-						"grypeDbNamespace":  "nvd",
+						"namespace":         "nvd",
 						"cpes":              []string{"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:ruby:*:*"},
 						"versionConstraint": "< 3.7.4 (semver)",
 					},
@@ -231,7 +231,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 						"cpe": "cpe:2.3:*:activerecord:activerecord:4.0.1:rando1:*:rando2:*:ruby:*:*",
 					},
 					SearchMatches: map[string]interface{}{
-						"grypeDbNamespace":  "nvd",
+						"namespace":         "nvd",
 						"cpes":              []string{"cpe:2.3:*:couldntgetthisrightcouldyou:activerecord:4.0.1:*:*:*:*:*:*:*"},
 						"versionConstraint": "= 4.0.1 (semver)",
 					},
@@ -276,7 +276,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 						"cpe": "cpe:2.3:*:awesome:awesome:98SE1:rando1:*:rando2:*:dunno:*:*",
 					},
 					SearchMatches: map[string]interface{}{
-						"grypeDbNamespace":  "nvd",
+						"namespace":         "nvd",
 						"cpes":              []string{"cpe:2.3:*:awesome:awesome:*:*:*:*:*:*:*:*"},
 						"versionConstraint": "< 98SP3 (unknown)",
 					},

--- a/grype/matcher/common/cpe_matchers_test.go
+++ b/grype/matcher/common/cpe_matchers_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/version"
 	"github.com/anchore/grype/grype/vulnerability"
-	"github.com/anchore/grype/internal"
 	syftPkg "github.com/anchore/syft/syft/pkg"
+	"github.com/stretchr/testify/assert"
 )
 
 func must(c syftPkg.CPE, e error) syftPkg.CPE {
@@ -39,6 +39,7 @@ func (pr *mockCPEProvider) stub() {
 				CPEs: []syftPkg.CPE{
 					must(syftPkg.NewCPE("cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*")),
 				},
+				Namespace: "nvd",
 			},
 			{
 				Constraint: version.MustGetConstraint("< 3.7.4", version.SemanticFormat),
@@ -46,6 +47,7 @@ func (pr *mockCPEProvider) stub() {
 				CPEs: []syftPkg.CPE{
 					must(syftPkg.NewCPE("cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:ruby:*:*")),
 				},
+				Namespace: "nvd",
 			},
 			{
 				Constraint: version.MustGetConstraint("= 4.0.1", version.SemanticFormat),
@@ -53,6 +55,7 @@ func (pr *mockCPEProvider) stub() {
 				CPEs: []syftPkg.CPE{
 					must(syftPkg.NewCPE("cpe:2.3:*:couldntgetthisrightcouldyou:activerecord:4.0.1:*:*:*:*:*:*:*")),
 				},
+				Namespace: "nvd",
 			},
 			{
 				Constraint: version.MustGetConstraint("= 4.0.1", version.SemanticFormat),
@@ -60,6 +63,7 @@ func (pr *mockCPEProvider) stub() {
 				CPEs: []syftPkg.CPE{
 					must(syftPkg.NewCPE("cpe:2.3:*:couldntgetthisrightcouldyou:activerecord:4.0.1:*:*:*:*:*:*:*")),
 				},
+				Namespace: "nvd",
 			},
 		},
 		"awesome": {
@@ -69,6 +73,7 @@ func (pr *mockCPEProvider) stub() {
 				CPEs: []syftPkg.CPE{
 					must(syftPkg.NewCPE("cpe:2.3:*:awesome:awesome:*:*:*:*:*:*:*:*")),
 				},
+				Namespace: "nvd",
 			},
 		},
 	}
@@ -79,10 +84,11 @@ func (pr *mockCPEProvider) GetByCPE(c syftPkg.CPE) ([]*vulnerability.Vulnerabili
 }
 
 func TestFindMatchesByPackageCPE(t *testing.T) {
+	matcher := match.RubyGemMatcher
 	tests := []struct {
 		name     string
 		p        pkg.Package
-		expected []string
+		expected []match.Match
 	}{
 		{
 			name: "match from range",
@@ -96,8 +102,33 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 				Language: syftPkg.Ruby,
 				Type:     syftPkg.GemPkg,
 			},
-			expected: []string{
-				"CVE-2017-fake-1",
+			expected: []match.Match{
+				{
+					Type:       match.FuzzyMatch,
+					Confidence: 0.9,
+					Vulnerability: vulnerability.Vulnerability{
+						ID: "CVE-2017-fake-1",
+					},
+					Package: pkg.Package{
+						CPEs: []syftPkg.CPE{
+							must(syftPkg.NewCPE("cpe:2.3:*:activerecord:activerecord:3.7.5:rando1:*:rando2:*:ruby:*:*")),
+							must(syftPkg.NewCPE("cpe:2.3:*:activerecord:activerecord:3.7.5:rando4:*:rando3:*:rails:*:*")),
+						},
+						Name:     "activerecord",
+						Version:  "3.7.5",
+						Language: syftPkg.Ruby,
+						Type:     syftPkg.GemPkg,
+					},
+					SearchKey: map[string]interface{}{
+						"cpe": "cpe:2.3:*:activerecord:activerecord:3.7.5:rando1:*:rando2:*:ruby:*:*",
+					},
+					SearchMatches: map[string]interface{}{
+						"grypeDbNamespace":  "nvd",
+						"cpes":              []string{"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*"},
+						"versionConstraint": "< 3.7.6 (semver)",
+					},
+					Matcher: matcher,
+				},
 			},
 		},
 		{
@@ -112,9 +143,59 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 				Language: syftPkg.Ruby,
 				Type:     syftPkg.GemPkg,
 			},
-			expected: []string{
-				"CVE-2017-fake-1",
-				"CVE-2017-fake-2",
+			expected: []match.Match{
+				{
+					Type:       match.FuzzyMatch,
+					Confidence: 0.9,
+					Vulnerability: vulnerability.Vulnerability{
+						ID: "CVE-2017-fake-1",
+					},
+					Package: pkg.Package{
+						CPEs: []syftPkg.CPE{
+							must(syftPkg.NewCPE("cpe:2.3:*:activerecord:activerecord:3.7.3:rando1:*:rando2:*:ruby:*:*")),
+							must(syftPkg.NewCPE("cpe:2.3:*:activerecord:activerecord:3.7.3:rando4:*:rando3:*:rails:*:*")),
+						},
+						Name:     "activerecord",
+						Version:  "3.7.3",
+						Language: syftPkg.Ruby,
+						Type:     syftPkg.GemPkg,
+					},
+					SearchKey: map[string]interface{}{
+						"cpe": "cpe:2.3:*:activerecord:activerecord:3.7.3:rando1:*:rando2:*:ruby:*:*",
+					},
+					SearchMatches: map[string]interface{}{
+						"grypeDbNamespace":  "nvd",
+						"cpes":              []string{"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*"},
+						"versionConstraint": "< 3.7.6 (semver)",
+					},
+					Matcher: matcher,
+				},
+				{
+					Type:       match.FuzzyMatch,
+					Confidence: 0.9,
+					Vulnerability: vulnerability.Vulnerability{
+						ID: "CVE-2017-fake-2",
+					},
+					Package: pkg.Package{
+						CPEs: []syftPkg.CPE{
+							must(syftPkg.NewCPE("cpe:2.3:*:activerecord:activerecord:3.7.3:rando1:*:rando2:*:ruby:*:*")),
+							must(syftPkg.NewCPE("cpe:2.3:*:activerecord:activerecord:3.7.3:rando4:*:rando3:*:rails:*:*")),
+						},
+						Name:     "activerecord",
+						Version:  "3.7.3",
+						Language: syftPkg.Ruby,
+						Type:     syftPkg.GemPkg,
+					},
+					SearchKey: map[string]interface{}{
+						"cpe": "cpe:2.3:*:activerecord:activerecord:3.7.3:rando1:*:rando2:*:ruby:*:*",
+					},
+					SearchMatches: map[string]interface{}{
+						"grypeDbNamespace":  "nvd",
+						"cpes":              []string{"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:ruby:*:*"},
+						"versionConstraint": "< 3.7.4 (semver)",
+					},
+					Matcher: matcher,
+				},
 			},
 		},
 		{
@@ -129,8 +210,33 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 				Language: syftPkg.Ruby,
 				Type:     syftPkg.GemPkg,
 			},
-			expected: []string{
-				"CVE-2017-fake-3",
+			expected: []match.Match{
+				{
+					Type:       match.FuzzyMatch,
+					Confidence: 0.9,
+					Vulnerability: vulnerability.Vulnerability{
+						ID: "CVE-2017-fake-3",
+					},
+					Package: pkg.Package{
+						CPEs: []syftPkg.CPE{
+							must(syftPkg.NewCPE("cpe:2.3:*:activerecord:activerecord:4.0.1:rando1:*:rando2:*:ruby:*:*")),
+							must(syftPkg.NewCPE("cpe:2.3:*:activerecord:activerecord:4.0.1:rando4:*:rando3:*:rails:*:*")),
+						},
+						Name:     "activerecord",
+						Version:  "4.0.1",
+						Language: syftPkg.Ruby,
+						Type:     syftPkg.GemPkg,
+					},
+					SearchKey: map[string]interface{}{
+						"cpe": "cpe:2.3:*:activerecord:activerecord:4.0.1:rando1:*:rando2:*:ruby:*:*",
+					},
+					SearchMatches: map[string]interface{}{
+						"grypeDbNamespace":  "nvd",
+						"cpes":              []string{"cpe:2.3:*:couldntgetthisrightcouldyou:activerecord:4.0.1:*:*:*:*:*:*:*"},
+						"versionConstraint": "= 4.0.1 (semver)",
+					},
+					Matcher: matcher,
+				},
 			},
 		},
 		{
@@ -141,7 +247,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 				Language: syftPkg.Ruby,
 				Type:     syftPkg.GemPkg,
 			},
-			expected: []string{},
+			expected: []match.Match{},
 		},
 		{
 			name: "fuzzy version match",
@@ -152,55 +258,40 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 				Name:    "awesome",
 				Version: "98SE1",
 			},
-			expected: []string{
-				"CVE-2017-fake-4",
+			expected: []match.Match{
+				{
+					Type:       match.FuzzyMatch,
+					Confidence: 0.9,
+					Vulnerability: vulnerability.Vulnerability{
+						ID: "CVE-2017-fake-4",
+					},
+					Package: pkg.Package{
+						CPEs: []syftPkg.CPE{
+							must(syftPkg.NewCPE("cpe:2.3:*:awesome:awesome:98SE1:rando1:*:rando2:*:dunno:*:*")),
+						},
+						Name:    "awesome",
+						Version: "98SE1",
+					},
+					SearchKey: map[string]interface{}{
+						"cpe": "cpe:2.3:*:awesome:awesome:98SE1:rando1:*:rando2:*:dunno:*:*",
+					},
+					SearchMatches: map[string]interface{}{
+						"grypeDbNamespace":  "nvd",
+						"cpes":              []string{"cpe:2.3:*:awesome:awesome:*:*:*:*:*:*:*:*"},
+						"versionConstraint": "< 98SP3 (unknown)",
+					},
+					Matcher: matcher,
+				},
 			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			store := newMockProviderByCPE()
-			actual, err := FindMatchesByPackageCPE(store, test.p, match.PythonMatcher)
-			if err != nil {
-				t.Fatalf("error while finding matches: %+v", err)
-			}
-
-			if len(actual) != len(test.expected) {
-				for _, a := range actual {
-					t.Errorf("   entry: %+v", a)
-				}
-				t.Fatalf("unexpected matches count: %d != %d", len(actual), len(test.expected))
-			}
-
-			foundCVEs := internal.NewStringSet()
-
-			for _, a := range actual {
-				foundCVEs.Add(a.Vulnerability.ID)
-
-				if a.Type != match.FuzzyMatch {
-					t.Error("fuzzy match not indicated")
-				}
-
-				if a.Package.Name != test.p.Name {
-					t.Errorf("failed to capture correct original package: %s", a.Package.Name)
-				}
-
-				if a.Matcher != match.PythonMatcher {
-					t.Errorf("failed to capture matcher name: %s", a.Matcher)
-				}
-
-				if a.Confidence != 0.9 {
-					t.Fatalf("unexpected confidence: %f", a.Confidence)
-				}
-			}
-
-			for _, id := range test.expected {
-				if !foundCVEs.Contains(id) {
-					t.Errorf("missing CVE: %s", id)
-				}
-			}
+			actual, err := FindMatchesByPackageCPE(store, test.p, matcher)
+			assert.NoError(t, err)
+			assertMatchesWithoutVulnData(t, test.expected, actual)
 		})
 	}
 }

--- a/grype/matcher/common/distro_matchers.go
+++ b/grype/matcher/common/distro_matchers.go
@@ -49,7 +49,7 @@ func FindMatchesByPackageDistro(store vulnerability.ProviderByDistro, d *distro.
 					},
 				},
 				SearchMatches: map[string]interface{}{
-					"grypeDbNamespace":  vuln.Namespace,
+					"namespace":         vuln.Namespace,
 					"versionConstraint": vuln.Constraint.String(),
 				},
 			})

--- a/grype/matcher/common/distro_matchers.go
+++ b/grype/matcher/common/distro_matchers.go
@@ -49,7 +49,8 @@ func FindMatchesByPackageDistro(store vulnerability.ProviderByDistro, d *distro.
 					},
 				},
 				SearchMatches: map[string]interface{}{
-					"constraint": vuln.Constraint.String(),
+					"grypeDbNamespace":  vuln.Namespace,
+					"versionConstraint": vuln.Constraint.String(),
 				},
 			})
 		}

--- a/grype/matcher/common/distro_matchers_test.go
+++ b/grype/matcher/common/distro_matchers_test.go
@@ -99,5 +99,5 @@ func TestFindMatchesByPackageDistro(t *testing.T) {
 	store := newMockProviderByDistro()
 	actual, err := FindMatchesByPackageDistro(store, &d, p, match.PythonMatcher)
 	assert.NoError(t, err)
-	assertMatchesWithoutVulnData(t, expected, actual)
+	assertMatchesUsingIDsForVulnerabilities(t, expected, actual)
 }

--- a/grype/matcher/common/distro_matchers_test.go
+++ b/grype/matcher/common/distro_matchers_test.go
@@ -89,7 +89,7 @@ func TestFindMatchesByPackageDistro(t *testing.T) {
 				},
 			},
 			SearchMatches: map[string]interface{}{
-				"grypeDbNamespace":  "debian:8",
+				"namespace":         "debian:8",
 				"versionConstraint": "< 2014.1.5-6 (deb)",
 			},
 			Matcher: match.PythonMatcher,

--- a/grype/matcher/common/language_matchers.go
+++ b/grype/matcher/common/language_matchers.go
@@ -40,7 +40,7 @@ func FindMatchesByPackageLanguage(store vulnerability.ProviderByLanguage, l syft
 					"language": l.String(),
 				},
 				SearchMatches: map[string]interface{}{
-					"grypeDbNamespace":  vuln.Namespace,
+					"namespace":         vuln.Namespace,
 					"versionConstraint": vuln.Constraint.String(),
 				},
 			})

--- a/grype/matcher/common/language_matchers.go
+++ b/grype/matcher/common/language_matchers.go
@@ -40,7 +40,8 @@ func FindMatchesByPackageLanguage(store vulnerability.ProviderByLanguage, l syft
 					"language": l.String(),
 				},
 				SearchMatches: map[string]interface{}{
-					"constraint": vuln.Constraint.String(),
+					"grypeDbNamespace":  vuln.Namespace,
+					"versionConstraint": vuln.Constraint.String(),
 				},
 			})
 		}

--- a/grype/matcher/common/language_matchers_test.go
+++ b/grype/matcher/common/language_matchers_test.go
@@ -80,5 +80,5 @@ func TestFindMatchesByPackageLanguage(t *testing.T) {
 	store := newMockProviderByLanguage()
 	actual, err := FindMatchesByPackageLanguage(store, p.Language, p, match.RubyGemMatcher)
 	assert.NoError(t, err)
-	assertMatchesWithoutVulnData(t, expected, actual)
+	assertMatchesUsingIDsForVulnerabilities(t, expected, actual)
 }

--- a/grype/matcher/common/language_matchers_test.go
+++ b/grype/matcher/common/language_matchers_test.go
@@ -70,7 +70,7 @@ func TestFindMatchesByPackageLanguage(t *testing.T) {
 				"language": "ruby",
 			},
 			SearchMatches: map[string]interface{}{
-				"grypeDbNamespace":  "github:ruby",
+				"namespace":         "github:ruby",
 				"versionConstraint": "< 3.7.6 (semver)",
 			},
 			Matcher: match.RubyGemMatcher,

--- a/grype/matcher/common/utils_test.go
+++ b/grype/matcher/common/utils_test.go
@@ -1,0 +1,33 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/go-test/deep"
+	"github.com/scylladb/go-set"
+	"github.com/stretchr/testify/assert"
+)
+
+func assertMatchesWithoutVulnData(t testing.TB, expected, actual []match.Match) {
+	expectedCves := set.NewStringSet()
+	for _, e := range expected {
+		expectedCves.Add(e.Vulnerability.ID)
+	}
+
+	foundCVEs := set.NewStringSet()
+
+	for idx, a := range actual {
+		foundCVEs.Add(a.Vulnerability.ID)
+
+		// only compare the vulnerability ID, nothing else
+		a.Vulnerability = vulnerability.Vulnerability{ID: a.Vulnerability.ID}
+
+		for _, d := range deep.Equal(expected[idx], a) {
+			t.Errorf("diff idx=%d: %+v", idx, d)
+		}
+	}
+
+	assert.Equal(t, true, expectedCves.IsEqual(foundCVEs))
+}

--- a/grype/matcher/common/utils_test.go
+++ b/grype/matcher/common/utils_test.go
@@ -6,28 +6,14 @@ import (
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/go-test/deep"
-	"github.com/scylladb/go-set"
-	"github.com/stretchr/testify/assert"
 )
 
-func assertMatchesWithoutVulnData(t testing.TB, expected, actual []match.Match) {
-	expectedCves := set.NewStringSet()
-	for _, e := range expected {
-		expectedCves.Add(e.Vulnerability.ID)
-	}
-
-	foundCVEs := set.NewStringSet()
-
+func assertMatchesUsingIDsForVulnerabilities(t testing.TB, expected, actual []match.Match) {
 	for idx, a := range actual {
-		foundCVEs.Add(a.Vulnerability.ID)
-
 		// only compare the vulnerability ID, nothing else
 		a.Vulnerability = vulnerability.Vulnerability{ID: a.Vulnerability.ID}
-
 		for _, d := range deep.Equal(expected[idx], a) {
 			t.Errorf("diff idx=%d: %+v", idx, d)
 		}
 	}
-
-	assert.Equal(t, true, expectedCves.IsEqual(foundCVEs))
 }

--- a/grype/vulnerability/store_adapter_test.go
+++ b/grype/vulnerability/store_adapter_test.go
@@ -3,6 +3,8 @@ package vulnerability
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/go-test/deep"
 
 	"github.com/anchore/grype/grype/pkg"
@@ -28,27 +30,26 @@ func TestGetByDistro(t *testing.T) {
 		t.Fatalf("failed to get by distro: %+v", err)
 	}
 
-	if len(actual) != 2 {
-		t.Fatalf("unexpected distro length: %d", len(actual))
-	}
-
 	expected := []Vulnerability{
 		{
 			Constraint: version.MustGetConstraint("< 2014.1.3-6", version.DebFormat),
 			ID:         "CVE-2014-fake-1",
+			Namespace:  "debian:8",
+			CPEs:       []syftPkg.CPE{},
 		},
 		{
 			Constraint: version.MustGetConstraint("< 2013.0.2-1", version.DebFormat),
 			ID:         "CVE-2013-fake-2",
+			Namespace:  "debian:8",
+			CPEs:       []syftPkg.CPE{},
 		},
 	}
 
+	assert.Len(t, actual, len(expected))
+
 	for idx, vuln := range actual {
-		if vuln.ID != expected[idx].ID {
-			t.Errorf("mismatched vuln ID: %s!=%s", vuln.ID, actual[idx].ID)
-		}
-		if vuln.Constraint.String() != expected[idx].Constraint.String() {
-			t.Errorf("mismatched vuln constraint: '%s'!='%s'", vuln.Constraint.String(), actual[idx].Constraint.String())
+		for _, d := range deep.Equal(&expected[idx], vuln) {
+			t.Errorf("diff: %+v", d)
 		}
 	}
 
@@ -79,6 +80,7 @@ func TestGetByCPE(t *testing.T) {
 					CPEs: []syftPkg.CPE{
 						must(syftPkg.NewCPE("cpe:2.3:*:activerecord:activerecord:*:*:something:*:*:ruby:*:*")),
 					},
+					Namespace: "nvd",
 				},
 			},
 		},
@@ -93,6 +95,7 @@ func TestGetByCPE(t *testing.T) {
 					CPEs: []syftPkg.CPE{
 						must(syftPkg.NewCPE("cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*")),
 					},
+					Namespace: "nvd",
 				},
 				{
 					Constraint: version.MustGetConstraint("< 3.7.4", version.UnknownFormat),
@@ -100,6 +103,7 @@ func TestGetByCPE(t *testing.T) {
 					CPEs: []syftPkg.CPE{
 						must(syftPkg.NewCPE("cpe:2.3:*:activerecord:activerecord:*:*:something:*:*:ruby:*:*")),
 					},
+					Namespace: "nvd",
 				},
 			},
 		},
@@ -123,19 +127,11 @@ func TestGetByCPE(t *testing.T) {
 				t.Fatalf("expected an err, got none")
 			}
 
-			if len(actual) != len(test.expected) {
-				for _, a := range actual {
-					t.Errorf("   entry: %+v", a)
-				}
-				t.Fatalf("unexpected length: %d", len(actual))
-			}
+			assert.Len(t, actual, len(test.expected))
 
 			for idx, vuln := range actual {
-				diffs := deep.Equal(&test.expected[idx], vuln)
-				if len(diffs) > 0 {
-					for _, d := range diffs {
-						t.Errorf("diff: %+v", d)
-					}
+				for _, d := range deep.Equal(&test.expected[idx], vuln) {
+					t.Errorf("diff: %+v", d)
 				}
 			}
 		})

--- a/grype/vulnerability/vulnerability.go
+++ b/grype/vulnerability/vulnerability.go
@@ -13,6 +13,7 @@ type Vulnerability struct {
 	CPEs           []pkg.CPE
 	ID             string
 	RecordSource   string
+	Namespace      string
 	FixedInVersion string
 }
 
@@ -29,6 +30,7 @@ func NewVulnerability(vuln db.Vulnerability) (*Vulnerability, error) {
 		ID:             vuln.ID,
 		CPEs:           make([]pkg.CPE, 0),
 		RecordSource:   vuln.RecordSource,
+		Namespace:      vuln.Namespace,
 		FixedInVersion: vuln.FixedInVersion,
 	}, nil
 }


### PR DESCRIPTION
Adds a new `grypeDbNamespace` field to the match details indicating the namespace within grype-db that the match was found in.

Closes #283 