### PR TITLE
Support for MSRC matching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca
 	github.com/anchore/grype-db v0.0.0-20210322113357-5aec8a7cb962
 	github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6
-	github.com/anchore/syft v0.15.1
+	github.com/anchore/syft v0.15.2-0.20210429185904-284b0c20b08e // indirect
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/dustin/go-humanize v1.0.0
 	github.com/facebookincubator/nvdtools v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,7 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alicebob/sqlittle v1.4.0 h1:vgYt0nAjhdf/hg52MjKJ84g/uTzBPfrvI+VUBrIghxA=
 github.com/alicebob/sqlittle v1.4.0/go.mod h1:Co1L1qxHqCwf41puWhk2HOodojR0mcsAV4BIt8byZh8=
+github.com/anchore/client-go v0.0.0-20210222170800-9c70f9b80bcf h1:DYssiUV1pBmKqzKsm4mqXx8artqC0Q8HgZsVI3lMsAg=
 github.com/anchore/client-go v0.0.0-20210222170800-9c70f9b80bcf/go.mod h1:FaODhIA06mxO1E6R32JE0TL1JWZZkmjRIAd4ULvHUKk=
 github.com/anchore/go-rpmdb v0.0.0-20210415132930-2460011e83c6 h1:wEN3HXc3VuC4wo7Cz27YCpeQ4gaB5ASKwMwM5GdFsew=
 github.com/anchore/go-rpmdb v0.0.0-20210415132930-2460011e83c6/go.mod h1:8jNYOxCJC5kyD/Ct4MbzsDN2hOhRoCAzQcb/7KdYYGw=
@@ -128,9 +129,12 @@ github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6 h1:g9ZS2V/T0wx
 github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
 github.com/anchore/syft v0.15.1 h1:PoaOL9/4EPMamPw/+1cUm7H4EpMvOG9ZkfEuXz3nRRo=
 github.com/anchore/syft v0.15.1/go.mod h1:5k4L4CA5ZFFmRdk64oj0AV1ZqvLFZVOpfCk8DfUOsVc=
+github.com/anchore/syft v0.15.2-0.20210429185904-284b0c20b08e h1:yE+naFfUHwZc9XWq8h6gF98hjdygd8VbWg+2vJeeT/o=
+github.com/anchore/syft v0.15.2-0.20210429185904-284b0c20b08e/go.mod h1:5k4L4CA5ZFFmRdk64oj0AV1ZqvLFZVOpfCk8DfUOsVc=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
+github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apex/log v1.1.4/go.mod h1:AlpoD9aScyQfJDVHmLMEcx4oU6LqzkWp4Mg9GdAcEvQ=
 github.com/apex/log v1.3.0 h1:1fyfbPvUwD10nMoh3hY6MXzvZShJQn9/ck7ATgAt5pA=
@@ -649,6 +653,7 @@ github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/profile v1.5.0 h1:042Buzk+NhDI+DeSAA62RwJL8VAuZUMQZUjCsRz1Mug=
 github.com/pkg/profile v1.5.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/grype/match/matcher_type.go
+++ b/grype/match/matcher_type.go
@@ -9,6 +9,7 @@ const (
 	JavaMatcher
 	PythonMatcher
 	JavascriptMatcher
+	MsrcMatcher
 )
 
 var matcherTypeStr = []string{
@@ -20,6 +21,7 @@ var matcherTypeStr = []string{
 	"java-matcher",
 	"python-matcher",
 	"javascript-matcher",
+	"msrc-matcher",
 }
 
 var AllMatcherTypes = []MatcherType{
@@ -30,6 +32,7 @@ var AllMatcherTypes = []MatcherType{
 	JavaMatcher,
 	PythonMatcher,
 	JavascriptMatcher,
+	MsrcMatcher,
 }
 
 type MatcherType int

--- a/grype/matcher/controller.go
+++ b/grype/matcher/controller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/anchore/grype/grype/matcher/dpkg"
 	"github.com/anchore/grype/grype/matcher/java"
 	"github.com/anchore/grype/grype/matcher/javascript"
+	"github.com/anchore/grype/grype/matcher/msrc"
 	"github.com/anchore/grype/grype/matcher/python"
 	"github.com/anchore/grype/grype/matcher/rpmdb"
 	"github.com/anchore/grype/grype/matcher/ruby"
@@ -46,6 +47,7 @@ func newController() controller {
 	ctrlr.add(&java.Matcher{})
 	ctrlr.add(&javascript.Matcher{})
 	ctrlr.add(&apk.Matcher{})
+	ctrlr.add(&msrc.Matcher{})
 	return ctrlr
 }
 

--- a/grype/matcher/msrc/matcher.go
+++ b/grype/matcher/msrc/matcher.go
@@ -1,0 +1,40 @@
+package msrc
+
+import (
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/matcher/common"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/syft/syft/distro"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+type Matcher struct {
+}
+
+func (m *Matcher) PackageTypes() []syftPkg.Type {
+	// This looks like there is a special package, but in reality, this is just
+	// a workaround. MSRC matching is done at the KB-patch level, and so this
+	// treats KBs as "packages" but they aren't packages, they are patches
+	return []syftPkg.Type{syftPkg.KbPkg}
+}
+
+func (m *Matcher) Type() match.MatcherType {
+	return match.MsrcMatcher
+}
+
+func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Package) ([]match.Match, error) {
+	var matches []match.Match
+
+	// find KB matches for the MSFT version given in the package and version.
+	// The "distro" holds the information about the Windows version, and its
+	// patch (KB)
+	kbMatches, err := common.FindMatchesByPackageDistro(store, d, p, m.Type())
+	if err != nil {
+		return nil, err
+	}
+
+	matches = append(matches, kbMatches...)
+
+	return matches, nil
+}

--- a/grype/matcher/msrc/matcher_test.go
+++ b/grype/matcher/msrc/matcher_test.go
@@ -1,0 +1,74 @@
+package msrc
+
+import (
+	"testing"
+
+	"github.com/anchore/grype-db/pkg/db"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/syft/syft/distro"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockStore struct {
+	backend map[string]map[string][]db.Vulnerability
+}
+
+func (s *mockStore) GetVulnerability(namespace, name string) ([]db.Vulnerability, error) {
+	namespaceMap := s.backend[namespace]
+	if namespaceMap == nil {
+		return nil, nil
+	}
+	return namespaceMap[name], nil
+}
+
+func TestMatches(t *testing.T) {
+	store := mockStore{
+		backend: map[string]map[string][]db.Vulnerability{
+			"microsoft": {
+				"Windows 10 Version 1903 for ARM64-based Systems": []db.Vulnerability{
+					{
+						ID:                "CVE-2020-1",
+						VersionConstraint: "878786 || 878787",
+						VersionFormat:     "kb",
+					},
+					{
+						// Does not match, version constraints do not apply
+						ID:                "CVE-2020-1",
+						VersionConstraint: "778786 || 778787",
+						VersionFormat:     "kb",
+					},
+				},
+				// Does not match, the package is Windows 10, not 11
+				"Windows 11 Version 1903 for ARM64-based Systems": []db.Vulnerability{
+					{
+						ID:                "CVE-2020-1",
+						VersionConstraint: "878786 || 878787",
+						VersionFormat:     "kb",
+					},
+				},
+			},
+		},
+	}
+
+	provider := vulnerability.NewProviderFromStore(&store)
+
+	m := Matcher{}
+	d, err := distro.NewDistro(distro.Windows, "878787", "Windows 10 Version 1903 for ARM64-based Systems")
+	if err != nil {
+		t.Fatalf("failed to create a new distro: %+v", err)
+	}
+	p := pkg.Package{
+		Name:    "Windows 10 Version 1903 for ARM64-based Systems",
+		Version: "878787",
+		Type:    syftPkg.KbPkg,
+	}
+	matches, err := m.Match(provider, &d, p)
+
+	if err != nil {
+		t.Fatalf("failed to get matches: %+v", err)
+	}
+
+	assert.Len(t, matches, 1)
+}

--- a/grype/version/constraint.go
+++ b/grype/version/constraint.go
@@ -24,6 +24,8 @@ func GetConstraint(constStr string, format Format) (Constraint, error) {
 		// 1.0b2.post345.dev456 which is allowed by the spec. In that case (a dev release of a post release)
 		// the comparator will fail. See https://www.python.org/dev/peps/pep-0440
 		return newFuzzyConstraint(constStr, "python")
+	case KBFormat:
+		return newKBConstraint(constStr)
 	case UnknownFormat:
 		return newFuzzyConstraint(constStr, "unknown")
 	}

--- a/grype/version/format.go
+++ b/grype/version/format.go
@@ -12,6 +12,7 @@ const (
 	DebFormat
 	RpmFormat
 	PythonFormat
+	KBFormat
 )
 
 type Format int
@@ -22,6 +23,7 @@ var formatStr = []string{
 	"Deb",
 	"RPM",
 	"Python",
+	"KB",
 }
 
 var Formats = []Format{
@@ -29,6 +31,7 @@ var Formats = []Format{
 	DebFormat,
 	RpmFormat,
 	PythonFormat,
+	KBFormat,
 }
 
 func ParseFormat(userStr string) Format {
@@ -41,6 +44,8 @@ func ParseFormat(userStr string) Format {
 		return RpmFormat
 	case strings.ToLower(PythonFormat.String()), "python":
 		return PythonFormat
+	case strings.ToLower(KBFormat.String()), "kb":
+		return KBFormat
 	}
 	return UnknownFormat
 }
@@ -56,6 +61,8 @@ func FormatFromPkgType(t pkg.Type) Format {
 		format = SemanticFormat
 	case pkg.PythonPkg:
 		format = PythonFormat
+	case pkg.KbPkg:
+		format = KBFormat
 	default:
 		format = UnknownFormat
 	}

--- a/grype/version/kb_contraint.go
+++ b/grype/version/kb_contraint.go
@@ -1,0 +1,63 @@
+package version
+
+import (
+	"fmt"
+)
+
+type kbConstraint struct {
+	raw        string
+	expression constraintExpression
+}
+
+func newKBConstraint(raw string) (kbConstraint, error) {
+	if raw == "" {
+		// an empty constraint is always satisfied
+		return kbConstraint{}, nil
+	}
+
+	constraints, err := newConstraintExpression(raw, newKBComparator)
+	if err != nil {
+		return kbConstraint{}, fmt.Errorf("unable to parse kb constraint phrase: %w", err)
+	}
+
+	return kbConstraint{
+		raw:        raw,
+		expression: constraints,
+	}, nil
+}
+
+func newKBComparator(unit constraintUnit) (Comparator, error) {
+	// XXX unit.version is probably not needed because newKBVersion doesn't do anything
+	ver := newKBVersion(unit.version)
+	return &ver, nil
+}
+
+func (c kbConstraint) supported(format Format) bool {
+	return format == KBFormat
+}
+
+func (c kbConstraint) Satisfied(version *Version) (bool, error) {
+	if c.raw == "" && version != nil {
+		// an empty constraint is always satisfied
+		return true, nil
+	} else if version == nil {
+		if c.raw != "" {
+			// a non-empty constraint with no version given should always fail
+			return false, nil
+		}
+		return true, nil
+	}
+
+	if !c.supported(version.Format) {
+		return false, fmt.Errorf("(kb) unsupported format: %s", version.Format)
+	}
+
+	return c.expression.satisfied(version)
+}
+
+func (c kbConstraint) String() string {
+	if c.raw == "" {
+		return "none (kb)"
+	}
+	return fmt.Sprintf("%s (kb)", c.raw)
+}

--- a/grype/version/kb_contraint_test.go
+++ b/grype/version/kb_contraint_test.go
@@ -1,0 +1,28 @@
+package version
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestVersionKbConstraint(t *testing.T) {
+	tests := []testCase{
+		{version: "", constraint: "", satisfied: true},
+		{version: "", constraint: "foo", satisfied: false},
+		{version: "1", constraint: "foo", satisfied: false},
+		{version: "1", constraint: "1", satisfied: true},
+		{version: "878787", constraint: "979797 || 101010 || 878787", satisfied: true},
+		{version: "478787", constraint: "979797 || 101010 || 878787", satisfied: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name(), func(t *testing.T) {
+			constraint, err := newKBConstraint(test.constraint)
+			if !errors.Is(err, test.constErr) {
+				t.Fatalf("unexpected constraint error: '%+v'!='%+v'", err, test.constErr)
+			}
+
+			test.assert(t, KBFormat, constraint)
+		})
+	}
+}

--- a/grype/version/kb_version.go
+++ b/grype/version/kb_version.go
@@ -1,0 +1,40 @@
+package version
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type kbVersion struct {
+	version string
+}
+
+func newKBVersion(raw string) kbVersion {
+	// XXX Is this even useful/necessary?
+	return kbVersion{
+		version: raw,
+	}
+}
+
+func (v *kbVersion) Compare(other *Version) (int, error) {
+	if other.Format != KBFormat {
+		return -1, fmt.Errorf("unable to compare kb to given format: %s", other.Format)
+	}
+	if other.rich.kbVer == nil {
+		return -1, fmt.Errorf("given empty kbVersion object")
+	}
+
+	return other.rich.kbVer.compare(*v), nil
+}
+
+// Compare returns 0 if v == v2, 1 otherwise
+func (v kbVersion) compare(v2 kbVersion) int {
+	if reflect.DeepEqual(v, v2) {
+		return 0
+	}
+	return 1
+}
+
+func (v kbVersion) String() string {
+	return v.version
+}

--- a/grype/version/rpm_constraint.go
+++ b/grype/version/rpm_constraint.go
@@ -17,7 +17,7 @@ func newRpmConstraint(raw string) (rpmConstraint, error) {
 
 	constraints, err := newConstraintExpression(raw, newRpmComparator)
 	if err != nil {
-		return rpmConstraint{}, fmt.Errorf("unable to parse deb constraint phrase: %w", err)
+		return rpmConstraint{}, fmt.Errorf("unable to parse rpm constraint phrase: %w", err)
 	}
 
 	return rpmConstraint{

--- a/grype/version/version.go
+++ b/grype/version/version.go
@@ -18,6 +18,7 @@ type rich struct {
 	semVer  *semanticVersion
 	debVer  *debVersion
 	rpmVer  *rpmVersion
+	kbVer   *kbVersion
 }
 
 func NewVersion(raw string, format Format) (*Version, error) {
@@ -60,6 +61,10 @@ func (v *Version) populate() error {
 		return err
 	case PythonFormat:
 		// use the fuzzy constraint
+		return nil
+	case KBFormat:
+		ver := newKBVersion(v.Raw)
+		v.rich.kbVer = &ver
 		return nil
 	case UnknownFormat:
 		// use the raw string + fuzzy constraint

--- a/grype/vulnerability/namespace.go
+++ b/grype/vulnerability/namespace.go
@@ -10,6 +10,8 @@ import (
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
+const microsoftNamespace = "microsoft"
+
 type namer func(p pkg.Package) []string
 
 func defaultNamer(p pkg.Package) []string {
@@ -34,7 +36,12 @@ func githubJavaNamer(p pkg.Package) []string {
 	return names.ToSlice()
 }
 
-// TODO: expand with namer mapping to be more generic?
+// distroNamespace returns the correct Feed Service namespace for the given
+// distro. A namespace is a distinct identifier from the Feed Service, and it
+// can be a combination of distro name and version(s), for example "amzn:8".
+// This is critical to query the database and correlate the distro version with
+// feed contents. Namespaces have to exist in the Feed Service, otherwise,
+// this causes no results to be returned when the database is queried.
 func distroNamespace(d distro.Distro) string {
 	// TODO: can we drive this from information from grype-db? that would be ideal...
 	var versionSegments []int
@@ -55,6 +62,8 @@ func distroNamespace(d distro.Distro) string {
 		case distro.Alpine:
 			// XXX this assumes that a major and minor versions will always exist in Segments
 			return fmt.Sprintf("alpine:%d.%d", versionSegments[0], versionSegments[1])
+		case distro.Windows:
+			return microsoftNamespace
 		}
 	}
 	return fmt.Sprintf("%s:%s", strings.ToLower(d.Type.String()), d.FullVersion())

--- a/grype/vulnerability/namespace_test.go
+++ b/grype/vulnerability/namespace_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/scylladb/go-set/strset"
-
 	"github.com/anchore/syft/syft/distro"
+	"github.com/scylladb/go-set/strset"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDistroNamespace_AllDistros(t *testing.T) {
@@ -107,6 +107,11 @@ func TestDistroNamespace_AllDistros(t *testing.T) {
 			version:  "4.0",
 			expected: "photon:4.0",
 		},
+		{
+			dist:     distro.Windows,
+			version:  "471816",
+			expected: "microsoft",
+		},
 	}
 
 	observedDistros := strset.New()
@@ -127,9 +132,7 @@ func TestDistroNamespace_AllDistros(t *testing.T) {
 			observedDistros.Add(d.Type.String())
 
 			actual := distroNamespace(d)
-			if actual != test.expected {
-				t.Errorf("mismatched distro namespace: '%s'!='%s'", actual, test.expected)
-			}
+			assert.Equal(t, actual, test.expected)
 		})
 	}
 

--- a/test/integration/match_coverage_test.go
+++ b/test/integration/match_coverage_test.go
@@ -334,6 +334,7 @@ func TestPkgCoverageImage(t *testing.T) {
 
 	observedMatchers.Remove(match.UnknownMatcherType.String())
 	definedMatchers.Remove(match.UnknownMatcherType.String())
+	definedMatchers.Remove(match.MsrcMatcher.String())
 
 	if len(observedMatchers) != len(definedMatchers) {
 		t.Errorf("matcher coverage incomplete (matchers=%d, coverage=%d)", len(definedMatchers), len(observedMatchers))


### PR DESCRIPTION
This PR brings matching support for MSRC matching to Grype and requires Syft [changes](https://github.com/anchore/syft/pull/389) 

Closes #286 

From the following database metadata:

```
                   pk = 563027
                   id = CVE-2020-1556
        record_source = microsoft:msrc:11646
         package_name = Windows 10 Version 1903 for ARM64-based Systems
            namespace = microsoft
   version_constraint = 4517389 || 4524147 || 4524570 || 4528760 || 4530684 || 4532693 || 4540673 || 4549951 || 4556799 || 4560960 || 4565483
       version_format = unknown
                 cpes = null
     fixed_in_version = 4565351,4574727,4577671,4586786,4592449
```

And the following SBOM from Syft:

```json
{
 "artifacts": [
  {
   "id": "30381e7b-497b-4d10-a70c-a9b1af8f7046",
   "name": "Windows 10 Version 1903 for ARM64-based Systems",
   "version": "4524570",
   "type": "msrc-kb",
   "foundBy": "kb-cataloger",
   "locations": [],
   "licenses": [],
   "language": "",
   "cpes": [],
   "purl": "",
   "metadataType": "KbPackageMetadata",
   "metadata": {}
  }
 ],
 "source": {
  "type": "image",
  "target": {
   "userInput": "alpine:3.12",
   "imageID": "sha256:7230e588e9549d0908631c36c6907a05ac987b4ff003b6c27e1a721c5b134ce3",
   "manifestDigest": "sha256:92321ad97d25cdd654f3aefd4a68b822adbcf9635ad3c9e87552e47ebacb9a11",
   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
   "tags": [
    "alpine:3.12"
   ],
   "imageSize": 5572926,
   "scope": "Squashed",
   "layers": [
    {
     "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
     "digest": "sha256:b0b9881431d721cee6e2a7f3465c2769e71a182699a519387460bca497262e69",
     "size": 5572926
    }
   ],
   "manifest": "eyJzY2hlbWFWZXJzaW9uIjoyLCJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwiY29uZmlnIjp7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuY29udGFpbmVyLmltYWdlLnYxK2pzb24iLCJzaXplIjoxNDcyLCJkaWdlc3QiOiJzaGEyNTY6NzIzMGU1ODhlOTU0OWQwOTA4NjMxYzM2YzY5MDdhMDVhYzk4N2I0ZmYwMDNiNmMyN2UxYTcyMWM1YjEzNGNlMyJ9LCJsYXllcnMiOlt7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuaW1hZ2Uucm9vdGZzLmRpZmYudGFyLmd6aXAiLCJzaXplIjo1ODQ3NTUyLCJkaWdlc3QiOiJzaGEyNTY6YjBiOTg4MTQzMWQ3MjFjZWU2ZTJhN2YzNDY1YzI3NjllNzFhMTgyNjk5YTUxOTM4NzQ2MGJjYTQ5NzI2MmU2OSJ9XX0=",
   "config": "eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsImNvbmZpZyI6eyJIb3N0bmFtZSI6IiIsIkRvbWFpbm5hbWUiOiIiLCJVc2VyIjoiIiwiQXR0YWNoU3RkaW4iOmZhbHNlLCJBdHRhY2hTdGRvdXQiOmZhbHNlLCJBdHRhY2hTdGRlcnIiOmZhbHNlLCJUdHkiOmZhbHNlLCJPcGVuU3RkaW4iOmZhbHNlLCJTdGRpbk9uY2UiOmZhbHNlLCJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iXSwiQ21kIjpbIi9iaW4vc2giXSwiSW1hZ2UiOiJzaGEyNTY6ZThmNzhhZjgzY2QyMWMzZDU1Y2Q2NDA2NTRhNTRhYjA1YmQ4Yjc2NWE3MTBkOGEyYjI3OTdjZTQ4YzhlODBmZCIsIlZvbHVtZXMiOm51bGwsIldvcmtpbmdEaXIiOiIiLCJFbnRyeXBvaW50IjpudWxsLCJPbkJ1aWxkIjpudWxsLCJMYWJlbHMiOm51bGx9LCJjb250YWluZXIiOiIxN2YyNjU0ZTg0NDQzNjQwY2M3MjhhZmUyNzlkZGE1MmI3NThmNWMxYmU2MWQyMWUzMDdkMDNmZGI0MzYyY2I0IiwiY29udGFpbmVyX2NvbmZpZyI6eyJIb3N0bmFtZSI6IjE3ZjI2NTRlODQ0NCIsIkRvbWFpbm5hbWUiOiIiLCJVc2VyIjoiIiwiQXR0YWNoU3RkaW4iOmZhbHNlLCJBdHRhY2hTdGRvdXQiOmZhbHNlLCJBdHRhY2hTdGRlcnIiOmZhbHNlLCJUdHkiOmZhbHNlLCJPcGVuU3RkaW4iOmZhbHNlLCJTdGRpbk9uY2UiOmZhbHNlLCJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iXSwiQ21kIjpbIi9iaW4vc2giLCItYyIsIiMobm9wKSAiLCJDTUQgW1wiL2Jpbi9zaFwiXSJdLCJJbWFnZSI6InNoYTI1NjplOGY3OGFmODNjZDIxYzNkNTVjZDY0MDY1NGE1NGFiMDViZDhiNzY1YTcxMGQ4YTJiMjc5N2NlNDhjOGU4MGZkIiwiVm9sdW1lcyI6bnVsbCwiV29ya2luZ0RpciI6IiIsIkVudHJ5cG9pbnQiOm51bGwsIk9uQnVpbGQiOm51bGwsIkxhYmVscyI6e319LCJjcmVhdGVkIjoiMjAyMS0wMy0zMVQyMDoxMDoxMy40MDI5OTUxODRaIiwiZG9ja2VyX3ZlcnNpb24iOiIxOS4wMy4xMiIsImhpc3RvcnkiOlt7ImNyZWF0ZWQiOiIyMDIxLTAzLTMxVDIwOjEwOjEzLjIyNTg0NjA0NVoiLCJjcmVhdGVkX2J5IjoiL2Jpbi9zaCAtYyAjKG5vcCkgQUREIGZpbGU6Zjc3ZGI4ZTViOTM3ZDhlYmI3ZTI1NGVjY2Q0ZDMxMTc5OGVhOWY0ZGQ1MDgxZWEyYTdlMmIxZDM3OTAzMDBjMiBpbiAvICJ9LHsiY3JlYXRlZCI6IjIwMjEtMDMtMzFUMjA6MTA6MTMuNDAyOTk1MTg0WiIsImNyZWF0ZWRfYnkiOiIvYmluL3NoIC1jICMobm9wKSAgQ01EIFtcIi9iaW4vc2hcIl0iLCJlbXB0eV9sYXllciI6dHJ1ZX1dLCJvcyI6ImxpbnV4Iiwicm9vdGZzIjp7InR5cGUiOiJsYXllcnMiLCJkaWZmX2lkcyI6WyJzaGEyNTY6YjBiOTg4MTQzMWQ3MjFjZWU2ZTJhN2YzNDY1YzI3NjllNzFhMTgyNjk5YTUxOTM4NzQ2MGJjYTQ5NzI2MmU2OSJdfX0="
  }
 },
 "distro": {
  "name": "windows",
  "version": "0",
  "idLike": "Windows 10 Version 1903 for ARM64-based Systems"
 },
 "descriptor": {
  "name": "syft",
  "version": "0.14.0"
 },
 "schema": {
  "version": "1.0.2",
  "url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-1.0.2.json"
 },
 "artifactRelationships": []
}
```

The following (redacted for readability) output is produced:

```
 go run main.go sbom:~/tmp/sbom.json
 ✔ Vulnerability DB        [no update available]
 ✔ Scanned image           [770 vulnerabilities]

NAME                                             INSTALLED  FIXED-IN                                                                                                         VULNERABILITY   SEVERITY
Windows 10 Version 1903 for ARM64-based Systems  4524570    4586786,4592449                                                                                                  CVE-2020-17090  Medium
Windows 10 Version 1903 for ARM64-based Systems  4524570    4540673,4549951,4551762,4556799,4560960,4565351,4565483,4574727,4577671,4586786,4592449                          CVE-2020-0869   High
Windows 10 Version 1903 for ARM64-based Systems  4524570    4549951,4556799,4560960,4565351,4565483,4574727,4577671,4586786,4592449                                          CVE-2020-0946   Medium
Windows 10 Version 1903 for ARM64-based Systems  4524570    4549951,4556799,4560960,4565351,4565483,4574727,4577671,4586786,4592449                                          CVE-2020-0916   High
Windows 10 Version 1903 for ARM64-based Systems  4524570    4560960,4565351,4565483,4574727,4577671,4586786,4592449                                                          CVE-2020-1276   High
Windows 10 Version 1903 for ARM64-based Systems  4524570    4565351,4574727,4577671,4586786,4592449                                                                          CVE-2020-1486   Unknown
Windows 10 Version 1903 for ARM64-based Systems  4524570    4574727,4577671,4586786,4592449                                                                                  CVE-2020-1308   High
Windows 10 Version 1903 for ARM64-based Systems  4524570    4574727,4577671,4586786,4592449                                                                                  CVE-2020-1162   High
Windows 10 Version 1903 for ARM64-based Systems  4524570    4586786,4592449
```