### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/grype/db/curator.go
+++ b/grype/db/curator.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -220,7 +219,7 @@ func (c *Curator) Validate() error {
 // ImportFrom takes a DB archive file and imports it into the final DB location.
 func (c *Curator) ImportFrom(dbArchivePath string) error {
 	// note: the temp directory is persisted upon download/validation/activation failure to allow for investigation
-	tempDir, err := ioutil.TempDir("", "grype-import")
+	tempDir, err := os.MkdirTemp("", "grype-import")
 	if err != nil {
 		return fmt.Errorf("unable to create db temp dir: %w", err)
 	}
@@ -255,7 +254,7 @@ func (c *Curator) ImportFrom(dbArchivePath string) error {
 }
 
 func (c *Curator) download(listing *curation.ListingEntry, downloadProgress *progress.Manual) (string, error) {
-	tempDir, err := ioutil.TempDir("", "grype-scratch")
+	tempDir, err := os.MkdirTemp("", "grype-scratch")
 	if err != nil {
 		return "", fmt.Errorf("unable to create db temp dir: %w", err)
 	}

--- a/grype/presenter/template/presenter.go
+++ b/grype/presenter/template/presenter.go
@@ -3,7 +3,7 @@ package template
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"text/template"
 
@@ -49,7 +49,7 @@ func (pres *Presenter) Present(output io.Writer) error {
 		return fmt.Errorf("unable to expand path %q", pres.pathToTemplateFile)
 	}
 
-	templateContents, err := ioutil.ReadFile(expandedPathToTemplateFile)
+	templateContents, err := os.ReadFile(expandedPathToTemplateFile)
 	if err != nil {
 		return fmt.Errorf("unable to get output template: %w", err)
 	}

--- a/internal/file/copy.go
+++ b/internal/file/copy.go
@@ -3,7 +3,6 @@ package file
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -12,7 +11,7 @@ import (
 
 func CopyDir(fs afero.Fs, src string, dst string) error {
 	var err error
-	var fds []os.FileInfo
+	var fds []os.DirEntry
 	var srcinfo os.FileInfo
 
 	if srcinfo, err = fs.Stat(src); err != nil {
@@ -23,7 +22,7 @@ func CopyDir(fs afero.Fs, src string, dst string) error {
 		return err
 	}
 
-	if fds, err = ioutil.ReadDir(src); err != nil {
+	if fds, err = os.ReadDir(src); err != nil {
 		return err
 	}
 	for _, fd := range fds {

--- a/internal/logger/logrus.go
+++ b/internal/logger/logrus.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -51,7 +50,7 @@ func NewLogrusLogger(cfg LogrusConfig) *LogrusLogger {
 		}
 		output = logFile
 	default:
-		output = ioutil.Discard
+		output = io.Discard
 	}
 
 	appLogger.SetOutput(output)

--- a/internal/version/update.go
+++ b/internal/version/update.go
@@ -2,7 +2,7 @@ package version
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -58,7 +58,7 @@ func fetchLatestApplicationVersion() (*hashiVersion.Version, error) {
 		return nil, fmt.Errorf("HTTP %d on fetching latest version: %s", resp.StatusCode, resp.Status)
 	}
 
-	versionBytes, err := ioutil.ReadAll(resp.Body)
+	versionBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read latest version: %w", err)
 	}

--- a/test/integration/compare_sbom_input_vs_lib_test.go
+++ b/test/integration/compare_sbom_input_vs_lib_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -57,7 +56,7 @@ func TestCompareSBOMInputToLibResults(t *testing.T) {
 
 			// get SBOM from syft, write to temp file
 			sbomBytes := getSyftSBOM(t, imageSource)
-			sbomFile, err := ioutil.TempFile("", "")
+			sbomFile, err := os.CreateTemp("", "")
 			assert.NoError(t, err)
 			t.Cleanup(func() {
 				assert.NoError(t, os.Remove(sbomFile.Name()))


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.