### PR TITLE
Bump untar file size threshold

### DIFF
--- a/internal/file/tar.go
+++ b/internal/file/tar.go
@@ -15,8 +15,8 @@ const (
 	KB = 1 << (10 * iota)
 	MB
 	GB
-	// Why 5GB? This is somewhat of an arbitrary threshold, however, we need to keep this at at minimum 2GB
-	// to accommodate possible grype DB sizes.
+	// limit the tar reader to 5GB per file to prevent decompression bomb attacks. Why 5GB? This is somewhat of an
+	// arbitrary threshold, however, we need to keep this at at minimum 2GB to accommodate possible grype DB sizes.
 	decompressionByteReadLimit = 5 * GB
 )
 
@@ -96,12 +96,11 @@ func UnTarGz(dst string, r io.Reader) error {
 	}
 }
 
-func copyWithLimits(writer io.Writer, reader io.Reader, byteReadLimit int64, target string) error {
-	// limit the tar reader to 5GB per file to prevent decompression bomb attacks
+func copyWithLimits(writer io.Writer, reader io.Reader, byteReadLimit int64, pathInArchive string) error {
 	if numBytes, err := io.Copy(writer, io.LimitReader(reader, byteReadLimit)); err != nil {
-		return fmt.Errorf("failed to copy file (%s): %w", target, err)
+		return fmt.Errorf("failed to copy file (%s): %w", pathInArchive, err)
 	} else if numBytes >= byteReadLimit {
-		return fmt.Errorf("failed to copy file (%s): read limit (%d bytes) reached ", target, byteReadLimit)
+		return fmt.Errorf("failed to copy file (%s): read limit (%d bytes) reached ", pathInArchive, byteReadLimit)
 	}
 	return nil
 }

--- a/internal/file/tar.go
+++ b/internal/file/tar.go
@@ -15,6 +15,9 @@ const (
 	KB = 1 << (10 * iota)
 	MB
 	GB
+	// Why 5GB? This is somewhat of an arbitrary threshold, however, we need to keep this at at minimum 2GB
+	// to accommodate possible grype DB sizes.
+	decompressionByteReadLimit = 5 * GB
 )
 
 type errZipSlipDetected struct {
@@ -82,9 +85,8 @@ func UnTarGz(dst string, r io.Reader) error {
 				return fmt.Errorf("failed to open file (%s): %w", target, err)
 			}
 
-			// limit the tar reader to 1GB per file to prevent decompression bomb attacks
-			if _, err := io.Copy(f, io.LimitReader(tr, 1*GB)); err != nil {
-				return fmt.Errorf("failed to copy file (%s): %w", target, err)
+			if err := copyWithLimits(f, tr, decompressionByteReadLimit, target); err != nil {
+				return err
 			}
 
 			if err = f.Close(); err != nil {
@@ -92,4 +94,14 @@ func UnTarGz(dst string, r io.Reader) error {
 			}
 		}
 	}
+}
+
+func copyWithLimits(writer io.Writer, reader io.Reader, byteReadLimit int64, target string) error {
+	// limit the tar reader to 5GB per file to prevent decompression bomb attacks
+	if numBytes, err := io.Copy(writer, io.LimitReader(reader, byteReadLimit)); err != nil {
+		return fmt.Errorf("failed to copy file (%s): %w", target, err)
+	} else if numBytes >= byteReadLimit {
+		return fmt.Errorf("failed to copy file (%s): read limit (%d bytes) reached ", target, byteReadLimit)
+	}
+	return nil
 }

--- a/internal/file/tar_test.go
+++ b/internal/file/tar_test.go
@@ -1,8 +1,10 @@
 package file
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,6 +81,58 @@ func TestSafeJoin(t *testing.T) {
 			actual, err := safeJoin(test.prefix, test.args...)
 			test.errAssertion(t, err)
 			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func Test_copyWithLimits(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		byteReadLimit int64
+		target        string
+		expectWritten string
+		expectErr     bool
+	}{
+		{
+			name:          "write bytes",
+			input:         "something here",
+			byteReadLimit: 1000,
+			target:        "dont care",
+			expectWritten: "something here",
+			expectErr:     false,
+		},
+		{
+			name:          "surpass upper limit",
+			input:         "something here",
+			byteReadLimit: 11,
+			target:        "dont care",
+			expectWritten: "something h",
+			expectErr:     true,
+		},
+		// since we want the threshold being reached to be easily detectable, simply reaching the threshold is
+		// enough to cause an error. Otherwise surpassing the threshold would be undetectable.
+		{
+			name:          "reach limit exactly",
+			input:         "something here",
+			byteReadLimit: 14,
+			target:        "dont care",
+			expectWritten: "something here",
+			expectErr:     true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			writer := &bytes.Buffer{}
+			err := copyWithLimits(writer, strings.NewReader(test.input), test.byteReadLimit, test.target)
+			if (err != nil) != test.expectErr {
+				t.Errorf("copyWithLimits() error = %v, want %v", err, test.expectErr)
+				return
+			} else if err != nil {
+				assert.Contains(t, err.Error(), test.target)
+			}
+			assert.Equal(t, test.expectWritten, writer.String())
+
 		})
 	}
 }

--- a/internal/file/tar_test.go
+++ b/internal/file/tar_test.go
@@ -90,7 +90,7 @@ func Test_copyWithLimits(t *testing.T) {
 		name          string
 		input         string
 		byteReadLimit int64
-		target        string
+		pathInArchive string
 		expectWritten string
 		expectErr     bool
 	}{
@@ -98,7 +98,7 @@ func Test_copyWithLimits(t *testing.T) {
 			name:          "write bytes",
 			input:         "something here",
 			byteReadLimit: 1000,
-			target:        "dont care",
+			pathInArchive: "dont care",
 			expectWritten: "something here",
 			expectErr:     false,
 		},
@@ -106,7 +106,7 @@ func Test_copyWithLimits(t *testing.T) {
 			name:          "surpass upper limit",
 			input:         "something here",
 			byteReadLimit: 11,
-			target:        "dont care",
+			pathInArchive: "dont care",
 			expectWritten: "something h",
 			expectErr:     true,
 		},
@@ -116,7 +116,7 @@ func Test_copyWithLimits(t *testing.T) {
 			name:          "reach limit exactly",
 			input:         "something here",
 			byteReadLimit: 14,
-			target:        "dont care",
+			pathInArchive: "dont care",
 			expectWritten: "something here",
 			expectErr:     true,
 		},
@@ -124,12 +124,12 @@ func Test_copyWithLimits(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			writer := &bytes.Buffer{}
-			err := copyWithLimits(writer, strings.NewReader(test.input), test.byteReadLimit, test.target)
+			err := copyWithLimits(writer, strings.NewReader(test.input), test.byteReadLimit, test.pathInArchive)
 			if (err != nil) != test.expectErr {
 				t.Errorf("copyWithLimits() error = %v, want %v", err, test.expectErr)
 				return
 			} else if err != nil {
-				assert.Contains(t, err.Error(), test.target)
+				assert.Contains(t, err.Error(), test.pathInArchive)
 			}
 			assert.Equal(t, test.expectWritten, writer.String())
 


### PR DESCRIPTION
Today the tar helper is used to extract grype DB files from archives. However, it is possible for the grype DB to reach large sizes on development builds (up to 2GB currently). For this reason the maximum allowable file size in a tar needs to be raised (this threshold exists today to mitigate decompression bomb attacks).