### PR TITLE
Add reference to logrus logging levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,7 @@ log:
 
   # the log level; note: detailed logging suppress the ETUI
   # same as GRYPE_LOG_LEVEL env var
+  # Uses logrus logging levels: https://github.com/sirupsen/logrus#level-logging
   level: "error"
 
   # location to write the log file (default is not to have a log file)


### PR DESCRIPTION
Hi all,

Was looking through the docs and I couldn't understand the possible values for logging levels.

I looked through the code and saw that you're using logrus.

So, this PR is to update the README docs to add a reference to those levels for those who may be unsure whether the tool uses standard levels or not. 

(happy to adjust this to just list the levels if that's prefered.)