### PR TITLE
Allow registry auth config without authority value

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca
 	github.com/anchore/grype-db v0.0.0-20210322113357-5aec8a7cb962
-	github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6
+	github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f
 	github.com/anchore/syft v0.15.3-0.20210524151556-2ca2f0350133
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/anchore/grype-db v0.0.0-20210322113357-5aec8a7cb962 h1:yW3xed7hbEjdmE
 github.com/anchore/grype-db v0.0.0-20210322113357-5aec8a7cb962/go.mod h1:LINmipRzG88vnJEWvgMMDVCFH1qZsj7+bjmpERlSyaA=
 github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6 h1:g9ZS2V/T0wxseccI4t1hQTqWBek5DVOQZOzzdWBjwnU=
 github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
+github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f h1:bFadyOLOkzME3BrZFZ5m8cf/b2hsn3aMSS9s+SKubRk=
+github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
 github.com/anchore/syft v0.15.3-0.20210524151556-2ca2f0350133 h1:37KItVunSU9vX8umE0PoH8SKZ+XR7itt2+DehSjxv9A=
 github.com/anchore/syft v0.15.3-0.20210524151556-2ca2f0350133/go.mod h1:5k4L4CA5ZFFmRdk64oj0AV1ZqvLFZVOpfCk8DfUOsVc=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=

--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -29,7 +29,7 @@ func (cfg *registry) parseConfigValues() {
 		os.Getenv("GRYPE_REGISTRY_AUTH_PASSWORD"),
 		os.Getenv("GRYPE_REGISTRY_AUTH_TOKEN")
 
-	if hasNonEmptyCredentials(authority, username, password, token) {
+	if hasNonEmptyCredentials(username, password, token) {
 		// note: we prepend the credentials such that the environment variables take precedence over on-disk configuration.
 		cfg.Auth = append([]RegistryCredentials{
 			{
@@ -42,8 +42,8 @@ func (cfg *registry) parseConfigValues() {
 	}
 }
 
-func hasNonEmptyCredentials(authority, username, password, token string) bool {
-	return authority != "" && password != "" && username != "" || authority != "" && token != ""
+func hasNonEmptyCredentials(username, password, token string) bool {
+	return password != "" && username != "" || token != ""
 }
 
 func (cfg *registry) ToOptions() *image.RegistryOptions {

--- a/internal/config/registry_test.go
+++ b/internal/config/registry_test.go
@@ -9,51 +9,47 @@ import (
 
 func TestHasNonEmptyCredentials(t *testing.T) {
 	tests := []struct {
-		auth, username, password, token string
-		expected                        bool
+		username, password, token string
+		expected                  bool
 	}{
 		{
-			"", "", "", "",
+			"", "", "",
 			false,
 		},
 		{
-			"auth", "", "", "",
+			"user", "", "",
 			false,
 		},
 		{
-			"auth", "user", "", "",
+			"", "pass", "",
 			false,
 		},
 		{
-			"auth", "", "pass", "",
-			false,
-		},
-		{
-			"auth", "", "pass", "tok",
+			"", "pass", "tok",
 			true,
 		},
 		{
-			"auth", "user", "", "tok",
+			"user", "", "tok",
 			true,
 		},
 		{
-			"auth", "", "", "tok",
+			"", "", "tok",
 			true,
 		},
 		{
-			"auth", "user", "pass", "tok",
+			"user", "pass", "tok",
 			true,
 		},
 
 		{
-			"auth", "user", "pass", "",
+			"user", "pass", "",
 			true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
-			assert.Equal(t, test.expected, hasNonEmptyCredentials(test.auth, test.username, test.password, test.token))
+			assert.Equal(t, test.expected, hasNonEmptyCredentials(test.username, test.password, test.token))
 		})
 	}
 }

--- a/test/cli/registry_auth_test.go
+++ b/test/cli/registry_auth_test.go
@@ -32,7 +32,7 @@ func TestRegistryAuth(t *testing.T) {
 			assertions: []traitAssertion{
 				assertInOutput("source=OciRegistry"),
 				assertInOutput("localhost:5000/something:latest"),
-				assertInOutput(`using registry credentials for "localhost:5000"`),
+				assertInOutput(`using basic auth for registry "localhost:5000"`),
 			},
 		},
 		{
@@ -45,7 +45,7 @@ func TestRegistryAuth(t *testing.T) {
 			assertions: []traitAssertion{
 				assertInOutput("source=OciRegistry"),
 				assertInOutput("localhost:5000/something:latest"),
-				assertInOutput(`using registry token for "localhost:5000"`),
+				assertInOutput(`using token for registry "localhost:5000"`),
 			},
 		},
 		{


### PR DESCRIPTION
Related to anchore/stereoscope#68

Allows Grype to use registry credentials in cases where the user hasn't provided an "authority" config value