### PR TITLE
175 patch - allow ignore not fixed to work independently of configured rules

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,9 +34,9 @@ import (
 var persistentOpts = config.CliOnlyOptions{}
 
 var ignoreNonFixedMatches = []match.IgnoreRule{
-	{FixedState: string(grypeDb.NotFixedState)},
-	{FixedState: string(grypeDb.WontFixState)},
-	{FixedState: string(grypeDb.UnknownFixState)},
+	{FixState: string(grypeDb.NotFixedState)},
+	{FixState: string(grypeDb.WontFixState)},
+	{FixState: string(grypeDb.UnknownFixState)},
 }
 
 var (

--- a/grype/match/ignore.go
+++ b/grype/match/ignore.go
@@ -18,7 +18,7 @@ type IgnoredMatch struct {
 // rule to apply.
 type IgnoreRule struct {
 	Vulnerability string            `yaml:"vulnerability" json:"vulnerability" mapstructure:"vulnerability"`
-	FixedState    string            `yaml:"fixed_state" json:"fixedState" mapstructure:"fixed_state"`
+	FixState      string            `yaml:"fix-state" json:"fix-state" mapstructure:"fix-state"`
 	Package       IgnoreRulePackage `yaml:"package" json:"package" mapstructure:"package"`
 }
 
@@ -109,14 +109,14 @@ func getIgnoreConditionsForRule(rule IgnoreRule) []ignoreCondition {
 		ignoreConditions = append(ignoreConditions, ifPackageLocationApplies(l))
 	}
 
-	if fs := rule.FixedState; fs != "" {
-		ignoreConditions = append(ignoreConditions, ifVulnerabilityFixedStateApplies(fs))
+	if fs := rule.FixState; fs != "" {
+		ignoreConditions = append(ignoreConditions, ifFixStateApplies(fs))
 	}
 
 	return ignoreConditions
 }
 
-func ifVulnerabilityFixedStateApplies(fs string) ignoreCondition {
+func ifFixStateApplies(fs string) ignoreCondition {
 	return func(match Match) bool {
 		return fs == string(match.Vulnerability.Fix.State)
 	}

--- a/grype/match/ignore_test.go
+++ b/grype/match/ignore_test.go
@@ -200,9 +200,9 @@ func TestApplyIgnoreRules(t *testing.T) {
 			name:       "ignore matches without fix",
 			allMatches: allMatches,
 			ignoreRules: []IgnoreRule{
-				{FixedState: string(grypeDb.NotFixedState)},
-				{FixedState: string(grypeDb.WontFixState)},
-				{FixedState: string(grypeDb.UnknownFixState)},
+				{FixState: string(grypeDb.NotFixedState)},
+				{FixState: string(grypeDb.WontFixState)},
+				{FixState: string(grypeDb.UnknownFixState)},
 			},
 			expectedRemainingMatches: []Match{
 				allMatches[0],
@@ -212,7 +212,7 @@ func TestApplyIgnoreRules(t *testing.T) {
 					Match: allMatches[1],
 					AppliedIgnoreRules: []IgnoreRule{
 						{
-							FixedState: "not-fixed",
+							FixState: "not-fixed",
 						},
 					},
 				},
@@ -220,7 +220,7 @@ func TestApplyIgnoreRules(t *testing.T) {
 					Match: allMatches[2],
 					AppliedIgnoreRules: []IgnoreRule{
 						{
-							FixedState: "wont-fix",
+							FixState: "wont-fix",
 						},
 					},
 				},
@@ -228,7 +228,7 @@ func TestApplyIgnoreRules(t *testing.T) {
 					Match: allMatches[3],
 					AppliedIgnoreRules: []IgnoreRule{
 						{
-							FixedState: "unknown",
+							FixState: "unknown",
 						},
 					},
 				},


### PR DESCRIPTION
Signed-off-by: Christopher Angelo Phillips <christopher.phillips@anchore.com>

### Things to discuss on this PR before we merge the patch:
With the new logic `removing the need for rules` the flag behaves as intended:
```
go run main.go docker:gradle:6.8.3-jdk --only-fixed -v -o json > test.json
│[0009]  INFO identified distro: ubuntu 20.04 from-lib=syft
│[0009]  INFO cataloging image from-lib=syft
│[0012]  INFO Ignoring 54 matches due to user-provided ignore rules
```

The output above was with no rules and default config.

With this PR `Unknown`, `Fixed`, and `Wont-Fix` are still in the JSON/template output, but `not-fixed` is filtered out to be in the `ignoredMatches` field.

CycloneDX and Table have not been updated to reflect this change for the new flag OR for rules.

@luhring Do you want the `table.NewPresenter(matches, packages, metadataProvider)` to also be updated with the ignoredMatches?