### PR TITLE
Add matches helper

### DIFF
--- a/grype/match/matches.go
+++ b/grype/match/matches.go
@@ -33,6 +33,17 @@ func (r *Matches) GetByPkgID(id pkg.ID) (matches []Match) {
 	return matches
 }
 
+// AllByPkgID returns a map of all matches organized by package ID
+func (r *Matches) AllByPkgID() map[pkg.ID][]Match {
+	matches := make(map[pkg.ID][]Match)
+	for id, fingerprints := range r.byPackage {
+		for _, fingerprint := range fingerprints {
+			matches[id] = append(matches[id], r.byFingerprint[fingerprint])
+		}
+	}
+	return matches
+}
+
 func (r *Matches) Merge(other Matches) {
 	for _, fingerprints := range other.byPackage {
 		for _, fingerprint := range fingerprints {

--- a/grype/match/matches_test.go
+++ b/grype/match/matches_test.go
@@ -112,6 +112,48 @@ func TestMatchesSortByVulnerability(t *testing.T) {
 
 }
 
+func TestMatches_AllByPkgID(t *testing.T) {
+	first := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2020-0010",
+		},
+		Package: pkg.Package{
+			ID:      pkg.ID(uuid.NewString()),
+			Name:    "package-b",
+			Version: "1.0.0",
+			Type:    syftPkg.RpmPkg,
+		},
+	}
+	second := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2020-0010",
+		},
+		Package: pkg.Package{
+			ID:      pkg.ID(uuid.NewString()),
+			Name:    "package-c",
+			Version: "1.0.0",
+			Type:    syftPkg.RpmPkg,
+		},
+	}
+
+	input := []Match{
+		second, first,
+	}
+	matches := NewMatches(input...)
+
+	expected := map[pkg.ID][]Match{
+		first.Package.ID: {
+			first,
+		},
+		second.Package.ID: {
+			second,
+		},
+	}
+
+	assert.Equal(t, expected, matches.AllByPkgID())
+
+}
+
 func TestMatchesSortByPackage(t *testing.T) {
 	first := Match{
 		Vulnerability: vulnerability.Vulnerability{


### PR DESCRIPTION
A helper for consumers that is looking to see a set of vulnerabilities for each package in a collection of matches.