### PR TITLE
(#374) - RPM Matcher - Package Name from Source Update

### DIFF
--- a/grype/matcher/common/distro_matchers.go
+++ b/grype/matcher/common/distro_matchers.go
@@ -15,7 +15,7 @@ func FindMatchesByPackageDistro(store vulnerability.ProviderByDistro, d *distro.
 		return nil, nil
 	}
 
-	verObj, err := version.NewVersionFromPkg(p) // Incorrect version if desynced
+	verObj, err := version.NewVersionFromPkg(p)
 	if err != nil {
 		return nil, fmt.Errorf("matcher failed to parse version pkg='%s' ver='%s': %w", p.Name, p.Version, err)
 	}

--- a/grype/matcher/common/distro_matchers.go
+++ b/grype/matcher/common/distro_matchers.go
@@ -15,7 +15,7 @@ func FindMatchesByPackageDistro(store vulnerability.ProviderByDistro, d *distro.
 		return nil, nil
 	}
 
-	verObj, err := version.NewVersionFromPkg(p)
+	verObj, err := version.NewVersionFromPkg(p) // Incorrect version if desynced
 	if err != nil {
 		return nil, fmt.Errorf("matcher failed to parse version pkg='%s' ver='%s': %w", p.Name, p.Version, err)
 	}

--- a/grype/matcher/rpmdb/matcher.go
+++ b/grype/matcher/rpmdb/matcher.go
@@ -68,7 +68,6 @@ func (m *Matcher) matchBySourceIndirection(store vulnerability.ProviderByDistro,
 		log.Warnf("ignoring multiple SourceRPMs for %s", p)
 	}
 
-	fmt.Printf("g = %+v\n", groupMatches)
 	// note: the result is match is the full match followed by the sub matches, in our case we're interested in the first capture group
 	var sourcePackageName = groupMatches[1]
 

--- a/grype/matcher/rpmdb/matcher.go
+++ b/grype/matcher/rpmdb/matcher.go
@@ -65,8 +65,6 @@ func (m *Matcher) matchBySourceIndirection(store vulnerability.ProviderByDistro,
 	if len(groupMatches) == 0 {
 		log.Warnf("unable to extract name from SourceRPM for %s", p)
 		return nil, nil
-	} else if len(groupMatches) > 1 {
-		log.Warnf("ignoring multiple SourceRPMs for %s", p)
 	}
 
 	// note: the result is match is the full match followed by the sub matches, in our case we're interested in the first capture group

--- a/grype/matcher/rpmdb/matcher.go
+++ b/grype/matcher/rpmdb/matcher.go
@@ -68,6 +68,7 @@ func (m *Matcher) matchBySourceIndirection(store vulnerability.ProviderByDistro,
 		log.Warnf("ignoring multiple SourceRPMs for %s", p)
 	}
 
+	fmt.Printf("g = %+v\n", groupMatches)
 	// note: the result is match is the full match followed by the sub matches, in our case we're interested in the first capture group
 	var sourcePackageName = groupMatches[1]
 
@@ -86,6 +87,7 @@ func (m *Matcher) matchBySourceIndirection(store vulnerability.ProviderByDistro,
 
 	// use the source package name
 	indirectPackage.Name = sourcePackageName
+	indirectPackage.Version = groupMatches[2]
 
 	matches, err := common.FindMatchesByPackageDistro(store, d, indirectPackage, m.Type())
 	if err != nil {

--- a/grype/matcher/rpmdb/matcher.go
+++ b/grype/matcher/rpmdb/matcher.go
@@ -16,7 +16,8 @@ import (
 
 // the source-rpm field has something akin to "util-linux-ng-2.17.2-12.28.el6_9.2.src.rpm"
 // in which case the pattern will extract out "util-linux-ng" as the left-most capture group
-var rpmPackageNamePattern = regexp.MustCompile(`(.*)-(.*)-(.*?)\.(.*)(\.rpm)`)
+// name, version, release, epoch, arch
+var rpmPackageNamePattern = regexp.MustCompile(`(?P<name>.*)-(?P<version>.*)-(?P<release>.*?)\.(?P<arch>.*)(\.rpm)`)
 
 type Matcher struct {
 }

--- a/grype/matcher/rpmdb/matcher.go
+++ b/grype/matcher/rpmdb/matcher.go
@@ -17,7 +17,7 @@ import (
 // the source-rpm field has something akin to "util-linux-ng-2.17.2-12.28.el6_9.2.src.rpm"
 // in which case the pattern will extract out "util-linux-ng" as the left-most capture group
 // name, version, release, epoch, arch
-var rpmPackageNamePattern = regexp.MustCompile(`(?P<name>.*)-(?P<version>.*)-(?P<release>.*?)\.(?P<arch>.*)(\.rpm)`)
+var rpmPackageNamePattern = regexp.MustCompile(`^(?P<name>.*)-(?P<version>.*)-(?P<release>.*?)\.(?P<arch>.*)(\.rpm)$`)
 
 type Matcher struct {
 }

--- a/grype/matcher/rpmdb/matcher.go
+++ b/grype/matcher/rpmdb/matcher.go
@@ -8,6 +8,7 @@ import (
 	"github.com/anchore/grype/grype/matcher/common"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/grype/internal"
 	"github.com/anchore/grype/internal/log"
 	"github.com/anchore/syft/syft/distro"
 	syftPkg "github.com/anchore/syft/syft/pkg"
@@ -60,7 +61,7 @@ func (m *Matcher) matchBySourceIndirection(store vulnerability.ProviderByDistro,
 		return []match.Match{}, nil
 	}
 
-	groupMatches := rpmPackageNamePattern.FindStringSubmatch(metadata.SourceRpm)
+	groupMatches := internal.MatchCaptureGroups(rpmPackageNamePattern, metadata.SourceRpm)
 	if len(groupMatches) == 0 {
 		log.Warnf("unable to extract name from SourceRPM for %s", p)
 		return nil, nil
@@ -69,7 +70,7 @@ func (m *Matcher) matchBySourceIndirection(store vulnerability.ProviderByDistro,
 	}
 
 	// note: the result is match is the full match followed by the sub matches, in our case we're interested in the first capture group
-	var sourcePackageName = groupMatches[1]
+	var sourcePackageName = groupMatches["name"]
 
 	// don't include matches if the source package name matches the current package name
 	if sourcePackageName == p.Name {
@@ -86,7 +87,7 @@ func (m *Matcher) matchBySourceIndirection(store vulnerability.ProviderByDistro,
 
 	// use the source package name
 	indirectPackage.Name = sourcePackageName
-	indirectPackage.Version = groupMatches[2]
+	indirectPackage.Version = groupMatches["version"]
 
 	matches, err := common.FindMatchesByPackageDistro(store, d, indirectPackage, m.Type())
 	if err != nil {

--- a/grype/matcher/rpmdb/matcher.go
+++ b/grype/matcher/rpmdb/matcher.go
@@ -16,7 +16,7 @@ import (
 
 // the source-rpm field has something akin to "util-linux-ng-2.17.2-12.28.el6_9.2.src.rpm"
 // in which case the pattern will extract out "util-linux-ng" as the left-most capture group
-var rpmPackageNamePattern = regexp.MustCompile(`(?P<name>^[a-zA-Z0-9\-]+)-\d+\.`)
+var rpmPackageNamePattern = regexp.MustCompile(`(.*)-(.*)-(.*?)\.(.*)(\.rpm)`)
 
 type Matcher struct {
 }
@@ -42,6 +42,7 @@ func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Pa
 	if err != nil {
 		return nil, fmt.Errorf("failed to match by exact package name: %w", err)
 	}
+
 	matches = append(matches, exactMatches...)
 
 	return matches, nil

--- a/grype/matcher/rpmdb/matcher_mocks_test.go
+++ b/grype/matcher/rpmdb/matcher_mocks_test.go
@@ -14,25 +14,25 @@ type mockProvider struct {
 	data map[string]map[string][]vulnerability.Vulnerability
 }
 
-func newMockProvider() *mockProvider {
+func newMockProvider(packageName, indrectName string) *mockProvider {
 	pr := mockProvider{
 		data: make(map[string]map[string][]vulnerability.Vulnerability),
 	}
-	pr.stub()
+	pr.stub(packageName, indrectName)
 	return &pr
 }
 
-func (pr *mockProvider) stub() {
+func (pr *mockProvider) stub(packageName, indrectName string) {
 	pr.data["rhel:8"] = map[string][]vulnerability.Vulnerability{
 		// direct...
-		"neutron-libs": {
+		packageName: {
 			{
 				Constraint: version.MustGetConstraint("<= 7.1.3-6", version.RpmFormat),
 				ID:         "CVE-2014-fake-1",
 			},
 		},
 		// indirect...
-		"neutron": {
+		indrectName: {
 			// expected...
 			{
 				Constraint: version.MustGetConstraint("< 7.1.4-5", version.RpmFormat),

--- a/grype/matcher/rpmdb/matcher_mocks_test.go
+++ b/grype/matcher/rpmdb/matcher_mocks_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/anchore/grype/grype/version"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/syft/syft/distro"
+	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
 type mockProvider struct {
@@ -57,4 +58,12 @@ func (pr *mockProvider) GetByDistro(d *distro.Distro, p pkg.Package) ([]vulnerab
 	}
 
 	return pr.data[ty+":"+d.FullVersion()][p.Name], nil
+}
+
+func (pr *mockProvider) GetByCPE(request syftPkg.CPE) (v []vulnerability.Vulnerability, err error) {
+	return v, err
+}
+
+func (pr *mockProvider) GetByLanguage(l syftPkg.Language, p pkg.Package) (v []vulnerability.Vulnerability, err error) {
+	return v, err
 }

--- a/grype/matcher/rpmdb/matcher_test.go
+++ b/grype/matcher/rpmdb/matcher_test.go
@@ -48,7 +48,7 @@ func TestMatcherRpmdb(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		{
+		{ // Regression against https://github.com/anchore/grype/issues/376
 			name: "Rpmdb Match matches by direct and by source indirection when the SourceRpm version is desynced from package version",
 			p: pkg.Package{
 				Name:    "neutron-libs",

--- a/grype/matcher/rpmdb/matcher_test.go
+++ b/grype/matcher/rpmdb/matcher_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal"
@@ -60,7 +59,8 @@ func TestMatcherRpmdb(t *testing.T) {
 
 			for _, a := range actual {
 				foundCVEs.Add(a.Vulnerability.ID)
-				assert.Equal(t, match.ExactIndirectMatch, a.Type, "indirect match not indicated") // TODO: Ask about tool case here
+				// TODO: Ask about tool case - we should see 3 indirect and 1 direct after Match is called
+				// assert.Equal(t, match.ExactIndirectMatch, a.Type, "indirect match not indicated")
 				assert.Equal(t, tt.p.Name, a.Package.Name, "failed to capture original package name")
 				for _, detail := range a.MatchDetails {
 					assert.Equal(t, matcher.Type(), detail.Matcher, "failed to capture matcher type")

--- a/grype/matcher/rpmdb/matcher_test.go
+++ b/grype/matcher/rpmdb/matcher_test.go
@@ -37,7 +37,7 @@ func TestMatcherRpmdb(t *testing.T) {
 					t.Fatal("could not create distro: ", err)
 				}
 
-				store := newMockProvider()
+				store := newMockProvider("neutron-libs", "neutron")
 
 				return store, d, matcher
 			},
@@ -47,6 +47,31 @@ func TestMatcherRpmdb(t *testing.T) {
 				"CVE-2013-fake-3": match.ExactIndirectMatch,
 			},
 			wantErr: false,
+		},
+		{
+			name: "Rpmdb Match matches by direct and ignores the source rpm when the package names are the same",
+			p: pkg.Package{
+				Name:    "neutron",
+				Version: "7.1.3-6",
+				Type:    syftPkg.RpmPkg,
+				Metadata: pkg.RpmdbMetadata{
+					SourceRpm: "neutron-7.1.3-6.el8.src.rpm",
+				},
+			},
+			setup: func() (vulnerability.Provider, distro.Distro, Matcher) {
+				matcher := Matcher{}
+				d, err := distro.NewDistro(distro.CentOS, "8", "")
+				if err != nil {
+					t.Fatal("could not create distro: ", err)
+				}
+
+				store := newMockProvider("neutron", "neutron-devel")
+
+				return store, d, matcher
+			},
+			expectedMatches: map[string]match.Type{
+				"CVE-2014-fake-1": match.ExactDirectMatch,
+			},
 		},
 		{ // Regression against https://github.com/anchore/grype/issues/376
 			name: "Rpmdb Match matches by direct and by source indirection when the SourceRpm version is desynced from package version",
@@ -65,7 +90,7 @@ func TestMatcherRpmdb(t *testing.T) {
 					t.Fatal("could not create distro: ", err)
 				}
 
-				store := newMockProvider()
+				store := newMockProvider("neutron-libs", "neutron")
 
 				return store, d, matcher
 			},

--- a/grype/matcher/rpmdb/matcher_test.go
+++ b/grype/matcher/rpmdb/matcher_test.go
@@ -46,7 +46,6 @@ func TestMatcherRpmdb(t *testing.T) {
 				"CVE-2014-fake-2": match.ExactIndirectMatch,
 				"CVE-2013-fake-3": match.ExactIndirectMatch,
 			},
-			wantErr: false,
 		},
 		{
 			name: "Rpmdb Match matches by direct and ignores the source rpm when the package names are the same",
@@ -97,7 +96,6 @@ func TestMatcherRpmdb(t *testing.T) {
 			expectedMatches: map[string]match.Type{
 				"CVE-2014-fake-1": match.ExactDirectMatch,
 			},
-			wantErr: false,
 		},
 	}
 
@@ -106,9 +104,8 @@ func TestMatcherRpmdb(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			store, d, matcher := tt.setup()
 			actual, err := matcher.Match(store, &d, tt.p)
-			if tt.wantErr {
-				assert.Equal(t, "", err) //TODO: error case
-				return
+			if err != nil {
+				t.Fatal("could not find match: ", err)
 			}
 
 			assert.Len(t, actual, len(tt.expectedMatches), "unexpected matches count")

--- a/grype/matcher/rpmdb/matcher_test.go
+++ b/grype/matcher/rpmdb/matcher_test.go
@@ -48,6 +48,32 @@ func TestMatcherRpmdb(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Rpmdb Match matches by direct and by source indirection when the SourceRpm version is desynced",
+			p: pkg.Package{
+				Name:    "neutron-libs",
+				Version: "7.1.3-6",
+				Type:    syftPkg.RpmPkg,
+				Metadata: pkg.RpmdbMetadata{
+					SourceRpm: "neutron-5.16.3-229.el8.src.rpm",
+				},
+			},
+			setup: func() (vulnerability.Provider, distro.Distro, Matcher) {
+				matcher := Matcher{}
+				d, err := distro.NewDistro(distro.CentOS, "8", "")
+				if err != nil {
+					t.Fatal("could not create distro: ", err)
+				}
+
+				store := newMockProvider()
+
+				return store, d, matcher
+			},
+			expectedMatches: map[string]match.Type{
+				"CVE-2014-fake-1": match.ExactDirectMatch,
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/grype/matcher/rpmdb/matcher_test.go
+++ b/grype/matcher/rpmdb/matcher_test.go
@@ -49,13 +49,13 @@ func TestMatcherRpmdb(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Rpmdb Match matches by direct and by source indirection when the SourceRpm version is desynced",
+			name: "Rpmdb Match matches by direct and by source indirection when the SourceRpm version is desynced from package version",
 			p: pkg.Package{
 				Name:    "neutron-libs",
 				Version: "7.1.3-6",
 				Type:    syftPkg.RpmPkg,
 				Metadata: pkg.RpmdbMetadata{
-					SourceRpm: "neutron-5.16.3-229.el8.src.rpm",
+					SourceRpm: "neutron-17.16.3-229.el8.src.rpm",
 				},
 			},
 			setup: func() (vulnerability.Provider, distro.Distro, Matcher) {

--- a/grype/matcher/rpmdb/matcher_test.go
+++ b/grype/matcher/rpmdb/matcher_test.go
@@ -7,74 +7,75 @@ import (
 
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal"
 	"github.com/anchore/syft/syft/distro"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
-func TestMatcherDpkg_matchBySourceIndirection(t *testing.T) {
-	matcher := Matcher{}
-	p := pkg.Package{
-		Name:    "neutron-libs",
-		Version: "7.1.3-6",
-		Type:    syftPkg.RpmPkg,
-		Metadata: pkg.RpmdbMetadata{
-			SourceRpm: "neutron-7.1.3-6.el8.src.rpm",
+func TestMatcherRpmdb(t *testing.T) {
+	tests := []struct {
+		name    string
+		p       pkg.Package
+		setup   func() (vulnerability.Provider, distro.Distro, Matcher)
+		wantErr bool
+	}{
+		{
+			name: "Rpmdb Match matches by source indirection",
+			p: pkg.Package{
+				Name:    "neutron-libs",
+				Version: "7.1.3-6",
+				Type:    syftPkg.RpmPkg,
+				Metadata: pkg.RpmdbMetadata{
+					SourceRpm: "neutron-7.1.3-6.el8.src.rpm",
+				},
+			},
+			setup: func() (vulnerability.Provider, distro.Distro, Matcher) {
+				matcher := Matcher{}
+				d, err := distro.NewDistro(distro.CentOS, "8", "")
+				if err != nil {
+					t.Fatal("could not create distro: ", err)
+				}
+
+				store := newMockProvider()
+
+				return store, d, matcher
+			},
+			wantErr: false,
 		},
 	}
 
-	d, err := distro.NewDistro(distro.CentOS, "8", "")
-	if err != nil {
-		t.Fatal("could not create distro: ", err)
+	for _, test := range tests {
+		tt := test
+		t.Run(test.name, func(t *testing.T) {
+			store, d, matcher := tt.setup()
+			actual, err := matcher.Match(store, &d, tt.p)
+			if tt.wantErr {
+				assert.Equal(t, "", err) //TODO: error case
+			}
+
+			assert.Len(t, actual, 3, "unexpected indirect matches count")
+
+			foundCVEs := internal.NewStringSet()
+
+			for _, a := range actual {
+				foundCVEs.Add(a.Vulnerability.ID)
+				assert.Equal(t, match.ExactIndirectMatch, a.Type, "indirect match not indicated") // TODO: Ask about tool case here
+				assert.Equal(t, tt.p.Name, a.Package.Name, "failed to capture original package name")
+				for _, detail := range a.MatchDetails {
+					assert.Equal(t, matcher.Type(), detail.Matcher, "failed to capture matcher type")
+				}
+			}
+
+			for _, id := range []string{"CVE-2014-fake-2", "CVE-2013-fake-3"} {
+				if !foundCVEs.Contains(id) {
+					t.Errorf("missing discovered CVE: %s", id)
+				}
+			}
+
+			if t.Failed() {
+				t.Logf("discovered CVES: %+v", foundCVEs)
+			}
+		})
 	}
-
-	store := newMockProvider()
-	actual, err := matcher.matchBySourceIndirection(store, &d, p)
-
-	assert.Len(t, actual, 2, "unexpected indirect matches count")
-
-	foundCVEs := internal.NewStringSet()
-
-	for _, a := range actual {
-		foundCVEs.Add(a.Vulnerability.ID)
-
-		assert.Equal(t, match.ExactIndirectMatch, a.Type, "indirect match not indicated")
-		assert.Equal(t, p.Name, a.Package.Name, "failed to capture original package name")
-		for _, detail := range a.MatchDetails {
-			assert.Equal(t, matcher.Type(), detail.Matcher, "failed to capture matcher type")
-		}
-	}
-
-	for _, id := range []string{"CVE-2014-fake-2", "CVE-2013-fake-3"} {
-		if !foundCVEs.Contains(id) {
-			t.Errorf("missing discovered CVE: %s", id)
-		}
-	}
-	if t.Failed() {
-		t.Logf("discovered CVES: %+v", foundCVEs)
-	}
-
-}
-
-func TestMatcherDpkg_matchBySourceIndirection_ignoreSource(t *testing.T) {
-	matcher := Matcher{}
-	p := pkg.Package{
-		Name:    "neutron",
-		Version: "7.1.3-6",
-		Type:    syftPkg.RpmPkg,
-		Metadata: pkg.RpmdbMetadata{
-			// this ends up being the same matches as the original package, thus should be ignored
-			SourceRpm: "neutron-7.1.3-6.el8.src.rpm",
-		},
-	}
-
-	d, err := distro.NewDistro(distro.CentOS, "8", "")
-	if err != nil {
-		t.Fatal("could not create distro: ", err)
-	}
-
-	store := newMockProvider()
-	actual, err := matcher.matchBySourceIndirection(store, &d, p)
-
-	assert.Len(t, actual, 0, "unexpected indirect matches count")
 }


### PR DESCRIPTION
## PR #374 

Works to Address issues from:
Fixes #374 
Fixes #376

Update Regex to Capture Separate package groups
Refactor test to assert on public contract of Match
Add base case as first table
Adjust the matchBySourceIndirection helper function for the rpmdb matcher (grype/matcher/rpmdb/marcher.go) to use additional source version information to construct the correct upstream package to match against.

TODO:

- [x] Ask about [version assumption in common](https://github.com/anchore/grype/blob/7b044b11541ea3dd99520ce488a7b3b27ee7c589/grype/matcher/common/distro_matchers.go#L18)
- [x] Ask about business case of Public vs private method
- [x] Add back second case regarding ignore source
- [x] Add capture group names for each section of package
- [x] Add cases testing new regexp against variant package types