### PR TITLE
Add byMatchName custom function for custom template users

### DIFF
--- a/grype/match/sort.go
+++ b/grype/match/sort.go
@@ -29,31 +29,3 @@ func (m ByElements) Less(i, j int) bool {
 func (m ByElements) Swap(i, j int) {
 	m[i], m[j] = m[j], m[i]
 }
-
-var _ sort.Interface = (*ByName)(nil)
-
-type ByName []Match
-
-// Len is the number of elements in the collection.
-func (m ByName) Len() int {
-	return len(m)
-}
-
-// Less reports whether the element with index i should sort before the element with index j.
-func (m ByName) Less(i, j int) bool {
-	if m[i].Package.Name == m[j].Package.Name {
-		if m[i].Vulnerability.ID == m[j].Vulnerability.ID {
-			if m[i].Package.Version == m[j].Package.Version {
-				return m[i].Package.Type < m[j].Package.Type
-			}
-			return m[i].Package.Version < m[j].Package.Version
-		}
-		return m[i].Vulnerability.ID < m[j].Vulnerability.ID
-	}
-	return m[i].Package.Name < m[j].Package.Name
-}
-
-// Swap swaps the elements with indexes i and j.
-func (m ByName) Swap(i, j int) {
-	m[i], m[j] = m[j], m[i]
-}

--- a/grype/match/sort.go
+++ b/grype/match/sort.go
@@ -29,3 +29,31 @@ func (m ByElements) Less(i, j int) bool {
 func (m ByElements) Swap(i, j int) {
 	m[i], m[j] = m[j], m[i]
 }
+
+var _ sort.Interface = (*ByName)(nil)
+
+type ByName []Match
+
+// Len is the number of elements in the collection.
+func (m ByName) Len() int {
+	return len(m)
+}
+
+// Less reports whether the element with index i should sort before the element with index j.
+func (m ByName) Less(i, j int) bool {
+	if m[i].Package.Name == m[j].Package.Name {
+		if m[i].Vulnerability.ID == m[j].Vulnerability.ID {
+			if m[i].Package.Version == m[j].Package.Version {
+				return m[i].Package.Type < m[j].Package.Type
+			}
+			return m[i].Package.Version < m[j].Package.Version
+		}
+		return m[i].Vulnerability.ID < m[j].Vulnerability.ID
+	}
+	return m[i].Package.Name < m[j].Package.Name
+}
+
+// Swap swaps the elements with indexes i and j.
+func (m ByName) Swap(i, j int) {
+	m[i], m[j] = m[j], m[i]
+}

--- a/grype/presenter/models/match.go
+++ b/grype/presenter/models/match.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
@@ -57,4 +58,32 @@ func newMatch(m match.Match, p pkg.Package, metadataProvider vulnerability.Metad
 		RelatedVulnerabilities: relatedVulnerabilities,
 		MatchDetails:           details,
 	}, nil
+}
+
+var _ sort.Interface = (*ByName)(nil)
+
+type ByName []Match
+
+// Len is the number of elements in the collection.
+func (m ByName) Len() int {
+	return len(m)
+}
+
+// Less reports whether the element with index i should sort before the element with index j.
+func (m ByName) Less(i, j int) bool {
+	if m[i].Artifact.Name == m[j].Artifact.Name {
+		if m[i].Vulnerability.ID == m[j].Vulnerability.ID {
+			if m[i].Artifact.Version == m[j].Artifact.Version {
+				return m[i].Artifact.Type < m[j].Artifact.Type
+			}
+			return m[i].Artifact.Version < m[j].Artifact.Version
+		}
+		return m[i].Vulnerability.ID < m[j].Vulnerability.ID
+	}
+	return m[i].Artifact.Name < m[j].Artifact.Name
+}
+
+// Swap swaps the elements with indexes i and j.
+func (m ByName) Swap(i, j int) {
+	m[i], m[j] = m[j], m[i]
 }

--- a/grype/presenter/template/presenter.go
+++ b/grype/presenter/template/presenter.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"sort"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
@@ -83,6 +84,20 @@ var funcMap = func() template.FuncMap {
 		}
 
 		return 0
+	}
+	f["byName"] = func(collection interface{}) interface{} {
+		t := reflect.TypeOf(collection)
+		if t.Kind() != reflect.Slice {
+			return collection
+		}
+
+		matches, ok := collection.([]match.Match)
+		if !ok {
+			return collection
+		}
+
+		sort.Sort(match.ByName(matches))
+		return matches
 	}
 	return f
 }()

--- a/grype/presenter/template/presenter.go
+++ b/grype/presenter/template/presenter.go
@@ -91,12 +91,12 @@ var funcMap = func() template.FuncMap {
 			return collection
 		}
 
-		matches, ok := collection.([]match.Match)
+		matches, ok := collection.([]models.Match)
 		if !ok {
 			return collection
 		}
 
-		sort.Sort(match.ByName(matches))
+		sort.Sort(models.ByName(matches))
 		return matches
 	}
 	return f

--- a/grype/presenter/template/presenter.go
+++ b/grype/presenter/template/presenter.go
@@ -85,12 +85,7 @@ var funcMap = func() template.FuncMap {
 
 		return 0
 	}
-	f["byName"] = func(collection interface{}) interface{} {
-		t := reflect.TypeOf(collection)
-		if t.Kind() != reflect.Slice {
-			return collection
-		}
-
+	f["byMatchName"] = func(collection interface{}) interface{} {
 		matches, ok := collection.([]models.Match)
 		if !ok {
 			return collection


### PR DESCRIPTION
## Custom template functions `byName`

Add a `byName` custom function for custom template consumers.

Example template:
```
TYPE   NAME                 INSTALLED    VULN                 SEVERITY     FIXED?   FIXED IN     UPSTREAM PACKAGE
{{- range .Matches | byMatchName}}
{{printf "%-6s %-20s %-12s %-20s %-12s %-8s %-12s %s" .Artifact.Type .Artifact.Name .Artifact.Version .Vulnerability.ID .Vulnerability.Severity .Vulnerability.Fix.State (.Vulnerability.Fix.Versions | join ", ") (.Artifact.Upstreams | join ", ")}}
{{- end}}
```

Note the `|` for `Matches` to be sorted.

Using the above template run:
```
grype alpine:3.14.1 -o template -t mycustom.tmpl
```

Output should now be able to be sorted by name for custom templates:
![Screen Shot 2022-03-30 at 11 51 09 AM](https://user-images.githubusercontent.com/32073428/160877489-cb482bab-164b-463f-981e-ca7a15d3916c.png)

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>