### PR TITLE
Add workflow for automatic PR for new Syft releases

### DIFF
--- a/.github/workflows/update-syft-release.yml
+++ b/.github/workflows/update-syft-release.yml
@@ -23,7 +23,6 @@ jobs:
 
       - run: |
           LATEST_VERSION=$(curl "https://api.github.com/repos/anchore/syft/releases/latest" 2>/dev/null | jq -r '.tag_name')
-          echo "export const VERSION = \"$LATEST_VERSION\";" > src/SyftVersion.ts
 
           # update go.mod
           go get github.com/anchore/syft@$LATEST_VERSION

--- a/.github/workflows/update-syft-release.yml
+++ b/.github/workflows/update-syft-release.yml
@@ -1,0 +1,51 @@
+name: PR for latest Syft release
+on:
+  schedule:
+    - cron: "0 8 * * *" # 3 AM EST
+
+  workflow_dispatch:
+
+env:
+  GO_VERSION: "1.18.x"
+  GO_STABLE_VERSION: true
+
+jobs:
+  upgrade-syft:
+    runs-on: ubuntu-latest
+    if: github.repository == 'anchore/grype' # only run for main repo
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          stable: ${{ env.GO_STABLE_VERSION }}
+
+      - run: |
+          LATEST_VERSION=$(curl "https://api.github.com/repos/anchore/syft/releases/latest" 2>/dev/null | jq -r '.tag_name')
+          echo "export const VERSION = \"$LATEST_VERSION\";" > src/SyftVersion.ts
+
+          # update go.mod
+          go get github.com/anchore/syft@$LATEST_VERSION
+
+          # export the version for use with create-pull-request
+          echo "::set-output name=LATEST_VERSION::$LATEST_VERSION"
+        id: latest-version
+
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.TOKEN_APP_ID }}
+          private_key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
+
+      - uses: peter-evans/create-pull-request@v4
+        with:
+          signoff: true
+          delete-branch: true
+          branch: auto/latest
+          labels: dependencies
+          commit-message: "Update Syft to ${{ steps.latest-version.outputs.LATEST_VERSION }}"
+          title: "Update Syft to ${{ steps.latest-version.outputs.LATEST_VERSION }}"
+          body: |
+            Update Syft to ${{ steps.latest-version.outputs.LATEST_VERSION }}
+          token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
This PR adds a workflow that will automatically create a PR to update Syft if the released version of Syft is higher than what is specified in Grype. This will allow us to:
* More easily bump the Syft version if that's the only thing needed for a Grype release
* More quickly identify things that need to be fixed if upgrading the Syft release causes build or tests to fail

NOTE: this may have some added noise in the case we commit `syft@some-hash` instead of a release tag.

Unfortunately, we can't even test this until it gets merged into `main`...