### PR TITLE
update releaser code to tag with correct v prefix

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -128,7 +128,8 @@ brews:
 
 dockers:
   - image_templates:
-      - "anchore/grype:{{ .Version }}-amd64"
+      - "anchore/grype:latest"
+      - "anchore/grype:{{ .Tag }}-amd64"
       - "anchore/grype:v{{ .Major }}-amd64"
       - "anchore/grype:v{{ .Major }}.{{ .Minor }}-amd64"
     dockerfile: Dockerfile
@@ -141,7 +142,7 @@ dockers:
       - "--build-arg=VCS_URL={{.GitURL}}"
 
   - image_templates:
-      - "anchore/grype:{{ .Version }}-arm64v8"
+      - "anchore/grype:{{ .Tag }}-arm64v8"
       - "anchore/grype:v{{ .Major }}-arm64v8"
       - "anchore/grype:v{{ .Major }}.{{ .Minor }}-arm64v8"
     goarch: arm64
@@ -155,20 +156,20 @@ dockers:
       - "--build-arg=VCS_URL={{.GitURL}}"
 
 docker_manifests:
-  - name_template: anchore/grype:{{ .Version }}
+  - name_template: anchore/grype:{{ .Tag }}
     image_templates:
-      - anchore/grype:{{ .Version }}-amd64
+      - anchore/grype:{{ .Tag }}-amd64
       - anchore/grype:v{{ .Major }}-amd64
       - anchore/grype:v{{ .Major }}.{{ .Minor }}-amd64
-      - anchore/grype:{{ .Version }}-arm64v8
+      - anchore/grype:{{ .Tag }}-arm64v8
       - anchore/grype:v{{ .Major }}-arm64v8
       - anchore/grype:v{{ .Major }}.{{ .Minor }}-arm64v8
   - name_template: anchore/grype:latest
     image_templates:
-      - anchore/grype:{{ .Version }}-amd64
+      - anchore/grype:{{ .Tag }}-amd64
       - anchore/grype:v{{ .Major }}-amd64
       - anchore/grype:v{{ .Major }}.{{ .Minor }}-amd64
-      - anchore/grype:{{ .Version }}-arm64v8
+      - anchore/grype:{{ .Tag }}-arm64v8
       - anchore/grype:v{{ .Major }}-arm64v8
       - anchore/grype:v{{ .Major }}.{{ .Minor }}-arm64v8
 


### PR DESCRIPTION
Builds and publishes grype images with consistency in relation to how syft is published.

I ran the build command locally to generate the images and `v` is not prefixed.
![Screen Shot 2021-11-22 at 3 52 16 PM](https://user-images.githubusercontent.com/32073428/142933783-9c0aaed8-6a9d-4de0-a70b-5529795ecf07.png)

Signed-off-by: Christopher Angelo Phillips <christopher.phillips@anchore.com>