### PR TITLE
reduce log level for warning so not in default output for upstream matcher

### DIFF
--- a/grype/matcher/java/matcher.go
+++ b/grype/matcher/java/matcher.go
@@ -129,7 +129,7 @@ func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Pa
 	if m.SearchMavenUpstream {
 		upstreamMatches, err := m.matchUpstreamMavenPackages(store, p)
 		if err != nil {
-			log.Warnf("failed to match against upstream data for %s: %v", p.Name, err)
+			log.Debugf("failed to match against upstream data for %s: %v", p.Name, err)
 		} else {
 			matches = append(matches, upstreamMatches...)
 		}


### PR DESCRIPTION
The warning was too noisy for the default output. Reduce to `Debug` so users can view via `-vv`

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>