### PR TITLE
docs: update to include rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A vulnerability scanner for container images and filesystems. Easily [install th
   - Dotnet (deps.json)
   - Golang (go.mod)
   - PHP (Composer)
+  - Rust (Cargo)
 - Supports Docker and OCI image formats
 - Consume SBOM [attestations](https://github.com/anchore/syft#sbom-attestation).
 


### PR DESCRIPTION
## 📝 Description
I saw that the namespace `github:rust` got added to the database so now Grype supports indexing `cargo.lock` files and finding vulnerabilties. Updating the docs to reflect this addition