### PR TITLE
Add go.mod tidy CI check

### DIFF
--- a/.github/scripts/go_mod_tidy_check.sh
+++ b/.github/scripts/go_mod_tidy_check.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -u
+
+TMP_GOMOD=$(mktemp)
+TMP_GOSUM=$(mktemp)
+
+trap "rm -f ${TMP_GOSUM} ${TMP_GOMOD}" EXIT
+
+cp go.mod "${TMP_GOMOD}"
+cp go.sum "${TMP_GOSUM}"
+
+go mod tidy
+
+DIFF_MOD=$(diff -u "${TMP_GOMOD}" go.mod)
+DIFF_SUM=$(diff -u "${TMP_GOSUM}" go.sum)
+
+cp "${TMP_GOMOD}" go.mod
+cp "${TMP_GOSUM}" go.sum
+
+if [[ -n "${DIFF_MOD}" || -n "${DIFF_SUM}" ]]; then
+    echo "go tidy changes are needed; please run make tidy"
+    echo "go.mod diff:"
+    echo "${DIFF_MOD}"
+    echo "go.sum diff:"
+    echo "${DIFF_SUM}"
+    exit 1
+fi

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ bootstrap: ## Download and install all go dependencies (+ prep tooling in the ./
 	curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh -s -- -b $(TEMPDIR)/ v0.160.0
 
 .PHONY: static-analysis
-static-analysis: lint check-licenses
+static-analysis: lint check-go-mod-tidy check-licenses
 
 .PHONY: lint
 lint: ## Run gofmt + golangci lint checks
@@ -104,6 +104,9 @@ lint: ## Run gofmt + golangci lint checks
 	$(eval MALFORMED_FILENAMES := $(shell find . | grep -e ':'))
 	@bash -c "[[ '$(MALFORMED_FILENAMES)' == '' ]] || (printf '\nfound unsupported filename characters:\n$(MALFORMED_FILENAMES)\n\n' && false)"
 
+check-go-mod-tidy:
+	@ .github/scripts/go_mod_tidy_check.sh && echo "go.mod is tidy!"
+
 .PHONY: validate-cyclonedx-schema
 validate-cyclonedx-schema:
 	cd schema/cyclonedx && make
@@ -113,6 +116,7 @@ lint-fix: ## Auto-format all source code + run golangci lint fixers
 	$(call title,Running lint fixers)
 	gofmt -w -s .
 	$(LINTCMD) --fix
+	go mod tidy
 
 .PHONY: check-licenses
 check-licenses:

--- a/go.sum
+++ b/go.sum
@@ -124,7 +124,6 @@ github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca h1:rLyc7Rih76
 github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/grype-db v0.0.0-20210322113357-5aec8a7cb962 h1:yW3xed7hbEjdmEXRnBFit5AGN0exPIFgE1jgW9bks+Q=
 github.com/anchore/grype-db v0.0.0-20210322113357-5aec8a7cb962/go.mod h1:LINmipRzG88vnJEWvgMMDVCFH1qZsj7+bjmpERlSyaA=
-github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6 h1:g9ZS2V/T0wxseccI4t1hQTqWBek5DVOQZOzzdWBjwnU=
 github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f h1:bFadyOLOkzME3BrZFZ5m8cf/b2hsn3aMSS9s+SKubRk=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=


### PR DESCRIPTION
Our go.mod should always be tidy --this PR adds a specific linting step to verify this on each PR.

This is important during the release step, where we run `go mod download`, which may change the go.sum (putting the workspace into an unreleasable state). The current workaround is to run `go mod tidy` to re-tidy the `go.sum` after the `go mod download`. This is OK, however, the assumption is that the go.mod and go.sum were in a tidy state before the download. If this isn't the case then the git state will still be dirty and the workspace will be in an unreleasable state.