### PR TITLE
Add SBOM to releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -132,6 +132,10 @@ jobs:
           AC_USERNAME: ${{ secrets.ENG_CI_APPLE_ID }} # Used during macOS notarization.
           AC_PASSWORD: ${{ secrets.ENG_CI_APPLE_ID_PASS }} # Used during macOS notarization.
 
+      - uses: anchore/sbom-action@main
+        with:
+          artifact-name: sbom.spdx.json
+
       - uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -132,7 +132,7 @@ jobs:
           AC_USERNAME: ${{ secrets.ENG_CI_APPLE_ID }} # Used during macOS notarization.
           AC_PASSWORD: ${{ secrets.ENG_CI_APPLE_ID_PASS }} # Used during macOS notarization.
 
-      - uses: anchore/sbom-action@main
+      - uses: anchore/sbom-action@v0
         with:
           artifact-name: sbom.spdx.json
 


### PR DESCRIPTION
This will automatically create an SBOM using Syft during the release phase and add it as a release artifact with the name `sbom.spdx.json`. Note: this depends on https://github.com/anchore/sbom-action/pull/68 in order to upload to draft releases