### PR TITLE
fix: add vex json & xml to listed formats

### DIFF
--- a/grype/presenter/format.go
+++ b/grype/presenter/format.go
@@ -53,4 +53,6 @@ var AvailableFormats = []format{
 	cycloneDXFormat,
 	sarifFormat,
 	templateFormat,
+	embeddedVEXJSON,
+	embeddedVEXXML,
 }


### PR DESCRIPTION
Add missing outputs formats to the list of supported formats so they are shown when an invalid output format is given

Closes: https://github.com/anchore/grype/issues/801