### PR TITLE
Add data-driven language matching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/adrg/xdg v0.2.1
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4
-	github.com/anchore/grype-db v0.0.0-20210913215030-fe28197b36f1
+	github.com/anchore/grype-db v0.0.0-20210928194208-f146397d6cd0
 	github.com/anchore/stereoscope v0.0.0-20210817160504-0f4abc2a5a5a
 	github.com/anchore/syft v0.24.0
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 h1:rmZG77uXgE
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/grype v0.14.1-0.20210702143224-05ade7bbbf70/go.mod h1:yPh9WHflzInB/INwPrDs2wLKmRsa8owAuojmv4K8H6I=
 github.com/anchore/grype-db v0.0.0-20210527140125-6f881b00e927/go.mod h1:XSlPf1awNrMpah+rHbWrzgUvnmWLgn/KkdicxERVClg=
-github.com/anchore/grype-db v0.0.0-20210913215030-fe28197b36f1 h1:Jr7IuHtpd2mIktOzhcr014boySty6AzVwp+pJF6Iet0=
-github.com/anchore/grype-db v0.0.0-20210913215030-fe28197b36f1/go.mod h1:GniMuMokZ2iAX67Qrd5fJW7BstX8a+4U48LyypGC2g0=
+github.com/anchore/grype-db v0.0.0-20210928194208-f146397d6cd0 h1:Ci/9i16zOJF+vpuOuOJB/B/A1lY/2IlN+H/e7Ha7UFQ=
+github.com/anchore/grype-db v0.0.0-20210928194208-f146397d6cd0/go.mod h1:GniMuMokZ2iAX67Qrd5fJW7BstX8a+4U48LyypGC2g0=
 github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29 h1:K9LfnxwhqvihqU0+MF325FNy7fsKV9EGaUxdfR4gnWk=
 github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29/go.mod h1:Oc1UkGaJwY6ND6vtAqPSlYrptKRJngHwkwB6W7l1uP0=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=

--- a/grype/version/fuzzy_constraint.go
+++ b/grype/version/fuzzy_constraint.go
@@ -111,6 +111,8 @@ func (f *fuzzyConstraint) String() string {
 // but not for "2000" vs "11.7".
 // Returns -1 if v1 < v2, 1 if v1 > v2 and 0 if v1 == v2.
 func fuzzyVersionComparison(v1, v2 string) int {
+	v1 = stripLeadingV(v1)
+	v2 = stripLeadingV(v2)
 	for s1, s2 := v1, v2; len(s1) > 0 && len(s2) > 0; {
 		num1, cmpTo1, skip1 := parseVersionParts(s1)
 		num2, cmpTo2, skip2 := parseVersionParts(s2)
@@ -180,4 +182,8 @@ func leftPad(s string, n int) string {
 	}
 	sb.WriteString(s)
 	return sb.String()
+}
+
+func stripLeadingV(ver string) string {
+	return strings.TrimPrefix(ver, "v")
 }

--- a/grype/version/fuzzy_constraint_test.go
+++ b/grype/version/fuzzy_constraint_test.go
@@ -237,6 +237,30 @@ func TestFuzzyConstraintSatisfaction(t *testing.T) {
 			constraint: "\"4.5.1\" || \"4.5.2\"",
 			expected:   true,
 		},
+		{
+			name:       "strip unbalanced v from left side <",
+			version:    "v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible",
+			constraint: "< 1.5",
+			expected:   false,
+		},
+		{
+			name:       "strip unbalanced v from left side >",
+			version:    "v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible",
+			constraint: "> 1.5",
+			expected:   true,
+		},
+		{
+			name:       "strip unbalanced v from right side <",
+			version:    "17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible",
+			constraint: "< v1.5",
+			expected:   false,
+		},
+		{
+			name:       "strip unbalanced v from right side >",
+			version:    "17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible",
+			constraint: "> v1.5",
+			expected:   true,
+		},
 	}
 
 	for _, test := range tests {

--- a/grype/version/version_test.go
+++ b/grype/version/version_test.go
@@ -1,7 +1,0 @@
-package version
-
-// func TestNewVersionFromPkg(t *testing.T) {
-// 	tests := []struct{
-
-// 	}
-// }


### PR DESCRIPTION
Pulls in the upstream grype-db change for allow for using a "good" default language namespace guess when searching for vulnerabilities for potentially supported languages.

Additionally this PR fixes version comparisons for the fuzzy version constraint checks where one side includes a `v` prefix while the other side does not. This is a common case for the `docker` golang package since docker changed the version scheme after the first few versions. 