### PR TITLE
Restore behavior of JSON distro block

### DIFF
--- a/grype/presenter/json/test-fixtures/snapshot/TestEmptyJsonPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestEmptyJsonPresenter.golden
@@ -34,7 +34,7 @@
   }
  },
  "distro": {
-  "name": "",
+  "name": "centos",
   "version": "8.0",
   "idLike": [
    "rhel"

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
@@ -165,7 +165,7 @@
   "target": "/some/path"
  },
  "distro": {
-  "name": "",
+  "name": "centos",
   "version": "8.0",
   "idLike": [
    "rhel"

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
@@ -230,7 +230,7 @@
   }
  },
  "distro": {
-  "name": "",
+  "name": "centos",
   "version": "8.0",
   "idLike": [
    "rhel"

--- a/grype/presenter/template/test-fixtures/snapshot/TestPresenter_Present.golden
+++ b/grype/presenter/template/test-fixtures/snapshot/TestPresenter_Present.golden
@@ -1,4 +1,4 @@
-Identified distro as centos version 8.0.
+Identified distro as redhat version 8.0.
     Vulnerability: CVE-1999-0001
     Severity: Low
     Package: package-1 version 1.1.1 (deb)


### PR DESCRIPTION
This PR fixes the output of the JSON distro block from work done with https://github.com/anchore/syft/pull/742 and https://github.com/anchore/grype/pull/585 . Specifically, the mapping of the raw `linux.Distribution` struct during presentation is mapping the incorrect fields.

Additionally, it is more accurate to use the specific strong distro types that grype uses during matching (which was selected in this PR).

Example of the original distro block behavior between syft and grype:
```
docker run --rm anchore/syft:v0.35.1 -o json alpine:3.15 | jq .distro
{
 "name": "alpine",
 "version": "3.15.0",
 "idLike": ""
}
```
```
docker run --rm anchore/grype:v0.27.3 -o json alpine:3.15 | jq .distro
{
 "name": "alpine",
 "version": "3.15.0",
 "idLike": ""
}
```

Example of the new (bad) behavior of the distro block between syft and grype:
```
docker run --rm anchore/syft:latest -o json alpine:3.15 | jq .distro
{
 "prettyName": "Alpine Linux v3.15",
 "name": "Alpine Linux",
 "id": "alpine",
 "versionID": "3.15.0",
 "homeURL": "https://alpinelinux.org/",
 "bugReportURL": "https://bugs.alpinelinux.org/"
}
```
```
docker run --rm anchore/grype:latest -o json alpine:3.15 | jq .distro
{
 "name": "Alpine Linux",
 "version": "",
 "idLike": null
}
```

Reported by @westonsteimel  🙌 