### PR TITLE
Add platform selection

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -147,6 +147,11 @@ func setRootFlags(flags *pflag.FlagSet) {
 		"exclude", "", nil,
 		"exclude paths from being scanned using a glob expression",
 	)
+
+	flags.StringP(
+		"platform", "", "",
+		"an optional platform specifier for container image sources (e.g. 'linux/arm64', 'linux/arm64/v8', 'arm64', 'linux')",
+	)
 }
 
 func bindRootConfigOptions(flags *pflag.FlagSet) error {
@@ -183,6 +188,10 @@ func bindRootConfigOptions(flags *pflag.FlagSet) error {
 	}
 
 	if err := viper.BindPFlag("exclude", flags.Lookup("exclude")); err != nil {
+		return err
+	}
+
+	if err := viper.BindPFlag("platform", flags.Lookup("platform")); err != nil {
 		return err
 	}
 
@@ -354,6 +363,7 @@ func getProviderConfig() pkg.ProviderConfig {
 		Exclusions:          appConfig.Exclusions,
 		CatalogingOptions:   appConfig.Search.ToConfig(),
 		GenerateMissingCPEs: appConfig.GenerateMissingCPEs,
+		Platform:            appConfig.Platform,
 	}
 }
 

--- a/grype/pkg/provider_config.go
+++ b/grype/pkg/provider_config.go
@@ -10,4 +10,5 @@ type ProviderConfig struct {
 	Exclusions          []string
 	CatalogingOptions   cataloger.Config
 	GenerateMissingCPEs bool
+	Platform            string
 }

--- a/grype/pkg/syft_provider.go
+++ b/grype/pkg/syft_provider.go
@@ -10,7 +10,7 @@ func syftProvider(userInput string, config ProviderConfig) ([]Package, Context, 
 		return nil, Context{}, errDoesNotProvide
 	}
 
-	sourceInput, err := source.ParseInput(userInput, "", true)
+	sourceInput, err := source.ParseInput(userInput, config.Platform, true)
 	if err != nil {
 		return nil, Context{}, err
 	}

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -38,6 +38,7 @@ type Application struct {
 	Quiet               bool                    `yaml:"quiet" json:"quiet" mapstructure:"quiet"`                                              // -q, indicates to not show any status output to stderr (ETUI or logging UI)
 	CheckForAppUpdate   bool                    `yaml:"check-for-app-update" json:"check-for-app-update" mapstructure:"check-for-app-update"` // whether to check for an application update on start up or not
 	OnlyFixed           bool                    `yaml:"only-fixed" json:"only-fixed" mapstructure:"only-fixed"`                               // only fail if detected vulns have a fix
+	Platform            string                  `yaml:"platform" json:"platform" mapstructure:"platform"`                                     // --platform, override the target platform for a container image
 	CliOptions          CliOnlyOptions          `yaml:"-" json:"-"`
 	Search              search                  `yaml:"search" json:"search" mapstructure:"search"`
 	Ignore              []match.IgnoreRule      `yaml:"ignore" json:"ignore" mapstructure:"ignore"`

--- a/test/cli/cmd_test.go
+++ b/test/cli/cmd_test.go
@@ -31,6 +31,13 @@ func TestCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "platform-option-wired-up",
+			args: []string{"--platform", "arm64", "-o", "json", "registry:busybox:1.31"},
+			assertions: []traitAssertion{
+				assertInOutput("sha256:1ee006886991ad4689838d3a288e0dd3fd29b70e276622f16b67a8922831a853"), // linux/arm64 image digest
+			},
+		},
+		{
 			name: "responds-to-search-options",
 			args: []string{"-vv"},
 			env: map[string]string{


### PR DESCRIPTION
Adds `--platform` option to the root commands, allowing someone to specify values similar to `docker pull`, for example:

- os only override: `windows`
- architecture override: `arm64`
- combination: `linux/arm`
- architecture variants: `arm/v8`
- all options: `windows/arm/v6`

Additionally if you attempt to specify `--platform` on non-image sources you will receive an error.