### PR TITLE
fix: accept templates with custom functions

### DIFF
--- a/grype/presenter/config.go
+++ b/grype/presenter/config.go
@@ -3,9 +3,10 @@ package presenter
 import (
 	"errors"
 	"fmt"
-	presenterTemplate "github.com/anchore/grype/grype/presenter/template"
 	"os"
 	"text/template"
+
+	presenterTemplate "github.com/anchore/grype/grype/presenter/template"
 )
 
 // Config is the presenter domain's configuration data structure.

--- a/grype/presenter/config.go
+++ b/grype/presenter/config.go
@@ -3,6 +3,7 @@ package presenter
 import (
 	"errors"
 	"fmt"
+	presenterTemplate "github.com/anchore/grype/grype/presenter/template"
 	"os"
 	"text/template"
 )
@@ -39,7 +40,7 @@ func ValidatedConfig(output, outputTemplateFile string) (Config, error) {
 			return Config{}, fmt.Errorf("unable to read template file: %w", err)
 		}
 
-		if _, err := template.ParseFiles(outputTemplateFile); err != nil {
+		if _, err := template.New("").Funcs(presenterTemplate.FuncMap).ParseFiles(outputTemplateFile); err != nil {
 			return Config{}, fmt.Errorf("unable to parse template: %w", err)
 		}
 

--- a/grype/presenter/template/presenter.go
+++ b/grype/presenter/template/presenter.go
@@ -56,7 +56,7 @@ func (pres *Presenter) Present(output io.Writer) error {
 	}
 
 	templateName := expandedPathToTemplateFile
-	tmpl, err := template.New(templateName).Funcs(funcMap).Parse(string(templateContents))
+	tmpl, err := template.New(templateName).Funcs(FuncMap).Parse(string(templateContents))
 	if err != nil {
 		return fmt.Errorf("unable to parse template: %w", err)
 	}
@@ -75,8 +75,8 @@ func (pres *Presenter) Present(output io.Writer) error {
 	return nil
 }
 
-// These are custom functions available to template authors.
-var funcMap = func() template.FuncMap {
+// FuncMap is a function that returns template.FuncMap with custom functions available to template authors.
+var FuncMap = func() template.FuncMap {
 	f := sprig.HermeticTxtFuncMap()
 	f["getLastIndex"] = func(collection interface{}) int {
 		if v := reflect.ValueOf(collection); v.Kind() == reflect.Slice {

--- a/grype/presenter/template/test-fixtures/test.valid.template
+++ b/grype/presenter/template/test-fixtures/test.valid.template
@@ -1,6 +1,7 @@
 Identified distro as {{.Distro.Name}} version {{.Distro.Version}}.
 {{- range .Matches}}
     Vulnerability: {{.Vulnerability.ID}}
+    CVE: {{trimPrefix "CVE-" .Vulnerability.ID}}
     Severity: {{.Vulnerability.Severity}}
     Package: {{.Artifact.Name}} version {{.Artifact.Version}} ({{.Artifact.Type}})
     {{- range .MatchDetails}}


### PR DESCRIPTION
This change fixes problems with parsing templates with custom functions (like defined in `sprig` package) by using accepted `FuncMap` to parse the template.

Fixes https://github.com/anchore/grype/issues/784