### PR TITLE
Enhance version cmd

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,7 @@ builds:
       -s
       -extldflags '-static'
       -X github.com/anchore/grype/internal/version.version={{.Version}}
+      -X github.com/anchore/grype/internal/version.syftVersion={{.Env.SYFT_VERSION}}
       -X github.com/anchore/grype/internal/version.gitCommit={{.Commit}}
       -X github.com/anchore/grype/internal/version.buildDate={{.Date}}
       -X github.com/anchore/grype/internal/version.gitTreeState={{.Env.BUILD_GIT_TREE_STATE}}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,7 @@ builds:
       -s
       -extldflags '-static'
       -X github.com/anchore/grype/internal/version.version={{.Version}}
+      -X github.com/anchore/grype/internal/version.syftVersion={{.Env.SYFT_VERSION}}
       -X github.com/anchore/grype/internal/version.gitCommit={{.Commit}}
       -X github.com/anchore/grype/internal/version.buildDate={{.Date}}
       -X github.com/anchore/grype/internal/version.gitTreeState={{.Env.BUILD_GIT_TREE_STATE}}

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ BOOTSTRAP_CACHE="c7afb99ad"
 DISTDIR=./dist
 SNAPSHOTDIR=./snapshot
 GITTREESTATE=$(if $(shell git status --porcelain),dirty,clean)
-SYFTVERSION=$(shell go list -m all | grep github.com/anchore/syft | awk '{print $2}')
+SYFTVERSION=$(shell go list -m all | grep github.com/anchore/syft | awk '{print $$2}')
 OS := $(shell uname)
 
 ifeq ($(OS),Darwin)
@@ -63,10 +63,6 @@ endef
 .PHONY: all
 all: clean static-analysis test ## Run all checks (linting, license check, unit, integration, and linux acceptance tests tests)
 	@printf '$(SUCCESS)All checks pass!$(RESET)\n'
-
-.PHONY: foobar
-foobar:
-	@printf '$(SYFTVERSION)'
 
 .PHONY: test
 test: unit validate-cyclonedx-schema integration acceptance-linux cli ## Run all tests (unit, integration, linux acceptance, and CLI tests)
@@ -174,6 +170,7 @@ $(SNAPSHOTDIR): ## Build snapshot release binaries and packages
 
 	# build release snapshots
 	BUILD_GIT_TREE_STATE=$(GITTREESTATE) \
+	SYFT_VERSION=$(SYFTVERSION) \
 	$(TEMPDIR)/goreleaser release --skip-publish --skip-sign --rm-dist --snapshot --config $(TEMPDIR)/goreleaser.yaml
 
 .PHONY: acceptance-linux

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ BOOTSTRAP_CACHE="c7afb99ad"
 DISTDIR=./dist
 SNAPSHOTDIR=./snapshot
 GITTREESTATE=$(if $(shell git status --porcelain),dirty,clean)
+SYFT_VERSION=$(if $(shell go list -m all | grep github.com/anchore/syft | awk '{print $2}'))
 OS := $(shell uname)
 
 ifeq ($(OS),Darwin)
@@ -252,6 +253,7 @@ release: clean-dist validate-grype-test-config changelog-release ## Build and pu
 	# release (note the version transformation from v0.7.0 --> 0.7.0)
 	bash -c "\
 		BUILD_GIT_TREE_STATE=$(GITTREESTATE) \
+		SYFT_VERSION=$(SYFT_VERSION) \
 		VERSION=$(VERSION:v%=%) \
 		$(TEMPDIR)/goreleaser \
 			--rm-dist \

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ BOOTSTRAP_CACHE="c7afb99ad"
 DISTDIR=./dist
 SNAPSHOTDIR=./snapshot
 GITTREESTATE=$(if $(shell git status --porcelain),dirty,clean)
-SYFT_VERSION=$(if $(shell go list -m all | grep github.com/anchore/syft | awk '{print $2}'))
+SYFTVERSION=$(shell go list -m all | grep github.com/anchore/syft | awk '{print $2}')
 OS := $(shell uname)
 
 ifeq ($(OS),Darwin)
@@ -63,6 +63,10 @@ endef
 .PHONY: all
 all: clean static-analysis test ## Run all checks (linting, license check, unit, integration, and linux acceptance tests tests)
 	@printf '$(SUCCESS)All checks pass!$(RESET)\n'
+
+.PHONY: foobar
+foobar:
+	@printf '$(SYFTVERSION)'
 
 .PHONY: test
 test: unit validate-cyclonedx-schema integration acceptance-linux cli ## Run all tests (unit, integration, linux acceptance, and CLI tests)
@@ -253,7 +257,7 @@ release: clean-dist validate-grype-test-config changelog-release ## Build and pu
 	# release (note the version transformation from v0.7.0 --> 0.7.0)
 	bash -c "\
 		BUILD_GIT_TREE_STATE=$(GITTREESTATE) \
-		SYFT_VERSION=$(SYFT_VERSION) \
+		SYFT_VERSION=$(SYFTVERSION) \
 		VERSION=$(VERSION:v%=%) \
 		$(TEMPDIR)/goreleaser \
 			--rm-dist \

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -31,6 +31,7 @@ func printVersion(_ *cobra.Command, _ []string) {
 	case "text":
 		fmt.Println("Application:         ", internal.ApplicationName)
 		fmt.Println("Version:             ", versionInfo.Version)
+		fmt.Println("Syft Version:        ", versionInfo.SyftVersion)
 		fmt.Println("BuildDate:           ", versionInfo.BuildDate)
 		fmt.Println("GitCommit:           ", versionInfo.GitCommit)
 		fmt.Println("GitTreeState:        ", versionInfo.GitTreeState)

--- a/internal/version/build.go
+++ b/internal/version/build.go
@@ -8,6 +8,7 @@ import (
 const valueNotProvided = "[not provided]"
 
 var version = valueNotProvided
+var syftVersion = valueNotProvided
 var gitCommit = valueNotProvided
 var gitTreeState = valueNotProvided
 var buildDate = valueNotProvided
@@ -15,6 +16,7 @@ var platform = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
 
 type Version struct {
 	Version      string `json:"version"`
+	SyftVersion  string `json:"syftVersion"`
 	GitCommit    string `json:"gitCommit"`
 	GitTreeState string `json:"gitTreeState"`
 	BuildDate    string `json:"buildDate"`
@@ -26,6 +28,7 @@ type Version struct {
 func FromBuild() Version {
 	return Version{
 		Version:      version,
+		SyftVersion:  syftVersion,
 		GitCommit:    gitCommit,
 		GitTreeState: gitTreeState,
 		BuildDate:    buildDate,


### PR DESCRIPTION
To Test run
```
make bootstrap
make build
```

Locally you should see syft version populated in the build:
<img width="956" alt="Screen Shot 2021-09-16 at 10 13 07 AM" src="https://user-images.githubusercontent.com/32073428/133627970-3bdbce21-56e8-403b-8cd8-fda8607f1746.png">

When you run:
`./snapshot/grype-macos_darwin_amd64/grype version`

You should see syft version populated in the output:
<img width="952" alt="Screen Shot 2021-09-16 at 10 18 06 AM" src="https://user-images.githubusercontent.com/32073428/133628763-f49eb4c1-7089-46ed-88f5-3d990c0057e2.png">
