### PR TITLE
docs: update to include php

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Hosts Amy Bass from Docker Desktop and Christopher Phillips from Anchore OSS wil
   - Python (Egg, Wheel, Poetry, requirements.txt/setup.py files)
   - Dotnet (deps.json)
   - Golang (go.mod)
+  - PHP (composer.json)
 - Supports Docker and OCI image formats
 - Consume SBOM [attestations](https://github.com/anchore/syft#sbom-attestation).
 


### PR DESCRIPTION
Sorry for missing this in the last pr. `github:composer` is listed in the database as a namespace, so it should be reflected in the readme that Grype supports php

Closes https://github.com/anchore/grype/issues/792