### PR TITLE
Add option to enable connecting to registry over http #334

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,9 @@ registry:
   # skip TLS verification when communicating with the registry
   # GRYPE_REGISTRY_INSECURE_SKIP_TLS_VERIFY env var
   insecure-skip-tls-verify: false
+  # use http instead of https when connecting to the registry
+  # SYFT_REGISTRY_INSECURE_USE_HTTP env var
+  insecure-use-http: false
 
   # credentials for specific registries
   auth:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca
 	github.com/anchore/grype-db v0.0.0-20210809130557-72ff1b90af67
-	github.com/anchore/stereoscope v0.0.0-20210813210859-86db235079c0
+	github.com/anchore/stereoscope v0.0.0-20210817160504-0f4abc2a5a5a
 	github.com/anchore/syft v0.19.2-0.20210809195219-98d4749f86ce
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/dustin/go-humanize v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca
 	github.com/anchore/grype-db v0.0.0-20210809130557-72ff1b90af67
-	github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f
+	github.com/anchore/stereoscope v0.0.0-20210813210859-86db235079c0
 	github.com/anchore/syft v0.19.2-0.20210809195219-98d4749f86ce
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f h1:bFadyOLOkzM
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f h1:bFadyOLOkzME3BrZFZ5m8cf/b2hsn3aMSS9s+SKubRk=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
+github.com/anchore/stereoscope v0.0.0-20210813210859-86db235079c0 h1:n7kFClfP0Gbjp6dYMBG7+wTWAkIEIfTreTeMV1/35PI=
+github.com/anchore/stereoscope v0.0.0-20210813210859-86db235079c0/go.mod h1:165DfE5jApgEkHTWwu7Bijeml9fofudrgcpuWaD9+tk=
 github.com/anchore/syft v0.19.0/go.mod h1:ktWx72/MizsN9jgEh+Vzl9lfNIUC8tylQHk3ZjKehn0=
 github.com/anchore/syft v0.19.2-0.20210809195219-98d4749f86ce h1:5XzTAfrOpiJdKB5MOqH9wpWwNyjH99u7SydkV6z1dic=
 github.com/anchore/syft v0.19.2-0.20210809195219-98d4749f86ce/go.mod h1:M0s6E6KErgtjmDFzbbVPnrljJ43W2oH12g/4tQJitwY=

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/anchore/grype-db v0.0.0-20210809130557-72ff1b90af67 h1:JyK6DKtAWQ11jz
 github.com/anchore/grype-db v0.0.0-20210809130557-72ff1b90af67/go.mod h1:Hx1keM12D75ZDD3kYVcSqBSg1NRSPtsF0bfWOdXa4E0=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
-github.com/anchore/stereoscope v0.0.0-20210813210859-86db235079c0 h1:n7kFClfP0Gbjp6dYMBG7+wTWAkIEIfTreTeMV1/35PI=
-github.com/anchore/stereoscope v0.0.0-20210813210859-86db235079c0/go.mod h1:165DfE5jApgEkHTWwu7Bijeml9fofudrgcpuWaD9+tk=
+github.com/anchore/stereoscope v0.0.0-20210817160504-0f4abc2a5a5a h1:RQb+Gft1MKxjDfJCnHP/f1mwfy0Jz50Kp9QGgSWKQiY=
+github.com/anchore/stereoscope v0.0.0-20210817160504-0f4abc2a5a5a/go.mod h1:165DfE5jApgEkHTWwu7Bijeml9fofudrgcpuWaD9+tk=
 github.com/anchore/syft v0.19.0/go.mod h1:ktWx72/MizsN9jgEh+Vzl9lfNIUC8tylQHk3ZjKehn0=
 github.com/anchore/syft v0.19.2-0.20210809195219-98d4749f86ce h1:5XzTAfrOpiJdKB5MOqH9wpWwNyjH99u7SydkV6z1dic=
 github.com/anchore/syft v0.19.2-0.20210809195219-98d4749f86ce/go.mod h1:M0s6E6KErgtjmDFzbbVPnrljJ43W2oH12g/4tQJitwY=

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,6 @@ github.com/anchore/grype v0.14.1-0.20210702143224-05ade7bbbf70/go.mod h1:yPh9WHf
 github.com/anchore/grype-db v0.0.0-20210527140125-6f881b00e927/go.mod h1:XSlPf1awNrMpah+rHbWrzgUvnmWLgn/KkdicxERVClg=
 github.com/anchore/grype-db v0.0.0-20210809130557-72ff1b90af67 h1:JyK6DKtAWQ11jzzrvSe91gY07BW4I//IJQVdj5JKeIk=
 github.com/anchore/grype-db v0.0.0-20210809130557-72ff1b90af67/go.mod h1:Hx1keM12D75ZDD3kYVcSqBSg1NRSPtsF0bfWOdXa4E0=
-github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f h1:bFadyOLOkzME3BrZFZ5m8cf/b2hsn3aMSS9s+SKubRk=
-github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f h1:bFadyOLOkzME3BrZFZ5m8cf/b2hsn3aMSS9s+SKubRk=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
 github.com/anchore/stereoscope v0.0.0-20210813210859-86db235079c0 h1:n7kFClfP0Gbjp6dYMBG7+wTWAkIEIfTreTeMV1/35PI=
@@ -140,7 +138,6 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apex/log v1.1.4/go.mod h1:AlpoD9aScyQfJDVHmLMEcx4oU6LqzkWp4Mg9GdAcEvQ=
-github.com/apex/log v1.3.0 h1:1fyfbPvUwD10nMoh3hY6MXzvZShJQn9/ck7ATgAt5pA=
 github.com/apex/log v1.3.0/go.mod h1:jd8Vpsr46WAe3EZSQ/IUMs2qQD/GOycT5rPWCO1yGcs=
 github.com/apex/logs v0.0.4/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
@@ -774,7 +771,6 @@ github.com/tetafro/godot v0.3.7/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQx
 github.com/tetafro/godot v0.4.2/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
-github.com/tj/assert v0.0.0-20171129193455-018094318fb0 h1:Rw8kxzWo1mr6FSaYXjQELRe88y2KdfynXdnK72rdjtA=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
 github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,7 @@ func setNonCliDefaultValues(v *viper.Viper) {
 	v.SetDefault("dev.profile-cpu", false)
 	v.SetDefault("check-for-app-update", true)
 	v.SetDefault("registry.insecure-skip-tls-verify", false)
+	v.SetDefault("registry.insecure-use-http", false)
 	v.SetDefault("registry.auth", []RegistryCredentials{})
 }
 

--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -18,7 +18,7 @@ type RegistryCredentials struct {
 
 type registry struct {
 	InsecureSkipTLSVerify bool                  `yaml:"insecure-skip-tls-verify" json:"insecure-skip-tls-verify" mapstructure:"insecure-skip-tls-verify"`
-	InsecureUseHttp       bool                  `yaml:"insecure-use-http" json:"insecure-use-http" mapstructure:"insecure-use-http"`
+	InsecureUseHTTP       bool                  `yaml:"insecure-use-http" json:"insecure-use-http" mapstructure:"insecure-use-http"`
 	Auth                  []RegistryCredentials `yaml:"auth" json:"auth" mapstructure:"auth"`
 }
 
@@ -59,7 +59,7 @@ func (cfg *registry) ToOptions() *image.RegistryOptions {
 	}
 	return &image.RegistryOptions{
 		InsecureSkipTLSVerify: cfg.InsecureSkipTLSVerify,
-		InsecureUseHTTP:       cfg.InsecureUseHttp,
+		InsecureUseHTTP:       cfg.InsecureUseHTTP,
 		Credentials:           auth,
 	}
 }

--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -18,6 +18,7 @@ type RegistryCredentials struct {
 
 type registry struct {
 	InsecureSkipTLSVerify bool                  `yaml:"insecure-skip-tls-verify" json:"insecure-skip-tls-verify" mapstructure:"insecure-skip-tls-verify"`
+	InsecureUseHttp       bool                  `yaml:"insecure-use-http" json:"insecure-use-http" mapstructure:"insecure-use-http"`
 	Auth                  []RegistryCredentials `yaml:"auth" json:"auth" mapstructure:"auth"`
 }
 
@@ -58,6 +59,7 @@ func (cfg *registry) ToOptions() *image.RegistryOptions {
 	}
 	return &image.RegistryOptions{
 		InsecureSkipTLSVerify: cfg.InsecureSkipTLSVerify,
+		InsecureUseHTTP:       cfg.InsecureUseHttp,
 		Credentials:           auth,
 	}
 }

--- a/internal/config/registry_test.go
+++ b/internal/config/registry_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"github.com/anchore/stereoscope/pkg/image"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,33 +55,56 @@ func TestHasNonEmptyCredentials(t *testing.T) {
 	}
 }
 
-func TestRegistryOptions(t *testing.T) {
+func Test_registry_ToOptions(t *testing.T) {
 	tests := []struct {
-		InsecureSkipTLSVerify bool
-		InsecureUseHTTP       bool
+		name     string
+		input    registry
+		expected image.RegistryOptions
 	}{
 		{
-			false, false,
+			name:  "no registry options",
+			input: registry{},
+			expected: image.RegistryOptions{
+				Credentials: []image.RegistryCredentials{},
+			},
 		},
 		{
-			true, false,
+			name: "set InsecureSkipTLSVerify",
+			input: registry{
+				InsecureSkipTLSVerify: true,
+			},
+			expected: image.RegistryOptions{
+				InsecureSkipTLSVerify: true,
+				Credentials:           []image.RegistryCredentials{},
+			},
 		},
 		{
-			false, true,
+			name: "set InsecureUseHTTP",
+			input: registry{
+				InsecureUseHTTP: true,
+			},
+			expected: image.RegistryOptions{
+				InsecureUseHTTP: true,
+				Credentials:     []image.RegistryCredentials{},
+			},
 		},
 		{
-			true, true,
+			name: "set all bool options",
+			input: registry{
+				InsecureSkipTLSVerify: true,
+				InsecureUseHTTP:       true,
+			},
+			expected: image.RegistryOptions{
+				InsecureSkipTLSVerify: true,
+				InsecureUseHTTP:       true,
+				Credentials:           []image.RegistryCredentials{},
+			},
 		},
 	}
 
 	for _, test := range tests {
-		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
-			reg := registry{}
-			reg.InsecureSkipTLSVerify = test.InsecureSkipTLSVerify
-			reg.InsecureUseHTTP = test.InsecureUseHTTP
-			opt := reg.ToOptions()
-			assert.Equal(t, opt.InsecureSkipTLSVerify, test.InsecureSkipTLSVerify)
-			assert.Equal(t, opt.InsecureUseHTTP, test.InsecureUseHTTP)
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, &test.expected, test.input.ToOptions())
 		})
 	}
 }

--- a/internal/config/registry_test.go
+++ b/internal/config/registry_test.go
@@ -53,3 +53,34 @@ func TestHasNonEmptyCredentials(t *testing.T) {
 		})
 	}
 }
+
+func TestRegistryOptions(t *testing.T) {
+	tests := []struct {
+		InsecureSkipTLSVerify bool
+		InsecureUseHTTP       bool
+	}{
+		{
+			false, false,
+		},
+		{
+			true, false,
+		},
+		{
+			false, true,
+		},
+		{
+			true, true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
+			reg := registry{}
+			reg.InsecureSkipTLSVerify = test.InsecureSkipTLSVerify
+			reg.InsecureUseHTTP = test.InsecureUseHTTP
+			opt := reg.ToOptions()
+			assert.Equal(t, opt.InsecureSkipTLSVerify, test.InsecureSkipTLSVerify)
+			assert.Equal(t, opt.InsecureUseHTTP, test.InsecureUseHTTP)
+		})
+	}
+}

--- a/test/cli/registry_auth_test.go
+++ b/test/cli/registry_auth_test.go
@@ -60,6 +60,16 @@ func TestRegistryAuth(t *testing.T) {
 				assertInOutput(`no registry credentials configured, using the default keychain`),
 			},
 		},
+		{
+			name: "allows insecure http flag",
+			args: []string{"-vv", "registry:localhost:5000/something:latest"},
+			env: map[string]string{
+				"GRYPE_REGISTRY_INSECURE_USE_HTTP": "true",
+			},
+			assertions: []traitAssertion{
+				assertInOutput("insecure-use-http: true"),
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
As noted: this adds an option to connect to registries over http. This fixes #334 

Added just a very basic test, as this is just pushing configuration to `go-containerregistry`

Related to: https://github.com/anchore/syft/pull/482