### PR TITLE
Add default matcher (language + CPE matching)

### DIFF
--- a/grype/match/matcher_type.go
+++ b/grype/match/matcher_type.go
@@ -2,6 +2,7 @@ package match
 
 const (
 	UnknownMatcherType MatcherType = iota
+	StockMatcher
 	ApkMatcher
 	RubyGemMatcher
 	DpkgMatcher
@@ -14,6 +15,7 @@ const (
 
 var matcherTypeStr = []string{
 	"UnknownMatcherType",
+	"stock-matcher",
 	"apk-matcher",
 	"ruby-gem-matcher",
 	"dpkg-matcher",

--- a/grype/matcher/common/cpe_matchers.go
+++ b/grype/matcher/common/cpe_matchers.go
@@ -94,7 +94,7 @@ func FindMatchesByPackageCPE(store vulnerability.ProviderByCPE, p pkg.Package, u
 	return toMatches(matchesByFingerprint), nil
 }
 
-func addNewMatch(matchesByFingerprint map[match.Fingerprint]match.Match, vuln vulnerability.Vulnerability, p pkg.Package, pkgVersion version.Version, upstreamMatcher match.MatcherType, searchedByCPE syftPkg.CPE) {
+func addNewMatch(matchesByFingerprint map[match.Fingerprint]match.Match, vuln vulnerability.Vulnerability, p pkg.Package, searchVersion version.Version, upstreamMatcher match.MatcherType, searchedByCPE syftPkg.CPE) {
 	candidateMatch := match.Match{
 		Type:          match.FuzzyMatch,
 		Vulnerability: vuln,
@@ -117,7 +117,7 @@ func addNewMatch(matchesByFingerprint map[match.Fingerprint]match.Match, vuln vu
 			},
 			Found: FoundCPEs{
 				VersionConstraint: vuln.Constraint.String(),
-				CPEs:              cpesToString(filterCPEsByVersion(pkgVersion, vuln.CPEs)),
+				CPEs:              cpesToString(filterCPEsByVersion(searchVersion, vuln.CPEs)),
 			},
 		},
 	)

--- a/grype/matcher/controller.go
+++ b/grype/matcher/controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/anchore/grype/grype/matcher/python"
 	"github.com/anchore/grype/grype/matcher/rpmdb"
 	"github.com/anchore/grype/grype/matcher/ruby"
+	"github.com/anchore/grype/grype/matcher/stock"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal/bus"
@@ -83,13 +84,14 @@ func (c *controller) findMatches(provider vulnerability.Provider, d *distro.Dist
 
 	packagesProcessed, vulnerabilitiesDiscovered := c.trackMatcher()
 
+	defaultMatcher := &stock.Matcher{}
 	for _, p := range packages {
 		packagesProcessed.N++
 		log.Debugf("searching for vulnerability matches for pkg=%s", p)
 
 		matchers, ok := c.matchers[p.Type]
 		if !ok {
-			log.Warnf("no matchers available for package pkg=%s", p)
+			matchers = []Matcher{defaultMatcher}
 		}
 		for _, m := range matchers {
 			matches, err := m.Match(provider, d, p)

--- a/grype/matcher/stock/matcher.go
+++ b/grype/matcher/stock/matcher.go
@@ -1,0 +1,40 @@
+package stock
+
+import (
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/matcher/common"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/syft/syft/distro"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+type Matcher struct {
+}
+
+func (m *Matcher) PackageTypes() []syftPkg.Type {
+	return nil
+}
+
+func (m *Matcher) Type() match.MatcherType {
+	return match.StockMatcher
+}
+
+func (m *Matcher) Match(store vulnerability.Provider, _ *distro.Distro, p pkg.Package) ([]match.Match, error) {
+	var matches = make([]match.Match, 0)
+
+	if p.Language != "" {
+		langMatches, err := common.FindMatchesByPackageLanguage(store, p.Language, p, m.Type())
+		if err != nil {
+			return nil, err
+		}
+		matches = append(matches, langMatches...)
+	}
+
+	cpeMatches, err := common.FindMatchesByPackageCPE(store, p, m.Type())
+	if err != nil {
+		return nil, err
+	}
+	matches = append(matches, cpeMatches...)
+	return matches, nil
+}

--- a/test/integration/db_mock_test.go
+++ b/test/integration/db_mock_test.go
@@ -14,13 +14,27 @@ type mockStore struct {
 func newMockDbStore() *mockStore {
 	return &mockStore{
 		backend: map[string]map[string][]grypeDB.Vulnerability{
-			"nvd": {
+			grypeDB.NVDNamespace: {
 				"libvncserver": []grypeDB.Vulnerability{
 					{
 						ID:                "CVE-alpine-libvncserver",
 						VersionConstraint: "< 0.9.10",
 						VersionFormat:     "unknown",
 						CPEs:              []string{"cpe:2.3:a:lib_vnc_project-(server):libvncserver:*:*:*:*:*:*:*:*"},
+					},
+				},
+				"my-package": []grypeDB.Vulnerability{
+					{
+						ID:                "CVE-bogus-my-package-1",
+						VersionConstraint: "< 2.0",
+						VersionFormat:     "unknown",
+						CPEs:              []string{"cpe:2.3:a:bogus:my-package:*:*:*:*:*:*:something:*"},
+					},
+					{
+						ID:                "CVE-bogus-my-package-2-never-match",
+						VersionConstraint: "< 2.0",
+						VersionFormat:     "unknown",
+						CPEs:              []string{"cpe:2.3:a:something-wrong:my-package:*:*:*:*:*:*:something:*"},
 					},
 				},
 			},
@@ -47,6 +61,13 @@ func newMockDbStore() *mockStore {
 					{
 						ID:                "CVE-python-pygments",
 						VersionConstraint: "< 2.6.2",
+						VersionFormat:     "python",
+					},
+				},
+				"my-package": []grypeDB.Vulnerability{
+					{
+						ID:                "CVE-bogus-my-package-2-python",
+						VersionConstraint: "< 2.0",
 						VersionFormat:     "python",
 					},
 				},

--- a/test/integration/test-fixtures/sbom/syft-sbom-with-unknown-packages.json
+++ b/test/integration/test-fixtures/sbom/syft-sbom-with-unknown-packages.json
@@ -1,0 +1,36 @@
+{
+  "artifacts": [
+    {
+      "id": "eeb36c1c-c03a-425b-901f-df918cc3757e",
+      "name": "my-package",
+      "version": "1.0.5",
+      "type": "binary",
+      "language": "python",
+      "cpes": [
+        "cpe:2.3:a:my-package:my-package:1.0.5:*:*:*:*:*:*:*",
+        "cpe:2.3:a:bogus:my-package:1.0.5:*:*:*:*:*:*:*"
+      ]
+    }
+  ],
+  "artifactRelationships": [],
+  "source": {
+    "type": "image",
+    "target": {
+      "userInput": "my-awesome-image:latest",
+      "scope": "Squashed"
+    }
+  },
+  "distro": {
+    "name": "ubuntu",
+    "version": "20.04",
+    "idLike": ""
+  },
+  "descriptor": {
+    "name": "syft",
+    "version": "v0.19.1"
+  },
+  "schema": {
+    "version": "1.1.0",
+    "url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-1.1.0.json"
+  }
+}


### PR DESCRIPTION
Today if you input an SBOM into grype and there is a package with an unknown type then no vulnerability matching is done for that package. This PR adds a "stock" matcher (note: "default" is a reserve word in go); now any package will at least pass through this new stock matcher, which does CPE and language based matching.