### PR TITLE
Update KB constraint to not satisfy if raw constraint is empty.

### DIFF
--- a/grype/version/kb_contraint.go
+++ b/grype/version/kb_contraint.go
@@ -37,14 +37,10 @@ func (c kbConstraint) supported(format Format) bool {
 }
 
 func (c kbConstraint) Satisfied(version *Version) (bool, error) {
-	if c.raw == "" && version != nil {
-		// an empty constraint is always satisfied
-		return true, nil
+	if c.raw == "" {
+		// an empty constraint is never satisfied
+		return false, nil
 	} else if version == nil {
-		if c.raw != "" {
-			// a non-empty constraint with no version given should always fail
-			return false, nil
-		}
 		return true, nil
 	}
 

--- a/grype/version/kb_contraint_test.go
+++ b/grype/version/kb_contraint_test.go
@@ -7,8 +7,9 @@ import (
 
 func TestVersionKbConstraint(t *testing.T) {
 	tests := []testCase{
-		{version: "", constraint: "", satisfied: true},
+		{version: "", constraint: "", satisfied: false},
 		{version: "", constraint: "foo", satisfied: false},
+		{version: "878787", constraint: "", satisfied: false},
 		{version: "1", constraint: "foo", satisfied: false},
 		{version: "1", constraint: "1", satisfied: true},
 		{version: "878787", constraint: "979797 || 101010 || 878787", satisfied: true},


### PR DESCRIPTION
Per validation with legacy MSRC matching in Engine and current understanding of how MSRC vulnerabilities are reported, an image should not be vulnerable to a vulnerability if the match constraint is empty. This PR updates the kb constraint to match this understanding.