### PR TITLE
Bump go.mod minimum required go version to 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/anchore/grype)](https://goreportcard.com/report/github.com/anchore/grype)
 [![GitHub release](https://img.shields.io/github/release/anchore/grype.svg)](https://github.com/anchore/grype/releases/latest)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/anchore/grype/blob/main/LICENSE)
+[![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/anchore/grype.svg)](https://github.com/anchore/grype)
 
 A vulnerability scanner for container images and filesystems. [Easily install the binary](#installation) to try it out.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/grype
 
-go 1.14
+go 1.16
 
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d


### PR DESCRIPTION
Syft changes has driven the need to require go 1.16. Also adds a badge indicator in our readme.

Closes #279 