### PR TITLE
add qemu to acceptance tests

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -24,6 +24,9 @@ jobs:
 
       - uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Restore bootstrap cache
         id: cache
         uses: actions/cache@v2


### PR DESCRIPTION
Add QEMU support before acceptance tests.

This will resolve the error where goreleaser tries to build images during our tests that run on merge:
```
#4 [build 2/2] RUN apk --no-cache add ca-certificates
#4 0.578 standard_init_linux.go:228: exec user process caused: exec format error
#4 ERROR: executor failed running [/bin/sh -c apk --no-cache add ca-certificates]: exit code: 1
```
https://github.com/anchore/grype/runs/4010683399?check_suite_focus=true

Signed-off-by: Christopher Angelo Phillips <christopher.phillips@anchore.com>