### PR TITLE
fix: add support for partybus ui on `grype db update` cmd

### DIFF
--- a/cmd/db_update.go
+++ b/cmd/db_update.go
@@ -4,8 +4,14 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/wagoodman/go-partybus"
 
 	"github.com/anchore/grype/grype/db"
+	"github.com/anchore/grype/grype/event"
+	"github.com/anchore/grype/internal/bus"
+	"github.com/anchore/grype/internal/log"
+	"github.com/anchore/grype/internal/ui"
+	"github.com/anchore/stereoscope"
 )
 
 var dbUpdateCmd = &cobra.Command{
@@ -19,21 +25,48 @@ func init() {
 	dbCmd.AddCommand(dbUpdateCmd)
 }
 
+func startDBUpdateCmd() <-chan error {
+	errs := make(chan error)
+	go func() {
+		defer close(errs)
+		dbCurator, err := db.NewCurator(appConfig.DB.ToCuratorConfig())
+		if err != nil {
+			errs <- err
+			return
+		}
+		updated, err := dbCurator.Update()
+		if err != nil {
+			errs <- fmt.Errorf("unable to update vulnerability database: %+v", err)
+		}
+
+		result := "No vulnerability database update available\n"
+		if updated {
+			result = "Vulnerability database updated!\n"
+		}
+
+		bus.Publish(partybus.Event{
+			Type:  event.NonRootCommandFinished,
+			Value: result,
+		})
+	}()
+	return errs
+}
+
 func runDBUpdateCmd(_ *cobra.Command, _ []string) error {
-	dbCurator, err := db.NewCurator(appConfig.DB.ToCuratorConfig())
+	reporter, closer, err := reportWriter()
+	defer func() {
+		if err := closer(); err != nil {
+			log.Warnf("unable to write to report destination: %+v", err)
+		}
+	}()
 	if err != nil {
 		return err
 	}
-
-	updated, err := dbCurator.Update()
-	if err != nil {
-		fmt.Println("Unable to update vulnerability database")
-		return fmt.Errorf("unable to update vulnerability database: %+v", err)
-	}
-
-	if updated {
-		return stderrPrintLnf("Vulnerability database updated!")
-	}
-
-	return stderrPrintLnf("No vulnerability database update available")
+	return eventLoop(
+		startDBUpdateCmd(),
+		setupSignals(),
+		eventSubscription,
+		stereoscope.Cleanup,
+		ui.Select(isVerbose(), appConfig.Quiet, reporter)...,
+	)
 }

--- a/grype/event/event.go
+++ b/grype/event/event.go
@@ -9,4 +9,5 @@ const (
 	VulnerabilityScanningFinished  partybus.EventType = "grype-vulnerability-scanning-finished"
 	AttestationVerified            partybus.EventType = "grype-attestation-signature-passed"
 	AttestationVerificationSkipped partybus.EventType = "grype-attestation-verification-skipped"
+	NonRootCommandFinished         partybus.EventType = "grype-non-root-command-finished"
 )

--- a/grype/event/parsers/parsers.go
+++ b/grype/event/parsers/parsers.go
@@ -87,3 +87,16 @@ func ParseVulnerabilityScanningFinished(e partybus.Event) (presenter.Presenter, 
 
 	return pres, nil
 }
+
+func ParseNonRootCommandFinished(e partybus.Event) (*string, error) {
+	if err := checkEventType(e.Type, event.NonRootCommandFinished); err != nil {
+		return nil, err
+	}
+
+	result, ok := e.Value.(string)
+	if !ok {
+		return nil, newPayloadErr(e.Type, "Value", e.Value)
+	}
+
+	return &result, nil
+}

--- a/internal/ui/common_event_handlers.go
+++ b/internal/ui/common_event_handlers.go
@@ -21,3 +21,16 @@ func handleVulnerabilityScanningFinished(event partybus.Event, reportOutput io.W
 	}
 	return nil
 }
+
+func handleNonRootCommandFinished(event partybus.Event, reportOutput io.Writer) error {
+	// show the report to stdout
+	result, err := grypeEventParsers.ParseNonRootCommandFinished(event)
+	if err != nil {
+		return fmt.Errorf("bad NonRootCommandFinished event: %w", err)
+	}
+
+	if _, err := reportOutput.Write([]byte(*result)); err != nil {
+		return fmt.Errorf("unable to show vulnerability report: %w", err)
+	}
+	return nil
+}

--- a/internal/ui/ephemeral_terminal_ui.go
+++ b/internal/ui/ephemeral_terminal_ui.go
@@ -94,6 +94,16 @@ func (h *ephemeralTerminalUI) Handle(event partybus.Event) error {
 
 		// this is the last expected event, stop listening to events
 		return h.unsubscribe()
+
+	case event.Type == grypeEvent.NonRootCommandFinished:
+		h.closeScreen(false)
+
+		if err := handleNonRootCommandFinished(event, h.reportOutput); err != nil {
+			log.Errorf("unable to show %s event: %+v", event.Type, err)
+		}
+
+		// this is the last expected event, stop listening to events
+		return h.unsubscribe()
 	}
 	return nil
 }

--- a/internal/ui/logger_ui.go
+++ b/internal/ui/logger_ui.go
@@ -27,13 +27,18 @@ func (l *loggerUI) Setup(unsubscribe func() error) error {
 }
 
 func (l loggerUI) Handle(event partybus.Event) error {
-	// ignore all events except for the final event
-	if event.Type != grypeEvent.VulnerabilityScanningFinished {
+	switch event.Type {
+	case grypeEvent.VulnerabilityScanningFinished:
+		if err := handleVulnerabilityScanningFinished(event, l.reportOutput); err != nil {
+			log.Warnf("unable to show catalog image finished event: %+v", err)
+		}
+	case grypeEvent.NonRootCommandFinished:
+		if err := handleNonRootCommandFinished(event, l.reportOutput); err != nil {
+			log.Warnf("unable to show command finished event: %+v", err)
+		}
+	// ignore all events except for the final events
+	default:
 		return nil
-	}
-
-	if err := handleVulnerabilityScanningFinished(event, l.reportOutput); err != nil {
-		log.Warnf("unable to show catalog image finished event: %+v", err)
 	}
 
 	// this is the last expected event, stop listening to events


### PR DESCRIPTION
Currently this command publishes to partybus and I'd expect some UI on it, but it doesn't run in the event loop to properly publish. Adding this `event.NonRootCommandFinished` construct will be useful in the db diff command since the command will take some time and it would be helpful for a user to be able to track the progress for it.

Closes: https://github.com/anchore/grype/issues/805