### PR TITLE
Add gosimports linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,7 +19,6 @@ linters:
     - gocritic
     - gocyclo
     - gofmt
-    - goimports
     - goprintffuncname
     - gosec
     - gosimple
@@ -46,6 +45,7 @@ linters:
 #    - godot
 #    - godox
 #    - goerr113
+#    - goimports   # we're using gosimports now instead to account for extra whitespaces (see https://github.com/golang/go/issues/20818)
 #    - golint      # deprecated
 #    - gomnd       # this is too aggressive
 #    - interfacer  # this is a good idea, but is no longer supported and is prone to false positives

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,8 @@ bootstrap-tools: $(TEMPDIR)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMPDIR)/ v1.42.1
 	curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMPDIR)/ v0.3.0
 	curl -sSfL https://raw.githubusercontent.com/anchore/chronicle/main/install.sh | sh -s -- -b $(TEMPDIR)/ v0.3.0
+	# the only difference between goimports and gosimports is that gosimports removes extra whitespace between import blocks (see https://github.com/golang/go/issues/20818)
+	GOBIN="$(shell realpath $(TEMPDIR))" go install github.com/rinchsan/gosimports/cmd/gosimports@v0.1.5
 	.github/scripts/goreleaser-install.sh -b $(TEMPDIR)/ v1.4.1
 
 .PHONY: bootstrap-go
@@ -124,6 +126,7 @@ lint: ## Run gofmt + golangci lint checks
 lint-fix: ## Auto-format all source code + run golangci lint fixers
 	$(call title,Running lint fixers)
 	gofmt -w -s .
+	$(TEMPDIR)/gosimports -local github.com/anchore -w internal .
 	$(LINTCMD) --fix
 	go mod tidy
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -6,6 +6,11 @@ import (
 	"os"
 	"sort"
 
+	"github.com/gookit/color"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/wagoodman/go-partybus"
+
 	"github.com/anchore/grype/grype"
 	"github.com/anchore/grype/internal/config"
 	"github.com/anchore/grype/internal/log"
@@ -13,10 +18,6 @@ import (
 	"github.com/anchore/grype/internal/version"
 	"github.com/anchore/stereoscope"
 	"github.com/anchore/syft/syft"
-	"github.com/gookit/color"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"github.com/wagoodman/go-partybus"
 )
 
 var (

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
-
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/db_check.go
+++ b/cmd/db_check.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/anchore/grype/grype/db"
 	"github.com/spf13/cobra"
+
+	"github.com/anchore/grype/grype/db"
 )
 
 var dbCheckCmd = &cobra.Command{

--- a/cmd/db_delete.go
+++ b/cmd/db_delete.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/anchore/grype/grype/db"
 	"github.com/spf13/cobra"
+
+	"github.com/anchore/grype/grype/db"
 )
 
 var dbDeleteCmd = &cobra.Command{

--- a/cmd/db_import.go
+++ b/cmd/db_import.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/anchore/grype/internal"
+	"github.com/spf13/cobra"
 
 	"github.com/anchore/grype/grype/db"
-	"github.com/spf13/cobra"
+	"github.com/anchore/grype/internal"
 )
 
 var dbImportCmd = &cobra.Command{

--- a/cmd/db_list.go
+++ b/cmd/db_list.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/anchore/grype/grype/db"
 	"github.com/spf13/cobra"
+
+	"github.com/anchore/grype/grype/db"
 )
 
 var dbListOutputFormat string

--- a/cmd/db_status.go
+++ b/cmd/db_status.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/anchore/grype/grype/db"
-
 	"github.com/spf13/cobra"
+
+	"github.com/anchore/grype/grype/db"
 )
 
 var statusCmd = &cobra.Command{

--- a/cmd/db_update.go
+++ b/cmd/db_update.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/anchore/grype/grype/db"
 	"github.com/spf13/cobra"
+
+	"github.com/anchore/grype/grype/db"
 )
 
 var dbUpdateCmd = &cobra.Command{

--- a/cmd/event_loop.go
+++ b/cmd/event_loop.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/anchore/grype/internal/log"
-	"github.com/anchore/grype/internal/ui"
 	"github.com/hashicorp/go-multierror"
 	"github.com/wagoodman/go-partybus"
+
+	"github.com/anchore/grype/internal/log"
+	"github.com/anchore/grype/internal/ui"
 )
 
 // eventLoop listens to worker errors (from execution path), worker events (from a partybus subscription), and

--- a/cmd/event_loop_test.go
+++ b/cmd/event_loop_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/anchore/grype/grype/event"
-	"github.com/anchore/grype/internal/ui"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/wagoodman/go-partybus"
+
+	"github.com/anchore/grype/grype/event"
+	"github.com/anchore/grype/internal/ui"
 )
 
 var _ ui.UI = (*uiMock)(nil)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,8 +5,15 @@ import (
 	"os"
 	"sync"
 
+	"github.com/pkg/profile"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/wagoodman/go-partybus"
+
 	"github.com/anchore/grype/grype"
 	"github.com/anchore/grype/grype/db"
+	grypeDb "github.com/anchore/grype/grype/db/v3"
 	"github.com/anchore/grype/grype/event"
 	"github.com/anchore/grype/grype/grypeerr"
 	"github.com/anchore/grype/grype/match"
@@ -22,13 +29,6 @@ import (
 	"github.com/anchore/grype/internal/version"
 	"github.com/anchore/stereoscope"
 	"github.com/anchore/syft/syft/source"
-	"github.com/pkg/profile"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
-	"github.com/wagoodman/go-partybus"
-
-	grypeDb "github.com/anchore/grype/grype/db/v3"
 )
 
 var persistentOpts = config.CliOnlyOptions{}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal"
 	"github.com/anchore/grype/internal/version"
-	"github.com/spf13/cobra"
 )
 
 var versionOutputFormat string

--- a/grype/cpe/cpe_test.go
+++ b/grype/cpe/cpe_test.go
@@ -3,9 +3,9 @@ package cpe
 import (
 	"testing"
 
-	"github.com/anchore/syft/syft/pkg"
-
 	"github.com/sergi/go-diff/diffmatchpatch"
+
+	"github.com/anchore/syft/syft/pkg"
 )
 
 func must(c pkg.CPE, e error) pkg.CPE {

--- a/grype/db/curator.go
+++ b/grype/db/curator.go
@@ -9,6 +9,11 @@ import (
 	"path"
 	"strconv"
 
+	"github.com/hashicorp/go-cleanhttp"
+	"github.com/spf13/afero"
+	"github.com/wagoodman/go-partybus"
+	"github.com/wagoodman/go-progress"
+
 	grypeDB "github.com/anchore/grype/grype/db/v3"
 	"github.com/anchore/grype/grype/db/v3/reader"
 	"github.com/anchore/grype/grype/event"
@@ -16,10 +21,6 @@ import (
 	"github.com/anchore/grype/internal/bus"
 	"github.com/anchore/grype/internal/file"
 	"github.com/anchore/grype/internal/log"
-	"github.com/hashicorp/go-cleanhttp"
-	"github.com/spf13/afero"
-	"github.com/wagoodman/go-partybus"
-	"github.com/wagoodman/go-progress"
 )
 
 const (

--- a/grype/db/curator_test.go
+++ b/grype/db/curator_test.go
@@ -15,13 +15,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/anchore/grype/internal"
-	"github.com/anchore/grype/internal/file"
 	"github.com/gookit/color"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wagoodman/go-progress"
+
+	"github.com/anchore/grype/internal"
+	"github.com/anchore/grype/internal/file"
 )
 
 type testGetter struct {

--- a/grype/db/listing_entry.go
+++ b/grype/db/listing_entry.go
@@ -9,8 +9,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/anchore/grype/internal/file"
 	"github.com/spf13/afero"
+
+	"github.com/anchore/grype/internal/file"
 )
 
 // ListingEntry represents basic metadata about a database archive such as what is in the archive (built/version)

--- a/grype/db/listing_test.go
+++ b/grype/db/listing_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/anchore/go-version"
 	"github.com/go-test/deep"
 	"github.com/spf13/afero"
+
+	"github.com/anchore/go-version"
 )
 
 func mustUrl(u *url.URL, err error) *url.URL {

--- a/grype/db/metadata.go
+++ b/grype/db/metadata.go
@@ -7,9 +7,10 @@ import (
 	"path"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"github.com/anchore/grype/internal/file"
 	"github.com/anchore/grype/internal/log"
-	"github.com/spf13/afero"
 )
 
 const MetadataFileName = "metadata.json"

--- a/grype/db/v1/reader/reader.go
+++ b/grype/db/v1/reader/reader.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/alicebob/sqlittle"
+
 	v1 "github.com/anchore/grype/grype/db/v1"
 	"github.com/anchore/grype/grype/db/v1/model"
 )

--- a/grype/db/v1/writer/writer.go
+++ b/grype/db/v1/writer/writer.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/go-test/deep"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite" // provide the sqlite dialect to gorm via import
+
 	v1 "github.com/anchore/grype/grype/db/v1"
 	"github.com/anchore/grype/grype/db/v1/model"
 	"github.com/anchore/grype/internal"
-	"github.com/go-test/deep"
-	"github.com/jinzhu/gorm"
-
-	// provide the sqlite dialect to gorm via import
-	_ "github.com/jinzhu/gorm/dialects/sqlite"
 )
 
 // Writer holds an instance of the database connection

--- a/grype/db/v1/writer/writer_test.go
+++ b/grype/db/v1/writer/writer_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-test/deep"
+
 	v1 "github.com/anchore/grype/grype/db/v1"
 	"github.com/anchore/grype/grype/db/v1/model"
 	"github.com/anchore/grype/grype/db/v1/reader"
-	"github.com/go-test/deep"
 )
 
 func assertIDReader(t *testing.T, reader v1.IDReader, expected v1.ID) {

--- a/grype/db/v2/reader/reader.go
+++ b/grype/db/v2/reader/reader.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/alicebob/sqlittle"
+
 	v2 "github.com/anchore/grype/grype/db/v2"
 	"github.com/anchore/grype/grype/db/v2/model"
 )

--- a/grype/db/v2/writer/writer.go
+++ b/grype/db/v2/writer/writer.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/go-test/deep"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite" // provide the sqlite dialect to gorm via import
+
 	v2 "github.com/anchore/grype/grype/db/v2"
 	"github.com/anchore/grype/grype/db/v2/model"
 	"github.com/anchore/grype/internal"
-	"github.com/go-test/deep"
-	"github.com/jinzhu/gorm"
-
-	// provide the sqlite dialect to gorm via import
-	_ "github.com/jinzhu/gorm/dialects/sqlite"
 )
 
 // Writer holds an instance of the database connection

--- a/grype/db/v2/writer/writer_test.go
+++ b/grype/db/v2/writer/writer_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-test/deep"
+
 	v2 "github.com/anchore/grype/grype/db/v2"
 	"github.com/anchore/grype/grype/db/v2/model"
 	"github.com/anchore/grype/grype/db/v2/reader"
-	"github.com/go-test/deep"
 )
 
 func assertIDReader(t *testing.T, reader v2.IDReader, expected v2.ID) {

--- a/grype/db/v3/namespace_test.go
+++ b/grype/db/v3/namespace_test.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/anchore/grype/grype/distro"
-	"github.com/anchore/grype/grype/pkg"
-	syftPkg "github.com/anchore/syft/syft/pkg"
 	"github.com/google/uuid"
 	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/grype/grype/distro"
+	"github.com/anchore/grype/grype/pkg"
+	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
 func Test_NamespaceFromRecordSource(t *testing.T) {

--- a/grype/db/v3/reader/reader.go
+++ b/grype/db/v3/reader/reader.go
@@ -3,9 +3,9 @@ package reader
 import (
 	"fmt"
 
-	v3 "github.com/anchore/grype/grype/db/v3"
-
 	"github.com/alicebob/sqlittle"
+
+	v3 "github.com/anchore/grype/grype/db/v3"
 	"github.com/anchore/grype/grype/db/v3/model"
 )
 

--- a/grype/db/v3/writer/writer.go
+++ b/grype/db/v3/writer/writer.go
@@ -4,15 +4,13 @@ import (
 	"fmt"
 	"sort"
 
-	v3 "github.com/anchore/grype/grype/db/v3"
-
-	"github.com/anchore/grype/grype/db/v3/model"
-	"github.com/anchore/grype/internal"
 	"github.com/go-test/deep"
 	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite" // provide the sqlite dialect to gorm via import
 
-	// provide the sqlite dialect to gorm via import
-	_ "github.com/jinzhu/gorm/dialects/sqlite"
+	v3 "github.com/anchore/grype/grype/db/v3"
+	"github.com/anchore/grype/grype/db/v3/model"
+	"github.com/anchore/grype/internal"
 )
 
 // Writer holds an instance of the database connection

--- a/grype/db/v3/writer/writer_test.go
+++ b/grype/db/v3/writer/writer_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 	"time"
 
-	v3 "github.com/anchore/grype/grype/db/v3"
-
-	"github.com/anchore/grype/grype/db/v3/model"
-	"github.com/anchore/grype/grype/db/v3/reader"
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
+
+	v3 "github.com/anchore/grype/grype/db/v3"
+	"github.com/anchore/grype/grype/db/v3/model"
+	"github.com/anchore/grype/grype/db/v3/reader"
 )
 
 func assertIDReader(t *testing.T, reader v3.IDReader, expected v3.ID) {

--- a/grype/db/vulnerability_metadata_provider.go
+++ b/grype/db/vulnerability_metadata_provider.go
@@ -3,9 +3,8 @@ package db
 import (
 	"fmt"
 
-	"github.com/anchore/grype/grype/vulnerability"
-
 	grypeDB "github.com/anchore/grype/grype/db/v3"
+	"github.com/anchore/grype/grype/vulnerability"
 )
 
 var _ vulnerability.MetadataProvider = (*VulnerabilityMetadataProvider)(nil)

--- a/grype/db/vulnerability_provider.go
+++ b/grype/db/vulnerability_provider.go
@@ -3,14 +3,14 @@ package db
 import (
 	"fmt"
 
-	"github.com/anchore/grype/grype/cpe"
+	"github.com/facebookincubator/nvdtools/wfn"
 
+	"github.com/anchore/grype/grype/cpe"
 	grypeDB "github.com/anchore/grype/grype/db/v3"
 	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
 	syftPkg "github.com/anchore/syft/syft/pkg"
-	"github.com/facebookincubator/nvdtools/wfn"
 )
 
 var _ vulnerability.Provider = (*VulnerabilityProvider)(nil)

--- a/grype/db/vulnerability_provider_test.go
+++ b/grype/db/vulnerability_provider_test.go
@@ -3,16 +3,14 @@ package db
 import (
 	"testing"
 
-	"github.com/anchore/grype/grype/vulnerability"
-	"github.com/google/uuid"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/go-test/deep"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/version"
+	"github.com/anchore/grype/grype/vulnerability"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 

--- a/grype/distro/distro.go
+++ b/grype/distro/distro.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/anchore/syft/syft/linux"
 	hashiVer "github.com/hashicorp/go-version"
+
+	"github.com/anchore/syft/syft/linux"
 )
 
 // Distro represents a Linux Distribution.

--- a/grype/distro/distro_test.go
+++ b/grype/distro/distro_test.go
@@ -3,12 +3,12 @@ package distro
 import (
 	"testing"
 
-	"github.com/anchore/grype/internal"
-	"github.com/anchore/syft/syft/source"
-
-	"github.com/anchore/syft/syft/linux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/grype/internal"
+	"github.com/anchore/syft/syft/linux"
+	"github.com/anchore/syft/syft/source"
 )
 
 func Test_NewDistroFromRelease(t *testing.T) {

--- a/grype/event/parsers/parsers.go
+++ b/grype/event/parsers/parsers.go
@@ -3,12 +3,12 @@ package parsers
 import (
 	"fmt"
 
-	"github.com/anchore/grype/grype/matcher"
-	"github.com/anchore/grype/grype/presenter"
+	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
 
 	"github.com/anchore/grype/grype/event"
-	"github.com/wagoodman/go-partybus"
+	"github.com/anchore/grype/grype/matcher"
+	"github.com/anchore/grype/grype/presenter"
 )
 
 type ErrBadPayload struct {

--- a/grype/lib.go
+++ b/grype/lib.go
@@ -1,6 +1,8 @@
 package grype
 
 import (
+	"github.com/wagoodman/go-partybus"
+
 	"github.com/anchore/grype/grype/db"
 	"github.com/anchore/grype/grype/logger"
 	"github.com/anchore/grype/grype/match"
@@ -13,7 +15,6 @@ import (
 	"github.com/anchore/syft/syft/linux"
 	"github.com/anchore/syft/syft/pkg/cataloger"
 	"github.com/anchore/syft/syft/source"
-	"github.com/wagoodman/go-partybus"
 )
 
 func FindVulnerabilities(provider vulnerability.Provider, userImageStr string, scopeOpt source.Scope, registryOptions *image.RegistryOptions) (match.Matches, pkg.Context, []pkg.Package, error) {

--- a/grype/match/explicit_ignores_test.go
+++ b/grype/match/explicit_ignores_test.go
@@ -3,10 +3,11 @@ package match
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
 	syftPkg "github.com/anchore/syft/syft/pkg"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_ApplyExplicitIgnoreRules(t *testing.T) {

--- a/grype/match/fingerprint.go
+++ b/grype/match/fingerprint.go
@@ -3,8 +3,9 @@ package match
 import (
 	"fmt"
 
-	"github.com/anchore/grype/grype/pkg"
 	"github.com/mitchellh/hashstructure/v2"
+
+	"github.com/anchore/grype/grype/pkg"
 )
 
 type Fingerprint struct {

--- a/grype/match/ignore_test.go
+++ b/grype/match/ignore_test.go
@@ -4,15 +4,12 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-
-	"github.com/anchore/syft/syft/source"
-
-	"github.com/anchore/grype/grype/pkg"
-	"github.com/anchore/grype/grype/vulnerability"
-
 	"github.com/stretchr/testify/assert"
 
 	grypeDb "github.com/anchore/grype/grype/db/v3"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/syft/syft/source"
 )
 
 var (

--- a/grype/match/match.go
+++ b/grype/match/match.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/scylladb/go-set/strset"
+
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
-	"github.com/scylladb/go-set/strset"
 )
 
 var ErrCannotMerge = fmt.Errorf("unable to merge vulnerability matches")

--- a/grype/match/matches.go
+++ b/grype/match/matches.go
@@ -3,9 +3,8 @@ package match
 import (
 	"sort"
 
-	"github.com/anchore/grype/internal/log"
-
 	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/internal/log"
 )
 
 type Matches struct {

--- a/grype/match/matches_test.go
+++ b/grype/match/matches_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
 	syftPkg "github.com/anchore/syft/syft/pkg"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMatchesSortMixedDimensions(t *testing.T) {

--- a/grype/matcher/apk/matcher_test.go
+++ b/grype/matcher/apk/matcher_test.go
@@ -1,19 +1,20 @@
 package apk
 
 import (
-	"github.com/anchore/grype/grype/search"
 	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/anchore/grype/grype/db"
 	grypeDB "github.com/anchore/grype/grype/db/v3"
 	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/search"
 	"github.com/anchore/grype/grype/vulnerability"
 	syftPkg "github.com/anchore/syft/syft/pkg"
-	"github.com/go-test/deep"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 )
 
 func must(c syftPkg.CPE, e error) syftPkg.CPE {

--- a/grype/matcher/controller.go
+++ b/grype/matcher/controller.go
@@ -1,6 +1,9 @@
 package matcher
 
 import (
+	"github.com/wagoodman/go-partybus"
+	"github.com/wagoodman/go-progress"
+
 	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/event"
 	"github.com/anchore/grype/grype/match"
@@ -19,8 +22,6 @@ import (
 	"github.com/anchore/grype/internal/log"
 	"github.com/anchore/syft/syft/linux"
 	syftPkg "github.com/anchore/syft/syft/pkg"
-	"github.com/wagoodman/go-partybus"
-	"github.com/wagoodman/go-progress"
 )
 
 var controllerInstance controller

--- a/grype/matcher/dpkg/matcher_test.go
+++ b/grype/matcher/dpkg/matcher_test.go
@@ -4,9 +4,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/match"

--- a/grype/matcher/msrc/matcher_test.go
+++ b/grype/matcher/msrc/matcher_test.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/anchore/grype/grype/db"
 	grypeDB "github.com/anchore/grype/grype/db/v3"
 	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/pkg"
 	syftPkg "github.com/anchore/syft/syft/pkg"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 )
 
 type mockStore struct {

--- a/grype/matcher/rpmdb/matcher_test.go
+++ b/grype/matcher/rpmdb/matcher_test.go
@@ -4,9 +4,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/match"

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -3,12 +3,13 @@ package pkg
 import (
 	"testing"
 
-	"github.com/anchore/syft/syft/file"
-	syftPkg "github.com/anchore/syft/syft/pkg"
-	"github.com/anchore/syft/syft/source"
 	"github.com/scylladb/go-set"
 	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/syft/syft/file"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/source"
 )
 
 func TestNew(t *testing.T) {

--- a/grype/pkg/provider_test.go
+++ b/grype/pkg/provider_test.go
@@ -3,11 +3,11 @@ package pkg
 import (
 	"testing"
 
-	"github.com/anchore/syft/syft/pkg/cataloger"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/anchore/stereoscope/pkg/imagetest"
+	"github.com/anchore/syft/syft/pkg/cataloger"
 	"github.com/anchore/syft/syft/source"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestProviderLocationExcludes(t *testing.T) {

--- a/grype/pkg/syft_sbom_provider.go
+++ b/grype/pkg/syft_sbom_provider.go
@@ -7,15 +7,12 @@ import (
 	"strings"
 
 	"github.com/gabriel-vasile/mimetype"
+	"github.com/mitchellh/go-homedir"
 
 	"github.com/anchore/grype/internal"
 	"github.com/anchore/grype/internal/log"
-
-	"github.com/anchore/syft/syft/format"
-
 	"github.com/anchore/syft/syft"
-
-	"github.com/mitchellh/go-homedir"
+	"github.com/anchore/syft/syft/format"
 )
 
 func syftSBOMProvider(userInput string) ([]Package, Context, error) {

--- a/grype/pkg/syft_sbom_provider_test.go
+++ b/grype/pkg/syft_sbom_provider_test.go
@@ -4,11 +4,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-test/deep"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/anchore/syft/syft/linux"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/source"
-	"github.com/go-test/deep"
-	"github.com/stretchr/testify/assert"
 )
 
 func must(c pkg.CPE, e error) pkg.CPE {

--- a/grype/pkg/upstream_package.go
+++ b/grype/pkg/upstream_package.go
@@ -3,8 +3,9 @@ package pkg
 import (
 	"strings"
 
-	"github.com/anchore/syft/syft/pkg"
 	"github.com/scylladb/go-set/strset"
+
+	"github.com/anchore/syft/syft/pkg"
 )
 
 type UpstreamPackage struct {

--- a/grype/pkg/upstream_package_test.go
+++ b/grype/pkg/upstream_package_test.go
@@ -1,9 +1,11 @@
 package pkg
 
 import (
-	"github.com/anchore/syft/syft/pkg"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/syft/syft/pkg"
 )
 
 func TestUpstreamPackages(t *testing.T) {

--- a/grype/presenter/cyclonedx/document.go
+++ b/grype/presenter/cyclonedx/document.go
@@ -3,13 +3,14 @@ package cyclonedx
 import (
 	"encoding/xml"
 
+	"github.com/google/uuid"
+
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal"
 	"github.com/anchore/grype/internal/version"
 	"github.com/anchore/syft/syft/source"
-	"github.com/google/uuid"
 )
 
 // source: https://github.com/CycloneDX/specification

--- a/grype/presenter/cyclonedx/presenter_test.go
+++ b/grype/presenter/cyclonedx/presenter_test.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/sergi/go-diff/diffmatchpatch"
+
 	"github.com/anchore/go-testutils"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
@@ -14,7 +16,6 @@ import (
 	"github.com/anchore/stereoscope/pkg/imagetest"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/source"
-	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
 var update = flag.Bool("update", false, "update the *.golden files for json presenters")

--- a/grype/presenter/cyclonedx/vulnerability.go
+++ b/grype/presenter/cyclonedx/vulnerability.go
@@ -5,10 +5,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
+
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal/log"
-	"github.com/google/uuid"
 )
 
 // Source: https://cyclonedx.org/ext/vulnerability/

--- a/grype/presenter/cyclonedx/vulnerability_test.go
+++ b/grype/presenter/cyclonedx/vulnerability_test.go
@@ -3,10 +3,11 @@ package cyclonedx
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCvssVersionToMethod(t *testing.T) {

--- a/grype/presenter/json/presenter.go
+++ b/grype/presenter/json/presenter.go
@@ -4,10 +4,9 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/anchore/grype/grype/presenter/models"
-
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/presenter/models"
 	"github.com/anchore/grype/grype/vulnerability"
 )
 

--- a/grype/presenter/json/presenter_test.go
+++ b/grype/presenter/json/presenter_test.go
@@ -5,18 +5,18 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/anchore/stereoscope/pkg/file"
-	"github.com/anchore/syft/syft/linux"
+	"github.com/sergi/go-diff/diffmatchpatch"
 
 	"github.com/anchore/go-testutils"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/presenter/models"
 	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/imagetest"
+	"github.com/anchore/syft/syft/linux"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 	syftSource "github.com/anchore/syft/syft/source"
-	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
 var update = flag.Bool("update", false, "update the *.golden files for json presenters")

--- a/grype/presenter/models/document_test.go
+++ b/grype/presenter/models/document_test.go
@@ -3,13 +3,14 @@ package models
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/syft/syft/linux"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 	syftSource "github.com/anchore/syft/syft/source"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPackagesAreSorted(t *testing.T) {

--- a/grype/presenter/models/source_test.go
+++ b/grype/presenter/models/source_test.go
@@ -3,10 +3,10 @@ package models
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	syftSource "github.com/anchore/syft/syft/source"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestNewSource(t *testing.T) {

--- a/grype/presenter/presenter.go
+++ b/grype/presenter/presenter.go
@@ -3,13 +3,12 @@ package presenter
 import (
 	"io"
 
-	"github.com/anchore/grype/grype/presenter/template"
-
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/presenter/cyclonedx"
 	"github.com/anchore/grype/grype/presenter/json"
 	"github.com/anchore/grype/grype/presenter/table"
+	"github.com/anchore/grype/grype/presenter/template"
 	"github.com/anchore/grype/grype/vulnerability"
 )
 

--- a/grype/presenter/table/presenter.go
+++ b/grype/presenter/table/presenter.go
@@ -6,11 +6,12 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/olekukonko/tablewriter"
+
 	grypeDb "github.com/anchore/grype/grype/db/v3"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
-	"github.com/olekukonko/tablewriter"
 )
 
 // Presenter is a generic struct for holding fields needed for reporting

--- a/grype/presenter/table/presenter_test.go
+++ b/grype/presenter/table/presenter_test.go
@@ -5,14 +5,15 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/go-test/deep"
+	"github.com/sergi/go-diff/diffmatchpatch"
+
 	"github.com/anchore/go-testutils"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/presenter/models"
 	"github.com/anchore/grype/grype/vulnerability"
 	syftPkg "github.com/anchore/syft/syft/pkg"
-	"github.com/go-test/deep"
-	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
 var update = flag.Bool("update", false, "update the *.golden files for json presenters")

--- a/grype/presenter/template/presenter.go
+++ b/grype/presenter/template/presenter.go
@@ -10,10 +10,9 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/mitchellh/go-homedir"
 
-	"github.com/anchore/grype/grype/presenter/models"
-
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/presenter/models"
 	"github.com/anchore/grype/grype/vulnerability"
 )
 

--- a/grype/presenter/template/presenter_test.go
+++ b/grype/presenter/template/presenter_test.go
@@ -7,9 +7,10 @@ import (
 	"path"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/anchore/go-testutils"
 	"github.com/anchore/grype/grype/presenter/models"
-	"github.com/stretchr/testify/assert"
 )
 
 var update = flag.Bool("update", false, "update the *.golden files for template presenters")

--- a/grype/search/cpe.go
+++ b/grype/search/cpe.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/facebookincubator/nvdtools/wfn"
+	"github.com/scylladb/go-set/strset"
+
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/version"
 	"github.com/anchore/grype/grype/vulnerability"
 	syftPkg "github.com/anchore/syft/syft/pkg"
-	"github.com/facebookincubator/nvdtools/wfn"
-	"github.com/scylladb/go-set/strset"
 )
 
 type CPEParameters struct {

--- a/grype/search/cpe_test.go
+++ b/grype/search/cpe_test.go
@@ -3,16 +3,16 @@ package search
 import (
 	"testing"
 
-	"github.com/anchore/grype/grype/db"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 
+	"github.com/anchore/grype/grype/db"
 	grypeDB "github.com/anchore/grype/grype/db/v3"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/version"
 	"github.com/anchore/grype/grype/vulnerability"
 	syftPkg "github.com/anchore/syft/syft/pkg"
-	"github.com/stretchr/testify/assert"
 )
 
 func must(c syftPkg.CPE, e error) syftPkg.CPE {

--- a/grype/search/distro_test.go
+++ b/grype/search/distro_test.go
@@ -4,14 +4,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/version"
 	"github.com/anchore/grype/grype/vulnerability"
 	syftPkg "github.com/anchore/syft/syft/pkg"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 )
 
 type mockDistroProvider struct {

--- a/grype/search/language_test.go
+++ b/grype/search/language_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/anchore/grype/grype/match"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/version"
 	"github.com/anchore/grype/grype/vulnerability"

--- a/grype/search/utils_test.go
+++ b/grype/search/utils_test.go
@@ -3,10 +3,11 @@ package search
 import (
 	"testing"
 
-	"github.com/anchore/grype/grype/match"
-	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/vulnerability"
 )
 
 func assertMatchesUsingIDsForVulnerabilities(t testing.TB, expected, actual []match.Match) {

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -7,15 +7,15 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/anchore/grype/grype/match"
-
 	"github.com/adrg/xdg"
-	"github.com/anchore/grype/grype/vulnerability"
-	"github.com/anchore/grype/internal"
 	"github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
+
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/grype/internal"
 )
 
 var ErrApplicationConfigNotFound = fmt.Errorf("application config not found")

--- a/internal/config/database.go
+++ b/internal/config/database.go
@@ -4,9 +4,10 @@ import (
 	"path"
 
 	"github.com/adrg/xdg"
+	"github.com/spf13/viper"
+
 	"github.com/anchore/grype/grype/db"
 	"github.com/anchore/grype/internal"
-	"github.com/spf13/viper"
 )
 
 type database struct {

--- a/internal/config/registry_test.go
+++ b/internal/config/registry_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/anchore/stereoscope/pkg/image"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/stereoscope/pkg/image"
 )
 
 func TestHasNonEmptyCredentials(t *testing.T) {

--- a/internal/config/search.go
+++ b/internal/config/search.go
@@ -3,9 +3,10 @@ package config
 import (
 	"fmt"
 
+	"github.com/spf13/viper"
+
 	"github.com/anchore/syft/syft/pkg/cataloger"
 	"github.com/anchore/syft/syft/source"
-	"github.com/spf13/viper"
 )
 
 type search struct {

--- a/internal/file/getter.go
+++ b/internal/file/getter.go
@@ -5,11 +5,11 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/go-getter/helper/url"
+	"github.com/wagoodman/go-progress"
 
 	"github.com/anchore/grype/internal"
-	"github.com/hashicorp/go-getter"
-	"github.com/wagoodman/go-progress"
 )
 
 var (

--- a/internal/ui/common_event_handlers.go
+++ b/internal/ui/common_event_handlers.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"io"
 
-	grypeEventParsers "github.com/anchore/grype/grype/event/parsers"
 	"github.com/wagoodman/go-partybus"
+
+	grypeEventParsers "github.com/anchore/grype/grype/event/parsers"
 )
 
 func handleVulnerabilityScanningFinished(event partybus.Event, reportOutput io.Writer) error {

--- a/internal/ui/ephemeral_terminal_ui.go
+++ b/internal/ui/ephemeral_terminal_ui.go
@@ -11,12 +11,13 @@ import (
 	"os"
 	"sync"
 
+	"github.com/wagoodman/go-partybus"
+	"github.com/wagoodman/jotframe/pkg/frame"
+
 	grypeEvent "github.com/anchore/grype/grype/event"
 	"github.com/anchore/grype/internal/log"
 	"github.com/anchore/grype/internal/logger"
 	"github.com/anchore/grype/ui"
-	"github.com/wagoodman/go-partybus"
-	"github.com/wagoodman/jotframe/pkg/frame"
 )
 
 // ephemeralTerminalUI provides an "ephemeral" terminal user interface to display the application state dynamically.

--- a/internal/ui/etui_event_handlers.go
+++ b/internal/ui/etui_event_handlers.go
@@ -9,11 +9,12 @@ import (
 	"io"
 	"sync"
 
-	grypeEventParsers "github.com/anchore/grype/grype/event/parsers"
-	"github.com/anchore/grype/internal"
 	"github.com/gookit/color"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/jotframe/pkg/frame"
+
+	grypeEventParsers "github.com/anchore/grype/grype/event/parsers"
+	"github.com/anchore/grype/internal"
 )
 
 func handleAppUpdateAvailable(_ context.Context, fr *frame.Frame, event partybus.Event, _ *sync.WaitGroup) error {

--- a/internal/ui/logger_ui.go
+++ b/internal/ui/logger_ui.go
@@ -3,9 +3,10 @@ package ui
 import (
 	"io"
 
+	"github.com/wagoodman/go-partybus"
+
 	grypeEvent "github.com/anchore/grype/grype/event"
 	"github.com/anchore/grype/internal/log"
-	"github.com/wagoodman/go-partybus"
 )
 
 type loggerUI struct {

--- a/test/integration/compare_sbom_input_vs_lib_test.go
+++ b/test/integration/compare_sbom_input_vs_lib_test.go
@@ -2,18 +2,18 @@ package integration
 
 import (
 	"fmt"
-	"github.com/anchore/syft/syft/format"
 	"os"
 	"testing"
+
+	"github.com/scylladb/go-set/strset"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/anchore/grype/grype"
 	"github.com/anchore/grype/grype/db"
 	"github.com/anchore/grype/internal"
+	"github.com/anchore/syft/syft/format"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/source"
-	"github.com/stretchr/testify/assert"
-
-	"github.com/scylladb/go-set/strset"
 )
 
 var imagesWithVulnerabilities = []string{

--- a/test/integration/match_by_image_test.go
+++ b/test/integration/match_by_image_test.go
@@ -3,9 +3,10 @@ package integration
 import (
 	"testing"
 
-	"github.com/anchore/grype/grype/db"
+	"github.com/sergi/go-diff/diffmatchpatch"
 
 	"github.com/anchore/grype/grype"
+	"github.com/anchore/grype/grype/db"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
@@ -15,7 +16,6 @@ import (
 	syftPkg "github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/pkg/cataloger"
 	"github.com/anchore/syft/syft/source"
-	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
 func addAlpineMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Catalog, theStore *mockStore, theResult *match.Matches) {

--- a/test/integration/match_by_sbom_document_test.go
+++ b/test/integration/match_by_sbom_document_test.go
@@ -2,19 +2,18 @@ package integration
 
 import (
 	"fmt"
-	"github.com/anchore/grype/grype/search"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
-	"github.com/anchore/grype/grype/db"
-
-	"github.com/anchore/grype/grype"
-	"github.com/anchore/grype/grype/match"
-	"github.com/anchore/syft/syft/source"
 	"github.com/go-test/deep"
 	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/grype/grype"
+	"github.com/anchore/grype/grype/db"
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/search"
+	"github.com/anchore/syft/syft/source"
 )
 
 func TestMatchBySBOMDocument(t *testing.T) {

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -9,13 +9,14 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/scylladb/go-set/strset"
+
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/format"
 	"github.com/anchore/syft/syft/pkg/cataloger"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/anchore/syft/syft/source"
-	"github.com/scylladb/go-set/strset"
 )
 
 const cacheDirRelativePath string = "./test-fixtures/cache"

--- a/ui/event_handlers.go
+++ b/ui/event_handlers.go
@@ -7,15 +7,16 @@ import (
 	"sync"
 	"time"
 
-	grypeEventParsers "github.com/anchore/grype/grype/event/parsers"
-	"github.com/anchore/grype/internal/ui/components"
-	syftUI "github.com/anchore/syft/ui"
 	"github.com/dustin/go-humanize"
 	"github.com/gookit/color"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
 	"github.com/wagoodman/go-progress/format"
 	"github.com/wagoodman/jotframe/pkg/frame"
+
+	grypeEventParsers "github.com/anchore/grype/grype/event/parsers"
+	"github.com/anchore/grype/internal/ui/components"
+	syftUI "github.com/anchore/syft/ui"
 )
 
 const maxBarWidth = 50

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"sync"
 
-	grypeEvent "github.com/anchore/grype/grype/event"
-	syftUI "github.com/anchore/syft/ui"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/jotframe/pkg/frame"
+
+	grypeEvent "github.com/anchore/grype/grype/event"
+	syftUI "github.com/anchore/syft/ui"
 )
 
 type Handler struct {


### PR DESCRIPTION
Today we use the `goimports` linter to check and fix imports preferences, however, there is a downside that IDEs tend to add extra whitespace when automatically adding import statements, a case that `goimports` ignores (see https://github.com/golang/go/issues/20818). This PR replaces `goimports` with `gosimports` which is 1:1 the same tool with the exception for this specific case. 

Additionally this PR incorporates @kzantow s suggestion to additionally group `anchore` imports last 🙌 .