### PR TITLE
update so install.sh is compatible with coreutils 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -247,7 +247,7 @@ extract_from_dmg() {
   dmg_file=$1
   mount_point="/Volumes/tmp-dmg"
   hdiutil attach -quiet -nobrowse -mountpoint "${mount_point}" "${dmg_file}"
-  cp -fR "${mount_point}/" ./
+  cp -fR "${mount_point}/." ./
   hdiutil detach -quiet -force "${mount_point}"
 }
 http_download_curl() {


### PR DESCRIPTION
See #560 for details and investigation.

This adds a `.` following the path in the `cp` command under `extract_from_dmg` to enhance compatibility with `coreutils`

Signed-off-by: Christopher Angelo Phillips <christopher.phillips@anchore.com>