### PR TITLE
feat: add filtering support using target software field in cpe

### DIFF
--- a/grype/search/cpe.go
+++ b/grype/search/cpe.go
@@ -82,6 +82,8 @@ func ByPackageCPE(store vulnerability.ProviderByCPE, p pkg.Package, upstreamMatc
 			return nil, fmt.Errorf("unable to filter cpe-related vulnerabilities: %w", err)
 		}
 
+		applicableVulns = onlyVulnerableTargets(p, allPkgVulns)
+
 		// for each vulnerability record found, check the version constraint. If the constraint is satisfied
 		// relative to the current version information from the CPE (or the package) then the given package
 		// is vulnerable.

--- a/grype/search/cpe.go
+++ b/grype/search/cpe.go
@@ -82,7 +82,7 @@ func ByPackageCPE(store vulnerability.ProviderByCPE, p pkg.Package, upstreamMatc
 			return nil, fmt.Errorf("unable to filter cpe-related vulnerabilities: %w", err)
 		}
 
-		applicableVulns = onlyVulnerableTargets(p, allPkgVulns)
+		applicableVulns = onlyVulnerableTargets(p, applicableVulns)
 
 		// for each vulnerability record found, check the version constraint. If the constraint is satisfied
 		// relative to the current version information from the CPE (or the package) then the given package

--- a/grype/search/cpe_test.go
+++ b/grype/search/cpe_test.go
@@ -465,6 +465,58 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "match included even though multiple cpes are mismatch",
+			p: pkg.Package{
+				CPEs: []syftPkg.CPE{
+					must(syftPkg.NewCPE("cpe:2.3:*:funfun:funfun:*:*:*:*:*:rust:*:*")),
+					must(syftPkg.NewCPE("cpe:2.3:*:funfun:funfun:*:*:*:*:*:rails:*:*")),
+					must(syftPkg.NewCPE("cpe:2.3:*:funfun:funfun:*:*:*:*:*:ruby:*:*")),
+					must(syftPkg.NewCPE("cpe:2.3:*:funfun:funfun:*:*:*:*:*:python:*:*")),
+				},
+				Name:     "funfun",
+				Version:  "5.2.1",
+				Language: syftPkg.Python,
+				Type:     syftPkg.PythonPkg,
+			},
+			expected: []match.Match{
+				{
+					Vulnerability: vulnerability.Vulnerability{
+						ID: "CVE-2017-fake-6",
+					},
+					Package: pkg.Package{
+						CPEs: []syftPkg.CPE{
+							must(syftPkg.NewCPE("cpe:2.3:*:funfun:funfun:*:*:*:*:*:rust:*:*")),
+							must(syftPkg.NewCPE("cpe:2.3:*:funfun:funfun:*:*:*:*:*:rails:*:*")),
+							must(syftPkg.NewCPE("cpe:2.3:*:funfun:funfun:*:*:*:*:*:ruby:*:*")),
+							must(syftPkg.NewCPE("cpe:2.3:*:funfun:funfun:*:*:*:*:*:python:*:*")),
+						},
+						Name:     "funfun",
+						Version:  "5.2.1",
+						Language: syftPkg.Python,
+						Type:     syftPkg.PythonPkg,
+					},
+					Details: []match.Detail{
+						{
+							Type:       match.CPEMatch,
+							Confidence: 0.9,
+							SearchedBy: CPEParameters{
+								CPEs:      []string{"cpe:2.3:*:funfun:funfun:*:*:*:*:*:python:*:*"},
+								Namespace: "nvd",
+							},
+							Found: CPEResult{
+								CPEs: []string{
+									"cpe:2.3:*:funfun:funfun:*:*:*:*:*:python:*:*",
+									"cpe:2.3:*:funfun:funfun:5.2.1:*:*:*:*:python:*:*",
+								},
+								VersionConstraint: "= 5.2.1 (python)",
+							},
+							Matcher: matcher,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/grype/search/cpe_test.go
+++ b/grype/search/cpe_test.go
@@ -97,6 +97,31 @@ func (pr *mockVulnStore) stub() {
 				Namespace: "nvd",
 			},
 		},
+		"funfun": {
+			{
+				PackageName:       "funfun",
+				VersionConstraint: "= 5.2.1",
+				VersionFormat:     version.PythonFormat.String(),
+				ID:                "CVE-2017-fake-6",
+				CPEs: []string{
+					"cpe:2.3:*:funfun:funfun:5.2.1:*:*:*:*:python:*:*",
+					"cpe:2.3:*:funfun:funfun:*:*:*:*:*:python:*:*",
+				},
+				Namespace: "nvd",
+			},
+		},
+		"sw": {
+			{
+				PackageName:       "sw",
+				VersionConstraint: "< 1.0",
+				VersionFormat:     version.UnknownFormat.String(),
+				ID:                "CVE-2017-fake-7",
+				CPEs: []string{
+					"cpe:2.3:*:sw:sw:*:*:*:*:*:puppet:*:*",
+				},
+				Namespace: "nvd",
+			},
+		},
 	}
 }
 
@@ -375,6 +400,64 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 									"cpe:2.3:*:multiple:multiple:1.0:*:*:*:*:*:*:*",
 								},
 								VersionConstraint: "< 4.0 (unknown)",
+							},
+							Matcher: matcher,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "filtered out match due to target_sw mismatch",
+			p: pkg.Package{
+				CPEs: []syftPkg.CPE{
+					must(syftPkg.NewCPE("cpe:2.3:*:funfun:funfun:*:*:*:*:*:*:*:*")),
+				},
+				Name:     "funfun",
+				Version:  "5.2.1",
+				Language: syftPkg.Rust,
+				Type:     syftPkg.RustPkg,
+			},
+			expected: []match.Match{},
+		},
+		{
+			name: "target_sw mismatch with unsupported target_sw",
+			p: pkg.Package{
+				CPEs: []syftPkg.CPE{
+					must(syftPkg.NewCPE("cpe:2.3:*:sw:sw:*:*:*:*:*:*:*:*")),
+				},
+				Name:     "sw",
+				Version:  "0.1",
+				Language: syftPkg.Go,
+				Type:     syftPkg.GoModulePkg,
+			},
+			expected: []match.Match{
+				{
+					Vulnerability: vulnerability.Vulnerability{
+						ID: "CVE-2017-fake-7",
+					},
+					Package: pkg.Package{
+						CPEs: []syftPkg.CPE{
+							must(syftPkg.NewCPE("cpe:2.3:*:sw:sw:*:*:*:*:*:*:*:*")),
+						},
+						Name:     "sw",
+						Version:  "0.1",
+						Language: syftPkg.Go,
+						Type:     syftPkg.GoModulePkg,
+					},
+					Details: []match.Detail{
+						{
+							Type:       match.CPEMatch,
+							Confidence: 0.9,
+							SearchedBy: CPEParameters{
+								CPEs:      []string{"cpe:2.3:*:sw:sw:*:*:*:*:*:*:*:*"},
+								Namespace: "nvd",
+							},
+							Found: CPEResult{
+								CPEs: []string{
+									"cpe:2.3:*:sw:sw:*:*:*:*:*:puppet:*:*",
+								},
+								VersionConstraint: "< 1.0 (unknown)",
 							},
 							Matcher: matcher,
 						},

--- a/grype/search/only_vulnerable_targets.go
+++ b/grype/search/only_vulnerable_targets.go
@@ -1,18 +1,19 @@
 package search
 
 import (
+	"github.com/facebookincubator/nvdtools/wfn"
+
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
 	syftPkg "github.com/anchore/syft/syft/pkg"
-	"github.com/facebookincubator/nvdtools/wfn"
 )
 
-//Determines if a vulnerability is an accurate match using the vulnerability's cpes' target software
+// Determines if a vulnerability is an accurate match using the vulnerability's cpes' target software
 func onlyVulnerableTargets(p pkg.Package, allVulns []vulnerability.Vulnerability) []vulnerability.Vulnerability {
 	var vulns []vulnerability.Vulnerability
 
 	for _, vuln := range allVulns {
-		isPackageVulnerable := len(vuln.CPEs) != 0
+		isPackageVulnerable := len(vuln.CPEs) == 0
 		for _, cpe := range vuln.CPEs {
 			targetSW := cpe.TargetSW
 			mismatchWithUnknownLanguage := targetSW != string(p.Language) && syftPkg.LanguageByName(targetSW) == syftPkg.UnknownLanguage

--- a/grype/search/only_vulnerable_targets.go
+++ b/grype/search/only_vulnerable_targets.go
@@ -1,0 +1,32 @@
+package search
+
+import (
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+	"github.com/facebookincubator/nvdtools/wfn"
+)
+
+//Determines if a vulnerability is an accurate match using the vulnerability's cpes' target software
+func onlyVulnerableTargets(p pkg.Package, allVulns []vulnerability.Vulnerability) []vulnerability.Vulnerability {
+	var vulns []vulnerability.Vulnerability
+
+	for _, vuln := range allVulns {
+		isPackageVulnerable := len(vuln.CPEs) != 0
+		for _, cpe := range vuln.CPEs {
+			targetSW := cpe.TargetSW
+			mismatchWithUnknownLanguage := targetSW != string(p.Language) && syftPkg.LanguageByName(targetSW) == syftPkg.UnknownLanguage
+			if targetSW == wfn.Any || targetSW == wfn.NA || targetSW == string(p.Language) || mismatchWithUnknownLanguage {
+				isPackageVulnerable = true
+			}
+		}
+
+		if !isPackageVulnerable {
+			continue
+		}
+
+		vulns = append(vulns, vuln)
+	}
+
+	return vulns
+}


### PR DESCRIPTION
## ⛰️ Background
In terms of addressing the concerns from the issue, I processed all the cpes, curtesy of @westonsteimel's [cpe repo](https://github.com/westonsteimel/nvd-data-analysis/tree/main/data/cpe), and identified the ~10k different possible product|vendor|target_sw pairings. I manually evaluated 200 of these from the set of those supported by Syft ~1500 (13%) and saw no language wrapping where filtering would cause a bad mismatch. [Work here](https://gist.github.com/cpendery/82aadba917c2dd380cf9de4ed5743899).

## 📝 Description
Add's support for filtering out vulnerabilities where every cpe's target software does not match the package's language and has the loosest possible filtering by including all target software's that Syft doesn't support regardless of if a match is found or not to reduce missed vulnerabilities. 

Closes https://github.com/anchore/grype/issues/390
Closes https://github.com/anchore/grype/issues/445
Closes https://github.com/anchore/grype/issues/771
Closes https://github.com/anchore/grype/issues/445