### PR TITLE
Include full ELVersion in RPM source-indirection matching

### DIFF
--- a/grype/matcher/apk/matcher_test.go
+++ b/grype/matcher/apk/matcher_test.go
@@ -81,6 +81,10 @@ func TestSecDBOnlyMatch(t *testing.T) {
 							"type":    d.Type.String(),
 							"version": d.RawVersion,
 						},
+						"package": map[string]string{
+							"name":    "libvncserver",
+							"version": "0.9.9",
+						},
 						"namespace": "secdb",
 					},
 					Found: map[string]interface{}{
@@ -160,6 +164,10 @@ func TestBothSecdbAndNvdMatches(t *testing.T) {
 						"distro": map[string]string{
 							"type":    d.Type.String(),
 							"version": d.RawVersion,
+						},
+						"package": map[string]string{
+							"name":    "libvncserver",
+							"version": "0.9.9",
 						},
 						"namespace": "secdb",
 					},
@@ -241,6 +249,10 @@ func TestBothSecdbAndNvdMatches_DifferentPackageName(t *testing.T) {
 						"distro": map[string]string{
 							"type":    d.Type.String(),
 							"version": d.RawVersion,
+						},
+						"package": map[string]string{
+							"name":    "libvncserver",
+							"version": "0.9.9",
 						},
 						"namespace": "secdb",
 					},

--- a/grype/matcher/common/distro_matchers.go
+++ b/grype/matcher/common/distro_matchers.go
@@ -51,6 +51,13 @@ func FindMatchesByPackageDistro(store vulnerability.ProviderByDistro, d *distro.
 							"type":    d.Type.String(),
 							"version": d.RawVersion,
 						},
+						// why include the package information? The given package searched with may be a source package
+						// for another package that is installed on the system. This makes it apparent exactly what
+						// was used in the search.
+						"package": map[string]string{
+							"name":    p.Name,
+							"version": p.Version,
+						},
 						"namespace": vuln.Namespace,
 					},
 					Found: map[string]interface{}{

--- a/grype/matcher/common/distro_matchers_test.go
+++ b/grype/matcher/common/distro_matchers_test.go
@@ -89,6 +89,10 @@ func TestFindMatchesByPackageDistro(t *testing.T) {
 							"type":    "debian",
 							"version": "8",
 						},
+						"package": map[string]string{
+							"name":    "neutron",
+							"version": "2014.1.3-6",
+						},
 						"namespace": "debian:8",
 					},
 					Found: map[string]interface{}{

--- a/grype/matcher/common/utils_test.go
+++ b/grype/matcher/common/utils_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func assertMatchesUsingIDsForVulnerabilities(t testing.TB, expected, actual []match.Match) {
+	t.Helper()
 	assert.Len(t, actual, len(expected))
 	for idx, a := range actual {
 		// only compare the vulnerability ID, nothing else

--- a/grype/matcher/rpmdb/matcher.go
+++ b/grype/matcher/rpmdb/matcher.go
@@ -3,6 +3,7 @@ package rpmdb
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/matcher/common"
@@ -16,9 +17,12 @@ import (
 )
 
 // the source-rpm field has something akin to "util-linux-ng-2.17.2-12.28.el6_9.2.src.rpm"
-// in which case the pattern will extract out "util-linux-ng" as the left-most capture group
-// name, version, release, epoch, arch
-var rpmPackageNamePattern = regexp.MustCompile(`^(?P<name>.*)-(?P<version>.*)-(?P<release>.*?)\.(?P<arch>.*)(\.rpm)$`)
+// in which case the pattern will extract out the following values for the named capture groups:
+//		name = "util-linux-ng"
+//		version = "2.17.2"
+//		release = "12.28.el6_9.2"
+//      arch = "src"
+var rpmPackageNamePattern = regexp.MustCompile(`^(?P<name>.*)-(?P<version>.*)-(?P<release>.*)\.(?P<arch>[a-zA-Z][^.]+)(\.rpm)$`)
 
 type Matcher struct {
 }
@@ -58,21 +62,18 @@ func (m *Matcher) matchBySourceIndirection(store vulnerability.ProviderByDistro,
 
 	// ignore packages without source indirection hints
 	if metadata.SourceRpm == "" {
-		return []match.Match{}, nil
-	}
-
-	groupMatches := internal.MatchCaptureGroups(rpmPackageNamePattern, metadata.SourceRpm)
-	if len(groupMatches) == 0 {
-		log.Warnf("unable to extract name from SourceRPM for %s", p)
 		return nil, nil
 	}
 
-	// note: the result is match is the full match followed by the sub matches, in our case we're interested in the first capture group
-	var sourcePackageName = groupMatches["name"]
+	sourceName, sourceVersion := getNameAndELVersion(metadata)
+	if sourceName == "" && sourceVersion == "" {
+		log.Warnf("unable to extract name and version from SourceRPM=%q for %s@%s", metadata.SourceRpm, p.Name, p.Version)
+		return nil, nil
+	}
 
 	// don't include matches if the source package name matches the current package name
-	if sourcePackageName == p.Name {
-		return []match.Match{}, nil
+	if sourceName == p.Name {
+		return nil, nil
 	}
 
 	// use source package name for exact package name matching
@@ -84,20 +85,33 @@ func (m *Matcher) matchBySourceIndirection(store vulnerability.ProviderByDistro,
 	}
 
 	// use the source package name
-	indirectPackage.Name = sourcePackageName
-	indirectPackage.Version = groupMatches["version"]
+	indirectPackage.Name = sourceName
+	indirectPackage.Version = sourceVersion
 
 	matches, err := common.FindMatchesByPackageDistro(store, d, indirectPackage, m.Type())
 	if err != nil {
 		return nil, fmt.Errorf("failed to find vulnerabilities by dpkg source indirection: %w", err)
 	}
 
-	// we want to make certain that we are tracking the match based on the package from the SBOM (not the indirect package)
-	// however, we also want to keep the indirect package around for future reference
+	// we want to make certain that we are tracking the match based on the package from the SBOM (not the indirect package).
+	// The match details already contains the specific indirect package information used to make the match.
 	for idx := range matches {
 		matches[idx].Type = match.ExactIndirectMatch
 		matches[idx].Package = p
 	}
 
 	return matches, nil
+}
+
+func getNameAndELVersion(metadata pkg.RpmdbMetadata) (string, string) {
+	groupMatches := internal.MatchCaptureGroups(rpmPackageNamePattern, metadata.SourceRpm)
+	version := groupMatches["version"] + "-" + groupMatches["release"]
+	// source RPMs never specify epoch, however, leaving out the epoch makes comparisons with other versions that do
+	// include epoch is invalid since: unset epoch < "0" epoch < "1" epoch < "2" epoch ...
+	// The version extracted from here will always be used for comparison against another version (from the vulnerability
+	// data) which may include epoch. For this reason the epoch from the original package is used (only if specified).
+	if metadata.Epoch != nil {
+		version = strconv.Itoa(*metadata.Epoch) + ":" + version
+	}
+	return groupMatches["name"], version
 }

--- a/grype/matcher/rpmdb/matcher.go
+++ b/grype/matcher/rpmdb/matcher.go
@@ -21,7 +21,7 @@ import (
 //		name = "util-linux-ng"
 //		version = "2.17.2"
 //		release = "12.28.el6_9.2"
-//      arch = "src"
+//		arch = "src"
 var rpmPackageNamePattern = regexp.MustCompile(`^(?P<name>.*)-(?P<version>.*)-(?P<release>.*)\.(?P<arch>[a-zA-Z][^.]+)(\.rpm)$`)
 
 type Matcher struct {

--- a/grype/matcher/rpmdb/matcher_test.go
+++ b/grype/matcher/rpmdb/matcher_test.go
@@ -72,7 +72,8 @@ func TestMatcherRpmdb(t *testing.T) {
 				"CVE-2014-fake-1": match.ExactDirectMatch,
 			},
 		},
-		{ // Regression against https://github.com/anchore/grype/issues/376
+		{
+			// Regression against https://github.com/anchore/grype/issues/376
 			name: "Rpmdb Match matches by direct and by source indirection when the SourceRpm version is desynced from package version",
 			p: pkg.Package{
 				Name:    "neutron-libs",
@@ -100,25 +101,24 @@ func TestMatcherRpmdb(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		tt := test
 		t.Run(test.name, func(t *testing.T) {
-			store, d, matcher := tt.setup()
-			actual, err := matcher.Match(store, &d, tt.p)
+			store, d, matcher := test.setup()
+			actual, err := matcher.Match(store, &d, test.p)
 			if err != nil {
 				t.Fatal("could not find match: ", err)
 			}
 
-			assert.Len(t, actual, len(tt.expectedMatches), "unexpected matches count")
+			assert.Len(t, actual, len(test.expectedMatches), "unexpected matches count")
 
 			for _, a := range actual {
-				if val, ok := tt.expectedMatches[a.Vulnerability.ID]; !ok {
+				if val, ok := test.expectedMatches[a.Vulnerability.ID]; !ok {
 					t.Errorf("return unkown match CVE: %s", a.Vulnerability.ID)
 					continue
 				} else {
 					assert.Equal(t, val, a.Type)
 				}
 
-				assert.Equal(t, tt.p.Name, a.Package.Name, "failed to capture original package name")
+				assert.Equal(t, test.p.Name, a.Package.Name, "failed to capture original package name")
 				for _, detail := range a.MatchDetails {
 					assert.Equal(t, matcher.Type(), detail.Matcher, "failed to capture matcher type")
 				}
@@ -127,6 +127,57 @@ func TestMatcherRpmdb(t *testing.T) {
 			if t.Failed() {
 				t.Logf("discovered CVES: %+v", actual)
 			}
+		})
+	}
+}
+
+func Test_getNameAndELVersion(t *testing.T) {
+	epoch := 1
+	tests := []struct {
+		name            string
+		metadata        pkg.RpmdbMetadata
+		expectedName    string
+		expectedVersion string
+	}{
+		{
+			name: "sqlite-3.26.0-6.el8.src.rpm",
+			metadata: pkg.RpmdbMetadata{
+				SourceRpm: "sqlite-3.26.0-6.el8.src.rpm",
+			},
+			expectedName:    "sqlite",
+			expectedVersion: "3.26.0-6.el8",
+		},
+		{
+			name: "util-linux-ng-2.17.2-12.28.el6_9.src.rpm",
+			metadata: pkg.RpmdbMetadata{
+				SourceRpm: "util-linux-ng-2.17.2-12.28.el6_9.src.rpm",
+			},
+			expectedName:    "util-linux-ng",
+			expectedVersion: "2.17.2-12.28.el6_9",
+		},
+		{
+			name: "util-linux-ng-2.17.2-12.28.el6_9.2.src.rpm",
+			metadata: pkg.RpmdbMetadata{
+				SourceRpm: "util-linux-ng-2.17.2-12.28.el6_9.2.src.rpm",
+			},
+			expectedName:    "util-linux-ng",
+			expectedVersion: "2.17.2-12.28.el6_9.2",
+		},
+		{
+			name: "epoch 1 + sqlite-3.26.0-6.el8.src.rpm",
+			metadata: pkg.RpmdbMetadata{
+				SourceRpm: "sqlite-3.26.0-6.el8.src.rpm",
+				Epoch:     &epoch,
+			},
+			expectedName:    "sqlite",
+			expectedVersion: "1:3.26.0-6.el8",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualName, actualVersion := getNameAndELVersion(test.metadata)
+			assert.Equal(t, test.expectedName, actualName)
+			assert.Equal(t, test.expectedVersion, actualVersion)
 		})
 	}
 }

--- a/grype/pkg/rpmdb_metadata.go
+++ b/grype/pkg/rpmdb_metadata.go
@@ -1,7 +1,6 @@
 package pkg
 
 type RpmdbMetadata struct {
-	// TODO: do we need to parse with json struct tags? (caps)
 	SourceRpm string
 	Epoch     *int
 }

--- a/grype/pkg/rpmdb_metadata.go
+++ b/grype/pkg/rpmdb_metadata.go
@@ -1,5 +1,7 @@
 package pkg
 
 type RpmdbMetadata struct {
+	// TODO: do we need to parse with json struct tags? (caps)
 	SourceRpm string
+	Epoch     *int
 }


### PR DESCRIPTION
This is a follow up from https://github.com/anchore/grype/issues/374 .

This PR makes two adjustments:
- When searching for possible upstream matches for RPM packages using the source RPM data, the current epoch, source version, and source release values are used to craft the package version used in the matching process.
- Package information is added to the `.matchDetails.[].searchedBy` map to clearly indicate the parameters that were used in the search. This is helpful in source-indirection is in play (the package and version from the source package, not the installed package, is used for matching) by indicating the source package information used in the search.
