### PR TITLE
add db staleness check

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ You can set the cache directory path using the environment variable `GRYPE_DB_CA
 
 #### Data staleness
 
-Grype needs up-to-date vulnerability information to provide good matches. By default, it will fail execution if the local database was not updated in the last 5 days. The data staleness check is configurable via the field `staleness-threshold`, under `db`. It uses golang's time duration syntax. Set it to 0 to disable staleness check.
+Grype needs up-to-date vulnerability information to provide accurate matches. By default, it will fail execution if the local database was not built in the last 5 days. The data staleness check is configurable via the field `max-allowed-db-age`, under `db`. It uses [golang's time duration syntax](https://pkg.go.dev/time#ParseDuration). Set it to 0 to disable staleness check.
 
 #### Offline and air-gapped environments
 
@@ -588,11 +588,11 @@ db:
   # same as GRYPE_DB_UPDATE_URL env var
   update-url: "https://toolbox-data.anchore.io/grype/databases/listing.json"
 
-  # if this period has passed since the
-  # last db update and `now` then db data is stale.
-  # Default threshold of 120h (or five days)
-  # Set it to 0 (zero) to disable staleness check
-  staleness-threshold: "120h"
+  # Max allowed age for vulnerability database,
+  # age being the time since it was built
+  # Default max age is 120h (or five days)
+  # Set it to 0 (zero) to disable check
+  max-allowed-db-age: "120h"
 
 search:
 

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ You can set the cache directory path using the environment variable `GRYPE_DB_CA
 
 #### Data staleness
 
-Grype needs up-to-date vulnerability information to provide accurate matches. By default, it will fail execution if the local database was not built in the last 5 days. The data staleness check is configurable via the field `max-allowed-db-age`, under `db`. It uses [golang's time duration syntax](https://pkg.go.dev/time#ParseDuration). Set it to 0 to disable staleness check.
+Grype needs up-to-date vulnerability information to provide accurate matches. By default, it will fail execution if the local database was not built in the last 5 days. The data staleness check is configurable via the field `max-allowed-built-age`, under `db`. It uses [golang's time duration syntax](https://pkg.go.dev/time#ParseDuration). Set it to 0 to disable staleness check.
 
 #### Offline and air-gapped environments
 
@@ -592,7 +592,7 @@ db:
   # age being the time since it was built
   # Default max age is 120h (or five days)
   # Set it to 0 (zero) to disable check
-  max-allowed-db-age: "120h"
+  max-allowed-built-age: "120h"
 
 search:
 

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ You can set the cache directory path using the environment variable `GRYPE_DB_CA
 
 #### Data staleness
 
-Grype needs up-to-date vulnerability information to provide accurate matches. By default, it will fail execution if the local database was not built in the last 5 days. The data staleness check is configurable via the field `max-allowed-built-age`, under `db`. It uses [golang's time duration syntax](https://pkg.go.dev/time#ParseDuration). Set it to 0 to disable staleness check.
+Grype needs up-to-date vulnerability information to provide accurate matches. By default, it will fail execution if the local database was not built in the last 5 days. The data staleness check is configurable via the field `max-allowed-built-age` and `validate-age`, under `db`. It uses [golang's time duration syntax](https://pkg.go.dev/time#ParseDuration). Set `validate-age` to `false` to disable staleness check.
 
 #### Offline and air-gapped environments
 
@@ -588,10 +588,13 @@ db:
   # same as GRYPE_DB_UPDATE_URL env var
   update-url: "https://toolbox-data.anchore.io/grype/databases/listing.json"
 
+  # it ensures db build is no older than the max-allowed-built-age
+  # set to false to disable check
+  validate-age: true
+
   # Max allowed age for vulnerability database,
   # age being the time since it was built
   # Default max age is 120h (or five days)
-  # Set it to 0 (zero) to disable check
   max-allowed-built-age: "120h"
 
 search:

--- a/README.md
+++ b/README.md
@@ -399,6 +399,10 @@ By default, the database is cached on the local filesystem in the directory `$XD
 
 You can set the cache directory path using the environment variable `GRYPE_DB_CACHE_DIR`.
 
+#### Data staleness
+
+Grype needs up-to-date vulnerability information to provide good matches. By default, it will fail execution if the local database was not updated in the last 5 days. The data staleness check is configurable via the field `staleness-threshold`, under `db`. It uses golang's time duration syntax. Set it to 0 to disable staleness check.
+
 #### Offline and air-gapped environments
 
 By default, Grype checks for a new database on every run, by making a network call over the Internet. You can tell Grype not to perform this check by setting the environment variable `GRYPE_DB_AUTO_UPDATE` to `false`.
@@ -584,6 +588,11 @@ db:
   # same as GRYPE_DB_UPDATE_URL env var
   update-url: "https://toolbox-data.anchore.io/grype/databases/listing.json"
 
+  # if this period has passed since the
+  # last db update and `now` then db data is stale.
+  # Default threshold of 120h (or five days)
+  # Set it to 0 (zero) to disable staleness check
+  staleness-threshold: "120h"
 
 search:
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -270,7 +270,7 @@ func startWorker(userInput string, failOnSeverity *vulnerability.Severity) <-cha
 				log.Errorf(err.Error())
 			}
 			if isAvailable {
-				log.Infof("New version of %s is available: %s", internal.ApplicationName, newVersion)
+				log.Infof("You're currently running %s version %s and a new version is available: %s", internal.ApplicationName, version.FromBuild().Version, newVersion)
 
 				bus.Publish(partybus.Event{
 					Type:  event.AppUpdateAvailable,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -270,7 +270,7 @@ func startWorker(userInput string, failOnSeverity *vulnerability.Severity) <-cha
 				log.Errorf(err.Error())
 			}
 			if isAvailable {
-				log.Infof("new version of %s is available: %s (current version is %s)", internal.ApplicationName, newVersion, version.FromBuild().Version)
+				log.Infof("new version of %s is available: %s (currently running: %s)", internal.ApplicationName, newVersion, version.FromBuild().Version)
 
 				bus.Publish(partybus.Event{
 					Type:  event.AppUpdateAvailable,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -270,7 +270,7 @@ func startWorker(userInput string, failOnSeverity *vulnerability.Severity) <-cha
 				log.Errorf(err.Error())
 			}
 			if isAvailable {
-				log.Infof("You're currently running %s version %s and a new version is available: %s", internal.ApplicationName, version.FromBuild().Version, newVersion)
+				log.Infof("New version of % available: %s. Currently running: %s", internal.ApplicationName, newVersion, version.FromBuild().Version)
 
 				bus.Publish(partybus.Event{
 					Type:  event.AppUpdateAvailable,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -270,7 +270,7 @@ func startWorker(userInput string, failOnSeverity *vulnerability.Severity) <-cha
 				log.Errorf(err.Error())
 			}
 			if isAvailable {
-				log.Infof("new version of %s available: %s (current version is %s)", internal.ApplicationName, newVersion, version.FromBuild().Version)
+				log.Infof("new version of %s is available: %s (current version is %s)", internal.ApplicationName, newVersion, version.FromBuild().Version)
 
 				bus.Publish(partybus.Event{
 					Type:  event.AppUpdateAvailable,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -270,7 +270,7 @@ func startWorker(userInput string, failOnSeverity *vulnerability.Severity) <-cha
 				log.Errorf(err.Error())
 			}
 			if isAvailable {
-				log.Infof("New version of % available: %s. Currently running: %s", internal.ApplicationName, newVersion, version.FromBuild().Version)
+				log.Infof("new version of %s available: %s (current version is %s)", internal.ApplicationName, newVersion, version.FromBuild().Version)
 
 				bus.Publish(partybus.Event{
 					Type:  event.AppUpdateAvailable,

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 
 require (
 	github.com/anchore/sqlite v1.4.6-0.20220607210448-bcc6ee5c4963
+	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/in-toto/in-toto-golang v0.3.4-0.20211211042327-af1f9fb822bf
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0
 	github.com/sigstore/cosign v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1139,6 +1139,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.12.1/go.mod h1:8XEsbTttt/W+VvjtQhLACqC
 github.com/grpc-ecosystem/grpc-gateway v1.14.6/go.mod h1:zdiPV4Yse/1gnckTHtghG4GkDEdKCRJduHpTxT3/jcw=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b h1:wDUNC2eKiL35DbLvsDhiblTUXHxcOPwQSCzi7xpQUN4=
+github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b/go.mod h1:VzxiSdG6j1pi7rwGm/xYI5RbtpBgM8sARDXlvEvxlu0=
 github.com/hanwen/go-fuse v1.0.0/go.mod h1:unqXarDXqzAk0rt98O2tVndEPIpUgLD9+rwFisZH3Ok=
 github.com/hanwen/go-fuse/v2 v2.1.0/go.mod h1:oRyA5eK+pvJyv5otpO/DgccS8y/RvYMaO00GgRLGryc=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=

--- a/grype/db/curator.go
+++ b/grype/db/curator.go
@@ -41,7 +41,7 @@ type Config struct {
 	ListingURL          string
 	CACert              string
 	ValidateByHashOnGet bool
-	DataStaleness       time.Duration
+	StalenessThreshold  time.Duration
 }
 
 type Curator struct {
@@ -72,7 +72,7 @@ func NewCurator(cfg Config) (Curator, error) {
 		dbPath:              path.Join(dbDir, FileName),
 		listingURL:          cfg.ListingURL,
 		validateByHashOnGet: cfg.ValidateByHashOnGet,
-		dataStalenessLimit:  cfg.DataStaleness,
+		dataStalenessLimit:  cfg.StalenessThreshold,
 	}, nil
 }
 

--- a/grype/db/curator.go
+++ b/grype/db/curator.go
@@ -290,7 +290,7 @@ func (c *Curator) validateStaleness(m *Metadata) error {
 	}
 
 	if age > DefaultStalenessThreshold {
-		log.Warnf("your vuln db was updated %s ago and it might generate wrong results. Update it with: grype db update", age)
+		log.Warnf("your vuln db was updated %s ago and it might generate wrong results. To update run: grype db update", age)
 	}
 
 	return nil

--- a/grype/db/curator.go
+++ b/grype/db/curator.go
@@ -30,13 +30,6 @@ const (
 	FileName = grypeDB.VulnerabilityStoreFileName
 )
 
-var (
-	// DefaultMaxAllowedBuiltAge defines the default max age for
-	// the vulnerability db build. After this period the db data
-	// is considered stale.
-	DefaultMaxAllowedBuiltAge = time.Hour * 24 * 5
-)
-
 type Config struct {
 	DBRootDir           string
 	ListingURL          string

--- a/grype/db/curator.go
+++ b/grype/db/curator.go
@@ -288,8 +288,7 @@ func (c *Curator) validateStaleness(m *Metadata) error {
 
 	limit := time.Now().Add(-c.dataStalenessLimit)
 	if m.Built.Before(limit) {
-		age := time.Now().Sub(m.Built)
-		return fmt.Errorf("%w: last updated %s ago (> threshold %s)", ErrDataIsStale, age, c.dataStalenessLimit)
+		return fmt.Errorf("%w: last updated %s ago (> threshold %s)", ErrDataIsStale, time.Since(m.Built), c.dataStalenessLimit)
 	}
 
 	return nil

--- a/grype/db/curator.go
+++ b/grype/db/curator.go
@@ -292,7 +292,7 @@ func (c *Curator) validateStaleness(m Metadata) error {
 	}
 
 	// built time is defined in UTC,
-	// we should campare it against UTC
+	// we should compare it against UTC
 	now := time.Now().UTC()
 
 	age := now.Sub(m.Built)

--- a/grype/db/curator.go
+++ b/grype/db/curator.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hako/durafmt"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/mholt/archiver/v3"
 	"github.com/spf13/afero"
@@ -294,12 +295,9 @@ func (c *Curator) validateStaleness(m Metadata) error {
 	// we should campare it against UTC
 	now := time.Now().UTC()
 
-	// duration comparison may have unnecessary precision,
-	// including fractions of minutes/seconds. Rounding it
-	// to hours provides enough information.
-	age := now.Sub(m.Built).Round(time.Hour)
+	age := now.Sub(m.Built)
 	if age > c.maxAllowedBuiltAge {
-		return fmt.Errorf("the vulnerability database was built %s ago (> max allowed %s)", age, c.maxAllowedBuiltAge)
+		return fmt.Errorf("the vulnerability database was built %s ago (> max allowed %s)", durafmt.ParseShort(age), durafmt.ParseShort(c.maxAllowedBuiltAge))
 	}
 
 	return nil

--- a/grype/db/curator_test.go
+++ b/grype/db/curator_test.go
@@ -310,6 +310,7 @@ func TestCurator_validateStaleness(t *testing.T) {
 		md              Metadata
 	}
 
+	now := time.Now().UTC()
 	tests := []struct {
 		name    string
 		cur     *Curator
@@ -319,7 +320,7 @@ func TestCurator_validateStaleness(t *testing.T) {
 		{
 			name: "no-validation",
 			fields: fields{
-				md: Metadata{Built: time.Now()},
+				md: Metadata{Built: now},
 			},
 			wantErr: assert.NoError,
 		},
@@ -328,7 +329,7 @@ func TestCurator_validateStaleness(t *testing.T) {
 			fields: fields{
 				maxAllowedDBAge: 2 * time.Hour,
 				validateAge:     true,
-				md:              Metadata{Built: time.Now()},
+				md:              Metadata{Built: now},
 			},
 			wantErr: assert.NoError,
 		},
@@ -337,7 +338,7 @@ func TestCurator_validateStaleness(t *testing.T) {
 			fields: fields{
 				maxAllowedDBAge: time.Hour,
 				validateAge:     true,
-				md:              Metadata{Built: time.Now().UTC().Add(-4 * time.Hour)},
+				md:              Metadata{Built: now.UTC().Add(-4 * time.Hour)},
 			},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				return assert.ErrorContains(t, err, "the vulnerability database was built")
@@ -348,7 +349,7 @@ func TestCurator_validateStaleness(t *testing.T) {
 			fields: fields{
 				maxAllowedDBAge: time.Hour,
 				validateAge:     false,
-				md:              Metadata{Built: time.Now().UTC().Add(-4 * time.Hour)},
+				md:              Metadata{Built: now.Add(-4 * time.Hour)},
 			},
 			wantErr: assert.NoError,
 		},

--- a/grype/db/curator_test.go
+++ b/grype/db/curator_test.go
@@ -282,7 +282,7 @@ func TestCuratorValidate(t *testing.T) {
 
 			cur.targetSchema = test.constraint
 
-			md, err := cur.validate(test.fixture)
+			md, err := cur.validateIntegrity(test.fixture)
 
 			if err == nil && test.err {
 				t.Errorf("expected an error but got none")

--- a/grype/db/curator_test.go
+++ b/grype/db/curator_test.go
@@ -336,7 +336,7 @@ func TestCurator_validateStaleness(t *testing.T) {
 				md:              &Metadata{Built: time.Now().Add(-4 * time.Hour)},
 			},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(t, err, "the vulnerability database was last built")
+				return assert.ErrorContains(t, err, "the vulnerability database was built")
 			},
 		},
 	}

--- a/grype/db/curator_test.go
+++ b/grype/db/curator_test.go
@@ -335,7 +335,7 @@ func TestCurator_validateStaleness(t *testing.T) {
 		{
 			name: "up-to-date",
 			fields: fields{
-				staleLimist: time.Hour,
+				staleLimist: 2 * time.Hour,
 				md:          &Metadata{Built: time.Now()},
 			},
 			wantErr: assert.NoError,
@@ -344,7 +344,7 @@ func TestCurator_validateStaleness(t *testing.T) {
 			name: "stale-data",
 			fields: fields{
 				staleLimist: time.Hour,
-				md:          &Metadata{Built: time.Now().Add(-3 * time.Hour)},
+				md:          &Metadata{Built: time.Now().Add(-4 * time.Hour)},
 			},
 			wantErr: assertAs("data is stale"),
 		},

--- a/grype/db/curator_test.go
+++ b/grype/db/curator_test.go
@@ -309,11 +309,9 @@ func assertAs(expected string) assert.ErrorAssertionFunc {
 }
 
 func TestCurator_validateStaleness(t *testing.T) {
-
 	type fields struct {
-		validateStalenss bool
-		staleLimist      time.Duration
-		md               *Metadata
+		staleLimist time.Duration
+		md          *Metadata
 	}
 
 	tests := []struct {
@@ -337,27 +335,24 @@ func TestCurator_validateStaleness(t *testing.T) {
 		{
 			name: "up-to-date",
 			fields: fields{
-				validateStalenss: true,
-				staleLimist:      time.Hour,
-				md:               &Metadata{Built: time.Now()},
+				staleLimist: time.Hour,
+				md:          &Metadata{Built: time.Now()},
 			},
 			wantErr: assert.NoError,
 		},
 		{
 			name: "stale-data",
 			fields: fields{
-				validateStalenss: true,
-				staleLimist:      time.Hour,
-				md:               &Metadata{Built: time.Now().Add(-3 * time.Hour)},
+				staleLimist: time.Hour,
+				md:          &Metadata{Built: time.Now().Add(-3 * time.Hour)},
 			},
 			wantErr: assertAs("data is stale"),
 		},
 		{
 			name: "db-without-built-time",
 			fields: fields{
-				validateStalenss: true,
-				staleLimist:      time.Hour,
-				md:               &Metadata{},
+				staleLimist: time.Hour,
+				md:          &Metadata{},
 			},
 			wantErr: assertAs("database built timestamp is empty: cannot verify if data is stale"),
 		},
@@ -365,8 +360,7 @@ func TestCurator_validateStaleness(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Curator{
-				validateDataStaleness: tt.fields.validateStalenss,
-				dataStalenessLimit:    tt.fields.staleLimist,
+				dataStalenessLimit: tt.fields.staleLimist,
 			}
 			tt.wantErr(t, c.validateStaleness(tt.fields.md), fmt.Sprintf("validateStaleness(%v)", tt.fields.md))
 		})

--- a/grype/db/curator_test.go
+++ b/grype/db/curator_test.go
@@ -348,14 +348,6 @@ func TestCurator_validateStaleness(t *testing.T) {
 			},
 			wantErr: assertAs("data is stale"),
 		},
-		{
-			name: "db-without-built-time",
-			fields: fields{
-				staleLimist: time.Hour,
-				md:          &Metadata{},
-			},
-			wantErr: assertAs("database built timestamp is empty: cannot verify if data is stale"),
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/config/database.go
+++ b/internal/config/database.go
@@ -17,7 +17,7 @@ type database struct {
 	CACert                string        `yaml:"ca-cert" json:"ca-cert" mapstructure:"ca-cert"`
 	AutoUpdate            bool          `yaml:"auto-update" json:"auto-update" mapstructure:"auto-update"`
 	ValidateByHashOnStart bool          `yaml:"validate-by-hash-on-start" json:"validate-by-hash-on-start" mapstructure:"validate-by-hash-on-start"`
-	StalenessThreshold    time.Duration `yaml:"staleness-threshold" json:"staleness-threshold" mapstructure:"staleness-threshold"`
+	MaxAllowedDBAge       time.Duration `yaml:"max-allowed-db-age" json:"max-allowed-db-age" mapstructure:"max-allowed-db-age"`
 }
 
 func (cfg database) loadDefaultValues(v *viper.Viper) {
@@ -26,7 +26,7 @@ func (cfg database) loadDefaultValues(v *viper.Viper) {
 	v.SetDefault("db.ca-cert", "")
 	v.SetDefault("db.auto-update", true)
 	v.SetDefault("db.validate-by-hash-on-start", false)
-	v.SetDefault("db.staleness-threshold", db.DefaultStalenessThreshold)
+	v.SetDefault("db.max-allowed-db-age", db.DefaultMaxAllowedDBAge)
 }
 
 func (cfg database) ToCuratorConfig() db.Config {
@@ -35,6 +35,6 @@ func (cfg database) ToCuratorConfig() db.Config {
 		ListingURL:          cfg.UpdateURL,
 		CACert:              cfg.CACert,
 		ValidateByHashOnGet: cfg.ValidateByHashOnStart,
-		StalenessThreshold:  cfg.StalenessThreshold,
+		MaxAllowedDBAge:     cfg.MaxAllowedDBAge,
 	}
 }

--- a/internal/config/database.go
+++ b/internal/config/database.go
@@ -26,7 +26,7 @@ func (cfg database) loadDefaultValues(v *viper.Viper) {
 	v.SetDefault("db.ca-cert", "")
 	v.SetDefault("db.auto-update", true)
 	v.SetDefault("db.validate-by-hash-on-start", false)
-	v.SetDefault("db.staleness-threshold", time.Hour*24*5)
+	v.SetDefault("db.staleness-threshold", db.DefaultStalenessThreshold)
 }
 
 func (cfg database) ToCuratorConfig() db.Config {

--- a/internal/config/database.go
+++ b/internal/config/database.go
@@ -28,7 +28,8 @@ func (cfg database) loadDefaultValues(v *viper.Viper) {
 	v.SetDefault("db.auto-update", true)
 	v.SetDefault("db.validate-by-hash-on-start", false)
 	v.SetDefault("db.validate-age", true)
-	v.SetDefault("db.max-allowed-built-age", db.DefaultMaxAllowedBuiltAge)
+	// After this period (5 days) the db data is considered stale
+	v.SetDefault("db.max-allowed-built-age", time.Hour*24*5)
 }
 
 func (cfg database) ToCuratorConfig() db.Config {

--- a/internal/config/database.go
+++ b/internal/config/database.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"path"
+	"time"
 
 	"github.com/adrg/xdg"
 	"github.com/spf13/viper"
@@ -11,11 +12,12 @@ import (
 )
 
 type database struct {
-	Dir                   string `yaml:"cache-dir" json:"cache-dir" mapstructure:"cache-dir"`
-	UpdateURL             string `yaml:"update-url" json:"update-url" mapstructure:"update-url"`
-	CACert                string `yaml:"ca-cert" json:"ca-cert" mapstructure:"ca-cert"`
-	AutoUpdate            bool   `yaml:"auto-update" json:"auto-update" mapstructure:"auto-update"`
-	ValidateByHashOnStart bool   `yaml:"validate-by-hash-on-start" json:"validate-by-hash-on-start" mapstructure:"validate-by-hash-on-start"`
+	Dir                   string        `yaml:"cache-dir" json:"cache-dir" mapstructure:"cache-dir"`
+	UpdateURL             string        `yaml:"update-url" json:"update-url" mapstructure:"update-url"`
+	CACert                string        `yaml:"ca-cert" json:"ca-cert" mapstructure:"ca-cert"`
+	AutoUpdate            bool          `yaml:"auto-update" json:"auto-update" mapstructure:"auto-update"`
+	ValidateByHashOnStart bool          `yaml:"validate-by-hash-on-start" json:"validate-by-hash-on-start" mapstructure:"validate-by-hash-on-start"`
+	StalenessThreshold    time.Duration `yaml:"staleness-threshold" json:"staleness-threshold" mapstructure:"staleness-threshold"`
 }
 
 func (cfg database) loadDefaultValues(v *viper.Viper) {
@@ -24,6 +26,7 @@ func (cfg database) loadDefaultValues(v *viper.Viper) {
 	v.SetDefault("db.ca-cert", "")
 	v.SetDefault("db.auto-update", true)
 	v.SetDefault("db.validate-by-hash-on-start", false)
+	v.SetDefault("db.staleness-threshold", time.Hour*24*5)
 }
 
 func (cfg database) ToCuratorConfig() db.Config {
@@ -32,5 +35,6 @@ func (cfg database) ToCuratorConfig() db.Config {
 		ListingURL:          cfg.UpdateURL,
 		CACert:              cfg.CACert,
 		ValidateByHashOnGet: cfg.ValidateByHashOnStart,
+		DataStaleness:       cfg.StalenessThreshold,
 	}
 }

--- a/internal/config/database.go
+++ b/internal/config/database.go
@@ -35,6 +35,6 @@ func (cfg database) ToCuratorConfig() db.Config {
 		ListingURL:          cfg.UpdateURL,
 		CACert:              cfg.CACert,
 		ValidateByHashOnGet: cfg.ValidateByHashOnStart,
-		DataStaleness:       cfg.StalenessThreshold,
+		StalenessThreshold:  cfg.StalenessThreshold,
 	}
 }

--- a/internal/config/database.go
+++ b/internal/config/database.go
@@ -17,7 +17,8 @@ type database struct {
 	CACert                string        `yaml:"ca-cert" json:"ca-cert" mapstructure:"ca-cert"`
 	AutoUpdate            bool          `yaml:"auto-update" json:"auto-update" mapstructure:"auto-update"`
 	ValidateByHashOnStart bool          `yaml:"validate-by-hash-on-start" json:"validate-by-hash-on-start" mapstructure:"validate-by-hash-on-start"`
-	MaxAllowedDBAge       time.Duration `yaml:"max-allowed-db-age" json:"max-allowed-db-age" mapstructure:"max-allowed-db-age"`
+	ValidateAge           bool          `yaml:"validate-age" json:"validate-age" mapstructure:"validate-age"`
+	MaxAllowedBuiltAge    time.Duration `yaml:"max-allowed-built-age" json:"max-allowed-built-age" mapstructure:"max-allowed-built-age"`
 }
 
 func (cfg database) loadDefaultValues(v *viper.Viper) {
@@ -26,7 +27,8 @@ func (cfg database) loadDefaultValues(v *viper.Viper) {
 	v.SetDefault("db.ca-cert", "")
 	v.SetDefault("db.auto-update", true)
 	v.SetDefault("db.validate-by-hash-on-start", false)
-	v.SetDefault("db.max-allowed-db-age", db.DefaultMaxAllowedDBAge)
+	v.SetDefault("db.validate-age", true)
+	v.SetDefault("db.max-allowed-built-age", db.DefaultMaxAllowedBuiltAge)
 }
 
 func (cfg database) ToCuratorConfig() db.Config {
@@ -35,6 +37,7 @@ func (cfg database) ToCuratorConfig() db.Config {
 		ListingURL:          cfg.UpdateURL,
 		CACert:              cfg.CACert,
 		ValidateByHashOnGet: cfg.ValidateByHashOnStart,
-		MaxAllowedDBAge:     cfg.MaxAllowedDBAge,
+		ValidateAge:         cfg.ValidateAge,
+		MaxAllowedBuiltAge:  cfg.MaxAllowedBuiltAge,
 	}
 }

--- a/internal/ui/etui_event_handlers.go
+++ b/internal/ui/etui_event_handlers.go
@@ -29,7 +29,7 @@ func handleAppUpdateAvailable(_ context.Context, fr *frame.Frame, event partybus
 		return err
 	}
 
-	message := color.Magenta.Sprintf("New version of %s available: %s (current version is %s)", internal.ApplicationName, newVersion, version.FromBuild().Version)
+	message := color.Magenta.Sprintf("New version of %s is available: %s (current version is %s)", internal.ApplicationName, newVersion, version.FromBuild().Version)
 	_, _ = io.WriteString(line, message)
 
 	return nil

--- a/internal/ui/etui_event_handlers.go
+++ b/internal/ui/etui_event_handlers.go
@@ -9,13 +9,13 @@ import (
 	"io"
 	"sync"
 
-	"github.com/anchore/grype/internal/version"
 	"github.com/gookit/color"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/jotframe/pkg/frame"
 
 	grypeEventParsers "github.com/anchore/grype/grype/event/parsers"
 	"github.com/anchore/grype/internal"
+	"github.com/anchore/grype/internal/version"
 )
 
 func handleAppUpdateAvailable(_ context.Context, fr *frame.Frame, event partybus.Event, _ *sync.WaitGroup) error {

--- a/internal/ui/etui_event_handlers.go
+++ b/internal/ui/etui_event_handlers.go
@@ -29,7 +29,7 @@ func handleAppUpdateAvailable(_ context.Context, fr *frame.Frame, event partybus
 		return err
 	}
 
-	message := color.Magenta.Sprintf("New version of %s is available: %s (current version is %s)", internal.ApplicationName, newVersion, version.FromBuild().Version)
+	message := color.Magenta.Sprintf("New version of %s is available: %s (currently running: %s)", internal.ApplicationName, newVersion, version.FromBuild().Version)
 	_, _ = io.WriteString(line, message)
 
 	return nil

--- a/internal/ui/etui_event_handlers.go
+++ b/internal/ui/etui_event_handlers.go
@@ -9,13 +9,13 @@ import (
 	"io"
 	"sync"
 
+	"github.com/anchore/grype/internal/version"
 	"github.com/gookit/color"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/jotframe/pkg/frame"
 
 	grypeEventParsers "github.com/anchore/grype/grype/event/parsers"
 	"github.com/anchore/grype/internal"
-	"github.com/anchore/grype/internal/version"
 )
 
 func handleAppUpdateAvailable(_ context.Context, fr *frame.Frame, event partybus.Event, _ *sync.WaitGroup) error {
@@ -29,7 +29,7 @@ func handleAppUpdateAvailable(_ context.Context, fr *frame.Frame, event partybus
 		return err
 	}
 
-	message := color.Magenta.Sprintf("You're currently running %s version %s and a new version is available: %s", internal.ApplicationName, version.FromBuild().Version, newVersion)
+	message := color.Magenta.Sprintf("New version of % available: %s (current version is %s)", internal.ApplicationName, newVersion, version.FromBuild().Version)
 	_, _ = io.WriteString(line, message)
 
 	return nil

--- a/internal/ui/etui_event_handlers.go
+++ b/internal/ui/etui_event_handlers.go
@@ -9,13 +9,13 @@ import (
 	"io"
 	"sync"
 
-	"github.com/anchore/grype/internal/version"
 	"github.com/gookit/color"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/jotframe/pkg/frame"
 
 	grypeEventParsers "github.com/anchore/grype/grype/event/parsers"
 	"github.com/anchore/grype/internal"
+	"github.com/anchore/grype/internal/version"
 )
 
 func handleAppUpdateAvailable(_ context.Context, fr *frame.Frame, event partybus.Event, _ *sync.WaitGroup) error {
@@ -29,7 +29,7 @@ func handleAppUpdateAvailable(_ context.Context, fr *frame.Frame, event partybus
 		return err
 	}
 
-	message := color.Magenta.Sprintf("New version of % available: %s (current version is %s)", internal.ApplicationName, newVersion, version.FromBuild().Version)
+	message := color.Magenta.Sprintf("New version of %s available: %s (current version is %s)", internal.ApplicationName, newVersion, version.FromBuild().Version)
 	_, _ = io.WriteString(line, message)
 
 	return nil

--- a/internal/ui/etui_event_handlers.go
+++ b/internal/ui/etui_event_handlers.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"sync"
 
+	"github.com/anchore/grype/internal/version"
 	"github.com/gookit/color"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/jotframe/pkg/frame"
@@ -28,7 +29,7 @@ func handleAppUpdateAvailable(_ context.Context, fr *frame.Frame, event partybus
 		return err
 	}
 
-	message := color.Magenta.Sprintf("New version of %s is available: %s", internal.ApplicationName, newVersion)
+	message := color.Magenta.Sprintf("You're currently running %s version %s and a new version is available: %s", internal.ApplicationName, version.FromBuild().Version, newVersion)
 	_, _ = io.WriteString(line, message)
 
 	return nil


### PR DESCRIPTION
* Add staleness check to vuln db. Execution fails if db is 5 or more days old.  Configurable via `grype.yaml` and enabled by default. 
* Warn user that db is stale even when staleness check is disabled.
* Add version banner comparing application version with new version available illustrating  to users how far behind their local grype is.

FIx: #240 

Note on staleness field type: it uses go's time duration notation. Anchore provides daily updates. However users might use grype with a different database and different release schedules. Go's duration notation has flexible granularity to different use cases. It also helps maintaining grype's config file consistent over time.

Signed-off-by: Jonas Xavier <jonasx@anchore.com>