### PR TITLE
Fix panic from distro nil pointer dereference

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -769,6 +769,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgho=
 github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/grype/matcher/apk/matcher.go
+++ b/grype/matcher/apk/matcher.go
@@ -57,7 +57,7 @@ func (m *Matcher) cpeMatchesWithoutSecDbFixes(store vulnerability.Provider, d *d
 
 	// remove cpe matches where there is an entry in the secDB for the particular package-vulnerability pairing, and the
 	// installed package version is >= the fixed in version for the secDB record.
-	secDbVulnerabilities, err := store.GetByDistro(*d, p)
+	secDbVulnerabilities, err := store.GetByDistro(d, p)
 	if err != nil {
 		return nil, err
 	}

--- a/grype/matcher/common/distro_matchers.go
+++ b/grype/matcher/common/distro_matchers.go
@@ -22,7 +22,7 @@ func FindMatchesByPackageDistro(store vulnerability.ProviderByDistro, d *distro.
 
 	var allPkgVulns []vulnerability.Vulnerability
 
-	allPkgVulns, err = store.GetByDistro(*d, p)
+	allPkgVulns, err = store.GetByDistro(d, p)
 	if err != nil {
 		return nil, fmt.Errorf("matcher failed to fetch distro='%s' pkg='%s': %w", d, p.Name, err)
 	}

--- a/grype/matcher/common/distro_matchers_test.go
+++ b/grype/matcher/common/distro_matchers_test.go
@@ -55,7 +55,7 @@ func (pr *mockDistroProvider) stub() {
 	}
 }
 
-func (pr *mockDistroProvider) GetByDistro(d distro.Distro, p pkg.Package) ([]vulnerability.Vulnerability, error) {
+func (pr *mockDistroProvider) GetByDistro(d *distro.Distro, p pkg.Package) ([]vulnerability.Vulnerability, error) {
 	return pr.data[strings.ToLower(d.Type.String())+":"+d.FullVersion()][p.Name], nil
 }
 

--- a/grype/matcher/dpkg/matcher_mocks_test.go
+++ b/grype/matcher/dpkg/matcher_mocks_test.go
@@ -50,6 +50,6 @@ func (pr *mockProvider) stub() {
 	}
 }
 
-func (pr *mockProvider) GetByDistro(d distro.Distro, p pkg.Package) ([]vulnerability.Vulnerability, error) {
+func (pr *mockProvider) GetByDistro(d *distro.Distro, p pkg.Package) ([]vulnerability.Vulnerability, error) {
 	return pr.data[strings.ToLower(d.Type.String())+":"+d.FullVersion()][p.Name], nil
 }

--- a/grype/matcher/rpmdb/matcher_mocks_test.go
+++ b/grype/matcher/rpmdb/matcher_mocks_test.go
@@ -50,7 +50,7 @@ func (pr *mockProvider) stub() {
 	}
 }
 
-func (pr *mockProvider) GetByDistro(d distro.Distro, p pkg.Package) ([]vulnerability.Vulnerability, error) {
+func (pr *mockProvider) GetByDistro(d *distro.Distro, p pkg.Package) ([]vulnerability.Vulnerability, error) {
 	var ty = strings.ToLower(d.Type.String())
 	if d.Type == distro.CentOS || d.Type == distro.RedHat {
 		ty = "rhel"

--- a/grype/vulnerability/provider.go
+++ b/grype/vulnerability/provider.go
@@ -13,7 +13,7 @@ type Provider interface {
 }
 
 type ProviderByDistro interface {
-	GetByDistro(distro.Distro, pkg.Package) ([]Vulnerability, error)
+	GetByDistro(*distro.Distro, pkg.Package) ([]Vulnerability, error)
 }
 
 type ProviderByLanguage interface {

--- a/grype/vulnerability/store_adapter.go
+++ b/grype/vulnerability/store_adapter.go
@@ -21,14 +21,18 @@ func NewProviderFromStore(store db.VulnerabilityStoreReader) *StoreAdapter {
 	}
 }
 
-func (pr *StoreAdapter) GetByDistro(d distro.Distro, p pkg.Package) ([]Vulnerability, error) {
-	vulns := make([]Vulnerability, 0)
+func (pr *StoreAdapter) GetByDistro(d *distro.Distro, p pkg.Package) ([]Vulnerability, error) {
+	if d == nil {
+		return nil, nil
+	}
 
-	namespace := distroNamespace(d)
+	namespace := distroNamespace(*d)
 	allPkgVulns, err := pr.store.GetVulnerability(namespace, p.Name)
 	if err != nil {
 		return nil, fmt.Errorf("provider failed to fetch namespace='%s' pkg='%s': %w", namespace, p.Name, err)
 	}
+
+	var vulnerabilities []Vulnerability
 
 	for _, vuln := range allPkgVulns {
 		vulnObj, err := NewVulnerability(vuln)
@@ -36,10 +40,10 @@ func (pr *StoreAdapter) GetByDistro(d distro.Distro, p pkg.Package) ([]Vulnerabi
 			return nil, fmt.Errorf("provider failed to parse distro='%s': %w", d, err)
 		}
 
-		vulns = append(vulns, *vulnObj)
+		vulnerabilities = append(vulnerabilities, *vulnObj)
 	}
 
-	return vulns, nil
+	return vulnerabilities, nil
 }
 
 func (pr *StoreAdapter) GetByLanguage(l syftPkg.Language, p pkg.Package) ([]Vulnerability, error) {

--- a/grype/vulnerability/store_adapter_test.go
+++ b/grype/vulnerability/store_adapter_test.go
@@ -54,7 +54,19 @@ func TestGetByDistro(t *testing.T) {
 			t.Errorf("diff: %+v", d)
 		}
 	}
+}
 
+func TestGetByDistro_nilDistro(t *testing.T) {
+	provider := NewProviderFromStore(newMockStore())
+
+	p := pkg.Package{
+		Name: "neutron",
+	}
+
+	vulnerabilities, err := provider.GetByDistro(nil, p)
+
+	assert.Empty(t, vulnerabilities)
+	assert.NoError(t, err)
 }
 
 func must(c syftPkg.CPE, e error) syftPkg.CPE {

--- a/grype/vulnerability/store_adapter_test.go
+++ b/grype/vulnerability/store_adapter_test.go
@@ -25,7 +25,7 @@ func TestGetByDistro(t *testing.T) {
 		Name: "neutron",
 	}
 
-	actual, err := provider.GetByDistro(d, p)
+	actual, err := provider.GetByDistro(&d, p)
 	if err != nil {
 		t.Fatalf("failed to get by distro: %+v", err)
 	}


### PR DESCRIPTION
Fixes #353 

Adjusts the `ProviderByDistro` interface (and its implementation `StoreAdapter`) by having the `GetByDistro` method take a pointer to a distro, rather than just a distro. By doing so, matches don't need to check for `nil` distro values before asking the store provider to match by distro.