### PR TITLE
Show limited package metadata in json presenter

### DIFF
--- a/grype/presenter/json/presenter_test.go
+++ b/grype/presenter/json/presenter_test.go
@@ -52,6 +52,7 @@ func TestJsonImgsPresenter(t *testing.T) {
 				Language: "python",
 			},
 		},
+		Metadata: pkg.DpkgMetadata{Source: "a source!"},
 	}
 
 	var pkg2 = pkg.Package{
@@ -173,6 +174,10 @@ func TestJsonDirsPresenter(t *testing.T) {
 		FoundBy: "the-cataloger-1",
 		Locations: []syftSource.Location{
 			{RealPath: "/some/path/pkg1"},
+		},
+		MetadataType: syftPkg.DpkgMetadataType,
+		Metadata: syftPkg.DpkgMetadata{
+			Source: "a source!",
 		},
 	})
 

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
@@ -35,7 +35,10 @@
     "language": "",
     "licenses": null,
     "cpes": [],
-    "purl": ""
+    "purl": "",
+    "metadata": {
+     "Source": "a source!"
+    }
    }
   },
   {
@@ -71,7 +74,10 @@
     "language": "",
     "licenses": null,
     "cpes": [],
-    "purl": ""
+    "purl": "",
+    "metadata": {
+     "Source": "a source!"
+    }
    }
   },
   {
@@ -102,7 +108,10 @@
     "language": "",
     "licenses": null,
     "cpes": [],
-    "purl": ""
+    "purl": "",
+    "metadata": {
+     "Source": "a source!"
+    }
    }
   }
  ],

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
@@ -38,7 +38,10 @@
     "cpes": [
      "cpe:2.3:a:anchore:engine:0.9.2:*:*:python:*:*:*:*"
     ],
-    "purl": ""
+    "purl": "",
+    "metadata": {
+     "Source": "a source!"
+    }
    }
   },
   {
@@ -77,7 +80,10 @@
     "cpes": [
      "cpe:2.3:a:anchore:engine:0.9.2:*:*:python:*:*:*:*"
     ],
-    "purl": ""
+    "purl": "",
+    "metadata": {
+     "Source": "a source!"
+    }
    }
   },
   {
@@ -111,7 +117,10 @@
     "cpes": [
      "cpe:2.3:a:anchore:engine:0.9.2:*:*:python:*:*:*:*"
     ],
-    "purl": ""
+    "purl": "",
+    "metadata": {
+     "Source": "a source!"
+    }
    }
   }
  ],

--- a/grype/presenter/models/package.go
+++ b/grype/presenter/models/package.go
@@ -16,6 +16,7 @@ type Package struct {
 	Licenses  []string              `json:"licenses"`
 	CPEs      []string              `json:"cpes"`
 	PURL      string                `json:"purl"`
+	Metadata  interface{}           `json:"metadata"`
 }
 
 func newPackage(p pkg.Package) Package {
@@ -33,5 +34,6 @@ func newPackage(p pkg.Package) Package {
 		Type:      p.Type,
 		CPEs:      cpes,
 		PURL:      p.PURL,
+		Metadata:  p.Metadata,
 	}
 }


### PR DESCRIPTION
Previously we removed the syft `pkg.Package.Metadata` field from being displayed as there is potentially a large amount of information, much which is not directly used in the matching process. Since then we have restricted the metadata field to only contain information that is pertinent to the matching process. The json presentation should be as transparent as possible about how matches are made, and now that irrelevant information has been pruned, it should be added back to the grype presentation model. Note: an equivalent `MetadataType` has not been added since it will not be directly used within grype and using the same values from syft could be misleading.