### PR TITLE
Always include severity in cyclonedx ratings

### DIFF
--- a/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenterDir.golden
+++ b/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenterDir.golden
@@ -26,12 +26,14 @@
           </v:source>
           <v:ratings>
             <v:rating>
+              <v:severity>Low</v:severity>
+            </v:rating>
+            <v:rating>
               <v:score>
                 <v:base>4</v:base>
                 <v:impact>0</v:impact>
                 <v:exploitability>0</v:exploitability>
               </v:score>
-              <v:severity>Low</v:severity>
               <v:method>CVSSv3</v:method>
               <v:vector>another vector</v:vector>
             </v:rating>
@@ -46,12 +48,14 @@
           </v:source>
           <v:ratings>
             <v:rating>
+              <v:severity>Critical</v:severity>
+            </v:rating>
+            <v:rating>
               <v:score>
                 <v:base>1</v:base>
                 <v:impact>3</v:impact>
                 <v:exploitability>2</v:exploitability>
               </v:score>
-              <v:severity>Critical</v:severity>
               <v:method>CVSSv2</v:method>
               <v:vector>vector</v:vector>
             </v:rating>

--- a/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenterImage.golden
+++ b/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenterImage.golden
@@ -26,12 +26,14 @@
           </v:source>
           <v:ratings>
             <v:rating>
+              <v:severity>Low</v:severity>
+            </v:rating>
+            <v:rating>
               <v:score>
                 <v:base>4</v:base>
                 <v:impact>0</v:impact>
                 <v:exploitability>0</v:exploitability>
               </v:score>
-              <v:severity>Low</v:severity>
               <v:method>CVSSv3</v:method>
               <v:vector>another vector</v:vector>
             </v:rating>
@@ -46,12 +48,14 @@
           </v:source>
           <v:ratings>
             <v:rating>
+              <v:severity>Critical</v:severity>
+            </v:rating>
+            <v:rating>
               <v:score>
                 <v:base>1</v:base>
                 <v:impact>3</v:impact>
                 <v:exploitability>2</v:exploitability>
               </v:score>
-              <v:severity>Critical</v:severity>
               <v:method>CVSSv2</v:method>
               <v:vector>vector</v:vector>
             </v:rating>

--- a/grype/presenter/cyclonedx/vulnerability.go
+++ b/grype/presenter/cyclonedx/vulnerability.go
@@ -36,7 +36,7 @@ type Source struct {
 
 // Rating has information about the intensity of a vulnerability
 type Rating struct {
-	Score    Score  `xml:"v:score"`
+	Score    *Score `xml:"v:score,omitempty"`
 	Severity string `xml:"v:severity,omitempty"`
 	Method   string `xml:"v:method,omitempty"`
 	Vector   string `xml:"v:vector,omitempty"`
@@ -86,33 +86,32 @@ func NewVulnerability(m match.Match, p vulnerability.MetadataProvider) (Vulnerab
 		severity = "Low"
 	}
 
-	var ratings = make([]Rating, 0)
-	if len(metadata.Cvss) == 0 {
-		ratings = append(ratings, Rating{
+	var ratings = []Rating{
+		{
 			Severity: severity,
-		})
+		},
 	}
 	for _, cvss := range metadata.Cvss {
 		var rating Rating
-		var score Score
+		score := &Score{
+			Base: cvss.Metrics.BaseScore,
+		}
 		if cvss.Metrics.ExploitabilityScore != nil {
 			score.Exploitability = *cvss.Metrics.ExploitabilityScore
 		}
 		if cvss.Metrics.ImpactScore != nil {
 			score.Impact = *cvss.Metrics.ImpactScore
 		}
-		score.Base = cvss.Metrics.BaseScore
 		rating.Score = score
-		rating.Severity = severity
 
 		method, err := cvssVersionToMethod(cvss.Version)
-		if err == nil {
-			rating.Method = method
-			rating.Vector = cvss.Vector
-		} else {
+		if err != nil {
 			log.Errorf("unable to parse CVSS version: %v", err)
 			// do not halt execution if one CVSS fails to provide an accurate Version
+			continue
 		}
+		rating.Method = method
+		rating.Vector = cvss.Vector
 
 		ratings = append(ratings, rating)
 	}

--- a/grype/presenter/cyclonedx/vulnerability.go
+++ b/grype/presenter/cyclonedx/vulnerability.go
@@ -79,7 +79,19 @@ func NewVulnerability(m match.Match, p vulnerability.MetadataProvider) (Vulnerab
 		return Vulnerability{}, fmt.Errorf("unable to fetch vuln=%q metadata: %+v", m.Vulnerability.ID, err)
 	}
 
+	// The schema does not allow "Negligible", only allowing the following:
+	// 'None', 'Low', 'Medium', 'High', 'Critical', 'Unknown'
+	severity := metadata.Severity
+	if metadata.Severity == "Negligible" {
+		severity = "Low"
+	}
+
 	var ratings = make([]Rating, 0)
+	if len(metadata.Cvss) == 0 {
+		ratings = append(ratings, Rating{
+			Severity: severity,
+		})
+	}
 	for _, cvss := range metadata.Cvss {
 		var rating Rating
 		var score Score
@@ -91,23 +103,16 @@ func NewVulnerability(m match.Match, p vulnerability.MetadataProvider) (Vulnerab
 		}
 		score.Base = cvss.Metrics.BaseScore
 		rating.Score = score
+		rating.Severity = severity
+
 		method, err := cvssVersionToMethod(cvss.Version)
-		if err != nil {
+		if err == nil {
+			rating.Method = method
+			rating.Vector = cvss.Vector
+		} else {
 			log.Errorf("unable to parse CVSS version: %v", err)
 			// do not halt execution if one CVSS fails to provide an accurate Version
-			continue
 		}
-		rating.Method = method
-		rating.Vector = cvss.Vector
-
-		// The schema does not allow "Negligible", only allowing the following:
-		// 'None', 'Low', 'Medium', 'High', 'Critical', 'Unknown'
-		severity := metadata.Severity
-		if metadata.Severity == "Negligible" {
-			severity = "Low"
-		}
-
-		rating.Severity = severity
 
 		ratings = append(ratings, rating)
 	}

--- a/grype/presenter/cyclonedx/vulnerability_test.go
+++ b/grype/presenter/cyclonedx/vulnerability_test.go
@@ -3,6 +3,9 @@ package cyclonedx
 import (
 	"testing"
 
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -54,6 +57,88 @@ func TestCvssVersionToMethod(t *testing.T) {
 			}
 
 			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+type metadataProvider struct {
+	severity string
+	cvss     []vulnerability.Cvss
+}
+
+func (m metadataProvider) GetMetadata(id, namespace string) (*vulnerability.Metadata, error) {
+	return &vulnerability.Metadata{
+		ID:          id,
+		DataSource:  "",
+		Namespace:   namespace,
+		Severity:    m.severity,
+		URLs:        nil,
+		Description: "",
+		Cvss:        m.cvss,
+	}, nil
+}
+
+func TestNewVulnerability_AlwaysIncludesSeverity(t *testing.T) {
+	tests := []struct {
+		name             string
+		match            match.Match
+		metadataProvider *metadataProvider
+	}{
+		{
+			name: "populates severity with missing CVSS records",
+			match: match.Match{
+				Type:          0,
+				Vulnerability: vulnerability.Vulnerability{},
+				Package:       pkg.Package{},
+				MatchDetails:  nil,
+			},
+			metadataProvider: &metadataProvider{
+				severity: "High",
+			},
+		},
+		{
+			name: "populates severity with all CVSS records",
+			match: match.Match{
+				Type:          0,
+				Vulnerability: vulnerability.Vulnerability{},
+				Package:       pkg.Package{},
+				MatchDetails:  nil,
+			},
+			metadataProvider: &metadataProvider{
+				severity: "High",
+				cvss: []vulnerability.Cvss{
+					{
+						Version: "2.0",
+						Metrics: vulnerability.CvssMetrics{
+							BaseScore: 1.1,
+						},
+					},
+					{
+						Version: "3.0",
+						Metrics: vulnerability.CvssMetrics{
+							BaseScore: 2.1,
+						},
+					},
+					{
+						Version: "3.1",
+						Metrics: vulnerability.CvssMetrics{
+							BaseScore: 3.1,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := NewVulnerability(test.match, test.metadataProvider)
+			assert.NoError(t, err)
+			if len(actual.Ratings) == 0 {
+				t.Fatalf("expected a rating but found none")
+			}
+			for _, r := range actual.Ratings {
+				assert.Equal(t, r.Severity, test.metadataProvider.severity)
+			}
 		})
 	}
 }

--- a/grype/presenter/cyclonedx/vulnerability_test.go
+++ b/grype/presenter/cyclonedx/vulnerability_test.go
@@ -136,8 +136,9 @@ func TestNewVulnerability_AlwaysIncludesSeverity(t *testing.T) {
 			if len(actual.Ratings) == 0 {
 				t.Fatalf("expected a rating but found none")
 			}
-			for _, r := range actual.Ratings {
-				assert.Equal(t, r.Severity, test.metadataProvider.severity)
+			assert.Equal(t, actual.Ratings[0].Severity, test.metadataProvider.severity)
+			for _, r := range actual.Ratings[1:] {
+				assert.Equal(t, r.Severity, "")
 			}
 		})
 	}


### PR DESCRIPTION
Some feeds don't include CVSS but still report severity of a CVE

Fix #364 and #366