### PR TITLE
Improve documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to `grype`
+# Contributing to Grype
 
-If you are looking to contribute to this project and want to open a Github pull request ("PR"), there are a few guidelines of what we are looking for in patches. Make sure you go through this document and ensure that your code proposal is aligned.
+If you are looking to contribute to this project and want to open a GitHub pull request ("PR"), there are a few guidelines of what we are looking for in patches. Make sure you go through this document and ensure that your code proposal is aligned.
 
-## Sign your work
+## Sign off your work
 
 The `sign-off` is an added line at the end of the explanation for the commit, certifying that you wrote it or otherwise have the right to submit it as an open-source patch. By submitting a contribution, you agree to be bound by the terms of the DCO Version 1.1 and Apache License Version 2.0.
 
-Signing a commit certifies the below Developer's Certificate of Origin (DCO):
+Signing off a commit certifies the below Developer's Certificate of Origin (DCO):
 
 ```text
 Developer's Certificate of Origin 1.1
@@ -51,13 +51,13 @@ $ git config --global user.name "John Doe"
 $ git config --global user.email "john.doe@example.com"
 ```
 
-Creating a signed commit is then possible with `-s`:
+Creating a signed-off commit is then possible with `-s` or `--signoff`:
 
 ```text
 $ git commit -s -m "this is a commit message"
 ```
 
-To double check if the commit was signed, look at the log output:
+To double-check if the commit was signed-off, look at the log output:
 
 ```text
 $ git log -1
@@ -82,6 +82,11 @@ Date:   Mon Aug 1 11:27:13 2020 -0400
 
 [//]: # (TODO: PR title and description)
 
+## Sign your commits
+
+To ensure the authenticity and integrity of code contributions, **we require that all commits are signed**. Signing commits proves that your commits were truly created by you, as the holder of a private key.
+
+Configuring git to sign your commits is a straightforward process. To get set up, see [GitHub's documentation on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 
 ## Test your changes
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 [![Acceptance](https://github.com/anchore/grype/workflows/Acceptance/badge.svg)](https://github.com/anchore/grype/actions?query=workflow%3AAcceptance)
 [![Go Report Card](https://goreportcard.com/badge/github.com/anchore/grype)](https://goreportcard.com/report/github.com/anchore/grype)
 [![GitHub release](https://img.shields.io/github/release/anchore/grype.svg)](https://github.com/anchore/grype/releases/latest)
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/anchore/grype/blob/main/LICENSE)
 [![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/anchore/grype.svg)](https://github.com/anchore/grype)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/anchore/grype/blob/main/LICENSE)
+[![Slack Invite](https://img.shields.io/badge/Slack-Join-blue?logo=slack)](https://anchore.com/slack)
 
 A vulnerability scanner for container images and filesystems. Easily [install the binary](#installation) to try it out. Works with [Syft](https://github.com/anchore/syft), the powerful SBOM (software bill of materials) tool for container images and filesystems.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,29 @@ We’ll have free swag, giveaways, snacks, and sips. Space will be limited, so m
 
 If you encounter an issue, please [let us know using the issue tracker](https://github.com/anchore/grype/issues).
 
+## Installation
+
+### Recommended
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+```
+
+...or, you can specify a release version and destination directory for the installation:
+
+```
+curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b <DESTINATION_DIR> <RELEASE_VERSION>
+```
+
+### Homebrew
+
+```bash
+brew tap anchore/grype
+brew install grype
+```
+
+**Note**: Currently, Grype is built only for macOS and Linux.
+
 ## Getting started
 
 [Install the binary](#installation), and make sure that `grype` is available in your path. To scan for vulnerabilities in an image:
@@ -193,25 +216,6 @@ Grype pulls a database of vulnerabilities derived from the publicly available [A
 
 ```
 grype db update
-```
-
-## Installation
-
-**Recommended (macOS and Linux)**
-
-```bash
-# install the latest version to /usr/local/bin
-curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
-
-# install a specific version into a specific dir
-curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b <SOME_BIN_PATH> <RELEASE_VERSION>
-```
-
-**Homebrew (macOS)**
-
-```bash
-brew tap anchore/grype
-brew install grype
 ```
 
 ## Shell completion


### PR DESCRIPTION
This PR improves Grype's documentation in the following ways:

1. Makes installation methods more obvious to readers of our `README.md`
2. Adds a new markdown badge for joining our Slack community
3. Documents the new requirement for signing commits in `CONTRIBUTING.md`