### PR TITLE
bump grype-db to tip of main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,17 +7,15 @@ require (
 	github.com/adrg/xdg v0.2.1
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4
-	github.com/anchore/grype-db v0.0.0-20211004133852-e0170394d953
+	github.com/anchore/grype-db v0.0.0-20211115233739-c0e91d61ed51
 	github.com/anchore/stereoscope v0.0.0-20211024152658-003132a67c10
 	github.com/anchore/syft v0.30.1
 	github.com/bmatcuk/doublestar/v2 v2.0.4
-	github.com/containerd/containerd v1.4.11 // indirect
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/dustin/go-humanize v1.0.0
 	github.com/facebookincubator/nvdtools v0.1.4
 	github.com/gabriel-vasile/mimetype v1.3.0
 	github.com/go-test/deep v1.0.7
-	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/go-cmp v0.4.1
 	github.com/google/uuid v1.2.0
 	github.com/gookit/color v1.4.2
@@ -37,7 +35,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.7.0
-	github.com/ulikunitz/xz v0.5.8 // indirect
 	github.com/wagoodman/go-partybus v0.0.0-20210627031916-db1f5573bbc5
 	github.com/wagoodman/go-progress v0.0.0-20200807221327-51d465df1451
 	github.com/wagoodman/jotframe v0.0.0-20200730190914-3517092dd163

--- a/go.sum
+++ b/go.sum
@@ -127,9 +127,11 @@ github.com/anchore/go-version v1.2.2-0.20200810141238-330bef18dbca/go.mod h1:Bkc
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 h1:rmZG77uXgE+o2gozGEBoUMpX27lsku+xrMwlmBZJtbg=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/grype v0.14.1-0.20210702143224-05ade7bbbf70/go.mod h1:yPh9WHflzInB/INwPrDs2wLKmRsa8owAuojmv4K8H6I=
+github.com/anchore/grype v0.24.2-0.20211115221156-a2762bbbf043/go.mod h1:/MP3vfuCUqCfBSrXymncltcJNd8/dn85rXGtJdR83Ks=
 github.com/anchore/grype-db v0.0.0-20210527140125-6f881b00e927/go.mod h1:XSlPf1awNrMpah+rHbWrzgUvnmWLgn/KkdicxERVClg=
-github.com/anchore/grype-db v0.0.0-20211004133852-e0170394d953 h1:+oxiCcI0xwNdFZxDFwP4/dzWSmew3SlZZT318lc3ukE=
-github.com/anchore/grype-db v0.0.0-20211004133852-e0170394d953/go.mod h1:GniMuMokZ2iAX67Qrd5fJW7BstX8a+4U48LyypGC2g0=
+github.com/anchore/grype-db v0.0.0-20210928194208-f146397d6cd0/go.mod h1:GniMuMokZ2iAX67Qrd5fJW7BstX8a+4U48LyypGC2g0=
+github.com/anchore/grype-db v0.0.0-20211115233739-c0e91d61ed51 h1:39XbpqI17fDF0MGscxUXZFft7S4pY94SmEdSRK30ef0=
+github.com/anchore/grype-db v0.0.0-20211115233739-c0e91d61ed51/go.mod h1:PANGB2KzOSPq4lBmLgF9mKjLEHuQYEpUUAP5qcuEA/8=
 github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29 h1:K9LfnxwhqvihqU0+MF325FNy7fsKV9EGaUxdfR4gnWk=
 github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29/go.mod h1:Oc1UkGaJwY6ND6vtAqPSlYrptKRJngHwkwB6W7l1uP0=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=


### PR DESCRIPTION
Upgrade grype to use latest DB

Without the latest version of the `grype-db` the vulnerability results for rockylinux are incomplete:

**This screenshot shows what's on main:**
![Screen Shot 2021-11-16 at 12 29 22 PM](https://user-images.githubusercontent.com/32073428/142035632-43eeec20-c8b8-4f70-94a9-8094bdbdb766.png)

**This screenshot shows what's on this PR with the latest database:**
![Screen Shot 2021-11-16 at 12 28 54 PM](https://user-images.githubusercontent.com/32073428/142035679-392072f4-e7a3-4581-9314-03fd0beecd5a.png)

Signed-off-by: Christopher Angelo Phillips <christopher.phillips@anchore.com>