### PR TITLE
Fix nil pointer access in SARIF output

### DIFF
--- a/grype/presenter/sarif/presenter.go
+++ b/grype/presenter/sarif/presenter.go
@@ -240,13 +240,13 @@ func (pres *Presenter) cvssScore(v vulnerability.Vulnerability) float64 {
 	var all []*vulnerability.Metadata
 
 	meta, err := pres.metadataProvider.GetMetadata(v.ID, v.Namespace)
-	if err == nil {
+	if err == nil && meta != nil {
 		all = append(all, meta)
 	}
 
 	for _, related := range v.RelatedVulnerabilities {
 		meta, err = pres.metadataProvider.GetMetadata(related.ID, related.Namespace)
-		if err == nil {
+		if err == nil && meta != nil {
 			all = append(all, meta)
 		}
 	}

--- a/grype/presenter/sarif/presenter_test.go
+++ b/grype/presenter/sarif/presenter_test.go
@@ -252,6 +252,12 @@ func redact(s []byte) []byte {
 	return s
 }
 
+type NilMetadataProvider struct{}
+
+func (m *NilMetadataProvider) GetMetadata(_, _ string) (*vulnerability.Metadata, error) {
+	return nil, nil
+}
+
 type MockMetadataProvider struct{}
 
 func (m *MockMetadataProvider) GetMetadata(id, namespace string) (*vulnerability.Metadata, error) {
@@ -281,6 +287,17 @@ func (m *MockMetadataProvider) GetMetadata(id, namespace string) (*vulnerability
 		}
 	}
 	return nil, fmt.Errorf("not found")
+}
+
+func Test_cvssScoreWithNilMetadata(t *testing.T) {
+	pres := Presenter{
+		metadataProvider: &NilMetadataProvider{},
+	}
+	score := pres.cvssScore(vulnerability.Vulnerability{
+		ID:        "id",
+		Namespace: "namespace",
+	})
+	assert.Equal(t, float64(-1), score)
 }
 
 func Test_cvssScore(t *testing.T) {


### PR DESCRIPTION
Got a SIGSEGV when outputting SARIF in one unexplained case; this should prevent that from happening.