### PR TITLE
Remove v3 staging db references from test config

### DIFF
--- a/test/grype-test-config.yaml
+++ b/test/grype-test-config.yaml
@@ -1,3 +1,1 @@
 check-for-app-update: false
-db:
-  update-url: https://toolbox-data.anchore.io/grype/staging-databases/listing.json

--- a/test/inline-compare/Makefile
+++ b/test/inline-compare/Makefile
@@ -1,5 +1,5 @@
 ifndef GRYPE_CMD
-	GRYPE_CMD = go run ../../main.go
+	GRYPE_CMD = go run ../../main.go -c ../../test/grype-test-config.yaml
 endif
 
 IMAGE_CLEAN = $(shell basename $(COMPARE_IMAGE) | tr ":" "_")


### PR DESCRIPTION
Now that V3 DBs have been promoted to production the DB staging references for V3 should be removed to always test against product. Additionally the inline-compare tests have been updated to use the `./test/grype-test-config.yaml` for future configuration tweaks like this.