### PR TITLE
Silence usage and errors on root command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,8 +42,9 @@ var ignoreNonFixedMatches = []match.IgnoreRule{
 var (
 	rootCmd = &cobra.Command{
 		Use:   fmt.Sprintf("%s [IMAGE]", internal.ApplicationName),
-		Short: "A vulnerability scanner for container images and filesystems",
-		Long: format.Tprintf(`
+		Short: "A vulnerability scanner for container images, filesystems, and SBOMs",
+		Long: format.Tprintf(`A vulnerability scanner for container images, filesystems, and SBOMs.
+
 Supports the following image sources:
     {{.appName}} yourrepo/yourimage:tag     defaults to using images from a Docker daemon
     {{.appName}} path/to/yourproject        a Docker tar, OCI tar, OCI directory, or generic filesystem directory
@@ -278,10 +279,11 @@ func startWorker(userInput string, failOnSeverity *vulnerability.Severity) <-cha
 
 func validateRootArgs(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 && !internal.IsPipedInput() {
+		// in the case that no arguments are given and there is no piped input we want to show the help text and return with a non-0 return code.
 		if err := cmd.Help(); err != nil {
 			return fmt.Errorf("unable to display help: %w", err)
 		}
-		return fmt.Errorf("")
+		return fmt.Errorf("an image/directory argument is required")
 	}
 
 	return cobra.MaximumNArgs(1)(cmd, args)

--- a/test/cli/cmd_test.go
+++ b/test/cli/cmd_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCmd(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		env        map[string]string
+		assertions []traitAssertion
+	}{
+		{
+			name: "no-args-shows-help",
+			args: []string{},
+			assertions: []traitAssertion{
+				assertInOutput("an image/directory argument is required"),                              // specific error that should be shown
+				assertInOutput("A vulnerability scanner for container images, filesystems, and SBOMs"), // excerpt from help description
+				assertFailingReturnCode,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd, stdout, stderr := runGrype(t, test.env, test.args...)
+			for _, traitFn := range test.assertions {
+				traitFn(t, stdout, stderr, cmd.ProcessState.ExitCode())
+			}
+			if t.Failed() {
+				t.Log("STDOUT:\n", stdout)
+				t.Log("STDERR:\n", stderr)
+				t.Log("COMMAND:", strings.Join(cmd.Args, " "))
+			}
+		})
+	}
+}

--- a/test/cli/json_descriptor_test.go
+++ b/test/cli/json_descriptor_test.go
@@ -28,7 +28,7 @@ func TestJsonDescriptor(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmd, stdout, stderr := runGrypeCommand(t, test.env, test.args...)
+			cmd, stdout, stderr := runGrype(t, test.env, test.args...)
 			for _, traitAssertionFn := range test.assertions {
 				traitAssertionFn(t, stdout, stderr, cmd.ProcessState.ExitCode())
 			}

--- a/test/cli/registry_auth_test.go
+++ b/test/cli/registry_auth_test.go
@@ -74,7 +74,7 @@ func TestRegistryAuth(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmd, stdout, stderr := runGrypeCommand(t, test.env, test.args...)
+			cmd, stdout, stderr := runGrype(t, test.env, test.args...)
 			for _, traitAssertionFn := range test.assertions {
 				traitAssertionFn(t, stdout, stderr, cmd.ProcessState.ExitCode())
 			}

--- a/test/cli/trait_assertions_test.go
+++ b/test/cli/trait_assertions_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/acarl005/stripansi"
+)
+
+type traitAssertion func(tb testing.TB, stdout, stderr string, rc int)
+
+func assertInOutput(data string) traitAssertion {
+	return func(tb testing.TB, stdout, stderr string, _ int) {
+		tb.Helper()
+
+		if !strings.Contains(stripansi.Strip(stderr), data) && !strings.Contains(stripansi.Strip(stdout), data) {
+			tb.Errorf("data=%q was NOT found in any output, but should have been there", data)
+		}
+	}
+}
+
+func assertFailingReturnCode(tb testing.TB, _, _ string, rc int) {
+	tb.Helper()
+	if rc == 0 {
+		tb.Errorf("expected a failure but got rc=%d", rc)
+	}
+}


### PR DESCRIPTION
Brings these command configurations from Syft into Grype to prevent the usage text from appearing when the command returns an error.

https://github.com/anchore/syft/blob/main/cmd/packages.go#L62-L63

Fixes #461 