### PR TITLE
Bugfixes + Integration test for sbom input vs grype library comparison

### DIFF
--- a/.bouncer.yaml
+++ b/.bouncer.yaml
@@ -6,4 +6,4 @@ permit:
   - ISC
 ignore-packages:
   # packageurl-go is released under the MIT license located in the root of the repo at /mit.LICENSE
-  - github.com/package-url/packageurl-go
+  - github.com/anchore/packageurl-go

--- a/.github/workflows/static-unit-integration.yaml
+++ b/.github/workflows/static-unit-integration.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: Restore integration test cache
         uses: actions/cache@v2
         with:
-          path: ${{ github.workspace }}test/integration/test-fixtures/cache
+          path: ${{ github.workspace }}/test/integration/test-fixtures/cache
           key: ${{ runner.os }}-integration-test-cache-${{ hashFiles('test/integration/test-fixtures/cache.fingerprint') }}
 
       - name: Run integration tests

--- a/.github/workflows/static-unit-integration.yaml
+++ b/.github/workflows/static-unit-integration.yaml
@@ -80,8 +80,8 @@ jobs:
       - name: Restore integration test cache
         uses: actions/cache@v2
         with:
-          path: ${{ github.workspace }}/integration/test-fixtures/cache
-          key: ${{ runner.os }}-integration-test-cache-${{ hashFiles('integration/test-fixtures/cache.fingerprint') }}
+          path: ${{ github.workspace }}test/integration/test-fixtures/cache
+          key: ${{ runner.os }}-integration-test-cache-${{ hashFiles('test/integration/test-fixtures/cache.fingerprint') }}
 
       - name: Run integration tests
         run: make integration

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ integration: ## Run integration tests
 # note: this is used by CI to determine if the integration test fixture cache (docker image tars) should be busted
 .PHONY: integration-fingerprint
 integration-fingerprint:
-	find test/integration/test-fixtures/image-* -type f -exec md5sum {} + | awk '{print $1}' | sort | md5sum | tee test/integration/test-fixtures/cache.fingerprint
+	find test/integration/*.go test/integration/test-fixtures/image-* -type f -exec md5sum {} + | awk '{print $1}' | sort | md5sum | tee test/integration/test-fixtures/cache.fingerprint
 
 .PHONY: cli
 cli: $(SNAPSHOTDIR) ## Run CLI tests

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4
 	github.com/anchore/grype-db v0.0.0-20210913215030-fe28197b36f1
 	github.com/anchore/stereoscope v0.0.0-20210817160504-0f4abc2a5a5a
-	github.com/anchore/syft v0.23.0
+	github.com/anchore/syft v0.24.0
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/dustin/go-humanize v1.0.0
 	github.com/facebookincubator/nvdtools v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -114,9 +114,7 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alicebob/sqlittle v1.4.0 h1:vgYt0nAjhdf/hg52MjKJ84g/uTzBPfrvI+VUBrIghxA=
 github.com/alicebob/sqlittle v1.4.0/go.mod h1:Co1L1qxHqCwf41puWhk2HOodojR0mcsAV4BIt8byZh8=
-github.com/anchore/client-go v0.0.0-20210222170800-9c70f9b80bcf h1:DYssiUV1pBmKqzKsm4mqXx8artqC0Q8HgZsVI3lMsAg=
 github.com/anchore/client-go v0.0.0-20210222170800-9c70f9b80bcf/go.mod h1:FaODhIA06mxO1E6R32JE0TL1JWZZkmjRIAd4ULvHUKk=
-github.com/anchore/go-rpmdb v0.0.0-20210602151223-1f0f707a2894 h1:VvCq7fFNU8dwWkCTGUykm4p64nVaDCYkKrj87x350Sk=
 github.com/anchore/go-rpmdb v0.0.0-20210602151223-1f0f707a2894/go.mod h1:8jNYOxCJC5kyD/Ct4MbzsDN2hOhRoCAzQcb/7KdYYGw=
 github.com/anchore/go-rpmdb v0.0.0-20210914181456-a9c52348da63 h1:C9W/LAydEz/qdUhx1MdjO9l8NEcFKYknkxDVyo9LAoM=
 github.com/anchore/go-rpmdb v0.0.0-20210914181456-a9c52348da63/go.mod h1:6qH8c6U/3CBVvDDDBZnPSTbTINq3cIdADUYTaVf75EM=
@@ -137,14 +135,12 @@ github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1
 github.com/anchore/stereoscope v0.0.0-20210817160504-0f4abc2a5a5a h1:RQb+Gft1MKxjDfJCnHP/f1mwfy0Jz50Kp9QGgSWKQiY=
 github.com/anchore/stereoscope v0.0.0-20210817160504-0f4abc2a5a5a/go.mod h1:165DfE5jApgEkHTWwu7Bijeml9fofudrgcpuWaD9+tk=
 github.com/anchore/syft v0.19.0/go.mod h1:ktWx72/MizsN9jgEh+Vzl9lfNIUC8tylQHk3ZjKehn0=
-github.com/anchore/syft v0.23.0 h1:7I0r5RflkUIWQjXcecolO7niuJASP4D0xEzB0PfojwU=
 github.com/anchore/syft v0.23.0/go.mod h1:sr+rUnzPjdf97YUwZrbeuD8sebS5VsAZVTp6nXsjOWo=
 github.com/anchore/syft v0.24.0 h1:OHllBCyDOU0USkssnfBrQ0VJ3ZZ14flCVD7UPkI9Fmc=
 github.com/anchore/syft v0.24.0/go.mod h1:XqVz3ZZYUKng59SXdyypYW6aXlI5fG6ZNR1SGbWGFhA=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
-github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apex/log v1.1.4/go.mod h1:AlpoD9aScyQfJDVHmLMEcx4oU6LqzkWp4Mg9GdAcEvQ=
 github.com/apex/log v1.3.0/go.mod h1:jd8Vpsr46WAe3EZSQ/IUMs2qQD/GOycT5rPWCO1yGcs=
@@ -298,7 +294,6 @@ github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8
 github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dpr1UfpPtxFw+EFuQ41HhCWZfha5jSVRG7C7I=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
-github.com/go-restruct/restruct v0.0.0-20191227155143-5734170a48a1 h1:LoN2wx/aN8JPGebG+2DaUyk4M+xRcqJXfuIbs8AWHdE=
 github.com/go-restruct/restruct v0.0.0-20191227155143-5734170a48a1/go.mod h1:KqrpKpn4M8OLznErihXTGLlsXFGeLxHUrLRRI/1YjGk=
 github.com/go-restruct/restruct v1.2.0-alpha h1:2Lp474S/9660+SJjpVxoKuWX09JsXHSrdV7Nv3/gkvc=
 github.com/go-restruct/restruct v1.2.0-alpha/go.mod h1:KqrpKpn4M8OLznErihXTGLlsXFGeLxHUrLRRI/1YjGk=
@@ -650,7 +645,6 @@ github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5X
 github.com/opencontainers/runc v0.1.1 h1:GlxAyO6x8rfZYN9Tt0Kti5a/cP41iuiO2yYT0IJGY8Y=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
-github.com/package-url/packageurl-go v0.1.0 h1:efWBc98O/dBZRg1pw2xiDzovnlMjCa9NPnfaiBduh8I=
 github.com/package-url/packageurl-go v0.1.0/go.mod h1:C/ApiuWpmbpni4DIOECf6WCjFUZV7O1Fx7VAzrZHgBw=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
@@ -664,7 +658,6 @@ github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/profile v1.5.0 h1:042Buzk+NhDI+DeSAA62RwJL8VAuZUMQZUjCsRz1Mug=
 github.com/pkg/profile v1.5.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/go.sum
+++ b/go.sum
@@ -724,6 +724,7 @@ github.com/sourcegraph/go-diff v0.5.1/go.mod h1:j2dHj3m8aZgQO8lMTcTnBcXkRRRqi34c
 github.com/sourcegraph/go-diff v0.5.3/go.mod h1:v9JDtjCE4HHHCZGId75rg8gkKKa98RVjBcBGsVmMmak=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spdx/gordf v0.0.0-20201111095634-7098f93598fb/go.mod h1:uKWaldnbMnjsSAXRurWqqrdyZen1R7kxl8TkmWk2OyM=
+github.com/spdx/tools-golang v0.1.0 h1:iDMNEPqQk6CdiDj6eWDIDw85j0wQ3IR3pH9p0X05TSQ=
 github.com/spdx/tools-golang v0.1.0/go.mod h1:RO4Y3IFROJnz+43JKm1YOrbtgQNljW4gAPpA/sY2eqo=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=

--- a/go.sum
+++ b/go.sum
@@ -114,9 +114,12 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alicebob/sqlittle v1.4.0 h1:vgYt0nAjhdf/hg52MjKJ84g/uTzBPfrvI+VUBrIghxA=
 github.com/alicebob/sqlittle v1.4.0/go.mod h1:Co1L1qxHqCwf41puWhk2HOodojR0mcsAV4BIt8byZh8=
+github.com/anchore/client-go v0.0.0-20210222170800-9c70f9b80bcf h1:DYssiUV1pBmKqzKsm4mqXx8artqC0Q8HgZsVI3lMsAg=
 github.com/anchore/client-go v0.0.0-20210222170800-9c70f9b80bcf/go.mod h1:FaODhIA06mxO1E6R32JE0TL1JWZZkmjRIAd4ULvHUKk=
 github.com/anchore/go-rpmdb v0.0.0-20210602151223-1f0f707a2894 h1:VvCq7fFNU8dwWkCTGUykm4p64nVaDCYkKrj87x350Sk=
 github.com/anchore/go-rpmdb v0.0.0-20210602151223-1f0f707a2894/go.mod h1:8jNYOxCJC5kyD/Ct4MbzsDN2hOhRoCAzQcb/7KdYYGw=
+github.com/anchore/go-rpmdb v0.0.0-20210914181456-a9c52348da63 h1:C9W/LAydEz/qdUhx1MdjO9l8NEcFKYknkxDVyo9LAoM=
+github.com/anchore/go-rpmdb v0.0.0-20210914181456-a9c52348da63/go.mod h1:6qH8c6U/3CBVvDDDBZnPSTbTINq3cIdADUYTaVf75EM=
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0vW0nnNKJfJieyH/TZ9UYAnTZs5/gHTdAe8=
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
@@ -127,6 +130,8 @@ github.com/anchore/grype v0.14.1-0.20210702143224-05ade7bbbf70/go.mod h1:yPh9WHf
 github.com/anchore/grype-db v0.0.0-20210527140125-6f881b00e927/go.mod h1:XSlPf1awNrMpah+rHbWrzgUvnmWLgn/KkdicxERVClg=
 github.com/anchore/grype-db v0.0.0-20210913215030-fe28197b36f1 h1:Jr7IuHtpd2mIktOzhcr014boySty6AzVwp+pJF6Iet0=
 github.com/anchore/grype-db v0.0.0-20210913215030-fe28197b36f1/go.mod h1:GniMuMokZ2iAX67Qrd5fJW7BstX8a+4U48LyypGC2g0=
+github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29 h1:K9LfnxwhqvihqU0+MF325FNy7fsKV9EGaUxdfR4gnWk=
+github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29/go.mod h1:Oc1UkGaJwY6ND6vtAqPSlYrptKRJngHwkwB6W7l1uP0=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
 github.com/anchore/stereoscope v0.0.0-20210817160504-0f4abc2a5a5a h1:RQb+Gft1MKxjDfJCnHP/f1mwfy0Jz50Kp9QGgSWKQiY=
@@ -134,9 +139,12 @@ github.com/anchore/stereoscope v0.0.0-20210817160504-0f4abc2a5a5a/go.mod h1:165D
 github.com/anchore/syft v0.19.0/go.mod h1:ktWx72/MizsN9jgEh+Vzl9lfNIUC8tylQHk3ZjKehn0=
 github.com/anchore/syft v0.23.0 h1:7I0r5RflkUIWQjXcecolO7niuJASP4D0xEzB0PfojwU=
 github.com/anchore/syft v0.23.0/go.mod h1:sr+rUnzPjdf97YUwZrbeuD8sebS5VsAZVTp6nXsjOWo=
+github.com/anchore/syft v0.24.0 h1:OHllBCyDOU0USkssnfBrQ0VJ3ZZ14flCVD7UPkI9Fmc=
+github.com/anchore/syft v0.24.0/go.mod h1:XqVz3ZZYUKng59SXdyypYW6aXlI5fG6ZNR1SGbWGFhA=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
+github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apex/log v1.1.4/go.mod h1:AlpoD9aScyQfJDVHmLMEcx4oU6LqzkWp4Mg9GdAcEvQ=
 github.com/apex/log v1.3.0/go.mod h1:jd8Vpsr46WAe3EZSQ/IUMs2qQD/GOycT5rPWCO1yGcs=
@@ -292,6 +300,8 @@ github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-restruct/restruct v0.0.0-20191227155143-5734170a48a1 h1:LoN2wx/aN8JPGebG+2DaUyk4M+xRcqJXfuIbs8AWHdE=
 github.com/go-restruct/restruct v0.0.0-20191227155143-5734170a48a1/go.mod h1:KqrpKpn4M8OLznErihXTGLlsXFGeLxHUrLRRI/1YjGk=
+github.com/go-restruct/restruct v1.2.0-alpha h1:2Lp474S/9660+SJjpVxoKuWX09JsXHSrdV7Nv3/gkvc=
+github.com/go-restruct/restruct v1.2.0-alpha/go.mod h1:KqrpKpn4M8OLznErihXTGLlsXFGeLxHUrLRRI/1YjGk=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -654,6 +664,7 @@ github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/profile v1.5.0 h1:042Buzk+NhDI+DeSAA62RwJL8VAuZUMQZUjCsRz1Mug=
 github.com/pkg/profile v1.5.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -37,7 +37,7 @@ func New(p *pkg.Package) Package {
 		}
 	case pkg.RpmdbMetadataType:
 		if value, ok := p.Metadata.(pkg.RpmdbMetadata); ok {
-			metadata = RpmdbMetadata{SourceRpm: value.SourceRpm}
+			metadata = RpmdbMetadata{SourceRpm: value.SourceRpm, Epoch: value.Epoch}
 		} else {
 			log.Warnf("unable to extract RPM metadata for %s", p)
 		}

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -76,7 +76,7 @@ func TestNew_MetadataExtraction(t *testing.T) {
 			},
 			metadata: RpmdbMetadata{
 				SourceRpm: "src-rpm-info",
-				Epoch:     func(val int) *int { return &val }(30),
+				Epoch:     intRef(30),
 			},
 		},
 		{

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -76,6 +76,7 @@ func TestNew_MetadataExtraction(t *testing.T) {
 			},
 			metadata: RpmdbMetadata{
 				SourceRpm: "src-rpm-info",
+				Epoch:     func(val int) *int { return &val }(30),
 			},
 		},
 		{

--- a/grype/pkg/syft_json_provider.go
+++ b/grype/pkg/syft_json_provider.go
@@ -152,6 +152,12 @@ func (p *partialSyftPackage) UnmarshalJSON(b []byte) error {
 	p.MetadataType = unpacker.MetadataType
 
 	switch p.MetadataType {
+	case pkg.ApkMetadataType:
+		var payload ApkMetadata
+		if err := json.Unmarshal(unpacker.Metadata, &payload); err != nil {
+			return err
+		}
+		p.Metadata = payload
 	case pkg.RpmdbMetadataType:
 		var payload RpmdbMetadata
 		if err := json.Unmarshal(unpacker.Metadata, &payload); err != nil {

--- a/test/integration/compare_sbom_input_vs_lib_test.go
+++ b/test/integration/compare_sbom_input_vs_lib_test.go
@@ -89,7 +89,8 @@ func TestCompareSBOMInputToLibResults(t *testing.T) {
 			matchSetFromSbom := getMatchSet(matchesFromSbom)
 			matchSetFromImage := getMatchSet(matchesFromImage)
 
-			assert.Empty(t, strset.SymmetricDifference(matchSetFromSbom, matchSetFromImage).List())
+			assert.Empty(t, strset.Difference(matchSetFromSbom, matchSetFromImage).List(), "vulnerabilities present only in results when using sbom as input")
+			assert.Empty(t, strset.Difference(matchSetFromImage, matchSetFromSbom).List(), "vulnerabilities present only in results when using image as input")
 
 			// track all covered package types (for use after the test)
 			for _, p := range pkgsFromSbom {

--- a/test/integration/compare_sbom_input_vs_lib_test.go
+++ b/test/integration/compare_sbom_input_vs_lib_test.go
@@ -1,0 +1,119 @@
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/anchore/grype/grype"
+	"github.com/anchore/grype/grype/db"
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/internal"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/source"
+	"github.com/scylladb/go-set/strset"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompareSBOMInputToLibResults(t *testing.T) {
+	// TODO: cache images between runs and use the tar
+
+	observedPkgTypes := strset.New()
+	definedPkgTypes := strset.New()
+	for _, p := range syftPkg.AllPkgs {
+		definedPkgTypes.Add(string(p))
+	}
+	// exceptions: rust and msrc (kb) are not under test
+	definedPkgTypes.Remove(string(syftPkg.RustPkg), string(syftPkg.KbPkg))
+
+	cases := []struct {
+		image string
+	}{
+		{
+			"anchore/test_images:vulnerabilities-alpine",
+		},
+		{
+			"anchore/test_images:gems",
+		},
+		{
+			"anchore/test_images:vulnerabilities-debian",
+		},
+		{
+			"anchore/test_images:vulnerabilities-centos",
+		},
+		{
+			"anchore/test_images:npm",
+		},
+		{
+			"anchore/engine-cli:v0.3.4",
+		},
+		{
+			"anchore/test_images:java",
+		},
+		{
+			"jenkins/jenkins:lts",
+		},
+		{
+			"golangci/golangci-lint:latest-alpine",
+		},
+	}
+
+	// get a grype DB
+	vulnProvider, _, _, err := grype.LoadVulnerabilityDb(db.Config{
+		DbRootDir:           "test-fixtures/grype-db",
+		ListingURL:          internal.DBUpdateURL,
+		ValidateByHashOnGet: false,
+	}, true)
+	assert.NoError(t, err)
+
+	for _, test := range cases {
+		t.Run(test.image, func(t *testing.T) {
+			t.Logf("Running case %s", test.image)
+
+			// get SBOM from syft, write to temp file
+			sbomBytes := getSyftSBOM(t, test.image)
+			sbomFile, err := ioutil.TempFile("", "")
+			assert.NoError(t, err)
+			t.Cleanup(func() {
+				assert.NoError(t, os.Remove(sbomFile.Name()))
+			})
+			_, err = sbomFile.WriteString(sbomBytes)
+			assert.NoError(t, err)
+			assert.NoError(t, sbomFile.Close())
+
+			// get vulns (sbom)
+			matchesFromSbom, _, pkgsFromSbom, err := grype.FindVulnerabilities(vulnProvider, fmt.Sprintf("sbom:%s", sbomFile.Name()), source.SquashedScope, nil)
+			assert.NoError(t, err)
+
+			// get vulns (image)
+			matchesFromImage, _, _, err := grype.FindVulnerabilities(vulnProvider, test.image, source.SquashedScope, nil)
+			assert.NoError(t, err)
+
+			// compare packages (shallow)
+			matchSetFromSbom := getMatchSet(matchesFromSbom)
+			matchSetFromImage := getMatchSet(matchesFromImage)
+
+			assert.Empty(t, strset.SymmetricDifference(matchSetFromSbom, matchSetFromImage).List())
+
+			// track all covered package types (for use after the test)
+			for _, p := range pkgsFromSbom {
+				observedPkgTypes.Add(string(p.Type))
+			}
+
+		})
+	}
+
+	// ensure we've covered all package types (-rust, -kb)
+	unobservedPackageTypes := strset.Difference(definedPkgTypes, observedPkgTypes)
+	assert.Empty(t, unobservedPackageTypes.List(), "not all package type were covered in testing")
+
+}
+
+func getMatchSet(matches match.Matches) *strset.Set {
+	s := strset.New()
+	for _, m := range matches.Sorted() {
+		s.Add(fmt.Sprintf("%s-%s-%s-%s", m.Vulnerability.ID, m.Package.Name, m.Package.Version, string(m.Package.Type)))
+	}
+	return s
+}

--- a/test/integration/compare_sbom_input_vs_lib_test.go
+++ b/test/integration/compare_sbom_input_vs_lib_test.go
@@ -35,12 +35,6 @@ func TestCompareSBOMInputToLibResults(t *testing.T) {
 			"anchore/test_images:npm",
 		},
 		{
-			"anchore/test_images:vulnerabilities-alpine",
-		},
-		{
-			"anchore/test_images:java",
-		},
-		{
 			"anchore/test_images:java",
 		},
 		{

--- a/test/integration/compare_sbom_input_vs_lib_test.go
+++ b/test/integration/compare_sbom_input_vs_lib_test.go
@@ -2,44 +2,29 @@ package integration
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
 	"github.com/anchore/grype/grype"
 	"github.com/anchore/grype/grype/db"
 	"github.com/anchore/grype/internal"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/source"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
-	"os"
-	"testing"
 
 	"github.com/scylladb/go-set/strset"
 )
 
 func TestCompareSBOMInputToLibResults(t *testing.T) {
-	cases := []struct {
-		image string
-	}{
-		{
-			"anchore/test_images:vulnerabilities-alpine",
-		},
-		{
-			"anchore/test_images:gems",
-		},
-		{
-			"anchore/test_images:vulnerabilities-debian",
-		},
-		{
-			"anchore/test_images:vulnerabilities-centos",
-		},
-		{
-			"anchore/test_images:npm",
-		},
-		{
-			"anchore/test_images:java",
-		},
-		{
-			"anchore/test_images:golang",
-		},
+	images := []string{
+		"anchore/test_images:vulnerabilities-alpine",
+		"anchore/test_images:gems",
+		"anchore/test_images:vulnerabilities-debian",
+		"anchore/test_images:vulnerabilities-centos",
+		"anchore/test_images:npm",
+		"anchore/test_images:java",
+		"anchore/test_images:golang",
 	}
 
 	// get a grype DB
@@ -58,12 +43,12 @@ func TestCompareSBOMInputToLibResults(t *testing.T) {
 	definedPkgTypes.Remove(string(syftPkg.RustPkg), string(syftPkg.KbPkg))
 	observedPkgTypes := strset.New()
 
-	for _, test := range cases {
-		t.Run(test.image, func(t *testing.T) {
+	for _, image := range images {
+		t.Run(image, func(t *testing.T) {
 
-			t.Logf("Running case %s", test.image)
+			t.Logf("Running case %s", image)
 
-			imageArchive := PullThroughImageCache(t, test.image)
+			imageArchive := PullThroughImageCache(t, image)
 			imageSource := fmt.Sprintf("docker-archive:%s", imageArchive)
 
 			// get SBOM from syft, write to temp file

--- a/test/integration/test-fixtures/.gitignore
+++ b/test/integration/test-fixtures/.gitignore
@@ -1,1 +1,2 @@
 !**/image-*/Dockerfile
+grype-db

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -1,0 +1,36 @@
+package integration
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/presenter/packages"
+	"github.com/anchore/syft/syft/source"
+)
+
+func getSyftSBOM(t testing.TB, image string) string {
+	src, cleanup, err := source.New(image, nil)
+	if err != nil {
+		t.Fatalf("can't get the source: %+v", err)
+	}
+	t.Cleanup(cleanup)
+
+	scope := source.SquashedScope
+	catalog, distro, err := syft.CatalogPackages(src, scope)
+
+	presenter := packages.Presenter(packages.JSONPresenterOption, packages.PresenterConfig{
+		SourceMetadata: src.Metadata,
+		Catalog:        catalog,
+		Distro:         distro,
+		Scope:          scope,
+	})
+
+	var buf bytes.Buffer
+	if err := presenter.Present(bufio.NewWriter(&buf)); err != nil {
+		t.Fatalf("presenter failed: %+v", err)
+	}
+
+	return buf.String()
+}

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -3,12 +3,65 @@ package integration
 import (
 	"bufio"
 	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/presenter/packages"
 	"github.com/anchore/syft/syft/source"
 )
+
+const cacheDirRelativePath string = "./test-fixtures/cache"
+
+func PullThroughImageCache(t testing.TB, imageName string) string {
+	cacheDirectory := getOrInitializeDirectory(t, cacheDirRelativePath)
+	re := regexp.MustCompile("[/:]")
+	archiveFileName := fmt.Sprintf("%s.tar", re.ReplaceAllString(imageName, "-"))
+	imageArchivePath := filepath.Join(cacheDirectory, archiveFileName)
+	if _, err := os.Stat(imageArchivePath); os.IsNotExist(err) {
+		t.Logf("Cache miss for image %s; copying to archive at %s", imageName, imageArchivePath)
+		saveImage(t, imageName, imageArchivePath)
+	}
+	return imageArchivePath
+}
+
+func saveImage(t testing.TB, imageName string, destPath string) {
+	sourceImage := fmt.Sprintf("docker://docker.io/%s", imageName)
+	destinationString := fmt.Sprintf("docker-archive:%s", destPath)
+	cmd := exec.Command("skopeo", "copy", "--override-os", "linux", sourceImage, destinationString)
+	out, err := cmd.Output()
+	if err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			t.Logf("Stderr: %s", exitError.Stderr)
+		}
+		t.Fatal(err)
+	}
+	t.Logf("Stdout: %s\n", out)
+}
+
+func getOrInitializeDirectory(t testing.TB, relativePath string) string {
+	if _, statErr := os.Stat(relativePath); statErr != nil {
+		if os.IsNotExist(statErr) {
+			mkdirError := os.Mkdir(relativePath, 0755)
+			if mkdirError != nil {
+				t.Fatalf("could not initialize cache directory %s; %v", relativePath, mkdirError)
+			}
+		} else {
+			t.Fatalf("could not check for existence of cache directory %s; %v", relativePath, statErr)
+		}
+	}
+	cacheDir, absErr := filepath.Abs(relativePath)
+	if absErr != nil {
+		t.Fatalf("could not get absolute path of cache directory %s; %v", relativePath, absErr)
+	}
+	return cacheDir
+}
 
 func getSyftSBOM(t testing.TB, image string) string {
 	src, cleanup, err := source.New(image, nil)


### PR DESCRIPTION
There is one failure in the tests right now, and that should get fixed by https://github.com/anchore/grype/pull/425.
This PR adds an integration test which compares the results of running grype against an image when the input comes from a syft sbom vs when the input comes from syft as a library.
The need for these tests comes from having discovered that the code that unmarshals the syft json was missing a handler for alpine metadata, and the code that transforms the metadata from syft as a library into grype's sbom format was missing the epoch field in RPM metadata.
The hope and intent of this test is to help developers catch scenarios where differences in sbom translation between both inputs cause vulnerability matches to get dropped.
The PR also includes bugfixes for the issues mentioned above.

Thanks to @wagoodman for pairing on initial implementation.

fixes: https://github.com/anchore/grype/issues/419