### PR TITLE
Add fix state, vendor advisories + JSON presentation refactors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,7 +28,6 @@ linters:
     - misspell
     - nakedret
     - nolintlint
-    - prealloc
     - rowserrcheck
     - scopelint
     - staticcheck
@@ -51,6 +50,7 @@ linters:
 #    - interfacer  # this is a good idea, but is no longer supported and is prone to false positives
 #    - lll         # without a way to specify per-line exception cases, this is not usable
 #    - maligned    # this is an excellent linter, but tricky to optimize and we are not sensitive to memory layout optimizations
+#    - prealloc    # following this rule isn't consistently a good idea, as it sometimes forces unnecessary allocations that result in less idiomatic code
 #    - nestif
 #    - testpackage
 #    - wsl

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -262,7 +262,7 @@ func hitSeverityThreshold(thresholdSeverity *vulnerability.Severity, matches mat
 	if thresholdSeverity != nil {
 		var maxDiscoveredSeverity vulnerability.Severity
 		for m := range matches.Enumerate() {
-			metadata, err := metadataProvider.GetMetadata(m.Vulnerability.ID, m.Vulnerability.RecordSource)
+			metadata, err := metadataProvider.GetMetadata(m.Vulnerability.ID, m.Vulnerability.Namespace)
 			if err != nil {
 				continue
 			}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -45,8 +45,8 @@ func TestAboveAllowableSeverity(t *testing.T) {
 	matches.Add(thePkg, match.Match{
 		Type: match.ExactDirectMatch,
 		Vulnerability: vulnerability.Vulnerability{
-			ID:           "CVE-2014-fake-1",
-			RecordSource: "source-1",
+			ID:        "CVE-2014-fake-1",
+			Namespace: "source-1",
 		},
 		Package: thePkg,
 	})

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -30,7 +30,7 @@ func printVersion(_ *cobra.Command, _ []string) {
 	switch outputFormat {
 	case "text":
 		fmt.Println("Application:         ", internal.ApplicationName)
-		fmt.Println("Versions:             ", versionInfo.Version)
+		fmt.Println("Version:             ", versionInfo.Version)
 		fmt.Println("BuildDate:           ", versionInfo.BuildDate)
 		fmt.Println("GitCommit:           ", versionInfo.GitCommit)
 		fmt.Println("GitTreeState:        ", versionInfo.GitTreeState)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -30,7 +30,7 @@ func printVersion(_ *cobra.Command, _ []string) {
 	switch outputFormat {
 	case "text":
 		fmt.Println("Application:         ", internal.ApplicationName)
-		fmt.Println("Version:             ", versionInfo.Version)
+		fmt.Println("Versions:             ", versionInfo.Version)
 		fmt.Println("BuildDate:           ", versionInfo.BuildDate)
 		fmt.Println("GitCommit:           ", versionInfo.GitCommit)
 		fmt.Println("GitTreeState:        ", versionInfo.GitTreeState)

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca
 	github.com/anchore/grype-db v0.0.0-20210527140125-6f881b00e927
-	github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6
-	github.com/anchore/syft v0.15.2-0.20210506190909-360eb74cc71c
+	github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f
+	github.com/anchore/syft v0.16.2-0.20210526131825-2754c889eb0e
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/dustin/go-humanize v1.0.0
 	github.com/facebookincubator/nvdtools v0.1.4

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/adrg/xdg v0.2.1
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca
-	github.com/anchore/grype-db v0.0.0-20210525151544-6d0ab949b8fb
-	github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f
-	github.com/anchore/syft v0.15.3-0.20210524151556-2ca2f0350133
+	github.com/anchore/grype-db v0.0.0-20210520150424-d5068175bf94
+	github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6
+	github.com/anchore/syft v0.15.2-0.20210506190909-360eb74cc71c
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/dustin/go-humanize v1.0.0
 	github.com/facebookincubator/nvdtools v0.1.4
@@ -44,3 +44,5 @@ require (
 	gopkg.in/ini.v1 v1.57.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 )
+
+replace github.com/anchore/grype-db => ../grype-db

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/adrg/xdg v0.2.1
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca
-	github.com/anchore/grype-db v0.0.0-20210520150424-d5068175bf94
+	github.com/anchore/grype-db v0.0.0-20210527140125-6f881b00e927
 	github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6
 	github.com/anchore/syft v0.15.2-0.20210506190909-360eb74cc71c
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
@@ -44,5 +44,3 @@ require (
 	gopkg.in/ini.v1 v1.57.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 )
-
-replace github.com/anchore/grype-db => ../grype-db

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,7 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca h1:rLyc7Rih769rYABQe4nBPt3jHJd/snBuVvKKGoy5HEc=
 github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/grype-db v0.0.0-20210525151544-6d0ab949b8fb h1:kngIkZ7X1mzY9mIo7me2iXx7GYrbzzEQiljBaOlQ4oc=
-github.com/anchore/grype-db v0.0.0-20210525151544-6d0ab949b8fb/go.mod h1:LINmipRzG88vnJEWvgMMDVCFH1qZsj7+bjmpERlSyaA=
+github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6 h1:g9ZS2V/T0wxseccI4t1hQTqWBek5DVOQZOzzdWBjwnU=
 github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f h1:bFadyOLOkzME3BrZFZ5m8cf/b2hsn3aMSS9s+SKubRk=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,7 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alicebob/sqlittle v1.4.0 h1:vgYt0nAjhdf/hg52MjKJ84g/uTzBPfrvI+VUBrIghxA=
 github.com/alicebob/sqlittle v1.4.0/go.mod h1:Co1L1qxHqCwf41puWhk2HOodojR0mcsAV4BIt8byZh8=
+github.com/anchore/client-go v0.0.0-20210222170800-9c70f9b80bcf h1:DYssiUV1pBmKqzKsm4mqXx8artqC0Q8HgZsVI3lMsAg=
 github.com/anchore/client-go v0.0.0-20210222170800-9c70f9b80bcf/go.mod h1:FaODhIA06mxO1E6R32JE0TL1JWZZkmjRIAd4ULvHUKk=
 github.com/anchore/go-rpmdb v0.0.0-20210415132930-2460011e83c6 h1:wEN3HXc3VuC4wo7Cz27YCpeQ4gaB5ASKwMwM5GdFsew=
 github.com/anchore/go-rpmdb v0.0.0-20210415132930-2460011e83c6/go.mod h1:8jNYOxCJC5kyD/Ct4MbzsDN2hOhRoCAzQcb/7KdYYGw=
@@ -124,13 +125,14 @@ github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca h1:rLyc7Rih76
 github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/grype-db v0.0.0-20210527140125-6f881b00e927 h1:4DX6mymMdYIH1ptYEXZupij8x8AeNYR0Q9ILsqbE3nc=
 github.com/anchore/grype-db v0.0.0-20210527140125-6f881b00e927/go.mod h1:XSlPf1awNrMpah+rHbWrzgUvnmWLgn/KkdicxERVClg=
-github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6 h1:g9ZS2V/T0wxseccI4t1hQTqWBek5DVOQZOzzdWBjwnU=
-github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
-github.com/anchore/syft v0.15.2-0.20210506190909-360eb74cc71c h1:+ZGL3hHwPxBhQPEjyBU9rB5+tTVAOd8P6d3NMvpxSNM=
-github.com/anchore/syft v0.15.2-0.20210506190909-360eb74cc71c/go.mod h1:5k4L4CA5ZFFmRdk64oj0AV1ZqvLFZVOpfCk8DfUOsVc=
+github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f h1:bFadyOLOkzME3BrZFZ5m8cf/b2hsn3aMSS9s+SKubRk=
+github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
+github.com/anchore/syft v0.16.2-0.20210526131825-2754c889eb0e h1:9ZDikTvJRDfIP4ltdChCZ4dd5iEAjn7ZrnGreM5dI+o=
+github.com/anchore/syft v0.16.2-0.20210526131825-2754c889eb0e/go.mod h1:9jf8z5ubQXc1XuMpmCnHnXtB6NtuMdO8k+hfcAWIsNM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
+github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apex/log v1.1.4/go.mod h1:AlpoD9aScyQfJDVHmLMEcx4oU6LqzkWp4Mg9GdAcEvQ=
 github.com/apex/log v1.3.0 h1:1fyfbPvUwD10nMoh3hY6MXzvZShJQn9/ck7ATgAt5pA=
@@ -649,6 +651,7 @@ github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/profile v1.5.0 h1:042Buzk+NhDI+DeSAA62RwJL8VAuZUMQZUjCsRz1Mug=
 github.com/pkg/profile v1.5.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/go.sum
+++ b/go.sum
@@ -122,12 +122,12 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca h1:rLyc7Rih769rYABQe4nBPt3jHJd/snBuVvKKGoy5HEc=
 github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
+github.com/anchore/grype-db v0.0.0-20210527140125-6f881b00e927 h1:4DX6mymMdYIH1ptYEXZupij8x8AeNYR0Q9ILsqbE3nc=
+github.com/anchore/grype-db v0.0.0-20210527140125-6f881b00e927/go.mod h1:XSlPf1awNrMpah+rHbWrzgUvnmWLgn/KkdicxERVClg=
 github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6 h1:g9ZS2V/T0wxseccI4t1hQTqWBek5DVOQZOzzdWBjwnU=
 github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
-github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f h1:bFadyOLOkzME3BrZFZ5m8cf/b2hsn3aMSS9s+SKubRk=
-github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
-github.com/anchore/syft v0.15.3-0.20210524151556-2ca2f0350133 h1:37KItVunSU9vX8umE0PoH8SKZ+XR7itt2+DehSjxv9A=
-github.com/anchore/syft v0.15.3-0.20210524151556-2ca2f0350133/go.mod h1:5k4L4CA5ZFFmRdk64oj0AV1ZqvLFZVOpfCk8DfUOsVc=
+github.com/anchore/syft v0.15.2-0.20210506190909-360eb74cc71c h1:+ZGL3hHwPxBhQPEjyBU9rB5+tTVAOd8P6d3NMvpxSNM=
+github.com/anchore/syft v0.15.2-0.20210506190909-360eb74cc71c/go.mod h1:5k4L4CA5ZFFmRdk64oj0AV1ZqvLFZVOpfCk8DfUOsVc=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=

--- a/grype/match/match.go
+++ b/grype/match/match.go
@@ -13,7 +13,7 @@ type Match struct {
 	Confidence    float64                     // The certainty of the match as a ratio (currently unused, reserved for future use).
 	Vulnerability vulnerability.Vulnerability // The vulnerability details of the match.
 	Package       pkg.Package                 // The package used to search for a match.
-	SearchKey     map[string]interface{}      // The specific attributes that were used to search (other than package name and version) --this indicates "how" the match was made.
+	SearchedBy    map[string]interface{}      // The specific attributes that were used to search (other than package name and version) --this indicates "how" the match was made.
 	SearchMatches map[string]interface{}      // The specific attributes on the vulnerability object that were matched with --this indicates "what" was matched on / within.
 	Matcher       MatcherType                 // The matcher object that discovered the match.
 }
@@ -25,5 +25,5 @@ func (m Match) String() string {
 
 // Summary is a short string representation of the match object.
 func (m Match) Summary() string {
-	return fmt.Sprintf("vuln='%s' type='%s' key='%s' foundBy='%s'", m.Vulnerability.ID, m.Type, m.SearchKey, m.Matcher)
+	return fmt.Sprintf("vuln='%s' type='%s' key='%s' foundBy='%s'", m.Vulnerability.ID, m.Type, m.SearchedBy, m.Matcher)
 }

--- a/grype/matcher/apk/matcher.go
+++ b/grype/matcher/apk/matcher.go
@@ -84,7 +84,7 @@ cveLoop:
 		// there is a secdb entry...
 		for _, vuln := range secDbVulnerabilitiesForID {
 			// ...is there a fixed in entry? (should always be yes)
-			if vuln.FixedInVersion == "" {
+			if len(vuln.Fix.Versions) == 0 {
 				continue
 			}
 

--- a/grype/matcher/apk/matcher_test.go
+++ b/grype/matcher/apk/matcher_test.go
@@ -75,7 +75,7 @@ func TestSecDBOnlyMatch(t *testing.T) {
 			Confidence:    1.0,
 			Vulnerability: *vulnFound,
 			Package:       p,
-			SearchKey: map[string]interface{}{
+			SearchedBy: map[string]interface{}{
 				"distro": map[string]string{
 					"type":    d.Type.String(),
 					"version": d.RawVersion,
@@ -151,7 +151,7 @@ func TestBothSecdbAndNvdMatches(t *testing.T) {
 			Confidence:    1.0,
 			Vulnerability: *vulnFound,
 			Package:       p,
-			SearchKey: map[string]interface{}{
+			SearchedBy: map[string]interface{}{
 				"distro": map[string]string{
 					"type":    d.Type.String(),
 					"version": d.RawVersion,
@@ -228,7 +228,7 @@ func TestBothSecdbAndNvdMatches_DifferentPackageName(t *testing.T) {
 			Confidence:    1.0,
 			Vulnerability: *vulnFound,
 			Package:       p,
-			SearchKey: map[string]interface{}{
+			SearchedBy: map[string]interface{}{
 				"distro": map[string]string{
 					"type":    d.Type.String(),
 					"version": d.RawVersion,
@@ -291,7 +291,7 @@ func TestNvdOnlyMatches(t *testing.T) {
 			Confidence:    0.9,
 			Vulnerability: *vulnFound,
 			Package:       p,
-			SearchKey: map[string]interface{}{
+			SearchedBy: map[string]interface{}{
 				"cpe": "cpe:2.3:a:*:libvncserver:0.9.9:*:*:*:*:*:*:*",
 			},
 			SearchMatches: map[string]interface{}{

--- a/grype/matcher/common/cpe_matchers.go
+++ b/grype/matcher/common/cpe_matchers.go
@@ -54,7 +54,7 @@ func FindMatchesByPackageCPE(store vulnerability.ProviderByCPE, p pkg.Package, u
 					Vulnerability: *vuln,
 					Package:       p,
 					Matcher:       upstreamMatcher,
-					SearchKey: map[string]interface{}{
+					SearchedBy: map[string]interface{}{
 						"cpe": cpe.BindToFmtString(),
 					},
 					SearchMatches: map[string]interface{}{

--- a/grype/matcher/common/cpe_matchers_test.go
+++ b/grype/matcher/common/cpe_matchers_test.go
@@ -119,7 +119,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 						Language: syftPkg.Ruby,
 						Type:     syftPkg.GemPkg,
 					},
-					SearchKey: map[string]interface{}{
+					SearchedBy: map[string]interface{}{
 						"cpe": "cpe:2.3:*:activerecord:activerecord:3.7.5:rando1:*:rando2:*:ruby:*:*",
 					},
 					SearchMatches: map[string]interface{}{
@@ -160,7 +160,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 						Language: syftPkg.Ruby,
 						Type:     syftPkg.GemPkg,
 					},
-					SearchKey: map[string]interface{}{
+					SearchedBy: map[string]interface{}{
 						"cpe": "cpe:2.3:*:activerecord:activerecord:3.7.3:rando1:*:rando2:*:ruby:*:*",
 					},
 					SearchMatches: map[string]interface{}{
@@ -186,7 +186,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 						Language: syftPkg.Ruby,
 						Type:     syftPkg.GemPkg,
 					},
-					SearchKey: map[string]interface{}{
+					SearchedBy: map[string]interface{}{
 						"cpe": "cpe:2.3:*:activerecord:activerecord:3.7.3:rando1:*:rando2:*:ruby:*:*",
 					},
 					SearchMatches: map[string]interface{}{
@@ -227,7 +227,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 						Language: syftPkg.Ruby,
 						Type:     syftPkg.GemPkg,
 					},
-					SearchKey: map[string]interface{}{
+					SearchedBy: map[string]interface{}{
 						"cpe": "cpe:2.3:*:activerecord:activerecord:4.0.1:rando1:*:rando2:*:ruby:*:*",
 					},
 					SearchMatches: map[string]interface{}{
@@ -272,7 +272,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 						Name:    "awesome",
 						Version: "98SE1",
 					},
-					SearchKey: map[string]interface{}{
+					SearchedBy: map[string]interface{}{
 						"cpe": "cpe:2.3:*:awesome:awesome:98SE1:rando1:*:rando2:*:dunno:*:*",
 					},
 					SearchMatches: map[string]interface{}{

--- a/grype/matcher/common/distro_matchers.go
+++ b/grype/matcher/common/distro_matchers.go
@@ -42,7 +42,7 @@ func FindMatchesByPackageDistro(store vulnerability.ProviderByDistro, d *distro.
 				Vulnerability: *vuln,
 				Package:       p,
 				Matcher:       upstreamMatcher,
-				SearchKey: map[string]interface{}{
+				SearchedBy: map[string]interface{}{
 					"distro": map[string]string{
 						"type":    d.Type.String(),
 						"version": d.RawVersion,

--- a/grype/matcher/common/distro_matchers_test.go
+++ b/grype/matcher/common/distro_matchers_test.go
@@ -82,7 +82,7 @@ func TestFindMatchesByPackageDistro(t *testing.T) {
 			},
 			Confidence: 1,
 			Package:    p,
-			SearchKey: map[string]interface{}{
+			SearchedBy: map[string]interface{}{
 				"distro": map[string]string{
 					"type":    "debian",
 					"version": "8",

--- a/grype/matcher/common/language_matchers.go
+++ b/grype/matcher/common/language_matchers.go
@@ -36,7 +36,7 @@ func FindMatchesByPackageLanguage(store vulnerability.ProviderByLanguage, l syft
 				Vulnerability: *vuln,
 				Package:       p,
 				Matcher:       upstreamMatcher,
-				SearchKey: map[string]interface{}{
+				SearchedBy: map[string]interface{}{
 					"language": l.String(),
 				},
 				SearchMatches: map[string]interface{}{

--- a/grype/matcher/common/language_matchers_test.go
+++ b/grype/matcher/common/language_matchers_test.go
@@ -66,7 +66,7 @@ func TestFindMatchesByPackageLanguage(t *testing.T) {
 			},
 			Confidence: 1,
 			Package:    p,
-			SearchKey: map[string]interface{}{
+			SearchedBy: map[string]interface{}{
 				"language": "ruby",
 			},
 			SearchMatches: map[string]interface{}{

--- a/grype/matcher/msrc/matcher_test.go
+++ b/grype/matcher/msrc/matcher_test.go
@@ -27,7 +27,7 @@ func TestMatches(t *testing.T) {
 	store := mockStore{
 		backend: map[string]map[string][]db.Vulnerability{
 			"microsoft": {
-				"Windows 10 Version 1903 for ARM64-based Systems": []db.Vulnerability{
+				"Windows 10 Versions 1903 for ARM64-based Systems": []db.Vulnerability{
 					{
 						ID:                "CVE-2020-1",
 						VersionConstraint: "878786 || 878787",
@@ -41,7 +41,7 @@ func TestMatches(t *testing.T) {
 					},
 				},
 				// Does not match, the package is Windows 10, not 11
-				"Windows 11 Version 1903 for ARM64-based Systems": []db.Vulnerability{
+				"Windows 11 Versions 1903 for ARM64-based Systems": []db.Vulnerability{
 					{
 						ID:                "CVE-2020-1",
 						VersionConstraint: "878786 || 878787",
@@ -55,12 +55,12 @@ func TestMatches(t *testing.T) {
 	provider := vulnerability.NewProviderFromStore(&store)
 
 	m := Matcher{}
-	d, err := distro.NewDistro(distro.Windows, "878787", "Windows 10 Version 1903 for ARM64-based Systems")
+	d, err := distro.NewDistro(distro.Windows, "878787", "Windows 10 Versions 1903 for ARM64-based Systems")
 	if err != nil {
 		t.Fatalf("failed to create a new distro: %+v", err)
 	}
 	p := pkg.Package{
-		Name:    "Windows 10 Version 1903 for ARM64-based Systems",
+		Name:    "Windows 10 Versions 1903 for ARM64-based Systems",
 		Version: "878787",
 		Type:    syftPkg.KbPkg,
 	}

--- a/grype/presenter/cyclonedx/presenter_test.go
+++ b/grype/presenter/cyclonedx/presenter_test.go
@@ -46,8 +46,8 @@ func createResults() (match.Matches, []pkg.Package) {
 	var match1 = match.Match{
 		Type: match.ExactDirectMatch,
 		Vulnerability: vulnerability.Vulnerability{
-			ID:           "CVE-1999-0001",
-			RecordSource: "source-1",
+			ID:        "CVE-1999-0001",
+			Namespace: "source-1",
 		},
 		Package: pkg1,
 		Matcher: match.DpkgMatcher,
@@ -56,8 +56,8 @@ func createResults() (match.Matches, []pkg.Package) {
 	var match2 = match.Match{
 		Type: match.ExactIndirectMatch,
 		Vulnerability: vulnerability.Vulnerability{
-			ID:           "CVE-1999-0002",
-			RecordSource: "source-2",
+			ID:        "CVE-1999-0002",
+			Namespace: "source-2",
 		},
 		Package: pkg2,
 		Matcher: match.DpkgMatcher,

--- a/grype/presenter/cyclonedx/presenter_test.go
+++ b/grype/presenter/cyclonedx/presenter_test.go
@@ -61,7 +61,7 @@ func createResults() (match.Matches, []pkg.Package) {
 		},
 		Package: pkg2,
 		Matcher: match.DpkgMatcher,
-		SearchKey: map[string]interface{}{
+		SearchedBy: map[string]interface{}{
 			"some": "key",
 		},
 	}

--- a/grype/presenter/cyclonedx/vulnerability.go
+++ b/grype/presenter/cyclonedx/vulnerability.go
@@ -74,7 +74,7 @@ func cvssVersionToMethod(version string) (string, error) {
 
 // NewVulnerability creates a Vulnerability document from a match and the metadata provider
 func NewVulnerability(m match.Match, p vulnerability.MetadataProvider) (Vulnerability, error) {
-	metadata, err := p.GetMetadata(m.Vulnerability.ID, m.Vulnerability.RecordSource)
+	metadata, err := p.GetMetadata(m.Vulnerability.ID, m.Vulnerability.Namespace)
 	if err != nil {
 		return Vulnerability{}, fmt.Errorf("unable to fetch vuln=%q metadata: %+v", m.Vulnerability.ID, err)
 	}
@@ -116,13 +116,13 @@ func NewVulnerability(m match.Match, p vulnerability.MetadataProvider) (Vulnerab
 		Ref: uuid.New().URN(),
 		ID:  m.Vulnerability.ID,
 		Source: Source{
-			Name: m.Vulnerability.RecordSource,
+			Name: m.Vulnerability.Namespace,
 			URL:  makeVulnerabilityURL(m.Vulnerability.ID),
 		},
 		Ratings:     ratings,
 		Description: metadata.Description,
 		Advisories: &Advisories{
-			Advisory: metadata.Links,
+			Advisory: metadata.URLs,
 		},
 	}
 

--- a/grype/presenter/json/presenter_test.go
+++ b/grype/presenter/json/presenter_test.go
@@ -77,7 +77,7 @@ func TestJsonImgsPresenter(t *testing.T) {
 		},
 		Package: pkg1,
 		Matcher: match.DpkgMatcher,
-		SearchKey: map[string]interface{}{
+		SearchedBy: map[string]interface{}{
 			"distro": map[string]string{
 				"type":    "ubuntu",
 				"version": "20.04",
@@ -96,7 +96,7 @@ func TestJsonImgsPresenter(t *testing.T) {
 		},
 		Package: pkg1,
 		Matcher: match.DpkgMatcher,
-		SearchKey: map[string]interface{}{
+		SearchedBy: map[string]interface{}{
 			"cpe": "somecpe",
 		},
 		SearchMatches: map[string]interface{}{
@@ -117,7 +117,7 @@ func TestJsonImgsPresenter(t *testing.T) {
 		},
 		Package: pkg1,
 		Matcher: match.DpkgMatcher,
-		SearchKey: map[string]interface{}{
+		SearchedBy: map[string]interface{}{
 			"language": "java",
 		},
 		SearchMatches: map[string]interface{}{
@@ -211,7 +211,7 @@ func TestJsonDirsPresenter(t *testing.T) {
 		},
 		Package: pkg1,
 		Matcher: match.DpkgMatcher,
-		SearchKey: map[string]interface{}{
+		SearchedBy: map[string]interface{}{
 			"distro": map[string]string{
 				"type":    "ubuntu",
 				"version": "20.04",
@@ -230,7 +230,7 @@ func TestJsonDirsPresenter(t *testing.T) {
 		},
 		Package: pkg1,
 		Matcher: match.DpkgMatcher,
-		SearchKey: map[string]interface{}{
+		SearchedBy: map[string]interface{}{
 			"cpe": "somecpe",
 		},
 		SearchMatches: map[string]interface{}{
@@ -251,7 +251,7 @@ func TestJsonDirsPresenter(t *testing.T) {
 		},
 		Package: pkg1,
 		Matcher: match.DpkgMatcher,
-		SearchKey: map[string]interface{}{
+		SearchedBy: map[string]interface{}{
 			"language": "java",
 		},
 		SearchMatches: map[string]interface{}{

--- a/grype/presenter/json/presenter_test.go
+++ b/grype/presenter/json/presenter_test.go
@@ -67,9 +67,13 @@ func TestJsonImgsPresenter(t *testing.T) {
 	var match1 = match.Match{
 		Type: match.ExactDirectMatch,
 		Vulnerability: vulnerability.Vulnerability{
-			ID:             "CVE-1999-0001",
-			RecordSource:   "source-1",
-			FixedInVersion: "the-next-version",
+			ID:        "CVE-1999-0001",
+			Namespace: "source-1",
+			Fix: vulnerability.Fix{
+				Versions: []string{
+					"the-next-versions",
+				},
+			},
 		},
 		Package: pkg1,
 		Matcher: match.DpkgMatcher,
@@ -87,8 +91,8 @@ func TestJsonImgsPresenter(t *testing.T) {
 	var match2 = match.Match{
 		Type: match.ExactIndirectMatch,
 		Vulnerability: vulnerability.Vulnerability{
-			ID:           "CVE-1999-0002",
-			RecordSource: "source-2",
+			ID:        "CVE-1999-0002",
+			Namespace: "source-2",
 		},
 		Package: pkg1,
 		Matcher: match.DpkgMatcher,
@@ -103,9 +107,13 @@ func TestJsonImgsPresenter(t *testing.T) {
 	var match3 = match.Match{
 		Type: match.ExactIndirectMatch,
 		Vulnerability: vulnerability.Vulnerability{
-			ID:             "CVE-1999-0003",
-			RecordSource:   "source-1",
-			FixedInVersion: "the-other-next-version",
+			ID:        "CVE-1999-0003",
+			Namespace: "source-1",
+			Fix: vulnerability.Fix{
+				Versions: []string{
+					"the-other-next-version",
+				},
+			},
 		},
 		Package: pkg1,
 		Matcher: match.DpkgMatcher,
@@ -193,9 +201,13 @@ func TestJsonDirsPresenter(t *testing.T) {
 	var match1 = match.Match{
 		Type: match.ExactDirectMatch,
 		Vulnerability: vulnerability.Vulnerability{
-			ID:             "CVE-1999-0001",
-			RecordSource:   "source-1",
-			FixedInVersion: "the-next-version",
+			ID:        "CVE-1999-0001",
+			Namespace: "source-1",
+			Fix: vulnerability.Fix{
+				Versions: []string{
+					"the-next-version",
+				},
+			},
 		},
 		Package: pkg1,
 		Matcher: match.DpkgMatcher,
@@ -213,8 +225,8 @@ func TestJsonDirsPresenter(t *testing.T) {
 	var match2 = match.Match{
 		Type: match.ExactIndirectMatch,
 		Vulnerability: vulnerability.Vulnerability{
-			ID:           "CVE-1999-0002",
-			RecordSource: "source-2",
+			ID:        "CVE-1999-0002",
+			Namespace: "source-2",
 		},
 		Package: pkg1,
 		Matcher: match.DpkgMatcher,
@@ -229,9 +241,13 @@ func TestJsonDirsPresenter(t *testing.T) {
 	var match3 = match.Match{
 		Type: match.ExactIndirectMatch,
 		Vulnerability: vulnerability.Vulnerability{
-			ID:             "CVE-1999-0003",
-			RecordSource:   "source-1",
-			FixedInVersion: "the-other-next-version",
+			ID:        "CVE-1999-0003",
+			Namespace: "source-1",
+			Fix: vulnerability.Fix{
+				Versions: []string{
+					"the-other-next-version",
+				},
+			},
 		},
 		Package: pkg1,
 		Matcher: match.DpkgMatcher,

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
@@ -3,7 +3,9 @@
   {
    "vulnerability": {
     "id": "CVE-1999-0001",
+    "dataSource": "",
     "severity": "Low",
+    "urls": [],
     "description": "1999-01 description",
     "cvss": [
      {
@@ -15,11 +17,18 @@
       "vendorMetadata": {}
      }
     ],
-    "fixedInVersion": "the-next-version"
+    "fix": {
+     "versions": [
+      "the-next-version"
+     ],
+     "state": ""
+    },
+    "advisories": []
    },
+   "relatedVulnerabilities": [],
    "matchDetails": {
     "matcher": "dpkg-matcher",
-    "searchKey": {
+    "searchedBy": {
      "distro": {
       "type": "ubuntu",
       "version": "20.04"
@@ -39,7 +48,7 @@
      }
     ],
     "language": "",
-    "licenses": null,
+    "licenses": [],
     "cpes": [],
     "purl": "",
     "metadata": {
@@ -50,7 +59,9 @@
   {
    "vulnerability": {
     "id": "CVE-1999-0002",
+    "dataSource": "",
     "severity": "Critical",
+    "urls": [],
     "description": "1999-02 description",
     "cvss": [
      {
@@ -66,11 +77,17 @@
        "Status": "verified"
       }
      }
-    ]
+    ],
+    "fix": {
+     "versions": [],
+     "state": ""
+    },
+    "advisories": []
    },
+   "relatedVulnerabilities": [],
    "matchDetails": {
     "matcher": "dpkg-matcher",
-    "searchKey": {
+    "searchedBy": {
      "cpe": "somecpe"
     },
     "matchedOn": {
@@ -87,7 +104,7 @@
      }
     ],
     "language": "",
-    "licenses": null,
+    "licenses": [],
     "cpes": [],
     "purl": "",
     "metadata": {
@@ -98,14 +115,23 @@
   {
    "vulnerability": {
     "id": "CVE-1999-0003",
+    "dataSource": "",
     "severity": "High",
+    "urls": [],
     "description": "1999-03 description",
     "cvss": [],
-    "fixedInVersion": "the-other-next-version"
+    "fix": {
+     "versions": [
+      "the-other-next-version"
+     ],
+     "state": ""
+    },
+    "advisories": []
    },
+   "relatedVulnerabilities": [],
    "matchDetails": {
     "matcher": "dpkg-matcher",
-    "searchKey": {
+    "searchedBy": {
      "language": "java"
     },
     "matchedOn": {
@@ -122,7 +148,7 @@
      }
     ],
     "language": "",
-    "licenses": null,
+    "licenses": [],
     "cpes": [],
     "purl": "",
     "metadata": {

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
@@ -3,7 +3,9 @@
   {
    "vulnerability": {
     "id": "CVE-1999-0001",
+    "dataSource": "",
     "severity": "Low",
+    "urls": [],
     "description": "1999-01 description",
     "cvss": [
      {
@@ -15,11 +17,18 @@
       "vendorMetadata": {}
      }
     ],
-    "fixedInVersion": "the-next-version"
+    "fix": {
+     "versions": [
+      "the-next-versions"
+     ],
+     "state": ""
+    },
+    "advisories": []
    },
+   "relatedVulnerabilities": [],
    "matchDetails": {
     "matcher": "dpkg-matcher",
-    "searchKey": {
+    "searchedBy": {
      "distro": {
       "type": "ubuntu",
       "version": "20.04"
@@ -40,7 +49,7 @@
      }
     ],
     "language": "",
-    "licenses": null,
+    "licenses": [],
     "cpes": [
      "cpe:2.3:a:anchore:engine:0.9.2:*:*:python:*:*:*:*"
     ],
@@ -53,7 +62,9 @@
   {
    "vulnerability": {
     "id": "CVE-1999-0002",
+    "dataSource": "",
     "severity": "Critical",
+    "urls": [],
     "description": "1999-02 description",
     "cvss": [
      {
@@ -69,11 +80,17 @@
        "Status": "verified"
       }
      }
-    ]
+    ],
+    "fix": {
+     "versions": [],
+     "state": ""
+    },
+    "advisories": []
    },
+   "relatedVulnerabilities": [],
    "matchDetails": {
     "matcher": "dpkg-matcher",
-    "searchKey": {
+    "searchedBy": {
      "cpe": "somecpe"
     },
     "matchedOn": {
@@ -91,7 +108,7 @@
      }
     ],
     "language": "",
-    "licenses": null,
+    "licenses": [],
     "cpes": [
      "cpe:2.3:a:anchore:engine:0.9.2:*:*:python:*:*:*:*"
     ],
@@ -104,14 +121,23 @@
   {
    "vulnerability": {
     "id": "CVE-1999-0003",
+    "dataSource": "",
     "severity": "High",
+    "urls": [],
     "description": "1999-03 description",
     "cvss": [],
-    "fixedInVersion": "the-other-next-version"
+    "fix": {
+     "versions": [
+      "the-other-next-version"
+     ],
+     "state": ""
+    },
+    "advisories": []
    },
+   "relatedVulnerabilities": [],
    "matchDetails": {
     "matcher": "dpkg-matcher",
-    "searchKey": {
+    "searchedBy": {
      "language": "java"
     },
     "matchedOn": {
@@ -129,7 +155,7 @@
      }
     ],
     "language": "",
-    "licenses": null,
+    "licenses": [],
     "cpes": [
      "cpe:2.3:a:anchore:engine:0.9.2:*:*:python:*:*:*:*"
     ],

--- a/grype/presenter/models/cvss.go
+++ b/grype/presenter/models/cvss.go
@@ -1,0 +1,37 @@
+package models
+
+import "github.com/anchore/grype/grype/vulnerability"
+
+type Cvss struct {
+	Version        string      `json:"version"`
+	Vector         string      `json:"vector"`
+	Metrics        CvssMetrics `json:"metrics"`
+	VendorMetadata interface{} `json:"vendorMetadata"`
+}
+
+type CvssMetrics struct {
+	BaseScore           float64  `json:"baseScore"`
+	ExploitabilityScore *float64 `json:"exploitabilityScore,omitempty"`
+	ImpactScore         *float64 `json:"impactScore,omitempty"`
+}
+
+func NewCVSS(metadata *vulnerability.Metadata) []Cvss {
+	cvss := make([]Cvss, 0)
+	for _, score := range metadata.Cvss {
+		vendorMetadata := score.VendorMetadata
+		if vendorMetadata == nil {
+			vendorMetadata = make(map[string]interface{})
+		}
+		cvss = append(cvss, Cvss{
+			Version: score.Version,
+			Vector:  score.Vector,
+			Metrics: CvssMetrics{
+				BaseScore:           score.Metrics.BaseScore,
+				ExploitabilityScore: score.Metrics.ExploitabilityScore,
+				ImpactScore:         score.Metrics.ImpactScore,
+			},
+			VendorMetadata: vendorMetadata,
+		})
+	}
+	return cvss
+}

--- a/grype/presenter/models/document.go
+++ b/grype/presenter/models/document.go
@@ -44,14 +44,14 @@ func NewDocument(packages []pkg.Package, context pkg.Context, matches match.Matc
 			return Document{}, fmt.Errorf("unable to find package in collection: %+v", p)
 		}
 
-		relatedVulnerabilities := make([]VulnerabilityMetadata, len(m.Vulnerability.RelatedVulnerabilities))
-		for idx, r := range m.Vulnerability.RelatedVulnerabilities {
+		relatedVulnerabilities := make([]VulnerabilityMetadata, 0)
+		for _, r := range m.Vulnerability.RelatedVulnerabilities {
 			relatedMetadata, err := metadataProvider.GetMetadata(r.ID, r.Namespace)
 			if err != nil {
 				return Document{}, fmt.Errorf("unable to fetch related vuln=%q metadata: %+v", r, err)
 			}
 			if relatedMetadata != nil {
-				relatedVulnerabilities[idx] = NewVulnerabilityMetadata(r.ID, r.Namespace, relatedMetadata)
+				relatedVulnerabilities = append(relatedVulnerabilities, NewVulnerabilityMetadata(r.ID, r.Namespace, relatedMetadata))
 			}
 		}
 

--- a/grype/presenter/models/match.go
+++ b/grype/presenter/models/match.go
@@ -1,0 +1,53 @@
+package models
+
+import (
+	"fmt"
+
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+)
+
+// Match is a single item for the JSON array reported
+type Match struct {
+	Vulnerability          Vulnerability           `json:"vulnerability"`
+	RelatedVulnerabilities []VulnerabilityMetadata `json:"relatedVulnerabilities"`
+	MatchDetails           MatchDetails            `json:"matchDetails"`
+	Artifact               Package                 `json:"artifact"`
+}
+
+// MatchDetails contains all data that indicates how the result match was found
+type MatchDetails struct {
+	Matcher    string                 `json:"matcher"`
+	SearchedBy map[string]interface{} `json:"searchedBy"`
+	MatchedOn  map[string]interface{} `json:"matchedOn"`
+}
+
+func newMatch(m match.Match, p pkg.Package, metadataProvider vulnerability.MetadataProvider) (*Match, error) {
+	relatedVulnerabilities := make([]VulnerabilityMetadata, 0)
+	for _, r := range m.Vulnerability.RelatedVulnerabilities {
+		relatedMetadata, err := metadataProvider.GetMetadata(r.ID, r.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf("unable to fetch related vuln=%q metadata: %+v", r, err)
+		}
+		if relatedMetadata != nil {
+			relatedVulnerabilities = append(relatedVulnerabilities, NewVulnerabilityMetadata(r.ID, r.Namespace, relatedMetadata))
+		}
+	}
+
+	metadata, err := metadataProvider.GetMetadata(m.Vulnerability.ID, m.Vulnerability.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch vuln=%q metadata: %+v", m.Vulnerability.ID, err)
+	}
+
+	return &Match{
+		Vulnerability:          NewVulnerability(m.Vulnerability, metadata),
+		Artifact:               newPackage(p),
+		RelatedVulnerabilities: relatedVulnerabilities,
+		MatchDetails: MatchDetails{
+			Matcher:    m.Matcher.String(),
+			SearchedBy: m.SearchKey,
+			MatchedOn:  m.SearchMatches,
+		},
+	}, nil
+}

--- a/grype/presenter/models/match.go
+++ b/grype/presenter/models/match.go
@@ -46,7 +46,7 @@ func newMatch(m match.Match, p pkg.Package, metadataProvider vulnerability.Metad
 		RelatedVulnerabilities: relatedVulnerabilities,
 		MatchDetails: MatchDetails{
 			Matcher:    m.Matcher.String(),
-			SearchedBy: m.SearchKey,
+			SearchedBy: m.SearchedBy,
 			MatchedOn:  m.SearchMatches,
 		},
 	}, nil

--- a/grype/presenter/models/metadata_mock.go
+++ b/grype/presenter/models/metadata_mock.go
@@ -65,7 +65,7 @@ func NewMetadataMock() *MetadataMock {
 }
 
 // GetMetadata returns vulnerability metadata for a given id and recordSource.
-func (m *MetadataMock) GetMetadata(id, recordSource string) (*vulnerability.Metadata, error) {
-	value := m.store[id][recordSource]
+func (m *MetadataMock) GetMetadata(id, namespace string) (*vulnerability.Metadata, error) {
+	value := m.store[id][namespace]
 	return &value, nil
 }

--- a/grype/presenter/models/models_helpers.go
+++ b/grype/presenter/models/models_helpers.go
@@ -40,7 +40,7 @@ func generateMatches(t *testing.T, p pkg.Package) match.Matches {
 			},
 			Package: p,
 			Matcher: match.DpkgMatcher,
-			SearchKey: map[string]interface{}{
+			SearchedBy: map[string]interface{}{
 				"distro": map[string]string{
 					"type":    "ubuntu",
 					"version": "20.04",
@@ -58,7 +58,7 @@ func generateMatches(t *testing.T, p pkg.Package) match.Matches {
 			},
 			Package: p,
 			Matcher: match.DpkgMatcher,
-			SearchKey: map[string]interface{}{
+			SearchedBy: map[string]interface{}{
 				"cpe": "somecpe",
 			},
 			SearchMatches: map[string]interface{}{

--- a/grype/presenter/models/models_helpers.go
+++ b/grype/presenter/models/models_helpers.go
@@ -3,6 +3,8 @@ package models
 import (
 	"testing"
 
+	grypeDb "github.com/anchore/grype-db/pkg/db"
+
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
@@ -29,9 +31,11 @@ func generateMatches(t *testing.T, p pkg.Package) match.Matches {
 		{
 			Type: match.ExactDirectMatch,
 			Vulnerability: vulnerability.Vulnerability{
-				ID:             "CVE-1999-0001",
-				RecordSource:   "source-1",
-				FixedInVersion: "the-next-version",
+				ID: "CVE-1999-0001",
+				Fix: vulnerability.Fix{
+					Versions: []string{"the-next-version"},
+					State:    grypeDb.FixedState,
+				},
 			},
 			Package: p,
 			Matcher: match.DpkgMatcher,
@@ -48,8 +52,7 @@ func generateMatches(t *testing.T, p pkg.Package) match.Matches {
 		{
 			Type: match.ExactIndirectMatch,
 			Vulnerability: vulnerability.Vulnerability{
-				ID:           "CVE-1999-0002",
-				RecordSource: "source-2",
+				ID: "CVE-1999-0002",
 			},
 			Package: p,
 			Matcher: match.DpkgMatcher,

--- a/grype/presenter/models/models_helpers.go
+++ b/grype/presenter/models/models_helpers.go
@@ -31,7 +31,8 @@ func generateMatches(t *testing.T, p pkg.Package) match.Matches {
 		{
 			Type: match.ExactDirectMatch,
 			Vulnerability: vulnerability.Vulnerability{
-				ID: "CVE-1999-0001",
+				ID:        "CVE-1999-0001",
+				Namespace: "source-1",
 				Fix: vulnerability.Fix{
 					Versions: []string{"the-next-version"},
 					State:    grypeDb.FixedState,
@@ -52,7 +53,8 @@ func generateMatches(t *testing.T, p pkg.Package) match.Matches {
 		{
 			Type: match.ExactIndirectMatch,
 			Vulnerability: vulnerability.Vulnerability{
-				ID: "CVE-1999-0002",
+				ID:        "CVE-1999-0002",
+				Namespace: "source-2",
 			},
 			Package: p,
 			Matcher: match.DpkgMatcher,

--- a/grype/presenter/models/package.go
+++ b/grype/presenter/models/package.go
@@ -25,11 +25,16 @@ func newPackage(p pkg.Package) Package {
 		cpes = append(cpes, c.BindToFmtString())
 	}
 
+	licenses := p.Licenses
+	if licenses == nil {
+		licenses = make([]string, 0)
+	}
+
 	return Package{
 		Name:      p.Name,
 		Version:   p.Version,
 		Locations: p.Locations,
-		Licenses:  p.Licenses,
+		Licenses:  licenses,
 		Language:  p.Language,
 		Type:      p.Type,
 		CPEs:      cpes,

--- a/grype/presenter/models/vulnerability.go
+++ b/grype/presenter/models/vulnerability.go
@@ -1,63 +1,52 @@
 package models
 
 import (
-	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/vulnerability"
 )
 
 type Vulnerability struct {
-	ID             string   `json:"id"`
-	Severity       string   `json:"severity,omitempty"`
-	Links          []string `json:"links,omitempty"`
-	Description    string   `json:"description,omitempty"`
-	Cvss           []Cvss   `json:"cvss"`
-	FixedInVersion string   `json:"fixedInVersion,omitempty"`
+	VulnerabilityMetadata
+	Fix        Fix        `json:"fix"`
+	Advisories []Advisory `json:"advisories"`
 }
 
-type Cvss struct {
-	Version        string      `json:"version"`
-	Vector         string      `json:"vector"`
-	Metrics        CvssMetrics `json:"metrics"`
-	VendorMetadata interface{} `json:"vendorMetadata"`
+type Fix struct {
+	Versions []string `json:"versions"`
+	State    string   `json:"state"`
 }
 
-type CvssMetrics struct {
-	BaseScore           float64  `json:"baseScore"`
-	ExploitabilityScore *float64 `json:"exploitabilityScore,omitempty"`
-	ImpactScore         *float64 `json:"impactScore,omitempty"`
+type Advisory struct {
+	ID   string `json:"id"`
+	Link string `json:"link"`
 }
 
-func NewVulnerability(m match.Match, metadata *vulnerability.Metadata) Vulnerability {
+func NewVulnerability(vuln vulnerability.Vulnerability, metadata *vulnerability.Metadata) Vulnerability {
 	if metadata == nil {
 		return Vulnerability{
-			ID: m.Vulnerability.ID,
+			VulnerabilityMetadata: NewVulnerabilityMetadata(vuln.ID, vuln.Namespace, metadata),
 		}
 	}
 
-	cvss := make([]Cvss, 0)
-	for _, score := range metadata.Cvss {
-		vendorMetadata := score.VendorMetadata
-		if vendorMetadata == nil {
-			vendorMetadata = make(map[string]interface{})
+	advisories := make([]Advisory, len(vuln.Advisories))
+	for idx, advisory := range vuln.Advisories {
+		advisories[idx] = Advisory{
+			ID:   advisory.ID,
+			Link: advisory.Link,
 		}
-		cvss = append(cvss, Cvss{
-			Version: score.Version,
-			Vector:  score.Vector,
-			Metrics: CvssMetrics{
-				BaseScore:           score.Metrics.BaseScore,
-				ExploitabilityScore: score.Metrics.ExploitabilityScore,
-				ImpactScore:         score.Metrics.ImpactScore,
-			},
-			VendorMetadata: vendorMetadata,
-		})
+	}
+
+	fixedInVersions := vuln.Fix.Versions
+	if fixedInVersions == nil {
+		// always allocate collections
+		fixedInVersions = make([]string, 0)
 	}
 
 	return Vulnerability{
-		ID:             m.Vulnerability.ID,
-		Severity:       metadata.Severity,
-		Links:          metadata.Links,
-		Description:    metadata.Description,
-		Cvss:           cvss,
-		FixedInVersion: m.Vulnerability.FixedInVersion,
+		VulnerabilityMetadata: NewVulnerabilityMetadata(vuln.ID, vuln.Namespace, metadata),
+		Fix: Fix{
+			Versions: fixedInVersions,
+			State:    string(vuln.Fix.State),
+		},
+		Advisories: advisories,
 	}
 }

--- a/grype/presenter/models/vulnerability_metadata.go
+++ b/grype/presenter/models/vulnerability_metadata.go
@@ -1,0 +1,63 @@
+package models
+
+import "github.com/anchore/grype/grype/vulnerability"
+
+type VulnerabilityMetadata struct {
+	ID          string   `json:"id"`
+	DataSource  string   `json:"dataSource"`
+	Namespace   string   `json:"namespace,omitempty"`
+	Severity    string   `json:"severity,omitempty"`
+	URLs        []string `json:"urls,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Cvss        []Cvss   `json:"cvss,omitempty"`
+}
+
+type Cvss struct {
+	Version        string      `json:"version"`
+	Vector         string      `json:"vector"`
+	Metrics        CvssMetrics `json:"metrics"`
+	VendorMetadata interface{} `json:"vendorMetadata"`
+}
+
+type CvssMetrics struct {
+	BaseScore           float64  `json:"baseScore"`
+	ExploitabilityScore *float64 `json:"exploitabilityScore,omitempty"`
+	ImpactScore         *float64 `json:"impactScore,omitempty"`
+}
+
+func NewVulnerabilityMetadata(id, namespace string, metadata *vulnerability.Metadata) VulnerabilityMetadata {
+	if metadata == nil {
+		return VulnerabilityMetadata{
+			ID:        id,
+			Namespace: namespace,
+		}
+	}
+
+	cvss := make([]Cvss, 0)
+	for _, score := range metadata.Cvss {
+		vendorMetadata := score.VendorMetadata
+		if vendorMetadata == nil {
+			vendorMetadata = make(map[string]interface{})
+		}
+		cvss = append(cvss, Cvss{
+			Version: score.Version,
+			Vector:  score.Vector,
+			Metrics: CvssMetrics{
+				BaseScore:           score.Metrics.BaseScore,
+				ExploitabilityScore: score.Metrics.ExploitabilityScore,
+				ImpactScore:         score.Metrics.ImpactScore,
+			},
+			VendorMetadata: vendorMetadata,
+		})
+	}
+
+	return VulnerabilityMetadata{
+		ID:          id,
+		DataSource:  metadata.DataSource,
+		Namespace:   metadata.Namespace,
+		Severity:    metadata.Severity,
+		URLs:        metadata.URLs,
+		Description: metadata.Description,
+		Cvss:        cvss,
+	}
+}

--- a/grype/presenter/models/vulnerability_metadata.go
+++ b/grype/presenter/models/vulnerability_metadata.go
@@ -7,22 +7,9 @@ type VulnerabilityMetadata struct {
 	DataSource  string   `json:"dataSource"`
 	Namespace   string   `json:"namespace,omitempty"`
 	Severity    string   `json:"severity,omitempty"`
-	URLs        []string `json:"urls,omitempty"`
+	URLs        []string `json:"urls"`
 	Description string   `json:"description,omitempty"`
-	Cvss        []Cvss   `json:"cvss,omitempty"`
-}
-
-type Cvss struct {
-	Version        string      `json:"version"`
-	Vector         string      `json:"vector"`
-	Metrics        CvssMetrics `json:"metrics"`
-	VendorMetadata interface{} `json:"vendorMetadata"`
-}
-
-type CvssMetrics struct {
-	BaseScore           float64  `json:"baseScore"`
-	ExploitabilityScore *float64 `json:"exploitabilityScore,omitempty"`
-	ImpactScore         *float64 `json:"impactScore,omitempty"`
+	Cvss        []Cvss   `json:"cvss"`
 }
 
 func NewVulnerabilityMetadata(id, namespace string, metadata *vulnerability.Metadata) VulnerabilityMetadata {
@@ -33,22 +20,9 @@ func NewVulnerabilityMetadata(id, namespace string, metadata *vulnerability.Meta
 		}
 	}
 
-	cvss := make([]Cvss, 0)
-	for _, score := range metadata.Cvss {
-		vendorMetadata := score.VendorMetadata
-		if vendorMetadata == nil {
-			vendorMetadata = make(map[string]interface{})
-		}
-		cvss = append(cvss, Cvss{
-			Version: score.Version,
-			Vector:  score.Vector,
-			Metrics: CvssMetrics{
-				BaseScore:           score.Metrics.BaseScore,
-				ExploitabilityScore: score.Metrics.ExploitabilityScore,
-				ImpactScore:         score.Metrics.ImpactScore,
-			},
-			VendorMetadata: vendorMetadata,
-		})
+	urls := metadata.URLs
+	if urls == nil {
+		urls = make([]string, 0)
 	}
 
 	return VulnerabilityMetadata{
@@ -56,8 +30,8 @@ func NewVulnerabilityMetadata(id, namespace string, metadata *vulnerability.Meta
 		DataSource:  metadata.DataSource,
 		Namespace:   metadata.Namespace,
 		Severity:    metadata.Severity,
-		URLs:        metadata.URLs,
+		URLs:        urls,
 		Description: metadata.Description,
-		Cvss:        cvss,
+		Cvss:        NewCVSS(metadata),
 	}
 }

--- a/grype/presenter/table/presenter.go
+++ b/grype/presenter/table/presenter.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 
+	grypeDb "github.com/anchore/grype-db/pkg/db"
+
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
@@ -36,7 +38,7 @@ func (pres *Presenter) Present(output io.Writer) error {
 	for m := range pres.results.Enumerate() {
 		var severity string
 
-		metadata, err := pres.metadataProvider.GetMetadata(m.Vulnerability.ID, m.Vulnerability.RecordSource)
+		metadata, err := pres.metadataProvider.GetMetadata(m.Vulnerability.ID, m.Vulnerability.Namespace)
 		if err != nil {
 			return fmt.Errorf("unable to fetch vuln=%q metadata: %+v", m.Vulnerability.ID, err)
 		}
@@ -45,10 +47,18 @@ func (pres *Presenter) Present(output io.Writer) error {
 			severity = metadata.Severity
 		}
 
+		fixVersion := strings.Join(m.Vulnerability.Fix.Versions, ", ")
+		switch m.Vulnerability.Fix.State {
+		case grypeDb.WontFixState:
+			fixVersion = "(won't fix)"
+		case grypeDb.UnknownFixState:
+			fixVersion = "(fixes indeterminate)"
+		}
+
 		row := []string{
 			m.Package.Name,
 			m.Package.Version,
-			m.Vulnerability.FixedInVersion,
+			fixVersion,
 			m.Vulnerability.ID,
 			severity,
 		}

--- a/grype/presenter/table/presenter.go
+++ b/grype/presenter/table/presenter.go
@@ -55,14 +55,7 @@ func (pres *Presenter) Present(output io.Writer) error {
 			fixVersion = "(fixes indeterminate)"
 		}
 
-		row := []string{
-			m.Package.Name,
-			m.Package.Version,
-			fixVersion,
-			m.Vulnerability.ID,
-			severity,
-		}
-		rows = append(rows, row)
+		rows = append(rows, []string{m.Package.Name, m.Package.Version, fixVersion, m.Vulnerability.ID, severity})
 	}
 
 	if len(rows) == 0 {

--- a/grype/presenter/table/presenter_test.go
+++ b/grype/presenter/table/presenter_test.go
@@ -57,7 +57,7 @@ func TestTablePresenter(t *testing.T) {
 		},
 		Package: pkg2,
 		Matcher: match.DpkgMatcher,
-		SearchKey: map[string]interface{}{
+		SearchedBy: map[string]interface{}{
 			"some": "key",
 		},
 	}

--- a/grype/presenter/table/presenter_test.go
+++ b/grype/presenter/table/presenter_test.go
@@ -37,8 +37,8 @@ func TestTablePresenter(t *testing.T) {
 	var match1 = match.Match{
 		Type: match.ExactDirectMatch,
 		Vulnerability: vulnerability.Vulnerability{
-			ID:           "CVE-1999-0001",
-			RecordSource: "source-1",
+			ID:        "CVE-1999-0001",
+			Namespace: "source-1",
 		},
 		Package: pkg1,
 		Matcher: match.DpkgMatcher,
@@ -47,9 +47,13 @@ func TestTablePresenter(t *testing.T) {
 	var match2 = match.Match{
 		Type: match.ExactIndirectMatch,
 		Vulnerability: vulnerability.Vulnerability{
-			ID:             "CVE-1999-0002",
-			RecordSource:   "source-2",
-			FixedInVersion: "the-next-version",
+			ID:        "CVE-1999-0002",
+			Namespace: "source-2",
+			Fix: vulnerability.Fix{
+				Versions: []string{
+					"the-next-version",
+				},
+			},
 		},
 		Package: pkg2,
 		Matcher: match.DpkgMatcher,

--- a/grype/presenter/template/presenter_test.go
+++ b/grype/presenter/template/presenter_test.go
@@ -32,5 +32,5 @@ func TestPresenter_Present(t *testing.T) {
 	actual := buffer.Bytes()
 	expected := testutils.GetGoldenFileContents(t)
 
-	assert.Equal(t, string(actual), string(expected))
+	assert.Equal(t, string(expected), string(actual))
 }

--- a/grype/vulnerability/advisory.go
+++ b/grype/vulnerability/advisory.go
@@ -1,0 +1,6 @@
+package vulnerability
+
+type Advisory struct {
+	ID   string
+	Link string
+}

--- a/grype/vulnerability/fix.go
+++ b/grype/vulnerability/fix.go
@@ -1,0 +1,10 @@
+package vulnerability
+
+import (
+	grypeDb "github.com/anchore/grype-db/pkg/db"
+)
+
+type Fix struct {
+	Versions []string
+	State    grypeDb.FixState
+}

--- a/grype/vulnerability/metadata.go
+++ b/grype/vulnerability/metadata.go
@@ -6,8 +6,10 @@ import (
 
 type Metadata struct {
 	ID          string
+	DataSource  string
+	Namespace   string
 	Severity    string
-	Links       []string
+	URLs        []string
 	Description string
 	Cvss        []Cvss
 }
@@ -31,8 +33,10 @@ func NewMetadata(m *db.VulnerabilityMetadata) (*Metadata, error) {
 	}
 	return &Metadata{
 		ID:          m.ID,
+		DataSource:  m.DataSource,
+		Namespace:   m.Namespace,
 		Severity:    m.Severity,
-		Links:       m.Links,
+		URLs:        m.URLs,
 		Description: m.Description,
 		Cvss:        NewCvss(m.Cvss),
 	}, nil

--- a/grype/vulnerability/metadata_store_adapter.go
+++ b/grype/vulnerability/metadata_store_adapter.go
@@ -16,10 +16,10 @@ func NewMetadataStoreProvider(store db.VulnerabilityMetadataStoreReader) *Metada
 	}
 }
 
-func (pr *MetadataStoreAdapter) GetMetadata(id, recordSource string) (*Metadata, error) {
-	metadata, err := pr.store.GetVulnerabilityMetadata(id, recordSource)
+func (pr *MetadataStoreAdapter) GetMetadata(id, namespace string) (*Metadata, error) {
+	metadata, err := pr.store.GetVulnerabilityMetadata(id, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("metadata provider failed to fetch id='%s' recordsource='%s': %w", id, recordSource, err)
+		return nil, fmt.Errorf("metadata provider failed to fetch id='%s' recordsource='%s': %w", id, namespace, err)
 	}
 
 	return NewMetadata(metadata)

--- a/grype/vulnerability/provider.go
+++ b/grype/vulnerability/provider.go
@@ -25,5 +25,5 @@ type ProviderByCPE interface {
 }
 
 type MetadataProvider interface {
-	GetMetadata(id, recordSource string) (*Metadata, error)
+	GetMetadata(id, namespace string) (*Metadata, error)
 }

--- a/grype/vulnerability/store_adapter_test.go
+++ b/grype/vulnerability/store_adapter_test.go
@@ -36,12 +36,14 @@ func TestGetByDistro(t *testing.T) {
 			ID:         "CVE-2014-fake-1",
 			Namespace:  "debian:8",
 			CPEs:       []syftPkg.CPE{},
+			Advisories: []Advisory{},
 		},
 		{
 			Constraint: version.MustGetConstraint("< 2013.0.2-1", version.DebFormat),
 			ID:         "CVE-2013-fake-2",
 			Namespace:  "debian:8",
 			CPEs:       []syftPkg.CPE{},
+			Advisories: []Advisory{},
 		},
 	}
 
@@ -80,7 +82,8 @@ func TestGetByCPE(t *testing.T) {
 					CPEs: []syftPkg.CPE{
 						must(syftPkg.NewCPE("cpe:2.3:*:activerecord:activerecord:*:*:something:*:*:ruby:*:*")),
 					},
-					Namespace: "nvd",
+					Namespace:  "nvd",
+					Advisories: []Advisory{},
 				},
 			},
 		},
@@ -95,7 +98,8 @@ func TestGetByCPE(t *testing.T) {
 					CPEs: []syftPkg.CPE{
 						must(syftPkg.NewCPE("cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*")),
 					},
-					Namespace: "nvd",
+					Namespace:  "nvd",
+					Advisories: []Advisory{},
 				},
 				{
 					Constraint: version.MustGetConstraint("< 3.7.4", version.UnknownFormat),
@@ -103,7 +107,8 @@ func TestGetByCPE(t *testing.T) {
 					CPEs: []syftPkg.CPE{
 						must(syftPkg.NewCPE("cpe:2.3:*:activerecord:activerecord:*:*:something:*:*:ruby:*:*")),
 					},
-					Namespace: "nvd",
+					Namespace:  "nvd",
+					Advisories: []Advisory{},
 				},
 			},
 		},

--- a/grype/vulnerability/vulnerability.go
+++ b/grype/vulnerability/vulnerability.go
@@ -8,13 +8,19 @@ import (
 	"github.com/anchore/syft/syft/pkg"
 )
 
+type Reference struct {
+	ID        string
+	Namespace string
+}
+
 type Vulnerability struct {
-	Constraint     version.Constraint
-	CPEs           []pkg.CPE
-	ID             string
-	RecordSource   string
-	Namespace      string
-	FixedInVersion string
+	Constraint             version.Constraint
+	CPEs                   []pkg.CPE
+	ID                     string
+	Namespace              string
+	Fix                    Fix
+	Advisories             []Advisory
+	RelatedVulnerabilities []Reference
 }
 
 func NewVulnerability(vuln db.Vulnerability) (*Vulnerability, error) {
@@ -25,13 +31,33 @@ func NewVulnerability(vuln db.Vulnerability) (*Vulnerability, error) {
 		return nil, fmt.Errorf("failed to parse constraint='%s' format='%s': %w", vuln.VersionConstraint, format, err)
 	}
 
+	advisories := make([]Advisory, len(vuln.Advisories))
+	for idx, advisory := range vuln.Advisories {
+		advisories[idx] = Advisory{
+			ID:   advisory.ID,
+			Link: advisory.Link,
+		}
+	}
+
+	var relatedVulnerabilities []Reference
+	for _, r := range vuln.RelatedVulnerabilities {
+		relatedVulnerabilities = append(relatedVulnerabilities, Reference{
+			ID:        r.ID,
+			Namespace: r.Namespace,
+		})
+	}
+
 	return &Vulnerability{
-		Constraint:     constraint,
-		ID:             vuln.ID,
-		CPEs:           make([]pkg.CPE, 0),
-		RecordSource:   vuln.RecordSource,
-		Namespace:      vuln.Namespace,
-		FixedInVersion: vuln.FixedInVersion,
+		Constraint: constraint,
+		ID:         vuln.ID,
+		CPEs:       make([]pkg.CPE, 0),
+		Namespace:  vuln.Namespace,
+		Fix: Fix{
+			Versions: vuln.Fix.Versions,
+			State:    vuln.Fix.State,
+		},
+		Advisories:             advisories,
+		RelatedVulnerabilities: relatedVulnerabilities,
 	}, nil
 }
 

--- a/test/integration/match_coverage_test.go
+++ b/test/integration/match_coverage_test.go
@@ -33,7 +33,7 @@ func addAlpineMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Ca
 		Confidence:    1.0,
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
-		SearchKey: map[string]interface{}{
+		SearchedBy: map[string]interface{}{
 			"cpe": "cpe:2.3:*:*:libvncserver:0.9.9:*:*:*:*:*:*:*",
 		},
 		SearchMatches: map[string]interface{}{
@@ -61,7 +61,7 @@ func addJavascriptMatches(t *testing.T, theSource source.Source, catalog *syftPk
 		Confidence:    1.0,
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
-		SearchKey: map[string]interface{}{
+		SearchedBy: map[string]interface{}{
 			"language": "javascript",
 		},
 		SearchMatches: map[string]interface{}{
@@ -91,7 +91,7 @@ func addPythonMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Ca
 		Confidence:    1.0,
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
-		SearchKey: map[string]interface{}{
+		SearchedBy: map[string]interface{}{
 			"language": "python",
 		},
 		SearchMatches: map[string]interface{}{
@@ -118,7 +118,7 @@ func addRubyMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Cata
 		Confidence:    1.0,
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
-		SearchKey: map[string]interface{}{
+		SearchedBy: map[string]interface{}{
 			"language": "ruby",
 		},
 		SearchMatches: map[string]interface{}{
@@ -154,7 +154,7 @@ func addJavaMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Cata
 		Confidence:    1.0,
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
-		SearchKey: map[string]interface{}{
+		SearchedBy: map[string]interface{}{
 			"language": "java",
 		},
 		SearchMatches: map[string]interface{}{
@@ -182,7 +182,7 @@ func addDpkgMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Cata
 		Confidence:    1.0,
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
-		SearchKey: map[string]interface{}{
+		SearchedBy: map[string]interface{}{
 			"distro": map[string]string{
 				"type":    "debian",
 				"version": "8",
@@ -212,7 +212,7 @@ func addRhelMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Cata
 		Confidence:    1.0,
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
-		SearchKey: map[string]interface{}{
+		SearchedBy: map[string]interface{}{
 			"distro": map[string]string{
 				"type":    "centos",
 				"version": "8",


### PR DESCRIPTION
This adds the v3 schema additions made in https://github.com/anchore/grype-db/pull/23 and https://github.com/anchore/grype-db-builder/pull/105 with the JSON presentation refactors. 

Primary Changes:
- Orients the search of vulnerability metadata around a pair of ID and namespace instead of ID and recordSource
- Added `relatedVulnerabilities` to JSON output, which shows the metadata for a vulnerability from a particular namespace (no advisory or fixed-in info).
- Added `vulnerability.advisories` to JSON output
- Added `vulnerability.fix` state and multiple fixed-in version support to JSON output
- Added `dataSource` to vulnerability and vulnerability metadata items in the JSON output
- Renamed `links` to `urls` in the JSON output

Additional Changes:
- `MatchDetails.SearchKey` has changed to `MatchDetails.SearchedBy`
- Removed the preallocation linter rule (consistent with other repos)
- Licenses is guaranteed to be an allocated collection

Notes:
1. The base branch to be merged into is `v3-schema`, not `main`
2. Checks will fail until the grype-db and grype-db-builder PRs are merged, incorporated here, and there is an updated staging DB available

Related to https://github.com/anchore/grype/issues/287 (this work is being merged into the feature branch for this issue) , https://github.com/anchore/grype/issues/276 , https://github.com/anchore/grype/issues/189 , and https://github.com/anchore/grype/issues/314