### PR TITLE
Update Syft to 0.42.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4
 	github.com/anchore/packageurl-go v0.1.1-0.20220314153042-1bcd40e5206b
-	github.com/anchore/stereoscope v0.0.0-20220315185520-25183ec78f40
-	github.com/anchore/syft v0.42.0
+	github.com/anchore/stereoscope v0.0.0-20220321131953-5e4083dd6a09
+	github.com/anchore/syft v0.42.1
 	github.com/bmatcuk/doublestar/v2 v2.0.4
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -272,10 +272,10 @@ github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 h1:rmZG77uXgE
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/packageurl-go v0.1.1-0.20220314153042-1bcd40e5206b h1:YJWYt/6KQXR9JR46lLHrTTYi8rcye42tKcyjREA/hvA=
 github.com/anchore/packageurl-go v0.1.1-0.20220314153042-1bcd40e5206b/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
-github.com/anchore/stereoscope v0.0.0-20220315185520-25183ec78f40 h1:OSyFMZgEwQW0wFyv10kEi9kmB52FQFRUQmc2H6d8LTY=
-github.com/anchore/stereoscope v0.0.0-20220315185520-25183ec78f40/go.mod h1:OVVJ4y/L26pspeeHNvNa7GeQfoLPWxJe13iODl9x5l4=
-github.com/anchore/syft v0.42.0 h1:xHy7Viga48U80NwVBaSv9x63ygk/Bqja8Dr/P8F4nUg=
-github.com/anchore/syft v0.42.0/go.mod h1:zmU1U+xOgPbQ1h0vS11/A/05b2RH8vlXXvyT2kzCFbQ=
+github.com/anchore/stereoscope v0.0.0-20220321131953-5e4083dd6a09 h1:as2fIXP5OhxT/r4D5wjKYPm/Z3Sj50gqRQMJmYZlwMg=
+github.com/anchore/stereoscope v0.0.0-20220321131953-5e4083dd6a09/go.mod h1:OVVJ4y/L26pspeeHNvNa7GeQfoLPWxJe13iODl9x5l4=
+github.com/anchore/syft v0.42.1 h1:n5lUwCCeW2PK9Yk0uunnmDvup4GJRBO54O+d05liUYU=
+github.com/anchore/syft v0.42.1/go.mod h1:Q/kpdrpXle1JV9qBy8zofH0D6FUjG6lmXGaWTk+fuYM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=


### PR DESCRIPTION
Updating to the latest Syft release, which includes fixes for decoding CycloneDX