### PR TITLE
Add arm64 support to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -68,8 +68,10 @@ execute() {
 get_binaries() {
   case "$PLATFORM" in
     darwin/amd64) BINARIES="grype" ;;
+    darwin/arm64) BINARIES="grype" ;;
     linux/amd64) BINARIES="grype" ;;
     windows/amd64) BINARIES="grype" ;;
+    linux/arm64) BINARIES="grype" ;;
     *)
       log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
       exit 1


### PR DESCRIPTION
Adds darwin + linux arm64 install capability from `install.sh` script