### PR TITLE
Update MSRC matching to include product ID in the suffix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/adrg/xdg v0.2.1
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca
-	github.com/anchore/grype-db v0.0.0-20210715172505-e527bcf6bc40
+	github.com/anchore/grype-db v0.0.0-20210809130557-72ff1b90af67
 	github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f
 	github.com/anchore/syft v0.19.2-0.20210809195219-98d4749f86ce
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
@@ -36,5 +36,3 @@ require (
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	gopkg.in/yaml.v2 v2.3.0
 )
-
-replace github.com/anchore/grype-db => ../grype-db

--- a/go.mod
+++ b/go.mod
@@ -36,3 +36,5 @@ require (
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	gopkg.in/yaml.v2 v2.3.0
 )
+
+replace github.com/anchore/grype-db => ../grype-db

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,9 @@ github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc
 github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca h1:rLyc7Rih769rYABQe4nBPt3jHJd/snBuVvKKGoy5HEc=
 github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/grype v0.14.1-0.20210702143224-05ade7bbbf70/go.mod h1:yPh9WHflzInB/INwPrDs2wLKmRsa8owAuojmv4K8H6I=
+github.com/anchore/grype-db v0.0.0-20210527140125-6f881b00e927/go.mod h1:XSlPf1awNrMpah+rHbWrzgUvnmWLgn/KkdicxERVClg=
+github.com/anchore/grype-db v0.0.0-20210809130557-72ff1b90af67 h1:JyK6DKtAWQ11jzzrvSe91gY07BW4I//IJQVdj5JKeIk=
+github.com/anchore/grype-db v0.0.0-20210809130557-72ff1b90af67/go.mod h1:Hx1keM12D75ZDD3kYVcSqBSg1NRSPtsF0bfWOdXa4E0=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f h1:bFadyOLOkzME3BrZFZ5m8cf/b2hsn3aMSS9s+SKubRk=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f h1:bFadyOLOkzME3BrZFZ5m8cf/b2hsn3aMSS9s+SKubRk=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=

--- a/go.sum
+++ b/go.sum
@@ -123,9 +123,6 @@ github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc
 github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca h1:rLyc7Rih769rYABQe4nBPt3jHJd/snBuVvKKGoy5HEc=
 github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/grype v0.14.1-0.20210702143224-05ade7bbbf70/go.mod h1:yPh9WHflzInB/INwPrDs2wLKmRsa8owAuojmv4K8H6I=
-github.com/anchore/grype-db v0.0.0-20210527140125-6f881b00e927/go.mod h1:XSlPf1awNrMpah+rHbWrzgUvnmWLgn/KkdicxERVClg=
-github.com/anchore/grype-db v0.0.0-20210715172505-e527bcf6bc40 h1:83qJtrq9tSQyD768rHIseF0z7fhG4c+32NpW98kx0YI=
-github.com/anchore/grype-db v0.0.0-20210715172505-e527bcf6bc40/go.mod h1:Hx1keM12D75ZDD3kYVcSqBSg1NRSPtsF0bfWOdXa4E0=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f h1:bFadyOLOkzME3BrZFZ5m8cf/b2hsn3aMSS9s+SKubRk=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f h1:bFadyOLOkzME3BrZFZ5m8cf/b2hsn3aMSS9s+SKubRk=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=


### PR DESCRIPTION
Incorporates the changes made in https://github.com/anchore/grype-db/pull/32 into the tests asserting the correctness of MSRC related data from SBOM input.

Related to anchore/grype-db-builder#122

~Note: still in draft until https://github.com/anchore/grype-db/pull/32 is merged~