### PR TITLE
Fix panic in FromCatalog function

### DIFF
--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -88,9 +88,9 @@ func New(p pkg.Package) Package {
 }
 
 func FromCatalog(catalog *pkg.Catalog) []Package {
-	var result = make([]Package, catalog.PackageCount())
-	for i, p := range catalog.Sorted() {
-		result[i] = New(p)
+	result := make([]Package, 0, catalog.PackageCount())
+	for _, p := range catalog.Sorted() {
+		result = append(result, New(p))
 	}
 	return result
 }

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -3,6 +3,8 @@ package pkg
 import (
 	"testing"
 
+	"github.com/anchore/syft/syft/source"
+
 	"github.com/anchore/syft/syft/file"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 	"github.com/scylladb/go-set"
@@ -237,6 +239,27 @@ func TestNew_MetadataExtraction(t *testing.T) {
 			strset.Difference(observedMetadataTypes, expectedMetadataTypes),
 		)
 	}
+}
+
+func TestFromCatalog_DoesNotPanic(t *testing.T) {
+	catalog := syftPkg.NewCatalog()
+
+	examplePackage := syftPkg.Package{
+		Name:    "test",
+		Version: "1.2.3",
+		Locations: []source.Location{
+			source.NewLocation("/test-path"),
+		},
+		Type: syftPkg.NpmPkg,
+	}
+
+	catalog.Add(examplePackage)
+	// add it again!
+	catalog.Add(examplePackage)
+
+	assert.NotPanics(t, func() {
+		_ = FromCatalog(catalog)
+	})
 }
 
 func intRef(i int) *int {


### PR DESCRIPTION
Fixes #548 

This PR prevents a panic in Grype that can occur in `pkg.FromCatalog`.

Since it's currently possible for `catalog.Sorted()` to return more items than the return value of `catalog.PackageCount()` indicates, this PR adjusts the loop such that:

- An `index out of range` panic is no longer possible, since slice items aren't being addressed by index.
- The **benefit** of avoiding unnecessary allocations for the `result` slice's underlying array is **preserved** for the case where the return value of `catalog.PackageCount()` is greater than or equal to `len(catalog.Sorted())` (which is the expected case).