### PR TITLE
Modify Document struct Components tag to use lower case 'component'

### DIFF
--- a/grype/presenter/cyclonedx/document.go
+++ b/grype/presenter/cyclonedx/document.go
@@ -22,7 +22,7 @@ type Document struct {
 	Version       int            `xml:"version,attr"`
 	SerialNumber  string         `xml:"serialNumber,attr"`
 	BomDescriptor *BomDescriptor `xml:"metadata"`
-	Components    []Component    `xml:"components>Component"`
+	Components    []Component    `xml:"components>component"`
 }
 
 // NewDocument returns a CycloneDX Document object populated with the SBOM and vulnerability findings.


### PR DESCRIPTION
The Grype scanner produces a CycloneDX Vulnerability Document which is in XML output with lower case component tags.

However the "Document" struct from this library has a Components tag that uses an upper case "Component". When the CycloneDX XML output is passed into a Document struct, it results in an empty Components array.

Fixing this issue https://github.com/anchore/grype/issues/345.

Signed-off-by: Robin Li <lrobin@vmware.com>