### PR TITLE
Upgrade install.sh to support installations for previous versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,10 +142,12 @@ jobs:
           AC_PASSWORD: ${{ secrets.ENG_CI_APPLE_ID_PASS }}
 
       - uses: anchore/sbom-action@v0
+        continue-on-error: true
         with:
           artifact-name: sbom.spdx.json
 
       - uses: 8398a7/action-slack@v3
+        continue-on-error: true
         with:
           status: ${{ job.status }}
           fields: repo,workflow,action,eventName

--- a/test/install/Makefile
+++ b/test/install/Makefile
@@ -13,6 +13,9 @@ UNIT=make unit-local
 # the line if there are breaking changes made that don't align with the latest release (but will be OK with the next
 # release)
 ACCEPTANCE_CMD=sh -c '../../install.sh -b /usr/local/bin  && grype version'
+# we also want to test against a previous release to ensure that install.sh defers execution to a former install.sh
+PREVIOUS_RELEASE=v0.24.0
+ACCEPTANCE_PREVIOUS_RELEASE_CMD=sh -c "../../install.sh -b /usr/local/bin $(PREVIOUS_RELEASE) && grype version"
 
 # CI cache busting values; change these if you want CI to not use previous stored cache
 INSTALL_TEST_CACHE_BUSTER=894d8ca
@@ -28,23 +31,37 @@ test: unit acceptance
 ci-test-mac: unit-local acceptance-local
 
 # note: do not add acceptance-local to this list
+.PHONY: acceptance
 acceptance: acceptance-ubuntu-20.04 acceptance-alpine-3.6 acceptance-busybox-1.35
 
+.PHONY: unit
 unit: unit-ubuntu-20.04
 
+.PHONY: unit-local
 unit-local:
 	$(call title,unit tests)
 	@for f in $(shell ls *_test.sh); do echo "Running unit test suite '$${f}'"; bash $${f} || exit 1; done
 
-acceptance-local:
-	$(acceptance)
+.PHONY: acceptance-local
+acceptance-local: acceptance-current-release-local acceptance-previous-release-local
 
+.PHONY: acceptance-current-release-local
+acceptance-current-release-local:
+	$(ACCEPTANCE_CMD)
+
+.PHONY: acceptance-previous-release-local
+acceptance-previous-release-local:
+	$(ACCEPTANCE_PREVIOUS_RELEASE_CMD)
+	grype version | grep $(shell echo $(PREVIOUS_RELEASE)| tr -d "v")
+
+.PHONY: save
 save: ubuntu-20.04 alpine-3.6 busybox-1.35
 	@mkdir cache || true
 	docker image save -o cache/ubuntu-env.tar $(UBUNTU_IMAGE)
 	docker image save -o cache/alpine-env.tar $(ALPINE_IMAGE)
 	docker image save -o cache/busybox-env.tar $(BUSYBOX_IMAGE)
 
+.PHONY: load
 load:
 	docker image load -i cache/ubuntu-env.tar
 	docker image load -i cache/alpine-env.tar
@@ -52,16 +69,19 @@ load:
 
 ## UBUNTU #######################################################
 
+.PHONY: acceptance-ubuntu-20.04
 acceptance-ubuntu-20.04: ubuntu-20.04
 	$(call title,ubuntu:20.04 - acceptance)
 	$(DOCKER_RUN) $(UBUNTU_IMAGE) \
 		$(ACCEPTANCE_CMD)
 
+.PHONY: unit-ubuntu-20.04
 unit-ubuntu-20.04: ubuntu-20.04
 	$(call title,ubuntu:20.04 - unit)
 	$(DOCKER_RUN) $(UBUNTU_IMAGE) \
 		$(UNIT)
 
+.PHONY: ubuntu-20.04
 ubuntu-20.04:
 	$(call title,ubuntu:20.04 - build environment)
 	docker build -t $(UBUNTU_IMAGE) -f $(ENVS)/Dockerfile-ubuntu-20.04 .
@@ -70,11 +90,13 @@ ubuntu-20.04:
 
 # note: unit tests cannot be run with sh (alpine dosn't have bash by default)
 
+.PHONY: acceptance-alpine-3.6
 acceptance-alpine-3.6: alpine-3.6
 	$(call title,alpine:3.6 - acceptance)
 	$(DOCKER_RUN) $(ALPINE_IMAGE) \
 		$(ACCEPTANCE_CMD)
 
+.PHONY: alpine-3.6
 alpine-3.6:
 	$(call title,alpine:3.6 - build environment)
 	docker build -t $(ALPINE_IMAGE) -f $(ENVS)/Dockerfile-alpine-3.6 .
@@ -85,12 +107,14 @@ alpine-3.6:
 
 # note: busybox by default will not have cacerts, so you will get TLS warnings (we want to test under these conditions)
 
+.PHONY: acceptance-busybox-1.35
 acceptance-busybox-1.35: busybox-1.35
 	$(call title,busybox-1.35 - acceptance)
 	$(DOCKER_RUN) $(BUSYBOX_IMAGE) \
 		$(ACCEPTANCE_CMD)
 	@echo "\n*** test note: you should see grype spit out a 'x509: certificate signed by unknown authority' error --this is expected ***"
 
+.PHONY: busybox-1.35
 busybox-1.35:
 	$(call title,busybox-1.35 - build environment)
 	docker pull $(BUSYBOX_IMAGE)


### PR DESCRIPTION
The sbom-action installation failed in the latest release run: https://github.com/anchore/grype/runs/5205757120?check_suite_focus=truecheck_suite_focus=true
```
[info] checking github for release tag='v0.33.0' 
[debug] http_download(url=[anchore/syft/releases/v0.33.0)](https://github.com/anchore/syft/releases/v0.33.0)) 
[info] using release tag='v0.33.0' version='0.33.0' os='darwin' arch='amd64' 
[debug] downloading files into /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmp.97tmb50y 
[debug] http_download(url=[v0.33.0 syft_0.33.0_checksums.txt) (download)](https://github.com/anchore/syft/releases/download/v0.33.0/syft_0.33.0_checksums.txt)) 
Error:  could not find release asset for os='darwin' arch='amd64' format='tar.gz'  
Error:  failed to install syft 
Error: ENOENT: no such file or directory, stat '/Users/runner/work/_temp/901a0c5a-dc08-47a2-bc9b-a747910548f2_syft/syft'
```

This is because install.sh is narrowly focused at being able to install assets for the current release. This update makes it so that install.sh will curl down the specific install.sh script for the release tag that has been resolved and uses that script.

A test for installing against v0.24.0 (which fails with todays install.sh without these additions from this branch) has been added as a regression test.