### PR TITLE
Show no value in table output for unknown fixes

### DIFF
--- a/grype/presenter/table/presenter.go
+++ b/grype/presenter/table/presenter.go
@@ -52,7 +52,7 @@ func (pres *Presenter) Present(output io.Writer) error {
 		case grypeDb.WontFixState:
 			fixVersion = "(won't fix)"
 		case grypeDb.UnknownFixState:
-			fixVersion = "(fixes indeterminate)"
+			fixVersion = ""
 		}
 
 		rows = append(rows, []string{m.Package.Name, m.Package.Version, fixVersion, m.Vulnerability.ID, severity})


### PR DESCRIPTION
- Removes a lingering use of the "fixes indeterminate" term from the table output — now, if the fix state is unknown, the table output shows nothing in the "FIXED-IN" column.