### PR TITLE
Fix vulndb fuzzy constraint matching

### DIFF
--- a/grype/version/constraint_unit.go
+++ b/grype/version/constraint_unit.go
@@ -28,7 +28,7 @@ func parseUnit(phrase string) (*constraintUnit, error) {
 	version = strings.Trim(version, " ")
 
 	// version may have quotes, attempt to unquote it (ignore errors)
-	unquoted, err := strconv.Unquote(version)
+	unquoted, err := trimQuotes(version)
 	if err == nil {
 		version = unquoted
 	}
@@ -41,6 +41,21 @@ func parseUnit(phrase string) (*constraintUnit, error) {
 		rangeOperator: op,
 		version:       version,
 	}, nil
+}
+
+// TrimQuotes will attempt to remove double quotes.
+// If removing double quotes is unsuccessful, it will attempt to remove single quotes.
+// If neither operation is successful, it will return an error.
+func trimQuotes(s string) (string, error) {
+	unquoted, err := strconv.Unquote(s)
+	switch {
+	case err == nil:
+		return unquoted, nil
+	case strings.HasPrefix(s, "'") && strings.HasSuffix(s, "'"):
+		return strings.Trim(s, "'"), nil
+	default:
+		return s, fmt.Errorf("string %s is not single or double quoted", s)
+	}
 }
 
 func (c *constraintUnit) Satisfied(comparison int) bool {

--- a/grype/version/fuzzy_constraint_test.go
+++ b/grype/version/fuzzy_constraint_test.go
@@ -225,6 +225,18 @@ func TestFuzzyConstraintSatisfaction(t *testing.T) {
 			constraint: "<= 1.3.3-r0",
 			expected:   true,
 		},
+		{
+			name:       "vulndb fuzzy constraint single quoted",
+			version:    "4.5.2",
+			constraint: "'4.5.1' || '4.5.2'",
+			expected:   true,
+		},
+		{
+			name:       "vulndb fuzzy constraint double quoted",
+			version:    "4.5.2",
+			constraint: "\"4.5.1\" || \"4.5.2\"",
+			expected:   true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Grype DB Builder was changed to use single quotes instead of double quotes for version constraints in [this PR](https://github.com/anchore/grype-db-builder/pull/146). This change broke constraint matching for vulndb records. This change fixes that by adding support for single quotes to the parseUnit function in `grype/version/constraint_unit.go`.