### PR TITLE
Include package type in table output

### DIFF
--- a/grype/presenter/cyclonedx/presenter_test.go
+++ b/grype/presenter/cyclonedx/presenter_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/anchore/syft/syft/source"
 )
 
-var update = flag.Bool("update", false, "update the *.golden files for json presenters")
+var update = flag.Bool("update", false, "update the *.golden files for cyclonedx presenters")
 
 func createResults() (match.Matches, []pkg.Package) {
 

--- a/grype/presenter/sarif/presenter_test.go
+++ b/grype/presenter/sarif/presenter_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/anchore/syft/syft/source"
 )
 
-var update = flag.Bool("update", false, "update the *.golden files for json presenters")
+var update = flag.Bool("update", false, "update the *.golden files for sarif presenters")
 
 func createResults() (match.Matches, []pkg.Package) {
 

--- a/grype/presenter/table/presenter.go
+++ b/grype/presenter/table/presenter.go
@@ -34,7 +34,7 @@ func NewPresenter(results match.Matches, packages []pkg.Package, metadataProvide
 func (pres *Presenter) Present(output io.Writer) error {
 	rows := make([][]string, 0)
 
-	columns := []string{"Name", "Type", "Installed", "Fixed-In", "Vulnerability", "Severity"}
+	columns := []string{"Name", "Installed", "Fixed-In", "Type", "Vulnerability", "Severity"}
 	for m := range pres.results.Enumerate() {
 		var severity string
 
@@ -55,7 +55,7 @@ func (pres *Presenter) Present(output io.Writer) error {
 			fixVersion = ""
 		}
 
-		rows = append(rows, []string{m.Package.Name, string(m.Package.Type), m.Package.Version, fixVersion, m.Vulnerability.ID, severity})
+		rows = append(rows, []string{m.Package.Name, m.Package.Version, fixVersion, string(m.Package.Type), m.Vulnerability.ID, severity})
 	}
 
 	if len(rows) == 0 {

--- a/grype/presenter/table/presenter.go
+++ b/grype/presenter/table/presenter.go
@@ -34,7 +34,7 @@ func NewPresenter(results match.Matches, packages []pkg.Package, metadataProvide
 func (pres *Presenter) Present(output io.Writer) error {
 	rows := make([][]string, 0)
 
-	columns := []string{"Name", "Installed", "Fixed-In", "Vulnerability", "Severity"}
+	columns := []string{"Name", "Type", "Installed", "Fixed-In", "Vulnerability", "Severity"}
 	for m := range pres.results.Enumerate() {
 		var severity string
 
@@ -55,7 +55,7 @@ func (pres *Presenter) Present(output io.Writer) error {
 			fixVersion = ""
 		}
 
-		rows = append(rows, []string{m.Package.Name, m.Package.Version, fixVersion, m.Vulnerability.ID, severity})
+		rows = append(rows, []string{m.Package.Name, string(m.Package.Type), m.Package.Version, fixVersion, m.Vulnerability.ID, severity})
 	}
 
 	if len(rows) == 0 {

--- a/grype/presenter/table/presenter_test.go
+++ b/grype/presenter/table/presenter_test.go
@@ -16,7 +16,7 @@ import (
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
-var update = flag.Bool("update", false, "update the *.golden files for json presenters")
+var update = flag.Bool("update", false, "update the *.golden files for table presenters")
 
 func TestTablePresenter(t *testing.T) {
 

--- a/grype/presenter/table/test-fixtures/snapshot/TestTablePresenter.golden
+++ b/grype/presenter/table/test-fixtures/snapshot/TestTablePresenter.golden
@@ -1,3 +1,3 @@
-NAME       INSTALLED  FIXED-IN          VULNERABILITY  SEVERITY 
-package-1  1.0.1                        CVE-1999-0001  Low       
-package-2  2.0.1      the-next-version  CVE-1999-0002  Critical  
+NAME       TYPE  INSTALLED  FIXED-IN          VULNERABILITY  SEVERITY 
+package-1  deb   1.0.1                        CVE-1999-0001  Low       
+package-2  deb   2.0.1      the-next-version  CVE-1999-0002  Critical  

--- a/grype/presenter/table/test-fixtures/snapshot/TestTablePresenter.golden
+++ b/grype/presenter/table/test-fixtures/snapshot/TestTablePresenter.golden
@@ -1,3 +1,3 @@
-NAME       TYPE  INSTALLED  FIXED-IN          VULNERABILITY  SEVERITY 
-package-1  deb   1.0.1                        CVE-1999-0001  Low       
-package-2  deb   2.0.1      the-next-version  CVE-1999-0002  Critical  
+NAME       INSTALLED  FIXED-IN          TYPE  VULNERABILITY  SEVERITY 
+package-1  1.0.1                        deb   CVE-1999-0001  Low       
+package-2  2.0.1      the-next-version  deb   CVE-1999-0002  Critical  


### PR DESCRIPTION
This helps avoid confusion between packages of the same name but different types.

Examples where I've hit this recently:
 - `tar` is a node package as well as a linux executable apk/rpm/deb
 - `msgpack` is a node package but also a python package
 - `jsonpointer` is also the name of both a node and a python package

In each case when I saw the vuln reported in grype output I started investigating the "wrong" one (call me unlucky!) and it took some digging to realise the issue.

The "type" is a succinct representation of _where_ Grype found this package, so hopefully including this should make things a lot clearer.

I'm aware of the templating functionality with `-o` however:

1. I've struggled to make a custom text-tabular format in order to simply add that column while retaining the nice alignment (I see `tablewriter` in `...table/presenter.go` but I don't think custom templates can make use of that via `...template/presenter.go`)
2. Even using `printf` with fixed-length padding (🤮) the ordering is problematic (#696)
3. This change hopefully makes an improvement which can benefit everyone by default.