### PR TITLE
reduce PR CI pain and flakyness

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,10 +7,10 @@ name: "CodeQL Security Scan"
 
 on:
   push:
-    branches: [main]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [main]
+    branches:
+      # only run when there are pushes to the main branch (not on PRs)
+      - main
+
   schedule:
     - cron: '0 14 * * 4'
 

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -2,6 +2,8 @@ name: "Validations"
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
   pull_request:
 
 env:


### PR DESCRIPTION
This PR mirrors the syft changes from https://github.com/anchore/syft/pull/858

- Adds polling check for install tests to ensure the snapshot server is up
- Elevates CodeQL to only run on main (not on PRs)
- De-duplicates checks as best as possible; CI checks only run on PRs and pushes to main. Pushes to feature branches will no longer trigger CI.