### PR TITLE
update go-tuf dep to fix GHSA-66x3-6cw3-v5gj

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -216,7 +216,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613 // indirect
 	github.com/thales-e-security/pool v0.0.2 // indirect
-	github.com/theupdateframework/go-tuf v0.0.0-20220211205608-f0c3294f63b9 // indirect
+	github.com/theupdateframework/go-tuf v0.3.0 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1924,8 +1924,8 @@ github.com/tetafro/godot v1.4.11/go.mod h1:LR3CJpxDVGlYOWn3ZZg1PgNZdTUvzsZWu8xaE
 github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gtvVDbmPg=
 github.com/thales-e-security/pool v0.0.2/go.mod h1:qtpMm2+thHtqhLzTwgDBj/OuNnMpupY8mv0Phz0gjhU=
 github.com/theupdateframework/go-tuf v0.0.0-20211203210025-7ded50136bf9/go.mod h1:n2n6wwC9BEnYS/C/APAtNln0eM5zYAYOkOTx6VEG/mA=
-github.com/theupdateframework/go-tuf v0.0.0-20220211205608-f0c3294f63b9 h1:U8bHY5mmNuZHc3+e7l2/LAmfTk7oiMiB3Qn8fsp4z5g=
-github.com/theupdateframework/go-tuf v0.0.0-20220211205608-f0c3294f63b9/go.mod h1:ENa0O55YQfI0U/nn4AAuqPydrbkqQCiq9GDw6YLCyXU=
+github.com/theupdateframework/go-tuf v0.3.0 h1:od2sc5+BSkKZhmUG2o2rmruy0BGSmhrbDhCnpxh87X8=
+github.com/theupdateframework/go-tuf v0.3.0/go.mod h1:E5XP0wXitrFUHe4b8cUcAAdxBW4LbfnqF4WXXGLgWNo=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=


### PR DESCRIPTION
scanning grype with grype reports:
```
NAME                                  INSTALLED                           FIXED-IN  TYPE       VULNERABILITY        SEVERITY
github.com/theupdateframework/go-tuf  v0.0.0-20220211205608-f0c3294f63b9  0.3.0     go-module  GHSA-66x3-6cw3-v5gj  High
```

That comes from sigstore:
```
$ go mod why github.com/theupdateframework/go-tuf                                                                                                                 grype 1ms
github.com/anchore/grype/grype/pkg
github.com/sigstore/cosign/pkg/signature
github.com/sigstore/cosign/pkg/cosign
github.com/sigstore/cosign/pkg/cosign/tuf
github.com/theupdateframework/go-tuf
```

`go get github.com/theupdateframework/go-tuf` brought in `0.3.0`. 
Now, grype fails with:
```
go run .
../../.gvm/pkgsets/go1.18.1/global/pkg/mod/github.com/sigstore/cosign@v1.8.0/pkg/cosign/tuf/client.go:429:27: undefined: client.IsLatestSnapshot
```

Signed-off-by: Jonas Xavier <jonasx@anchore.com>