### PR TITLE
Support namespace and language as additional criteria for ignoring vulnerability matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,10 +287,12 @@ If you're seeing Grype report **false positives** or any other vulnerability mat
 Each rule can specify any combination of the following criteria:
 
 - vulnerability ID (e.g. `"CVE-2008-4318"`)
+- namespace (e.g. `"nvd"`)
 - fix state (allowed values: `"fixed"`, `"not-fixed"`, `"wont-fix"`, or `"unknown"`)
 - package name (e.g. `"libcurl"`)
 - package version (e.g. `"1.5.1"`)
-- package type (e.g. `"npm"`; these values are defined [here](https://github.com/anchore/syft/blob/main/syft/pkg/type.go#L10-L21))
+- package language (e.g. `"python"`; these values are defined [here](https://github.com/anchore/syft/blob/main/syft/pkg/language.go#L14-L23))
+- package type (e.g. `"npm"`; these values are defined [here](https://github.com/anchore/syft/blob/main/syft/pkg/type.go#L10-L24))
 - package location (e.g. `"/usr/local/lib/node_modules/**"`; supports glob patterns)
 
 Here's an example `~/.grype.yaml` that demonstrates the expected format for ignore rules:

--- a/grype/match/ignore.go
+++ b/grype/match/ignore.go
@@ -27,6 +27,7 @@ type IgnoreRule struct {
 type IgnoreRulePackage struct {
 	Name     string `yaml:"name" json:"name" mapstructure:"name"`
 	Version  string `yaml:"version" json:"version" mapstructure:"version"`
+	Language string `yaml:"language" json:"language" mapstructure:"language"`
 	Type     string `yaml:"type" json:"type" mapstructure:"type"`
 	Location string `yaml:"location" json:"location" mapstructure:"location"`
 }
@@ -106,6 +107,10 @@ func getIgnoreConditionsForRule(rule IgnoreRule) []ignoreCondition {
 		ignoreConditions = append(ignoreConditions, ifPackageVersionApplies(v))
 	}
 
+	if l := rule.Package.Language; l != "" {
+		ignoreConditions = append(ignoreConditions, ifPackageLanguageApplies(l))
+	}
+
 	if t := rule.Package.Type; t != "" {
 		ignoreConditions = append(ignoreConditions, ifPackageTypeApplies(t))
 	}
@@ -148,6 +153,12 @@ func ifPackageNameApplies(name string) ignoreCondition {
 func ifPackageVersionApplies(version string) ignoreCondition {
 	return func(match Match) bool {
 		return version == match.Package.Version
+	}
+}
+
+func ifPackageLanguageApplies(language string) ignoreCondition {
+	return func(match Match) bool {
+		return language == string(match.Package.Language)
 	}
 }
 

--- a/grype/match/ignore.go
+++ b/grype/match/ignore.go
@@ -18,6 +18,7 @@ type IgnoredMatch struct {
 // rule to apply.
 type IgnoreRule struct {
 	Vulnerability string            `yaml:"vulnerability" json:"vulnerability" mapstructure:"vulnerability"`
+	Namespace     string            `yaml:"namespace" json:"namespace" mapstructure:"namespace"`
 	FixState      string            `yaml:"fix-state" json:"fix-state" mapstructure:"fix-state"`
 	Package       IgnoreRulePackage `yaml:"package" json:"package" mapstructure:"package"`
 }
@@ -93,6 +94,10 @@ func getIgnoreConditionsForRule(rule IgnoreRule) []ignoreCondition {
 		ignoreConditions = append(ignoreConditions, ifVulnerabilityApplies(v))
 	}
 
+	if ns := rule.Namespace; ns != "" {
+		ignoreConditions = append(ignoreConditions, ifNamespaceApplies(ns))
+	}
+
 	if n := rule.Package.Name; n != "" {
 		ignoreConditions = append(ignoreConditions, ifPackageNameApplies(n))
 	}
@@ -125,6 +130,12 @@ func ifFixStateApplies(fs string) ignoreCondition {
 func ifVulnerabilityApplies(vulnerability string) ignoreCondition {
 	return func(match Match) bool {
 		return vulnerability == match.Vulnerability.ID
+	}
+}
+
+func ifNamespaceApplies(namespace string) ignoreCondition {
+	return func(match Match) bool {
+		return namespace == match.Vulnerability.Namespace
 	}
 }
 

--- a/grype/match/ignore_test.go
+++ b/grype/match/ignore_test.go
@@ -1,7 +1,6 @@
 package match
 
 import (
-	syftPkg "github.com/anchore/syft/syft/pkg"
 	"testing"
 
 	"github.com/google/uuid"
@@ -10,6 +9,7 @@ import (
 	grypeDb "github.com/anchore/grype/grype/db/v3"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
+	syftPkg "github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/source"
 )
 

--- a/grype/match/ignore_test.go
+++ b/grype/match/ignore_test.go
@@ -1,6 +1,7 @@
 package match
 
 import (
+	syftPkg "github.com/anchore/syft/syft/pkg"
 	"testing"
 
 	"github.com/google/uuid"
@@ -16,7 +17,8 @@ var (
 	allMatches = []Match{
 		{
 			Vulnerability: vulnerability.Vulnerability{
-				ID: "CVE-123",
+				ID:        "CVE-123",
+				Namespace: "debian-vulns",
 				Fix: vulnerability.Fix{
 					State: grypeDb.FixedState,
 				},
@@ -31,48 +33,54 @@ var (
 		},
 		{
 			Vulnerability: vulnerability.Vulnerability{
-				ID: "CVE-456",
+				ID:        "CVE-456",
+				Namespace: "ruby-vulns",
 				Fix: vulnerability.Fix{
 					State: grypeDb.NotFixedState,
 				},
 			},
 			Package: pkg.Package{
-				ID:      pkg.ID(uuid.NewString()),
-				Name:    "reach",
-				Version: "100.0.50",
-				Type:    "gem",
+				ID:       pkg.ID(uuid.NewString()),
+				Name:     "reach",
+				Version:  "100.0.50",
+				Language: syftPkg.Ruby,
+				Type:     syftPkg.GemPkg,
 				Locations: source.NewLocationSet(source.NewVirtualLocation("/real/path/with/reach",
 					"/virtual/path/that/has/reach")),
 			},
 		},
 		{
 			Vulnerability: vulnerability.Vulnerability{
-				ID: "CVE-457",
+				ID:        "CVE-457",
+				Namespace: "ruby-vulns",
 				Fix: vulnerability.Fix{
 					State: grypeDb.WontFixState,
 				},
 			},
 			Package: pkg.Package{
-				ID:      pkg.ID(uuid.NewString()),
-				Name:    "beach",
-				Version: "100.0.51",
-				Type:    "gem",
+				ID:       pkg.ID(uuid.NewString()),
+				Name:     "beach",
+				Version:  "100.0.51",
+				Language: syftPkg.Ruby,
+				Type:     syftPkg.GemPkg,
 				Locations: source.NewLocationSet(source.NewVirtualLocation("/real/path/with/beach",
 					"/virtual/path/that/has/beach")),
 			},
 		},
 		{
 			Vulnerability: vulnerability.Vulnerability{
-				ID: "CVE-458",
+				ID:        "CVE-458",
+				Namespace: "ruby-vulns",
 				Fix: vulnerability.Fix{
 					State: grypeDb.UnknownFixState,
 				},
 			},
 			Package: pkg.Package{
-				ID:      pkg.ID(uuid.NewString()),
-				Name:    "speach",
-				Version: "100.0.52",
-				Type:    "gem",
+				ID:       pkg.ID(uuid.NewString()),
+				Name:     "speach",
+				Version:  "100.0.52",
+				Language: syftPkg.Ruby,
+				Type:     syftPkg.GemPkg,
 				Locations: source.NewLocationSet(source.NewVirtualLocation("/real/path/with/speach",
 					"/virtual/path/that/has/speach")),
 			},
@@ -214,6 +222,88 @@ func TestApplyIgnoreRules(t *testing.T) {
 					AppliedIgnoreRules: []IgnoreRule{
 						{
 							FixState: "unknown",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "ignore matches on namespace",
+			allMatches: allMatches,
+			ignoreRules: []IgnoreRule{
+				{Namespace: "ruby-vulns"},
+			},
+			expectedRemainingMatches: []Match{
+				allMatches[0],
+			},
+			expectedIgnoredMatches: []IgnoredMatch{
+				{
+					Match: allMatches[1],
+					AppliedIgnoreRules: []IgnoreRule{
+						{
+							Namespace: "ruby-vulns",
+						},
+					},
+				},
+				{
+					Match: allMatches[2],
+					AppliedIgnoreRules: []IgnoreRule{
+						{
+							Namespace: "ruby-vulns",
+						},
+					},
+				},
+				{
+					Match: allMatches[3],
+					AppliedIgnoreRules: []IgnoreRule{
+						{
+							Namespace: "ruby-vulns",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "ignore matches on language",
+			allMatches: allMatches,
+			ignoreRules: []IgnoreRule{
+				{
+					Package: IgnoreRulePackage{
+						Language: string(syftPkg.Ruby),
+					},
+				},
+			},
+			expectedRemainingMatches: []Match{
+				allMatches[0],
+			},
+			expectedIgnoredMatches: []IgnoredMatch{
+				{
+					Match: allMatches[1],
+					AppliedIgnoreRules: []IgnoreRule{
+						{
+							Package: IgnoreRulePackage{
+								Language: string(syftPkg.Ruby),
+							},
+						},
+					},
+				},
+				{
+					Match: allMatches[2],
+					AppliedIgnoreRules: []IgnoreRule{
+						{
+							Package: IgnoreRulePackage{
+								Language: string(syftPkg.Ruby),
+							},
+						},
+					},
+				},
+				{
+					Match: allMatches[3],
+					AppliedIgnoreRules: []IgnoreRule{
+						{
+							Package: IgnoreRulePackage{
+								Language: string(syftPkg.Ruby),
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Adds support for ignoring vulnerability matches based off of the vulnerability namespace as well as the package language