### PR TITLE
Add integration test for MSRC matching

### DIFF
--- a/test/integration/db_mock_test.go
+++ b/test/integration/db_mock_test.go
@@ -11,7 +11,7 @@ type mockStore struct {
 	backend map[string]map[string][]grypeDB.Vulnerability
 }
 
-func NewMockDbStore() *mockStore {
+func newMockDbStore() *mockStore {
 	return &mockStore{
 		backend: map[string]map[string][]grypeDB.Vulnerability{
 			"nvd": {
@@ -87,6 +87,15 @@ func NewMockDbStore() *mockStore {
 					},
 				},
 			},
+			"msrc:10816": {
+				"10816": []grypeDB.Vulnerability{
+					{
+						ID:                "CVE-2016-3333",
+						VersionConstraint: "3200970 || 878787 || base",
+						VersionFormat:     "kb",
+					},
+				},
+			},
 		},
 	}
 }
@@ -96,5 +105,12 @@ func (s *mockStore) GetVulnerability(namespace, name string) ([]grypeDB.Vulnerab
 	if namespaceMap == nil {
 		return nil, nil
 	}
-	return namespaceMap[name], nil
+	entries, ok := namespaceMap[name]
+	if !ok {
+		return entries, nil
+	}
+	for i := range entries {
+		entries[i].Namespace = namespace
+	}
+	return entries, nil
 }

--- a/test/integration/match_by_image_test.go
+++ b/test/integration/match_by_image_test.go
@@ -253,7 +253,7 @@ func addRhelMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Cata
 	})
 }
 
-func TestPkgCoverageImage(t *testing.T) {
+func TestMatchByImage(t *testing.T) {
 
 	observedMatchers := internal.NewStringSet()
 	definedMatchers := internal.NewStringSet()
@@ -297,7 +297,7 @@ func TestPkgCoverageImage(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.fixtureImage, func(t *testing.T) {
-			theStore := NewMockDbStore()
+			theStore := newMockDbStore()
 
 			imagetest.GetFixtureImage(t, "docker-archive", test.fixtureImage)
 			tarPath := imagetest.GetFixtureImageTarPath(t, test.fixtureImage)

--- a/test/integration/match_by_sbom_document_test.go
+++ b/test/integration/match_by_sbom_document_test.go
@@ -1,0 +1,71 @@
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/anchore/grype/grype"
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/syft/syft/source"
+	"github.com/go-test/deep"
+	"github.com/scylladb/go-set/strset"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchBySBOMDocument(t *testing.T) {
+	tests := []struct {
+		name            string
+		fixture         string
+		expectedIDs     []string
+		expectedDetails []match.Details
+	}{
+		{
+			name:        "single package",
+			fixture:     "test-fixtures/sbom/syft-sbom-with-kb-packages.json",
+			expectedIDs: []string{"CVE-2016-3333"},
+			expectedDetails: []match.Details{
+				{
+					SearchedBy: map[string]interface{}{
+						"distro": map[string]string{
+							"type":    "windows",
+							"version": "10816",
+						},
+						"namespace": "msrc:10816",
+						"package": map[string]string{
+							"name":    "10816",
+							"version": "3200970",
+						},
+					},
+					Found: map[string]interface{}{
+						"versionConstraint": "3200970 || 878787 || base (kb)",
+					},
+					Matcher:    match.MsrcMatcher,
+					Confidence: 1,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider := vulnerability.NewProviderFromStore(newMockDbStore())
+			matches, _, _, err := grype.FindVulnerabilities(provider, fmt.Sprintf("sbom:%s", test.fixture), source.SquashedScope, nil)
+			assert.NoError(t, err)
+			details := make([]match.Details, 0)
+			ids := strset.New()
+			for _, m := range matches.Sorted() {
+				details = append(details, m.MatchDetails...)
+				ids.Add(m.Vulnerability.ID)
+			}
+			assert.Len(t, details, len(test.expectedDetails))
+			for i := range test.expectedDetails {
+				for _, d := range deep.Equal(test.expectedDetails[i], details[i]) {
+					t.Error(d)
+				}
+			}
+
+			assert.ElementsMatch(t, test.expectedIDs, ids.List())
+		})
+	}
+}

--- a/test/integration/test-fixtures/sbom/syft-sbom-with-kb-packages.json
+++ b/test/integration/test-fixtures/sbom/syft-sbom-with-kb-packages.json
@@ -1,0 +1,31 @@
+{
+  "artifacts": [
+    {
+      "id": "eeb36c1c-c03a-425b-901f-df918cc3757e",
+      "name": "10816",
+      "version": "3200970",
+      "type": "msrc-kb"
+    }
+  ],
+  "artifactRelationships": [],
+  "source": {
+    "type": "image",
+    "target": {
+      "userInput": "my-awesome-image:latest",
+      "scope": "Squashed"
+    }
+  },
+  "distro": {
+    "name": "windows",
+    "version": "10816",
+    "idLike": ""
+  },
+  "descriptor": {
+    "name": "syft",
+    "version": "v0.19.1"
+  },
+  "schema": {
+    "version": "1.1.0",
+    "url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-1.1.0.json"
+  }
+}


### PR DESCRIPTION
Adds a test which exercises passing a syft SBOM with windows KB info that enables matching against mock MSRC vulnerability data.