### PR TITLE
Add package sorting for artifacts in json document

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca
 	github.com/anchore/grype-db v0.0.0-20210322113357-5aec8a7cb962
 	github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6
-	github.com/anchore/syft v0.15.2-0.20210429185904-284b0c20b08e // indirect
+	github.com/anchore/syft v0.15.2-0.20210506190909-360eb74cc71c
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/dustin/go-humanize v1.0.0
 	github.com/facebookincubator/nvdtools v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -114,7 +114,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alicebob/sqlittle v1.4.0 h1:vgYt0nAjhdf/hg52MjKJ84g/uTzBPfrvI+VUBrIghxA=
 github.com/alicebob/sqlittle v1.4.0/go.mod h1:Co1L1qxHqCwf41puWhk2HOodojR0mcsAV4BIt8byZh8=
-github.com/anchore/client-go v0.0.0-20210222170800-9c70f9b80bcf h1:DYssiUV1pBmKqzKsm4mqXx8artqC0Q8HgZsVI3lMsAg=
 github.com/anchore/client-go v0.0.0-20210222170800-9c70f9b80bcf/go.mod h1:FaODhIA06mxO1E6R32JE0TL1JWZZkmjRIAd4ULvHUKk=
 github.com/anchore/go-rpmdb v0.0.0-20210415132930-2460011e83c6 h1:wEN3HXc3VuC4wo7Cz27YCpeQ4gaB5ASKwMwM5GdFsew=
 github.com/anchore/go-rpmdb v0.0.0-20210415132930-2460011e83c6/go.mod h1:8jNYOxCJC5kyD/Ct4MbzsDN2hOhRoCAzQcb/7KdYYGw=
@@ -127,14 +126,11 @@ github.com/anchore/grype-db v0.0.0-20210322113357-5aec8a7cb962 h1:yW3xed7hbEjdmE
 github.com/anchore/grype-db v0.0.0-20210322113357-5aec8a7cb962/go.mod h1:LINmipRzG88vnJEWvgMMDVCFH1qZsj7+bjmpERlSyaA=
 github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6 h1:g9ZS2V/T0wxseccI4t1hQTqWBek5DVOQZOzzdWBjwnU=
 github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
-github.com/anchore/syft v0.15.1 h1:PoaOL9/4EPMamPw/+1cUm7H4EpMvOG9ZkfEuXz3nRRo=
-github.com/anchore/syft v0.15.1/go.mod h1:5k4L4CA5ZFFmRdk64oj0AV1ZqvLFZVOpfCk8DfUOsVc=
-github.com/anchore/syft v0.15.2-0.20210429185904-284b0c20b08e h1:yE+naFfUHwZc9XWq8h6gF98hjdygd8VbWg+2vJeeT/o=
-github.com/anchore/syft v0.15.2-0.20210429185904-284b0c20b08e/go.mod h1:5k4L4CA5ZFFmRdk64oj0AV1ZqvLFZVOpfCk8DfUOsVc=
+github.com/anchore/syft v0.15.2-0.20210506190909-360eb74cc71c h1:+ZGL3hHwPxBhQPEjyBU9rB5+tTVAOd8P6d3NMvpxSNM=
+github.com/anchore/syft v0.15.2-0.20210506190909-360eb74cc71c/go.mod h1:5k4L4CA5ZFFmRdk64oj0AV1ZqvLFZVOpfCk8DfUOsVc=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
-github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apex/log v1.1.4/go.mod h1:AlpoD9aScyQfJDVHmLMEcx4oU6LqzkWp4Mg9GdAcEvQ=
 github.com/apex/log v1.3.0 h1:1fyfbPvUwD10nMoh3hY6MXzvZShJQn9/ck7ATgAt5pA=
@@ -653,7 +649,6 @@ github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/profile v1.5.0 h1:042Buzk+NhDI+DeSAA62RwJL8VAuZUMQZUjCsRz1Mug=
 github.com/pkg/profile v1.5.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/grype/match/matches_test.go
+++ b/grype/match/matches_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMatchesSort(t *testing.T) {
+func TestMatchesSortMixedDimensions(t *testing.T) {
 	first := Match{
 		Vulnerability: vulnerability.Vulnerability{
 			ID: "CVE-2020-0010",
@@ -70,15 +70,142 @@ func TestMatchesSort(t *testing.T) {
 		matches.Add(i.Package, i)
 	}
 
-	actual := make([]Match, 0)
 	expected := []Match{
 		first, second, third, fourth, fifth,
 	}
 
-	for _, i := range matches.Sorted() {
-		actual = append(actual, i)
+	assert.Equal(t, expected, matches.Sorted())
+
+}
+
+func TestMatchesSortByVulnerability(t *testing.T) {
+	first := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2020-0010",
+		},
+		Package: pkg.Package{
+			Name:    "package-b",
+			Version: "1.0.0",
+			Type:    syftPkg.RpmPkg,
+		},
+	}
+	second := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2020-0020",
+		},
+		Package: pkg.Package{
+			Name:    "package-b",
+			Version: "1.0.0",
+			Type:    syftPkg.RpmPkg,
+		},
 	}
 
-	assert.Equal(t, expected, actual)
+	input := []Match{second, first}
+
+	matches := NewMatches()
+	for _, i := range input {
+		matches.Add(i.Package, i)
+	}
+
+	assert.Equal(t, []Match{first, second}, matches.Sorted())
+
+}
+
+func TestMatchesSortByPackage(t *testing.T) {
+	first := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2020-0010",
+		},
+		Package: pkg.Package{
+			Name:    "package-b",
+			Version: "1.0.0",
+			Type:    syftPkg.RpmPkg,
+		},
+	}
+	second := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2020-0010",
+		},
+		Package: pkg.Package{
+			Name:    "package-c",
+			Version: "1.0.0",
+			Type:    syftPkg.RpmPkg,
+		},
+	}
+
+	input := []Match{second, first}
+
+	matches := NewMatches()
+	for _, i := range input {
+		matches.Add(i.Package, i)
+	}
+
+	assert.Equal(t, []Match{first, second}, matches.Sorted())
+
+}
+
+func TestMatchesSortByPackageVersion(t *testing.T) {
+	first := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2020-0010",
+		},
+		Package: pkg.Package{
+			Name:    "package-b",
+			Version: "1.0.0",
+			Type:    syftPkg.RpmPkg,
+		},
+	}
+	second := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2020-0010",
+		},
+		Package: pkg.Package{
+			Name:    "package-b",
+			Version: "2.0.0",
+			Type:    syftPkg.RpmPkg,
+		},
+	}
+
+	input := []Match{second, first}
+
+	matches := NewMatches()
+	for _, i := range input {
+		matches.Add(i.Package, i)
+	}
+
+	assert.Equal(t, []Match{first, second}, matches.Sorted())
+
+}
+
+func TestMatchesSortByPackageType(t *testing.T) {
+	first := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2020-0010",
+		},
+		Package: pkg.Package{
+			Name:    "package-b",
+			Version: "1.0.0",
+			Type:    syftPkg.ApkPkg,
+		},
+	}
+	second := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2020-0010",
+		},
+		Package: pkg.Package{
+			Name:    "package-b",
+			Version: "1.0.0",
+			Type:    syftPkg.RpmPkg,
+		},
+	}
+
+	input := []Match{second, first}
+
+	matches := NewMatches()
+	for _, i := range input {
+		matches.Add(i.Package, i)
+	}
+
+	assert.Equal(t, []Match{first, second}, matches.Sorted())
 
 }

--- a/grype/match/matches_test.go
+++ b/grype/match/matches_test.go
@@ -1,0 +1,84 @@
+package match
+
+import (
+	"testing"
+
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchesSort(t *testing.T) {
+	first := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2020-0010",
+		},
+		Package: pkg.Package{
+			Name:    "package-b",
+			Version: "1.0.0",
+			Type:    syftPkg.RpmPkg,
+		},
+	}
+	second := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2020-0020",
+		},
+		Package: pkg.Package{
+			Name:    "package-a",
+			Version: "1.0.0",
+			Type:    syftPkg.NpmPkg,
+		},
+	}
+	third := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2020-0020",
+		},
+		Package: pkg.Package{
+			Name:    "package-a",
+			Version: "2.0.0",
+			Type:    syftPkg.RpmPkg,
+		},
+	}
+	fourth := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2020-0020",
+		},
+		Package: pkg.Package{
+			Name:    "package-c",
+			Version: "3.0.0",
+			Type:    syftPkg.ApkPkg,
+		},
+	}
+	fifth := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2020-0020",
+		},
+		Package: pkg.Package{
+			Name:    "package-d",
+			Version: "2.0.0",
+			Type:    syftPkg.RpmPkg,
+		},
+	}
+
+	matches := NewMatches()
+	input := []Match{
+		// shuffle vulnerability id, package name, package version, and package type
+		fifth, third, first, second, fourth,
+	}
+	for _, i := range input {
+		matches.Add(i.Package, i)
+	}
+
+	actual := make([]Match, 0)
+	expected := []Match{
+		first, second, third, fourth, fifth,
+	}
+
+	for _, i := range matches.Sorted() {
+		actual = append(actual, i)
+	}
+
+	assert.Equal(t, expected, actual)
+
+}

--- a/grype/presenter/models/document.go
+++ b/grype/presenter/models/document.go
@@ -37,7 +37,7 @@ func NewDocument(packages []pkg.Package, context pkg.Context, matches match.Matc
 	metadataProvider vulnerability.MetadataProvider, appConfig interface{}, dbStatus interface{}) (Document, error) {
 	// we must preallocate the findings to ensure the JSON document does not show "null" when no matches are found
 	var findings = make([]Match, 0)
-	for m := range matches.Enumerate() {
+	for _, m := range matches.Sorted() {
 		p := pkg.ByID(m.Package.ID(), packages)
 		if p == nil {
 			return Document{}, fmt.Errorf("unable to find package in collection: %+v", p)

--- a/grype/presenter/models/document_test.go
+++ b/grype/presenter/models/document_test.go
@@ -1,0 +1,81 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/syft/syft/distro"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+	syftSource "github.com/anchore/syft/syft/source"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPackagesAreSorted(t *testing.T) {
+
+	var pkg1 = pkg.Package{
+		Name:    "package-1",
+		Version: "1.1.1",
+		Type:    syftPkg.DebPkg,
+	}
+
+	var pkg2 = pkg.Package{
+		Name:    "package-2",
+		Version: "2.2.2",
+		Type:    syftPkg.DebPkg,
+	}
+
+	var match1 = match.Match{
+		Type: match.ExactDirectMatch,
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-1999-0003",
+		},
+		Package: pkg1,
+	}
+
+	var match2 = match.Match{
+		Type: match.ExactIndirectMatch,
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-1999-0002",
+		},
+		Package: pkg1,
+	}
+
+	var match3 = match.Match{
+		Type: match.ExactIndirectMatch,
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-1999-0001",
+		},
+		Package: pkg1,
+	}
+
+	d, err := distro.NewDistro(distro.CentOS, "8.0", "rhel")
+	if err != nil {
+		t.Fatalf("could not make distro: %+v", err)
+	}
+
+	matches := match.NewMatches()
+	matches.Add(pkg1, match1, match2, match3)
+
+	packages := []pkg.Package{pkg1, pkg2}
+
+	ctx := pkg.Context{
+		Source: &syftSource.Metadata{
+			Scheme:        syftSource.DirectoryScheme,
+			ImageMetadata: syftSource.ImageMetadata{},
+		},
+		Distro: &d,
+	}
+	doc, err := NewDocument(packages, ctx, matches, NewMetadataMock(), nil, nil)
+	if err != nil {
+		t.Fatalf("unable to get document: %+v", err)
+	}
+
+	var actualVulnerabilities []string
+	for _, m := range doc.Matches {
+		actualVulnerabilities = append(actualVulnerabilities, m.Vulnerability.ID)
+	}
+
+	assert.Equal(t, []string{"CVE-1999-0001", "CVE-1999-0002", "CVE-1999-0003"}, actualVulnerabilities)
+}


### PR DESCRIPTION
Sorts the JSON presenter output by vulnerability ID, package name, package version, then package type. This will help with more stable output when comparing two documents.

Closes #245 