### PR TITLE
Update inline comparison script to ignore RPM epoch

### DIFF
--- a/test/inline-compare/compare.py
+++ b/test/inline-compare/compare.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import re
 import sys
 import json
 import collections
@@ -150,7 +151,12 @@ class Grype:
             if not INCLUDE_SEVERITY:
                 severity = NO_COMPARE_VALUE
 
-            metadata[package.type][package] = Metadata(version=entry["artifact"]["version"], severity=severity)
+            # engine doesn't capture epoch info, so we cannot use it during comparison
+            version = entry["artifact"]["version"]
+            if re.match(r'^\d+:', version):
+                version = ":".join(version.split(":")[1:])
+
+            metadata[package.type][package] = Metadata(version=version, severity=severity)
 
         return vulnerabilities, metadata
 


### PR DESCRIPTION
[Now that RPM epoch is included in version info](https://github.com/anchore/grype/pull/331) we need to make certain that it is not included when comparing data fields against matches from inline-scan during validation.

Sample run locally with updates:
```
Gathering facts for debian:10.5
echo "Creating grype-reports/debian_10.5.json..."
Creating grype-reports/debian_10.5.json...
mkdir -p grype-reports
go run ../../main.go -c ../../test/grype-test-config.yaml debian:10.5 -o json > grype-reports/debian_10.5.json
 ✔ Vulnerability DB        [no update available]
 ✔ Loaded image
 ✔ Parsed image
 ✔ Cataloged packages      [91 packages]
 ✔ Scanned image           [108 vulnerabilities]

Gathering facts for centos:8.2.2004
echo "Creating grype-reports/centos_8.2.2004.json..."
Creating grype-reports/centos_8.2.2004.json...
mkdir -p grype-reports
go run ../../main.go -c ../../test/grype-test-config.yaml centos:8.2.2004 -o json > grype-reports/centos_8.2.2004.json
 ✔ Vulnerability DB        [no update available]
 ✔ Loaded image
 ✔ Parsed image
 ✔ Cataloged packages      [175 packages]
 ✔ Scanned image           [269 vulnerabilities]

Gathering facts for alpine:3.12.0
echo "Creating grype-reports/alpine_3.12.0.json..."
Creating grype-reports/alpine_3.12.0.json...
mkdir -p grype-reports
go run ../../main.go -c ../../test/grype-test-config.yaml alpine:3.12.0 -o json > grype-reports/alpine_3.12.0.json
 ✔ Vulnerability DB        [no update available]
 ✔ Loaded image
 ✔ Parsed image
 ✔ Cataloged packages      [14 packages]
 ✔ Scanned image           [2 vulnerabilities]

Gathering facts for alpine-vuln:latest
echo "Creating grype-reports/alpine-vuln_latest.json..."
Creating grype-reports/alpine-vuln_latest.json...
mkdir -p grype-reports
go run ../../main.go -c ../../test/grype-test-config.yaml alpine-vuln:latest -o json > grype-reports/alpine-vuln_latest.json
 ✔ Vulnerability DB        [no update available]
 ✔ Loaded image
 ✔ Parsed image
 ✔ Cataloged packages      [26 packages]
 ✔ Scanned image           [43 vulnerabilities]

Gathering facts for java-vuln:latest
echo "Creating grype-reports/java-vuln_latest.json..."
Creating grype-reports/java-vuln_latest.json...
mkdir -p grype-reports
go run ../../main.go -c ../../test/grype-test-config.yaml java-vuln:latest -o json > grype-reports/java-vuln_latest.json
 ✔ Vulnerability DB        [no update available]
 ✔ Loaded image
 ✔ Parsed image
 ✔ Cataloged packages      [15 packages]
 ✔ Scanned image           [4 vulnerabilities]

Gathering facts for python-vuln:latest
echo "Creating grype-reports/python-vuln_latest.json..."
Creating grype-reports/python-vuln_latest.json...
mkdir -p grype-reports
go run ../../main.go -c ../../test/grype-test-config.yaml python-vuln:latest -o json > grype-reports/python-vuln_latest.json
 ✔ Vulnerability DB        [no update available]
 ✔ Loaded image
 ✔ Parsed image
 ✔ Cataloged packages      [39 packages]
 ✔ Scanned image           [5 vulnerabilities]

Comparing results for debian:10.5
./compare.py debian:10.5
Image: debian:10.5
Warning: not comparing severity
Grype found extra vulnerabilities:
      Vulnerability(id='CVE-2016-10228', package=Package(name='libc-bin', type='dpkg'))       Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2016-10228', package=Package(name='libc6', type='dpkg'))          Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2016-2781', package=Package(name='coreutils', type='dpkg'))       Metadata(version='8.30-3', severity='n/a')
      Vulnerability(id='CVE-2018-12886', package=Package(name='gcc-8-base', type='dpkg'))     Metadata(version='8.3.0-6', severity='n/a')
      Vulnerability(id='CVE-2018-12886', package=Package(name='libgcc1', type='dpkg'))        Metadata(version='8.3.0-6', severity='n/a')
      Vulnerability(id='CVE-2018-12886', package=Package(name='libstdc++6', type='dpkg'))     Metadata(version='8.3.0-6', severity='n/a')
      Vulnerability(id='CVE-2018-7169', package=Package(name='login', type='dpkg'))           Metadata(version='4.5-1.1', severity='n/a')
      Vulnerability(id='CVE-2018-7169', package=Package(name='passwd', type='dpkg'))          Metadata(version='4.5-1.1', severity='n/a')
      Vulnerability(id='CVE-2019-12290', package=Package(name='libidn2-0', type='dpkg'))      Metadata(version='2.0.5-1+deb10u1', severity='n/a')
      Vulnerability(id='CVE-2019-13627', package=Package(name='libgcrypt20', type='dpkg'))    Metadata(version='1.8.4-5', severity='n/a')
      Vulnerability(id='CVE-2019-14855', package=Package(name='gpgv', type='dpkg'))           Metadata(version='2.2.12-1+deb10u1', severity='n/a')
      Vulnerability(id='CVE-2019-15847', package=Package(name='gcc-8-base', type='dpkg'))     Metadata(version='8.3.0-6', severity='n/a')
      Vulnerability(id='CVE-2019-15847', package=Package(name='libgcc1', type='dpkg'))        Metadata(version='8.3.0-6', severity='n/a')
      Vulnerability(id='CVE-2019-15847', package=Package(name='libstdc++6', type='dpkg'))     Metadata(version='8.3.0-6', severity='n/a')
      Vulnerability(id='CVE-2019-17543', package=Package(name='liblz4-1', type='dpkg'))       Metadata(version='1.8.3-1', severity='n/a')
      Vulnerability(id='CVE-2019-19126', package=Package(name='libc-bin', type='dpkg'))       Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2019-19126', package=Package(name='libc6', type='dpkg'))          Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2019-20795', package=Package(name='iproute2', type='dpkg'))       Metadata(version='4.20.0-2', severity='n/a')
      Vulnerability(id='CVE-2019-25013', package=Package(name='libc-bin', type='dpkg'))       Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2019-25013', package=Package(name='libc6', type='dpkg'))          Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2019-3843', package=Package(name='libsystemd0', type='dpkg'))     Metadata(version='241-7~deb10u4', severity='n/a')
      Vulnerability(id='CVE-2019-3843', package=Package(name='libudev1', type='dpkg'))        Metadata(version='241-7~deb10u4', severity='n/a')
      Vulnerability(id='CVE-2019-3844', package=Package(name='libsystemd0', type='dpkg'))     Metadata(version='241-7~deb10u4', severity='n/a')
      Vulnerability(id='CVE-2019-3844', package=Package(name='libudev1', type='dpkg'))        Metadata(version='241-7~deb10u4', severity='n/a')
      Vulnerability(id='CVE-2020-10029', package=Package(name='libc-bin', type='dpkg'))       Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2020-10029', package=Package(name='libc6', type='dpkg'))          Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2020-13529', package=Package(name='libsystemd0', type='dpkg'))    Metadata(version='241-7~deb10u4', severity='n/a')
      Vulnerability(id='CVE-2020-13529', package=Package(name='libudev1', type='dpkg'))       Metadata(version='241-7~deb10u4', severity='n/a')
      Vulnerability(id='CVE-2020-14155', package=Package(name='libpcre3', type='dpkg'))       Metadata(version='8.39-12', severity='n/a')
      Vulnerability(id='CVE-2020-1751', package=Package(name='libc-bin', type='dpkg'))        Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2020-1751', package=Package(name='libc6', type='dpkg'))           Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2020-1752', package=Package(name='libc-bin', type='dpkg'))        Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2020-1752', package=Package(name='libc6', type='dpkg'))           Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2020-24659', package=Package(name='libgnutls30', type='dpkg'))    Metadata(version='3.6.7-4+deb10u5', severity='n/a')
      Vulnerability(id='CVE-2020-27350', package=Package(name='apt', type='dpkg'))            Metadata(version='1.8.2.1', severity='n/a')
      Vulnerability(id='CVE-2020-27350', package=Package(name='libapt-pkg5.0', type='dpkg'))  Metadata(version='1.8.2.1', severity='n/a')
      Vulnerability(id='CVE-2020-27618', package=Package(name='libc-bin', type='dpkg'))       Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2020-27618', package=Package(name='libc6', type='dpkg'))          Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2020-29361', package=Package(name='libp11-kit0', type='dpkg'))    Metadata(version='0.23.15-2', severity='n/a')
      Vulnerability(id='CVE-2020-29362', package=Package(name='libp11-kit0', type='dpkg'))    Metadata(version='0.23.15-2', severity='n/a')
      Vulnerability(id='CVE-2020-29363', package=Package(name='libp11-kit0', type='dpkg'))    Metadata(version='0.23.15-2', severity='n/a')
      Vulnerability(id='CVE-2020-6096', package=Package(name='libc-bin', type='dpkg'))        Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2020-6096', package=Package(name='libc6', type='dpkg'))           Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2021-20193', package=Package(name='tar', type='dpkg'))            Metadata(version='1.30+dfsg-6', severity='n/a')
      Vulnerability(id='CVE-2021-20231', package=Package(name='libgnutls30', type='dpkg'))    Metadata(version='3.6.7-4+deb10u5', severity='n/a')
      Vulnerability(id='CVE-2021-20232', package=Package(name='libgnutls30', type='dpkg'))    Metadata(version='3.6.7-4+deb10u5', severity='n/a')
      Vulnerability(id='CVE-2021-20305', package=Package(name='libhogweed4', type='dpkg'))    Metadata(version='3.4.1-1', severity='n/a')
      Vulnerability(id='CVE-2021-20305', package=Package(name='libnettle6', type='dpkg'))     Metadata(version='3.4.1-1', severity='n/a')
      Vulnerability(id='CVE-2021-24031', package=Package(name='libzstd1', type='dpkg'))       Metadata(version='1.3.8+dfsg-3', severity='n/a')
      Vulnerability(id='CVE-2021-24032', package=Package(name='libzstd1', type='dpkg'))       Metadata(version='1.3.8+dfsg-3', severity='n/a')
      Vulnerability(id='CVE-2021-27645', package=Package(name='libc-bin', type='dpkg'))       Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2021-27645', package=Package(name='libc6', type='dpkg'))          Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2021-3326', package=Package(name='libc-bin', type='dpkg'))        Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2021-3326', package=Package(name='libc6', type='dpkg'))           Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2021-33560', package=Package(name='libgcrypt20', type='dpkg'))    Metadata(version='1.8.4-5', severity='n/a')
      Vulnerability(id='CVE-2021-33574', package=Package(name='libc-bin', type='dpkg'))       Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2021-33574', package=Package(name='libc6', type='dpkg'))          Metadata(version='2.28-10', severity='n/a')
      Vulnerability(id='CVE-2021-3520', package=Package(name='liblz4-1', type='dpkg'))        Metadata(version='1.8.3-1', severity='n/a')
      Vulnerability(id='CVE-2021-3580', package=Package(name='libhogweed4', type='dpkg'))     Metadata(version='3.4.1-1', severity='n/a')
      Vulnerability(id='CVE-2021-3580', package=Package(name='libnettle6', type='dpkg'))      Metadata(version='3.4.1-1', severity='n/a')

Grype mismatched metadata:
      for:  Package(name='libpcre3', type='dpkg')  :  Metadata(version='8.39-12', severity='n/a')  !=  Metadata(version='2:8.39-12', severity='n/a')
      for:  Package(name='login', type='dpkg')     :  Metadata(version='4.5-1.1', severity='n/a')  !=  Metadata(version='1:4.5-1.1', severity='n/a')
      for:  Package(name='passwd', type='dpkg')    :  Metadata(version='4.5-1.1', severity='n/a')  !=  Metadata(version='1:4.5-1.1', severity='n/a')

Summary:
   Image: debian:10.5
   Inline Vulnerabilities : 48
   Grype Vulnerabilities  : 108
                 (extra)  : 60 (note: this is ignored in the analysis!)
               (missing)  : 0
   Baseline Vulnerabilities Matched : 100.0 % (48/48 vulnerability)
   Baseline Metadata Matched        : 83.3 % (15/18 metadata)
   Overall Score: 91.7 %
   Quality Gate: pass (>= 85 %)

Comparing results for centos:8.2.2004
./compare.py centos:8.2.2004
Image: centos:8.2.2004
Warning: not comparing severity
Grype found extra vulnerabilities:
      Vulnerability(id='CVE-2016-10228', package=Package(name='glibc', type='rpm'))                     Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2016-10228', package=Package(name='glibc-common', type='rpm'))              Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2016-10228', package=Package(name='glibc-minimal-langpack', type='rpm'))    Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2017-14166', package=Package(name='libarchive', type='rpm'))                Metadata(version='3.3.2-8.el8_1', severity='n/a')
      Vulnerability(id='CVE-2017-14501', package=Package(name='libarchive', type='rpm'))                Metadata(version='3.3.2-8.el8_1', severity='n/a')
      Vulnerability(id='CVE-2017-14502', package=Package(name='libarchive', type='rpm'))                Metadata(version='3.3.2-8.el8_1', severity='n/a')
      Vulnerability(id='CVE-2017-18018', package=Package(name='coreutils-single', type='rpm'))          Metadata(version='8.30-7.el8_2.1', severity='n/a')
      Vulnerability(id='CVE-2018-1000654', package=Package(name='libtasn1', type='rpm'))                Metadata(version='4.13-3.el8', severity='n/a')
      Vulnerability(id='CVE-2018-1000858', package=Package(name='gnupg2', type='rpm'))                  Metadata(version='2.2.9-1.el8', severity='n/a')
      Vulnerability(id='CVE-2018-1000876', package=Package(name='binutils', type='rpm'))                Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-1000879', package=Package(name='libarchive', type='rpm'))              Metadata(version='3.3.2-8.el8_1', severity='n/a')
      Vulnerability(id='CVE-2018-1000880', package=Package(name='libarchive', type='rpm'))              Metadata(version='3.3.2-8.el8_1', severity='n/a')
      Vulnerability(id='CVE-2018-1121', package=Package(name='procps-ng', type='rpm'))                  Metadata(version='3.3.15-1.el8', severity='n/a')
      Vulnerability(id='CVE-2018-12641', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-12697', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-12698', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-12699', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-12700', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-12934', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-16428', package=Package(name='glib2', type='rpm'))                     Metadata(version='2.56.4-8.el8', severity='n/a')
      Vulnerability(id='CVE-2018-16429', package=Package(name='glib2', type='rpm'))                     Metadata(version='2.56.4-8.el8', severity='n/a')
      Vulnerability(id='CVE-2018-17360', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-17794', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-17985', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-18309', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-18483', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-18484', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-18605', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-18606', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-18607', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-18700', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-18701', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-19211', package=Package(name='ncurses-base', type='rpm'))              Metadata(version='6.1-7.20180224.el8', severity='n/a')
      Vulnerability(id='CVE-2018-19211', package=Package(name='ncurses-libs', type='rpm'))              Metadata(version='6.1-7.20180224.el8', severity='n/a')
      Vulnerability(id='CVE-2018-19217', package=Package(name='ncurses-base', type='rpm'))              Metadata(version='6.1-7.20180224.el8', severity='n/a')
      Vulnerability(id='CVE-2018-19217', package=Package(name='ncurses-libs', type='rpm'))              Metadata(version='6.1-7.20180224.el8', severity='n/a')
      Vulnerability(id='CVE-2018-19932', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-20002', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-20225', package=Package(name='python3-pip-wheel', type='rpm'))         Metadata(version='9.0.3-16.el8', severity='n/a')
      Vulnerability(id='CVE-2018-20623', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-20651', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-20657', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-20657', package=Package(name='libgcc', type='rpm'))                    Metadata(version='8.3.1-5.el8.0.2', severity='n/a')
      Vulnerability(id='CVE-2018-20657', package=Package(name='libstdc++', type='rpm'))                 Metadata(version='8.3.1-5.el8.0.2', severity='n/a')
      Vulnerability(id='CVE-2018-20671', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-20673', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2018-20673', package=Package(name='libgcc', type='rpm'))                    Metadata(version='8.3.1-5.el8.0.2', severity='n/a')
      Vulnerability(id='CVE-2018-20673', package=Package(name='libstdc++', type='rpm'))                 Metadata(version='8.3.1-5.el8.0.2', severity='n/a')
      Vulnerability(id='CVE-2018-20786', package=Package(name='vim-minimal', type='rpm'))               Metadata(version='8.0.1763-13.el8', severity='n/a')
      Vulnerability(id='CVE-2018-20839', package=Package(name='systemd', type='rpm'))                   Metadata(version='239-30.el8_2', severity='n/a')
      Vulnerability(id='CVE-2018-20843', package=Package(name='expat', type='rpm'))                     Metadata(version='2.2.5-3.el8', severity='n/a')
      Vulnerability(id='CVE-2018-6872', package=Package(name='binutils', type='rpm'))                   Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2019-1010022', package=Package(name='glibc', type='rpm'))                   Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2019-1010022', package=Package(name='glibc-common', type='rpm'))            Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2019-1010022', package=Package(name='glibc-minimal-langpack', type='rpm'))  Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2019-12904', package=Package(name='libgcrypt', type='rpm'))                 Metadata(version='1.8.3-4.el8', severity='n/a')
      Vulnerability(id='CVE-2019-12972', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2019-13050', package=Package(name='gnupg2', type='rpm'))                    Metadata(version='2.2.9-1.el8', severity='n/a')
      Vulnerability(id='CVE-2019-13750', package=Package(name='sqlite-libs', type='rpm'))               Metadata(version='3.26.0-6.el8', severity='n/a')
      Vulnerability(id='CVE-2019-13751', package=Package(name='sqlite-libs', type='rpm'))               Metadata(version='3.26.0-6.el8', severity='n/a')
      Vulnerability(id='CVE-2019-14250', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2019-14250', package=Package(name='libgcc', type='rpm'))                    Metadata(version='8.3.1-5.el8.0.2', severity='n/a')
      Vulnerability(id='CVE-2019-14250', package=Package(name='libstdc++', type='rpm'))                 Metadata(version='8.3.1-5.el8.0.2', severity='n/a')
      Vulnerability(id='CVE-2019-14866', package=Package(name='cpio', type='rpm'))                      Metadata(version='2.12-8.el8', severity='n/a')
      Vulnerability(id='CVE-2019-16168', package=Package(name='sqlite-libs', type='rpm'))               Metadata(version='3.26.0-6.el8', severity='n/a')
      Vulnerability(id='CVE-2019-17543', package=Package(name='lz4-libs', type='rpm'))                  Metadata(version='1.8.1.2-4.el8', severity='n/a')
      Vulnerability(id='CVE-2019-17594', package=Package(name='ncurses-base', type='rpm'))              Metadata(version='6.1-7.20180224.el8', severity='n/a')
      Vulnerability(id='CVE-2019-17594', package=Package(name='ncurses-libs', type='rpm'))              Metadata(version='6.1-7.20180224.el8', severity='n/a')
      Vulnerability(id='CVE-2019-17595', package=Package(name='ncurses-base', type='rpm'))              Metadata(version='6.1-7.20180224.el8', severity='n/a')
      Vulnerability(id='CVE-2019-17595', package=Package(name='ncurses-libs', type='rpm'))              Metadata(version='6.1-7.20180224.el8', severity='n/a')
      Vulnerability(id='CVE-2019-18218', package=Package(name='file-libs', type='rpm'))                 Metadata(version='5.33-13.el8', severity='n/a')
      Vulnerability(id='CVE-2019-19244', package=Package(name='sqlite-libs', type='rpm'))               Metadata(version='3.26.0-6.el8', severity='n/a')
      Vulnerability(id='CVE-2019-19603', package=Package(name='sqlite-libs', type='rpm'))               Metadata(version='3.26.0-6.el8', severity='n/a')
      Vulnerability(id='CVE-2019-20454', package=Package(name='pcre2', type='rpm'))                     Metadata(version='10.32-1.el8', severity='n/a')
      Vulnerability(id='CVE-2019-20916', package=Package(name='python3-pip-wheel', type='rpm'))         Metadata(version='9.0.3-16.el8', severity='n/a')
      Vulnerability(id='CVE-2019-25013', package=Package(name='glibc', type='rpm'))                     Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2019-25013', package=Package(name='glibc-common', type='rpm'))              Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2019-25013', package=Package(name='glibc-minimal-langpack', type='rpm'))    Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2019-5018', package=Package(name='sqlite-libs', type='rpm'))                Metadata(version='3.26.0-6.el8', severity='n/a')
      Vulnerability(id='CVE-2019-5827', package=Package(name='sqlite-libs', type='rpm'))                Metadata(version='3.26.0-6.el8', severity='n/a')
      Vulnerability(id='CVE-2019-8905', package=Package(name='file-libs', type='rpm'))                  Metadata(version='5.33-13.el8', severity='n/a')
      Vulnerability(id='CVE-2019-8906', package=Package(name='file-libs', type='rpm'))                  Metadata(version='5.33-13.el8', severity='n/a')
      Vulnerability(id='CVE-2019-9071', package=Package(name='binutils', type='rpm'))                   Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2019-9074', package=Package(name='binutils', type='rpm'))                   Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2019-9075', package=Package(name='binutils', type='rpm'))                   Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2019-9077', package=Package(name='binutils', type='rpm'))                   Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2019-9169', package=Package(name='glibc', type='rpm'))                      Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2019-9169', package=Package(name='glibc-common', type='rpm'))               Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2019-9169', package=Package(name='glibc-minimal-langpack', type='rpm'))     Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2019-9674', package=Package(name='platform-python', type='rpm'))            Metadata(version='3.6.8-23.el8', severity='n/a')
      Vulnerability(id='CVE-2019-9674', package=Package(name='python3-libs', type='rpm'))               Metadata(version='3.6.8-23.el8', severity='n/a')
      Vulnerability(id='CVE-2019-9923', package=Package(name='tar', type='rpm'))                        Metadata(version='1.30-4.el8', severity='n/a')
      Vulnerability(id='CVE-2020-12762', package=Package(name='json-c', type='rpm'))                    Metadata(version='0.13.1-0.2.el8', severity='n/a')
      Vulnerability(id='CVE-2020-14382', package=Package(name='cryptsetup-libs', type='rpm'))           Metadata(version='2.2.2-1.el8', severity='n/a')
      Vulnerability(id='CVE-2020-16598', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2020-1971', package=Package(name='openssl-libs', type='rpm'))               Metadata(version='1.1.1c-15.el8', severity='n/a')
      Vulnerability(id='CVE-2020-21674', package=Package(name='libarchive', type='rpm'))                Metadata(version='3.3.2-8.el8_1', severity='n/a')
      Vulnerability(id='CVE-2020-24659', package=Package(name='gnutls', type='rpm'))                    Metadata(version='3.6.8-10.el8_2', severity='n/a')
      Vulnerability(id='CVE-2020-24977', package=Package(name='libxml2', type='rpm'))                   Metadata(version='2.9.7-7.el8', severity='n/a')
      Vulnerability(id='CVE-2020-26116', package=Package(name='platform-python', type='rpm'))           Metadata(version='3.6.8-23.el8', severity='n/a')
      Vulnerability(id='CVE-2020-26116', package=Package(name='python3-libs', type='rpm'))              Metadata(version='3.6.8-23.el8', severity='n/a')
      Vulnerability(id='CVE-2020-27618', package=Package(name='glibc', type='rpm'))                     Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2020-27618', package=Package(name='glibc-common', type='rpm'))              Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2020-27618', package=Package(name='glibc-minimal-langpack', type='rpm'))    Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2020-27619', package=Package(name='platform-python', type='rpm'))           Metadata(version='3.6.8-23.el8', severity='n/a')
      Vulnerability(id='CVE-2020-27619', package=Package(name='python3-libs', type='rpm'))              Metadata(version='3.6.8-23.el8', severity='n/a')
      Vulnerability(id='CVE-2020-28196', package=Package(name='krb5-libs', type='rpm'))                 Metadata(version='1.17-18.el8', severity='n/a')
      Vulnerability(id='CVE-2020-29361', package=Package(name='p11-kit', type='rpm'))                   Metadata(version='0.23.14-5.el8_0', severity='n/a')
      Vulnerability(id='CVE-2020-29361', package=Package(name='p11-kit-trust', type='rpm'))             Metadata(version='0.23.14-5.el8_0', severity='n/a')
      Vulnerability(id='CVE-2020-29362', package=Package(name='p11-kit', type='rpm'))                   Metadata(version='0.23.14-5.el8_0', severity='n/a')
      Vulnerability(id='CVE-2020-29362', package=Package(name='p11-kit-trust', type='rpm'))             Metadata(version='0.23.14-5.el8_0', severity='n/a')
      Vulnerability(id='CVE-2020-29363', package=Package(name='p11-kit', type='rpm'))                   Metadata(version='0.23.14-5.el8_0', severity='n/a')
      Vulnerability(id='CVE-2020-29363', package=Package(name='p11-kit-trust', type='rpm'))             Metadata(version='0.23.14-5.el8_0', severity='n/a')
      Vulnerability(id='CVE-2020-35448', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2020-35493', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2020-35494', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2020-35495', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2020-35496', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2020-35507', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2020-35512', package=Package(name='dbus', type='rpm'))                      Metadata(version='1.12.8-9.el8', severity='n/a')
      Vulnerability(id='CVE-2020-35512', package=Package(name='dbus-common', type='rpm'))               Metadata(version='1.12.8-9.el8', severity='n/a')
      Vulnerability(id='CVE-2020-35512', package=Package(name='dbus-daemon', type='rpm'))               Metadata(version='1.12.8-9.el8', severity='n/a')
      Vulnerability(id='CVE-2020-35512', package=Package(name='dbus-libs', type='rpm'))                 Metadata(version='1.12.8-9.el8', severity='n/a')
      Vulnerability(id='CVE-2020-35512', package=Package(name='dbus-tools', type='rpm'))                Metadata(version='1.12.8-9.el8', severity='n/a')
      Vulnerability(id='CVE-2020-8284', package=Package(name='curl', type='rpm'))                       Metadata(version='7.61.1-12.el8', severity='n/a')
      Vulnerability(id='CVE-2020-8284', package=Package(name='libcurl-minimal', type='rpm'))            Metadata(version='7.61.1-12.el8', severity='n/a')
      Vulnerability(id='CVE-2020-8285', package=Package(name='curl', type='rpm'))                       Metadata(version='7.61.1-12.el8', severity='n/a')
      Vulnerability(id='CVE-2020-8285', package=Package(name='libcurl-minimal', type='rpm'))            Metadata(version='7.61.1-12.el8', severity='n/a')
      Vulnerability(id='CVE-2020-8286', package=Package(name='curl', type='rpm'))                       Metadata(version='7.61.1-12.el8', severity='n/a')
      Vulnerability(id='CVE-2020-8286', package=Package(name='libcurl-minimal', type='rpm'))            Metadata(version='7.61.1-12.el8', severity='n/a')
      Vulnerability(id='CVE-2020-8625', package=Package(name='bind-export-libs', type='rpm'))           Metadata(version='9.11.13-3.el8', severity='n/a')
      Vulnerability(id='CVE-2021-20193', package=Package(name='tar', type='rpm'))                       Metadata(version='1.30-4.el8', severity='n/a')
      Vulnerability(id='CVE-2021-20197', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2021-20231', package=Package(name='gnutls', type='rpm'))                    Metadata(version='3.6.8-10.el8_2', severity='n/a')
      Vulnerability(id='CVE-2021-20232', package=Package(name='gnutls', type='rpm'))                    Metadata(version='3.6.8-10.el8_2', severity='n/a')
      Vulnerability(id='CVE-2021-20266', package=Package(name='python3-rpm', type='rpm'))               Metadata(version='4.14.2-37.el8', severity='n/a')
      Vulnerability(id='CVE-2021-20266', package=Package(name='rpm', type='python'))                    Metadata(version='4.14.2', severity='n/a')
      Vulnerability(id='CVE-2021-20266', package=Package(name='rpm', type='rpm'))                       Metadata(version='4.14.2-37.el8', severity='n/a')
      Vulnerability(id='CVE-2021-20266', package=Package(name='rpm-build-libs', type='rpm'))            Metadata(version='4.14.2-37.el8', severity='n/a')
      Vulnerability(id='CVE-2021-20266', package=Package(name='rpm-libs', type='rpm'))                  Metadata(version='4.14.2-37.el8', severity='n/a')
      Vulnerability(id='CVE-2021-20269', package=Package(name='kexec-tools', type='rpm'))               Metadata(version='2.0.20-14.el8', severity='n/a')
      Vulnerability(id='CVE-2021-20271', package=Package(name='python3-rpm', type='rpm'))               Metadata(version='4.14.2-37.el8', severity='n/a')
      Vulnerability(id='CVE-2021-20271', package=Package(name='rpm', type='rpm'))                       Metadata(version='4.14.2-37.el8', severity='n/a')
      Vulnerability(id='CVE-2021-20271', package=Package(name='rpm-build-libs', type='rpm'))            Metadata(version='4.14.2-37.el8', severity='n/a')
      Vulnerability(id='CVE-2021-20271', package=Package(name='rpm-libs', type='rpm'))                  Metadata(version='4.14.2-37.el8', severity='n/a')
      Vulnerability(id='CVE-2021-20284', package=Package(name='binutils', type='rpm'))                  Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2021-20305', package=Package(name='gnutls', type='rpm'))                    Metadata(version='3.6.8-10.el8_2', severity='n/a')
      Vulnerability(id='CVE-2021-20305', package=Package(name='nettle', type='rpm'))                    Metadata(version='3.4.1-1.el8', severity='n/a')
      Vulnerability(id='CVE-2021-22876', package=Package(name='curl', type='rpm'))                      Metadata(version='7.61.1-12.el8', severity='n/a')
      Vulnerability(id='CVE-2021-22876', package=Package(name='libcurl-minimal', type='rpm'))           Metadata(version='7.61.1-12.el8', severity='n/a')
      Vulnerability(id='CVE-2021-22898', package=Package(name='curl', type='rpm'))                      Metadata(version='7.61.1-12.el8', severity='n/a')
      Vulnerability(id='CVE-2021-22898', package=Package(name='libcurl-minimal', type='rpm'))           Metadata(version='7.61.1-12.el8', severity='n/a')
      Vulnerability(id='CVE-2021-23336', package=Package(name='platform-python', type='rpm'))           Metadata(version='3.6.8-23.el8', severity='n/a')
      Vulnerability(id='CVE-2021-23336', package=Package(name='python3-libs', type='rpm'))              Metadata(version='3.6.8-23.el8', severity='n/a')
      Vulnerability(id='CVE-2021-23840', package=Package(name='openssl-libs', type='rpm'))              Metadata(version='1.1.1c-15.el8', severity='n/a')
      Vulnerability(id='CVE-2021-23841', package=Package(name='openssl-libs', type='rpm'))              Metadata(version='1.1.1c-15.el8', severity='n/a')
      Vulnerability(id='CVE-2021-24032', package=Package(name='libzstd', type='rpm'))                   Metadata(version='1.4.2-2.el8', severity='n/a')
      Vulnerability(id='CVE-2021-25214', package=Package(name='bind-export-libs', type='rpm'))          Metadata(version='9.11.13-3.el8', severity='n/a')
      Vulnerability(id='CVE-2021-25215', package=Package(name='bind-export-libs', type='rpm'))          Metadata(version='9.11.13-3.el8', severity='n/a')
      Vulnerability(id='CVE-2021-25217', package=Package(name='dhcp-client', type='rpm'))               Metadata(version='4.3.6-40.el8', severity='n/a')
      Vulnerability(id='CVE-2021-25217', package=Package(name='dhcp-common', type='rpm'))               Metadata(version='4.3.6-40.el8', severity='n/a')
      Vulnerability(id='CVE-2021-25217', package=Package(name='dhcp-libs', type='rpm'))                 Metadata(version='4.3.6-40.el8', severity='n/a')
      Vulnerability(id='CVE-2021-27218', package=Package(name='glib2', type='rpm'))                     Metadata(version='2.56.4-8.el8', severity='n/a')
      Vulnerability(id='CVE-2021-27219', package=Package(name='glib2', type='rpm'))                     Metadata(version='2.56.4-8.el8', severity='n/a')
      Vulnerability(id='CVE-2021-27645', package=Package(name='glibc', type='rpm'))                     Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2021-27645', package=Package(name='glibc-common', type='rpm'))              Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2021-27645', package=Package(name='glibc-minimal-langpack', type='rpm'))    Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2021-28153', package=Package(name='glib2', type='rpm'))                     Metadata(version='2.56.4-8.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3177', package=Package(name='platform-python', type='rpm'))            Metadata(version='3.6.8-23.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3177', package=Package(name='python3-libs', type='rpm'))               Metadata(version='3.6.8-23.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3200', package=Package(name='libsolv', type='rpm'))                    Metadata(version='0.7.7-1.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3326', package=Package(name='glibc', type='rpm'))                      Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3326', package=Package(name='glibc-common', type='rpm'))               Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3326', package=Package(name='glibc-minimal-langpack', type='rpm'))     Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2021-33560', package=Package(name='libgcrypt', type='rpm'))                 Metadata(version='1.8.3-4.el8', severity='n/a')
      Vulnerability(id='CVE-2021-33574', package=Package(name='glibc', type='rpm'))                     Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2021-33574', package=Package(name='glibc-common', type='rpm'))              Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2021-33574', package=Package(name='glibc-minimal-langpack', type='rpm'))    Metadata(version='2.28-101.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3421', package=Package(name='python3-rpm', type='rpm'))                Metadata(version='4.14.2-37.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3421', package=Package(name='rpm', type='python'))                     Metadata(version='4.14.2', severity='n/a')
      Vulnerability(id='CVE-2021-3421', package=Package(name='rpm', type='rpm'))                        Metadata(version='4.14.2-37.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3421', package=Package(name='rpm-build-libs', type='rpm'))             Metadata(version='4.14.2-37.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3421', package=Package(name='rpm-libs', type='rpm'))                   Metadata(version='4.14.2-37.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3426', package=Package(name='platform-python', type='rpm'))            Metadata(version='3.6.8-23.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3426', package=Package(name='python3-libs', type='rpm'))               Metadata(version='3.6.8-23.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3445', package=Package(name='libdnf', type='rpm'))                     Metadata(version='0.39.1-5.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3445', package=Package(name='python3-hawkey', type='rpm'))             Metadata(version='0.39.1-5.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3445', package=Package(name='python3-libdnf', type='rpm'))             Metadata(version='0.39.1-5.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3449', package=Package(name='openssl-libs', type='rpm'))               Metadata(version='1.1.1c-15.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3450', package=Package(name='openssl-libs', type='rpm'))               Metadata(version='1.1.1c-15.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3487', package=Package(name='binutils', type='rpm'))                   Metadata(version='2.30-73.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3516', package=Package(name='libxml2', type='rpm'))                    Metadata(version='2.9.7-7.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3517', package=Package(name='libxml2', type='rpm'))                    Metadata(version='2.9.7-7.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3518', package=Package(name='libxml2', type='rpm'))                    Metadata(version='2.9.7-7.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3520', package=Package(name='lz4-libs', type='rpm'))                   Metadata(version='1.8.1.2-4.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3537', package=Package(name='libxml2', type='rpm'))                    Metadata(version='2.9.7-7.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3541', package=Package(name='libxml2', type='rpm'))                    Metadata(version='2.9.7-7.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3572', package=Package(name='python3-pip-wheel', type='rpm'))          Metadata(version='9.0.3-16.el8', severity='n/a')
      Vulnerability(id='CVE-2021-3580', package=Package(name='nettle', type='rpm'))                     Metadata(version='3.4.1-1.el8', severity='n/a')

Grype missed vulnerabilities:
      Vulnerability(id='CVE-2019-20386', package=Package(name='systemd-libs', type='rpm'))  Metadata(version='239-30.el8_2', severity='n/a')
      Vulnerability(id='CVE-2019-20386', package=Package(name='systemd-pam', type='rpm'))   Metadata(version='239-30.el8_2', severity='n/a')
      Vulnerability(id='CVE-2019-20386', package=Package(name='systemd-udev', type='rpm'))  Metadata(version='239-30.el8_2', severity='n/a')
      Vulnerability(id='CVE-2019-3842', package=Package(name='systemd-libs', type='rpm'))   Metadata(version='239-30.el8_2', severity='n/a')
      Vulnerability(id='CVE-2019-3842', package=Package(name='systemd-pam', type='rpm'))    Metadata(version='239-30.el8_2', severity='n/a')
      Vulnerability(id='CVE-2019-3842', package=Package(name='systemd-udev', type='rpm'))   Metadata(version='239-30.el8_2', severity='n/a')
      Vulnerability(id='CVE-2020-13776', package=Package(name='systemd-libs', type='rpm'))  Metadata(version='239-30.el8_2', severity='n/a')
      Vulnerability(id='CVE-2020-13776', package=Package(name='systemd-pam', type='rpm'))   Metadata(version='239-30.el8_2', severity='n/a')
      Vulnerability(id='CVE-2020-13776', package=Package(name='systemd-udev', type='rpm'))  Metadata(version='239-30.el8_2', severity='n/a')
      Vulnerability(id='CVE-2020-15888', package=Package(name='lua-libs', type='rpm'))      Metadata(version='5.3.4-11.el8', severity='n/a')

Grype mismatched metadata:
      for:  Package(name='systemd-libs', type='rpm')  :  '--- MISSING ---'  !=  Metadata(version='239-30.el8_2', severity='n/a')
      for:  Package(name='systemd-pam', type='rpm')   :  '--- MISSING ---'  !=  Metadata(version='239-30.el8_2', severity='n/a')
      for:  Package(name='systemd-udev', type='rpm')  :  '--- MISSING ---'  !=  Metadata(version='239-30.el8_2', severity='n/a')

Summary:
   Image: centos:8.2.2004
   Inline Vulnerabilities : 80
   Grype Vulnerabilities  : 269
                 (extra)  : 199 (note: this is ignored in the analysis!)
               (missing)  : 10
   Baseline Vulnerabilities Matched : 87.5 % (70/80 vulnerability)
   Baseline Metadata Matched        : 92.1 % (35/38 metadata)
   Overall Score: 89.8 %
   Quality Gate: pass (>= 85 %)

Comparing results for alpine:3.12.0
./compare.py alpine:3.12.0
Image: alpine:3.12.0
Warning: not comparing severity
inline does not have any vulnerabilities to compare to
Comparing results for alpine-vuln:latest
./compare.py alpine-vuln:latest
Image: alpine-vuln:latest
Warning: not comparing severity
Grype found extra vulnerabilities:
      Vulnerability(id='CVE-2010-5304', package=Package(name='libvncserver', type='apkg'))    Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2014-6051', package=Package(name='libvncserver', type='apkg'))    Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2014-6052', package=Package(name='libvncserver', type='apkg'))    Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2014-6053', package=Package(name='libvncserver', type='apkg'))    Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2014-6054', package=Package(name='libvncserver', type='apkg'))    Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2014-6055', package=Package(name='libvncserver', type='apkg'))    Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2017-18922', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2018-15126', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2018-15127', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2018-20019', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2018-20020', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2018-20021', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2018-20022', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2018-20023', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2018-20024', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2018-20748', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2018-20749', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2018-20750', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2018-21247', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2018-6307', package=Package(name='libvncserver', type='apkg'))    Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2019-20788', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2020-14396', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2020-14398', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2020-25708', package=Package(name='libvncserver', type='apkg'))   Metadata(version='0.9.9-r0', severity='n/a')
      Vulnerability(id='CVE-2021-20205', package=Package(name='libjpeg-turbo', type='apkg'))  Metadata(version='2.0.5-r0', severity='n/a')
      Vulnerability(id='CVE-2021-20305', package=Package(name='nettle', type='apkg'))         Metadata(version='3.5.1-r1', severity='n/a')
      Vulnerability(id='CVE-2021-28831', package=Package(name='busybox', type='apkg'))        Metadata(version='1.31.1-r16', severity='n/a')
      Vulnerability(id='CVE-2021-30139', package=Package(name='apk-tools', type='apkg'))      Metadata(version='2.10.5-r1', severity='n/a')
      Vulnerability(id='CVE-2021-33560', package=Package(name='libgcrypt', type='apkg'))      Metadata(version='1.8.5-r0', severity='n/a')

Summary:
   Image: alpine-vuln:latest
   Inline Vulnerabilities : 14
   Grype Vulnerabilities  : 43
                 (extra)  : 29 (note: this is ignored in the analysis!)
               (missing)  : 0
   Baseline Vulnerabilities Matched : 100.0 % (14/14 vulnerability)
   Baseline Metadata Matched        : 100.0 % (1/1 metadata)
   Overall Score: 100.0 %
   Quality Gate: pass (>= 100 %)

Comparing results for java-vuln:latest
./compare.py java-vuln:latest
Image: java-vuln:latest
Warning: not comparing severity
Grype found extra vulnerabilities:
      Vulnerability(id='CVE-2019-13990', package=Package(name='quartz', type='java'))     Metadata(version='2.3.1', severity='n/a')
      Vulnerability(id='CVE-2021-28831', package=Package(name='busybox', type='apkg'))    Metadata(version='1.31.1-r16', severity='n/a')
      Vulnerability(id='CVE-2021-30139', package=Package(name='apk-tools', type='apkg'))  Metadata(version='2.10.5-r1', severity='n/a')

Summary:
   Image: java-vuln:latest
   Inline Vulnerabilities : 1
   Grype Vulnerabilities  : 4
                 (extra)  : 3 (note: this is ignored in the analysis!)
               (missing)  : 0
   Baseline Vulnerabilities Matched : 100.0 % (1/1 vulnerability)
   Baseline Metadata Matched        : 100.0 % (1/1 metadata)
   Overall Score: 100.0 %
   Quality Gate: pass (>= 100 %)

Comparing results for python-vuln:latest
./compare.py python-vuln:latest
Image: python-vuln:latest
Warning: not comparing severity
Grype found extra vulnerabilities:
      Vulnerability(id='CVE-2018-18074', package=Package(name='requests', type='python'))  Metadata(version='2.10.0', severity='n/a')
      Vulnerability(id='CVE-2018-20225', package=Package(name='pip', type='python'))       Metadata(version='20.2.3', severity='n/a')
      Vulnerability(id='CVE-2021-28831', package=Package(name='busybox', type='apkg'))     Metadata(version='1.31.1-r16', severity='n/a')
      Vulnerability(id='CVE-2021-30139', package=Package(name='apk-tools', type='apkg'))   Metadata(version='2.10.5-r1', severity='n/a')

Summary:
   Image: python-vuln:latest
   Inline Vulnerabilities : 1
   Grype Vulnerabilities  : 5
                 (extra)  : 4 (note: this is ignored in the analysis!)
               (missing)  : 0
   Baseline Vulnerabilities Matched : 100.0 % (1/1 vulnerability)
   Baseline Metadata Matched        : 100.0 % (1/1 metadata)
   Overall Score: 100.0 %
   Quality Gate: pass (>= 100 %)
```