### PR TITLE
add DBCloser. Clients can aviod db connection leak if vulnerability db is loaded many times

### DIFF
--- a/grype/db/curator.go
+++ b/grype/db/curator.go
@@ -77,15 +77,15 @@ func (c Curator) SupportedSchema() int {
 	return c.targetSchema
 }
 
-func (c *Curator) GetStore() (grypeDB.StoreReader, error) {
+func (c *Curator) GetStore() (grypeDB.StoreReader, grypeDB.DBCloser, error) {
 	// ensure the DB is ok
 	_, err := c.validateIntegrity(c.dbDir)
 	if err != nil {
-		return nil, fmt.Errorf("vulnerability database is invalid (run db update to correct): %+v", err)
+		return nil, nil, fmt.Errorf("vulnerability database is invalid (run db update to correct): %+v", err)
 	}
 
 	s, err := store.New(c.dbPath, false)
-	return s, err
+	return s, s, err
 }
 
 func (c *Curator) Status() Status {

--- a/grype/db/db_closer.go
+++ b/grype/db/db_closer.go
@@ -1,0 +1,9 @@
+package db
+
+import v4 "github.com/anchore/grype/grype/db/v4"
+
+// Closer lets receiver close the db connection and free any allocated db resources.
+// It's especially useful if vulnerability DB loaded repeatedly during some periodic SBOM scanning process.
+type Closer struct {
+	v4.DBCloser
+}

--- a/grype/db/v4/store.go
+++ b/grype/db/v4/store.go
@@ -3,6 +3,7 @@ package v4
 type Store interface {
 	StoreReader
 	StoreWriter
+	DBCloser
 }
 
 type StoreReader interface {
@@ -18,9 +19,12 @@ type StoreWriter interface {
 	VulnerabilityStoreWriter
 	VulnerabilityMetadataStoreWriter
 	VulnerabilityMatchExclusionStoreWriter
-	Close()
 }
 
 type DiffReader interface {
 	DiffStore(s StoreReader) (*[]Diff, error)
+}
+
+type DBCloser interface {
+	Close()
 }

--- a/grype/db/v4/store/store.go
+++ b/grype/db/v4/store/store.go
@@ -263,6 +263,11 @@ func (s *store) AddVulnerabilityMatchExclusion(exclusions ...v4.VulnerabilityMat
 
 func (s *store) Close() {
 	s.db.Exec("VACUUM;")
+
+	sqlDB, err := s.db.DB()
+	if err != nil {
+		_ = sqlDB.Close()
+	}
 }
 
 // GetAllVulnerabilities gets all vulnerabilities in the database

--- a/grype/differ/differ.go
+++ b/grype/differ/differ.go
@@ -117,15 +117,19 @@ func download(curator *db.Curator, listing *db.ListingEntry) error {
 }
 
 func (d *Differ) DiffDatabases() (*[]v4.Diff, error) {
-	baseStore, err := d.baseCurator.GetStore()
+	baseStore, baseDBCloser, err := d.baseCurator.GetStore()
 	if err != nil {
 		return nil, err
 	}
 
-	targetStore, err := d.targetCurator.GetStore()
+	defer baseDBCloser.Close()
+
+	targetStore, targetDBCloser, err := d.targetCurator.GetStore()
 	if err != nil {
 		return nil, err
 	}
+
+	defer targetDBCloser.Close()
 
 	return baseStore.DiffStore(targetStore)
 }

--- a/test/integration/compare_sbom_input_vs_lib_test.go
+++ b/test/integration/compare_sbom_input_vs_lib_test.go
@@ -43,12 +43,16 @@ func TestCompareSBOMInputToLibResults(t *testing.T) {
 	}
 
 	// get a grype DB
-	store, _, err := grype.LoadVulnerabilityDB(db.Config{
+	store, _, closer, err := grype.LoadVulnerabilityDB(db.Config{
 		DBRootDir:           "test-fixtures/grype-db",
 		ListingURL:          getListingURL(),
 		ValidateByHashOnGet: false,
 	}, true)
 	assert.NoError(t, err)
+
+	if closer != nil {
+		defer closer.Close()
+	}
 
 	definedPkgTypes := strset.New()
 	for _, p := range syftPkg.AllPkgs {


### PR DESCRIPTION
add DBCloser interface to LoadVulnerabilityDB() function. Clients can avoid db connection leak if vulnerability db is loaded many times.
Important for tools like https://github.com/ckotzbauer/vulnerability-operator which loads vulnerability db periodically during its runtime cycle.

Signed-off-by: Sergey Artamonov <artsv79@gmail.com>