### PR TITLE
Alpine match source pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/adrg/xdg v0.2.1
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
-	github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca
+	github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4
 	github.com/anchore/grype-db v0.0.0-20210809130557-72ff1b90af67
 	github.com/anchore/stereoscope v0.0.0-20210817160504-0f4abc2a5a5a
 	github.com/anchore/syft v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,9 @@ github.com/anchore/go-rpmdb v0.0.0-20210602151223-1f0f707a2894/go.mod h1:8jNYOxC
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0vW0nnNKJfJieyH/TZ9UYAnTZs5/gHTdAe8=
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca h1:rLyc7Rih769rYABQe4nBPt3jHJd/snBuVvKKGoy5HEc=
 github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
+github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 h1:rmZG77uXgE+o2gozGEBoUMpX27lsku+xrMwlmBZJtbg=
+github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/grype v0.14.1-0.20210702143224-05ade7bbbf70/go.mod h1:yPh9WHflzInB/INwPrDs2wLKmRsa8owAuojmv4K8H6I=
 github.com/anchore/grype-db v0.0.0-20210527140125-6f881b00e927/go.mod h1:XSlPf1awNrMpah+rHbWrzgUvnmWLgn/KkdicxERVClg=
 github.com/anchore/grype-db v0.0.0-20210809130557-72ff1b90af67 h1:JyK6DKtAWQ11jzzrvSe91gY07BW4I//IJQVdj5JKeIk=

--- a/grype/pkg/apk_metadata.go
+++ b/grype/pkg/apk_metadata.go
@@ -1,0 +1,5 @@
+package pkg
+
+type ApkMetadata struct {
+	OriginPackage string
+}

--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -63,6 +63,14 @@ func New(p *pkg.Package) Package {
 		} else {
 			log.Warnf("unable to extract Java metadata for %s", p)
 		}
+	case pkg.ApkMetadataType:
+		if value, ok := p.Metadata.(pkg.ApkMetadata); ok {
+			metadata = ApkMetadata{
+				OriginPackage: value.OriginPackage,
+			}
+		} else {
+			log.Warnf("unable to extract APK metadata for %s", p)
+		}
 	}
 
 	return Package{

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -119,11 +119,11 @@ func TestNew_MetadataExtraction(t *testing.T) {
 			syftPkg: syftPkg.Package{
 				MetadataType: syftPkg.ApkMetadataType,
 				Metadata: syftPkg.ApkMetadata{
-					Package:          "a",
-					OriginPackage:    "a",
-					Maintainer:       "a",
-					Version:          "a",
-					License:          "a",
+					Package:          "libcurl-tools",
+					OriginPackage:    "libcurl",
+					Maintainer:       "somone",
+					Version:          "1.2.3",
+					License:          "Apache",
 					Architecture:     "a",
 					URL:              "a",
 					Description:      "a",
@@ -134,7 +134,7 @@ func TestNew_MetadataExtraction(t *testing.T) {
 					GitCommitOfAport: "a",
 				},
 			},
-			metadata: nil,
+			metadata: ApkMetadata{OriginPackage: "libcurl"},
 		},
 		{
 			name: "npm-metadata",

--- a/grype/version/fuzzy_constraint_test.go
+++ b/grype/version/fuzzy_constraint_test.go
@@ -44,6 +44,7 @@ func TestSmartVerCmp(t *testing.T) {
 		{"10.0", "1.000", 1},
 		{"10.0", "1.000.0.1", 1},
 		{"1.0.4", "1.0.4+metadata", -1}, // this is also somewhat wrong, however, there is a semver parser that can handle this case (which should be leveraged when possible)
+		{"1.3.2-r0", "1.3.3-r0", -1},    // regression: regression for https://github.com/anchore/go-version/pull/2
 	}
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%q vs %q", c.v1, c.v2), func(t *testing.T) {
@@ -216,6 +217,13 @@ func TestFuzzyConstraintSatisfaction(t *testing.T) {
 			version:    "5a2",
 			constraint: "<5a2",
 			expected:   false,
+		},
+		// regression for https://github.com/anchore/go-version/pull/2
+		{
+			name:       "indirect package match",
+			version:    "1.3.2-r0",
+			constraint: "<= 1.3.3-r0",
+			expected:   true,
 		},
 	}
 


### PR DESCRIPTION
This PR allows grype to match with source packages for alpine. It adds Metadata for APK packages that have OriginPackage reference. This is then used in the apk matcher to match against the origin package. 

After discussion with @wagoodman, it was decided that we would match the source just like we do with the actual package itself. In alpine, this is a multi step process. First it matches against secdb and then uses the cpes to also find matches within nvd. Matching the source package against secdb simply requires changing the name on the indirectPackage, but matching against nvd is a little more complicated. We decided to take all the cpes that are generated for the package and replace the package name with the source package. These cpes are then used to match against nvd

This PR also updates the version of go-version and adds a test for the bug that was fixed there: https://github.com/anchore/go-version/pull/2

Fixes #343 