### PR TITLE
Add description + positional arg to help text for DB import

### DIFF
--- a/cmd/db_import.go
+++ b/cmd/db_import.go
@@ -4,13 +4,16 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/anchore/grype/internal"
+
 	"github.com/anchore/grype/grype/db"
 	"github.com/spf13/cobra"
 )
 
 var dbImportCmd = &cobra.Command{
-	Use:   "import",
+	Use:   "import FILE",
 	Short: "import a vulnerability database archive",
+	Long:  fmt.Sprintf("import a vulnerability database archive from a local FILE.\nDB archives can be obtained from %q.", internal.DBUpdateURL),
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ret := runDbImportCmd(cmd, args)


### PR DESCRIPTION
This change adds a description and positional arg in the usage text:
```
$ grype db import --help
import a vulnerability database archive from a local FILE.
DB archives can be obtained from "https://toolbox-data.anchore.io/grype/databases/listing.json".

Usage:
  grype db import FILE [flags]

Flags:
  -h, --help   help for import

Global Flags:
  -c, --config string   application config file
  -q, --quiet           suppress all logging output
  -v, --verbose count   increase verbosity (-v = info, -vv = debug)
```