### PR TITLE
Update json field values to be similar across codebase

### DIFF
--- a/grype/match/ignore.go
+++ b/grype/match/ignore.go
@@ -18,7 +18,7 @@ type IgnoredMatch struct {
 // rule to apply.
 type IgnoreRule struct {
 	Vulnerability string            `yaml:"vulnerability" json:"vulnerability" mapstructure:"vulnerability"`
-	FixState      string            `yaml:"fix-state" json:"fix-state" mapstructure:"fix-state"`
+	FixState      string            `yaml:"fix-state" json:"fixState" mapstructure:"fix-state"`
 	Package       IgnoreRulePackage `yaml:"package" json:"package" mapstructure:"package"`
 }
 

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -29,23 +29,23 @@ type parser interface {
 }
 
 type Application struct {
-	ConfigPath          string                  `yaml:",omitempty" json:"configPath"`                                                         // the location where the application config was read from (either from -c or discovered while loading)
-	Output              string                  `yaml:"output" json:"output" mapstructure:"output"`                                           // -o, the Presenter hint string to use for report formatting
-	File                string                  `yaml:"file" json:"file" mapstructure:"file"`                                                 // --file, the file to write report output to
-	Distro              string                  `yaml:"distro" json:"distro" mapstructure:"distro"`                                           // --distro, specify a distro to explicitly use
-	GenerateMissingCPEs bool                    `yaml:"add-cpes-if-none" json:"add-cpes-if-none" mapstructure:"add-cpes-if-none"`             // --add-cpes-if-none, automatically generate CPEs if they are not present in import (e.g. from a 3rd party SPDX document)
-	OutputTemplateFile  string                  `yaml:"output-template-file" json:"output-template-file" mapstructure:"output-template-file"` // -t, the template file to use for formatting the final report
-	Quiet               bool                    `yaml:"quiet" json:"quiet" mapstructure:"quiet"`                                              // -q, indicates to not show any status output to stderr (ETUI or logging UI)
-	CheckForAppUpdate   bool                    `yaml:"check-for-app-update" json:"check-for-app-update" mapstructure:"check-for-app-update"` // whether to check for an application update on start up or not
-	OnlyFixed           bool                    `yaml:"only-fixed" json:"only-fixed" mapstructure:"only-fixed"`                               // only fail if detected vulns have a fix
-	Platform            string                  `yaml:"platform" json:"platform" mapstructure:"platform"`                                     // --platform, override the target platform for a container image
+	ConfigPath          string                  `yaml:",omitempty" json:"configPath"`                                                       // the location where the application config was read from (either from -c or discovered while loading)
+	Output              string                  `yaml:"output" json:"output" mapstructure:"output"`                                         // -o, the Presenter hint string to use for report formatting
+	File                string                  `yaml:"file" json:"file" mapstructure:"file"`                                               // --file, the file to write report output to
+	Distro              string                  `yaml:"distro" json:"distro" mapstructure:"distro"`                                         // --distro, specify a distro to explicitly use
+	GenerateMissingCPEs bool                    `yaml:"add-cpes-if-none" json:"addCpesIfNone" mapstructure:"add-cpes-if-none"`              // --add-cpes-if-none, automatically generate CPEs if they are not present in import (e.g. from a 3rd party SPDX document)
+	OutputTemplateFile  string                  `yaml:"output-template-file" json:"outputTemplateFile" mapstructure:"output-template-file"` // -t, the template file to use for formatting the final report
+	Quiet               bool                    `yaml:"quiet" json:"quiet" mapstructure:"quiet"`                                            // -q, indicates to not show any status output to stderr (ETUI or logging UI)
+	CheckForAppUpdate   bool                    `yaml:"check-for-app-update" json:"checkForAppUpdate" mapstructure:"check-for-app-update"`  // whether to check for an application update on start up or not
+	OnlyFixed           bool                    `yaml:"only-fixed" json:"onlyFixed" mapstructure:"only-fixed"`                              // only fail if detected vulns have a fix
+	Platform            string                  `yaml:"platform" json:"platform" mapstructure:"platform"`                                   // --platform, override the target platform for a container image
 	CliOptions          CliOnlyOptions          `yaml:"-" json:"-"`
 	Search              search                  `yaml:"search" json:"search" mapstructure:"search"`
 	Ignore              []match.IgnoreRule      `yaml:"ignore" json:"ignore" mapstructure:"ignore"`
 	Exclusions          []string                `yaml:"exclude" json:"exclude" mapstructure:"exclude"`
 	DB                  database                `yaml:"db" json:"db" mapstructure:"db"`
 	Dev                 development             `yaml:"dev" json:"dev" mapstructure:"dev"`
-	FailOn              string                  `yaml:"fail-on-severity" json:"fail-on-severity" mapstructure:"fail-on-severity"`
+	FailOn              string                  `yaml:"fail-on-severity" json:"failOnSeverity" mapstructure:"fail-on-severity"`
 	FailOnSeverity      *vulnerability.Severity `yaml:"-" json:"-"`
 	Registry            registry                `yaml:"registry" json:"registry" mapstructure:"registry"`
 	Log                 logging                 `yaml:"log" json:"log" mapstructure:"log"`

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -33,7 +33,7 @@ type Application struct {
 	Output              string                  `yaml:"output" json:"output" mapstructure:"output"`                                         // -o, the Presenter hint string to use for report formatting
 	File                string                  `yaml:"file" json:"file" mapstructure:"file"`                                               // --file, the file to write report output to
 	Distro              string                  `yaml:"distro" json:"distro" mapstructure:"distro"`                                         // --distro, specify a distro to explicitly use
-	GenerateMissingCPEs bool                    `yaml:"add-cpes-if-none" json:"addCpesIfNone" mapstructure:"add-cpes-if-none"`              // --add-cpes-if-none, automatically generate CPEs if they are not present in import (e.g. from a 3rd party SPDX document)
+	GenerateMissingCPEs bool                    `yaml:"add-cpes-if-none" json:"addCPEsIfNone" mapstructure:"add-cpes-if-none"`              // --add-cpes-if-none, automatically generate CPEs if they are not present in import (e.g. from a 3rd party SPDX document)
 	OutputTemplateFile  string                  `yaml:"output-template-file" json:"outputTemplateFile" mapstructure:"output-template-file"` // -t, the template file to use for formatting the final report
 	Quiet               bool                    `yaml:"quiet" json:"quiet" mapstructure:"quiet"`                                            // -q, indicates to not show any status output to stderr (ETUI or logging UI)
 	CheckForAppUpdate   bool                    `yaml:"check-for-app-update" json:"checkForAppUpdate" mapstructure:"check-for-app-update"`  // whether to check for an application update on start up or not

--- a/internal/config/database.go
+++ b/internal/config/database.go
@@ -11,11 +11,11 @@ import (
 )
 
 type database struct {
-	Dir                   string `yaml:"cache-dir" json:"cache-dir" mapstructure:"cache-dir"`
-	UpdateURL             string `yaml:"update-url" json:"update-url" mapstructure:"update-url"`
-	CACert                string `yaml:"ca-cert" json:"ca-cert" mapstructure:"ca-cert"`
-	AutoUpdate            bool   `yaml:"auto-update" json:"auto-update" mapstructure:"auto-update"`
-	ValidateByHashOnStart bool   `yaml:"validate-by-hash-on-start" json:"validate-by-hash-on-start" mapstructure:"validate-by-hash-on-start"`
+	Dir                   string `yaml:"cache-dir" json:"cacheDir" mapstructure:"cache-dir"`
+	UpdateURL             string `yaml:"update-url" json:"updateUrl" mapstructure:"update-url"`
+	CACert                string `yaml:"ca-cert" json:"caCert" mapstructure:"ca-cert"`
+	AutoUpdate            bool   `yaml:"auto-update" json:"autoUpdate" mapstructure:"auto-update"`
+	ValidateByHashOnStart bool   `yaml:"validate-by-hash-on-start" json:"validateByHashOnStart" mapstructure:"validate-by-hash-on-start"`
 }
 
 func (cfg database) loadDefaultValues(v *viper.Viper) {


### PR DESCRIPTION
Some JSON fields in the output would have `snakecase` as their default tag. This leads to output errors in `jq` and other parsing tools like the one shown below.

![Screen Shot 2022-04-11 at 6 34 23 PM](https://user-images.githubusercontent.com/32073428/162995658-76ba6005-5b94-4c87-aff0-7b14d36c8f1c.png)

This PR attempts to move those fields in line with the `camelCase` values displayed across fields that can be parsed by automatic tooling.

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>