### PR TITLE
Add additional DB archive decompressors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/jinzhu/gorm v1.9.14
 	github.com/knqyf263/go-apk-version v0.0.0-20200609155635-041fdbb8563f
 	github.com/knqyf263/go-deb-version v0.0.0-20190517075300-09fca494f03d
+	github.com/mholt/archiver/v3 v3.5.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/olekukonko/tablewriter v0.0.5
@@ -102,7 +103,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mattn/go-sqlite3 v1.14.0 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
-	github.com/mholt/archiver/v3 v3.5.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect

--- a/grype/db/curator.go
+++ b/grype/db/curator.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/go-cleanhttp"
+	"github.com/mholt/archiver/v3"
 	"github.com/spf13/afero"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
@@ -224,18 +225,7 @@ func (c *Curator) ImportFrom(dbArchivePath string) error {
 		return fmt.Errorf("unable to create db temp dir: %w", err)
 	}
 
-	f, err := os.Open(dbArchivePath)
-	if err != nil {
-		return fmt.Errorf("unable to open archive (%s): %w", dbArchivePath, err)
-	}
-	defer func() {
-		err = f.Close()
-		if err != nil {
-			log.Errorf("unable to close archive (%s): %w", dbArchivePath, err)
-		}
-	}()
-
-	err = file.UnTarGz(tempDir, f)
+	err = archiver.DecompressFile(dbArchivePath, tempDir)
 	if err != nil {
 		return err
 	}

--- a/internal/file/getter.go
+++ b/internal/file/getter.go
@@ -13,15 +13,9 @@ import (
 )
 
 var (
-	archiveExtensions   []string
+	archiveExtensions   = getterDecompressorNames()
 	ErrNonArchiveSource = fmt.Errorf("non-archive sources are not supported for directory destinations")
 )
-
-func init() {
-	for name := range getter.Decompressors {
-		archiveExtensions = append(archiveExtensions, name)
-	}
-}
 
 type Getter interface {
 	// GetFile downloads the give URL into the given path. The URL must reference a single file.
@@ -140,4 +134,11 @@ func (a *progressAdapter) TrackProgress(_ string, currentSize, totalSize int64, 
 	return &readCloser{
 		Reader: *progress.NewProxyReader(stream, a.monitor),
 	}
+}
+
+func getterDecompressorNames() (names []string) {
+	for name := range getter.Decompressors {
+		names = append(names, name)
+	}
+	return names
 }

--- a/internal/file/getter.go
+++ b/internal/file/getter.go
@@ -13,14 +13,15 @@ import (
 )
 
 var (
-	archiveExtensions = []string{
-		".tar",
-		".tar.gz",
-		".tgz",
-		".zip",
-	}
+	archiveExtensions   []string
 	ErrNonArchiveSource = fmt.Errorf("non-archive sources are not supported for directory destinations")
 )
+
+func init() {
+	for name := range getter.Decompressors {
+		archiveExtensions = append(archiveExtensions, name)
+	}
+}
 
 type Getter interface {
 	// GetFile downloads the give URL into the given path. The URL must reference a single file.


### PR DESCRIPTION
This PR does a couple things:
- restores the original decompressors list to match that of `hashicorp/go-getter` used in the `grype db update` execution path
- adds more decompressors to the `grype db import` path

This paves the way for replacing `gzip` DB archives for `zstd` DB archives in the future.