### PR TITLE
Add java virtual path to package metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca
 	github.com/anchore/grype-db v0.0.0-20210322113357-5aec8a7cb962
 	github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6
-	github.com/anchore/syft v0.15.2-0.20210506190909-360eb74cc71c
+	github.com/anchore/syft v0.15.3-0.20210524151556-2ca2f0350133
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/dustin/go-humanize v1.0.0
 	github.com/facebookincubator/nvdtools v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/anchore/grype-db v0.0.0-20210322113357-5aec8a7cb962 h1:yW3xed7hbEjdmE
 github.com/anchore/grype-db v0.0.0-20210322113357-5aec8a7cb962/go.mod h1:LINmipRzG88vnJEWvgMMDVCFH1qZsj7+bjmpERlSyaA=
 github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6 h1:g9ZS2V/T0wxseccI4t1hQTqWBek5DVOQZOzzdWBjwnU=
 github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
-github.com/anchore/syft v0.15.2-0.20210506190909-360eb74cc71c h1:+ZGL3hHwPxBhQPEjyBU9rB5+tTVAOd8P6d3NMvpxSNM=
-github.com/anchore/syft v0.15.2-0.20210506190909-360eb74cc71c/go.mod h1:5k4L4CA5ZFFmRdk64oj0AV1ZqvLFZVOpfCk8DfUOsVc=
+github.com/anchore/syft v0.15.3-0.20210524151556-2ca2f0350133 h1:37KItVunSU9vX8umE0PoH8SKZ+XR7itt2+DehSjxv9A=
+github.com/anchore/syft v0.15.3-0.20210524151556-2ca2f0350133/go.mod h1:5k4L4CA5ZFFmRdk64oj0AV1ZqvLFZVOpfCk8DfUOsVc=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=

--- a/grype/pkg/java_metadata.go
+++ b/grype/pkg/java_metadata.go
@@ -1,6 +1,7 @@
 package pkg
 
 type JavaMetadata struct {
+	VirtualPath   string
 	PomArtifactID string
 	PomGroupID    string
 	ManifestName  string

--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -55,6 +55,7 @@ func New(p *pkg.Package) Package {
 			}
 
 			metadata = JavaMetadata{
+				VirtualPath:   value.VirtualPath,
 				PomArtifactID: artifact,
 				PomGroupID:    group,
 				ManifestName:  name,

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -1,0 +1,229 @@
+package pkg
+
+import (
+	"testing"
+
+	"github.com/scylladb/go-set/strset"
+
+	"github.com/anchore/syft/syft/file"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+	"github.com/scylladb/go-set"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPackageMetadataExtraction(t *testing.T) {
+	tests := []struct {
+		name     string
+		syftPkg  syftPkg.Package
+		metadata interface{}
+	}{
+		{
+			name: "dpkg-metadata",
+			syftPkg: syftPkg.Package{
+				MetadataType: syftPkg.DpkgMetadataType,
+				Metadata: syftPkg.DpkgMetadata{
+					Package:       "pkg-info",
+					Source:        "src-info",
+					Version:       "version-info",
+					SourceVersion: "src-version-info",
+					Architecture:  "arch-info",
+					Maintainer:    "maintainer-info",
+					InstalledSize: 10,
+					Files: []syftPkg.DpkgFileRecord{
+						{
+							Path: "path-info",
+							Digest: &file.Digest{
+								Algorithm: "algo-info",
+								Value:     "digest-info",
+							},
+							IsConfigFile: true,
+						},
+					},
+				},
+			},
+			metadata: DpkgMetadata{
+				Source: "src-info",
+			},
+		},
+		{
+			name: "rpmdb-metadata",
+			syftPkg: syftPkg.Package{
+				MetadataType: syftPkg.RpmdbMetadataType,
+				Metadata: syftPkg.RpmdbMetadata{
+					Name:      "name-info",
+					Version:   "version-info",
+					Epoch:     30,
+					Arch:      "arch-info",
+					Release:   "release-info",
+					SourceRpm: "src-rpm-info",
+					Size:      40,
+					License:   "license-info",
+					Vendor:    "vendor-info",
+					Files: []syftPkg.RpmdbFileRecord{
+						{
+							Path: "path-info",
+							Mode: 20,
+							Size: 10,
+							Digest: file.Digest{
+								Algorithm: "algo-info",
+								Value:     "digest-info",
+							},
+							UserName:  "user-info",
+							GroupName: "group-info",
+							Flags:     "flag-info",
+						},
+					},
+				},
+			},
+			metadata: RpmdbMetadata{
+				SourceRpm: "src-rpm-info",
+			},
+		},
+		{
+			name: "java-metadata",
+			syftPkg: syftPkg.Package{
+				MetadataType: syftPkg.JavaMetadataType,
+				Metadata: syftPkg.JavaMetadata{
+					VirtualPath: "virtual-path-info",
+					Manifest: &syftPkg.JavaManifest{
+						Main: map[string]string{
+							"Name": "main-section-name-info",
+						},
+						NamedSections: map[string]map[string]string{
+							"named-section": {
+								"named-section-key": "named-section-vaulue",
+							},
+						},
+					},
+					PomProperties: &syftPkg.PomProperties{
+						Path:       "pom-path-info",
+						Name:       "pom-name-info",
+						GroupID:    "pom-group-id-info",
+						ArtifactID: "pom-artifact-id-info",
+						Version:    "pom-version-info",
+						Extra: map[string]string{
+							"extra-key": "extra-value",
+						},
+					},
+				},
+			},
+			metadata: JavaMetadata{
+				VirtualPath:   "virtual-path-info",
+				PomArtifactID: "pom-artifact-id-info",
+				PomGroupID:    "pom-group-id-info",
+				ManifestName:  "main-section-name-info",
+			},
+		},
+		// below cases we assert that there is no mapped metadata
+		{
+			name: "apk-metadata",
+			syftPkg: syftPkg.Package{
+				MetadataType: syftPkg.ApkMetadataType,
+				Metadata: syftPkg.ApkMetadata{
+					Package:          "a",
+					OriginPackage:    "a",
+					Maintainer:       "a",
+					Version:          "a",
+					License:          "a",
+					Architecture:     "a",
+					URL:              "a",
+					Description:      "a",
+					Size:             1,
+					InstalledSize:    1,
+					PullDependencies: "a",
+					PullChecksum:     "a",
+					GitCommitOfAport: "a",
+				},
+			},
+			metadata: nil,
+		},
+		{
+			name: "npm-metadata",
+			syftPkg: syftPkg.Package{
+				MetadataType: syftPkg.NpmPackageJSONMetadataType,
+				Metadata: syftPkg.NpmPackageJSONMetadata{
+					Author:      "a",
+					Homepage:    "a",
+					Description: "a",
+					URL:         "a",
+				},
+			},
+			metadata: nil,
+		},
+		{
+			name: "python-metadata",
+			syftPkg: syftPkg.Package{
+				MetadataType: syftPkg.PythonPackageMetadataType,
+				Metadata: syftPkg.PythonPackageMetadata{
+					Name:                 "a",
+					Version:              "a",
+					License:              "a",
+					Author:               "a",
+					AuthorEmail:          "a",
+					Platform:             "a",
+					SitePackagesRootPath: "a",
+				},
+			},
+			metadata: nil,
+		},
+		{
+			name: "gem-metadata",
+			syftPkg: syftPkg.Package{
+				MetadataType: syftPkg.GemMetadataType,
+				Metadata: syftPkg.GemMetadata{
+					Name:     "a",
+					Version:  "a",
+					Homepage: "a",
+				},
+			},
+			metadata: nil,
+		},
+		{
+			name: "kb-metadata",
+			syftPkg: syftPkg.Package{
+				MetadataType: syftPkg.KbPackageMetadataType,
+				Metadata: syftPkg.KbPackageMetadata{
+					ProductID: "a",
+					Kb:        "a",
+				},
+			},
+			metadata: nil,
+		},
+		{
+			name: "rust-metadata",
+			syftPkg: syftPkg.Package{
+				MetadataType: syftPkg.RustCargoPackageMetadataType,
+				Metadata: syftPkg.CargoPackageMetadata{
+					Name:     "a",
+					Version:  "a",
+					Source:   "a",
+					Checksum: "a",
+				},
+			},
+			metadata: nil,
+		},
+	}
+
+	// capture each observed metadata type, we should see all of them relate to what syft provides by the end of testing
+	observedMetadataTypes := set.NewStringSet()
+	expectedMetadataTypes := set.NewStringSet()
+	for _, ty := range syftPkg.AllMetadataTypes {
+		expectedMetadataTypes.Add(string(ty))
+	}
+
+	// run all of our cases
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			observedMetadataTypes.Add(string(test.syftPkg.MetadataType))
+			assert.Equal(t, test.metadata, New(&test.syftPkg).Metadata)
+		})
+	}
+
+	// did we see all possible metadata types? if not, then there is an uncovered case and this test should error out
+	if !expectedMetadataTypes.IsEqual(observedMetadataTypes) {
+		t.Errorf("did not observe all possible package metadata types: missing: %+v extra %+v",
+			strset.Difference(expectedMetadataTypes, observedMetadataTypes),
+			strset.Difference(observedMetadataTypes, expectedMetadataTypes),
+		)
+	}
+}


### PR DESCRIPTION
The java virtual path is akin to the `Package.Locations` field except there is additional info that can track location information within nested jars with arbitrary depth. This brings further clarity as to which package exactly was matched on and exactly where it is. No other package type has this requirement, only java.

Testing was added to cover mapping of all package metadata from syft to the grype equivalent.