### PR TITLE
Add artifacthub owner

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,5 @@
+# See documentation here: https://github.com/artifacthub/hub/blob/v1.6.0/docs/metadata/artifacthub-repo.yml
+
+owners:
+  - name: wagoodman
+    email: wagoodman@gmail.com


### PR DESCRIPTION
Config is documented here: [https://github.com/artifacthub/hub/blob/v1.6.0/docs/metadata/artifacthub-repo.yml](https://github.com/artifacthub/hub/blob/v1.6.0/docs/metadata/artifacthub-repo.yml?rgh-link-date=2022-03-09T12%3A32%3A51Z)

This PR is meant only to establish ownership, a future PR will add the repo ID and more owners.