### PR TITLE
Add new matcher files for golang => remove main module FP matches

### DIFF
--- a/grype/match/matcher_type.go
+++ b/grype/match/matcher_type.go
@@ -12,6 +12,7 @@ const (
 	DotnetMatcher      MatcherType = "dotnet-matcher"
 	JavascriptMatcher  MatcherType = "javascript-matcher"
 	MsrcMatcher        MatcherType = "msrc-matcher"
+	GoModuleMatcher    MatcherType = "go-module-matcher"
 )
 
 var AllMatcherTypes = []MatcherType{
@@ -24,6 +25,7 @@ var AllMatcherTypes = []MatcherType{
 	DotnetMatcher,
 	JavascriptMatcher,
 	MsrcMatcher,
+	GoModuleMatcher,
 }
 
 type MatcherType string

--- a/grype/matcher/golang/matcher.go
+++ b/grype/matcher/golang/matcher.go
@@ -1,13 +1,14 @@
 package golang
 
 import (
+	"strings"
+
 	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/search"
 	"github.com/anchore/grype/grype/vulnerability"
 	syftPkg "github.com/anchore/syft/syft/pkg"
-	"strings"
 )
 
 type Matcher struct {

--- a/grype/matcher/golang/matcher.go
+++ b/grype/matcher/golang/matcher.go
@@ -22,7 +22,10 @@ func (m *Matcher) Type() match.MatcherType {
 
 func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Package) ([]match.Match, error) {
 	matches := make([]match.Match, 0)
-	metadata := p.Metadata.(pkg.GolangBinMetadata)
+	metadata := pkg.GolangBinMetadata{}
+	if p.Metadata != nil {
+		metadata = p.Metadata.(pkg.GolangBinMetadata)
+	}
 
 	// Golang currently does not have a standard way of incorporating the vcs version
 	// into the compiled binary: https://github.com/golang/go/issues/50603

--- a/grype/matcher/golang/matcher.go
+++ b/grype/matcher/golang/matcher.go
@@ -4,6 +4,7 @@ import (
 	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/search"
 	"github.com/anchore/grype/grype/vulnerability"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
@@ -21,5 +22,15 @@ func (m *Matcher) Type() match.MatcherType {
 
 func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Package) ([]match.Match, error) {
 	matches := make([]match.Match, 0)
+	metadata := p.Metadata.(syftPkg.GolangBinMetadata)
+
+	// Golang currently does not have a standard way of incorporating the vcs version
+	// into the compiled binary: https://github.com/golang/go/issues/50603
+	// current version information for the main module is incomplete leading to multiple FP
+	// TODO: remove this exclusion when vcs information is included in future go version
+	if p.Name != metadata.MainModule {
+		return search.ByCriteria(store, d, p, m.Type(), search.CommonCriteria...)
+	}
+
 	return matches, nil
 }

--- a/grype/matcher/golang/matcher.go
+++ b/grype/matcher/golang/matcher.go
@@ -34,8 +34,8 @@ func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Pa
 	// current version information for the main module is incomplete leading to multiple FP
 	// TODO: remove this exclusion when vcs information is included in future go version
 	if p.Name == metadata.MainModule && strings.HasPrefix(p.Version, "v0.0.0-") {
-		return search.ByCriteria(store, d, p, m.Type(), search.CommonCriteria...)
+		return matches, nil
 	}
 
-	return matches, nil
+	return search.ByCriteria(store, d, p, m.Type(), search.CommonCriteria...)
 }

--- a/grype/matcher/golang/matcher.go
+++ b/grype/matcher/golang/matcher.go
@@ -22,7 +22,7 @@ func (m *Matcher) Type() match.MatcherType {
 
 func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Package) ([]match.Match, error) {
 	matches := make([]match.Match, 0)
-	metadata := p.Metadata.(syftPkg.GolangBinMetadata)
+	metadata := p.Metadata.(pkg.GolangBinMetadata)
 
 	// Golang currently does not have a standard way of incorporating the vcs version
 	// into the compiled binary: https://github.com/golang/go/issues/50603

--- a/grype/matcher/golang/matcher.go
+++ b/grype/matcher/golang/matcher.go
@@ -33,7 +33,8 @@ func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Pa
 	// into the compiled binary: https://github.com/golang/go/issues/50603
 	// current version information for the main module is incomplete leading to multiple FP
 	// TODO: remove this exclusion when vcs information is included in future go version
-	if p.Name == metadata.MainModule && strings.HasPrefix(p.Version, "v0.0.0-") {
+	isNotCorrected := strings.HasPrefix(p.Version, "v0.0.0-") || strings.HasPrefix(p.Version, "(devel)")
+	if p.Name == metadata.MainModule && isNotCorrected {
 		return matches, nil
 	}
 

--- a/grype/matcher/golang/matcher.go
+++ b/grype/matcher/golang/matcher.go
@@ -7,6 +7,7 @@ import (
 	"github.com/anchore/grype/grype/search"
 	"github.com/anchore/grype/grype/vulnerability"
 	syftPkg "github.com/anchore/syft/syft/pkg"
+	"strings"
 )
 
 type Matcher struct {
@@ -31,7 +32,7 @@ func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Pa
 	// into the compiled binary: https://github.com/golang/go/issues/50603
 	// current version information for the main module is incomplete leading to multiple FP
 	// TODO: remove this exclusion when vcs information is included in future go version
-	if p.Name != metadata.MainModule {
+	if p.Name == metadata.MainModule && strings.HasPrefix(p.Version, "v0.0.0-") {
 		return search.ByCriteria(store, d, p, m.Type(), search.CommonCriteria...)
 	}
 

--- a/grype/matcher/golang/matcher_test.go
+++ b/grype/matcher/golang/matcher_test.go
@@ -1,0 +1,1 @@
+package golang

--- a/grype/matcher/golang/matcher_test.go
+++ b/grype/matcher/golang/matcher_test.go
@@ -1,1 +1,70 @@
 package golang
+
+import (
+	"testing"
+
+	"github.com/anchore/grype/grype/distro"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/version"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+func TestMatcherGolang_DropMainPackage(t *testing.T) {
+	p := pkg.Package{
+		ID:           pkg.ID(uuid.NewString()),
+		Name:         "istio.io/istio",
+		Version:      "v0.0.0-20220606222826-f59ce19ec6b6",
+		Type:         syftPkg.GoModulePkg,
+		MetadataType: pkg.GolangBinMetadataType,
+		Metadata: pkg.GolangBinMetadata{
+			MainModule: "istio.io/istio",
+		},
+	}
+
+	matcher := Matcher{}
+	store := newMockProvider()
+
+	actual, _ := matcher.Match(store, nil, p)
+	assert.Len(t, actual, 0, "unexpected match count; should not match main module")
+}
+
+func newMockProvider() *mockProvider {
+	mp := mockProvider{
+		data: make(map[syftPkg.Language]map[string][]vulnerability.Vulnerability),
+	}
+
+	mp.populateData()
+
+	return &mp
+}
+
+type mockProvider struct {
+	data map[syftPkg.Language]map[string][]vulnerability.Vulnerability
+}
+
+func (mp *mockProvider) populateData() {
+	mp.data[syftPkg.Go] = map[string][]vulnerability.Vulnerability{
+		"istio.io/istio": {
+			{
+				Constraint: version.MustGetConstraint("<5.0.7", version.UnknownFormat),
+				ID:         "CVE-2013-fake-BAD",
+			},
+		},
+	}
+}
+
+func (mp *mockProvider) GetByCPE(p syftPkg.CPE) ([]vulnerability.Vulnerability, error) {
+	return []vulnerability.Vulnerability{}, nil
+}
+
+func (mp *mockProvider) GetByDistro(d *distro.Distro, p pkg.Package) ([]vulnerability.Vulnerability, error) {
+	return []vulnerability.Vulnerability{}, nil
+}
+
+func (mp *mockProvider) GetByLanguage(l syftPkg.Language, p pkg.Package) ([]vulnerability.Vulnerability, error) {
+	return mp.data[l][p.Name], nil
+}

--- a/grype/matcher/golang/matcher_test.go
+++ b/grype/matcher/golang/matcher_test.go
@@ -3,13 +3,13 @@ package golang
 import (
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/version"
 	"github.com/anchore/grype/grype/vulnerability"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 

--- a/grype/matcher/golang/mather.go
+++ b/grype/matcher/golang/mather.go
@@ -1,0 +1,1 @@
+package golang

--- a/grype/matcher/golang/mather.go
+++ b/grype/matcher/golang/mather.go
@@ -1,1 +1,25 @@
 package golang
+
+import (
+	"github.com/anchore/grype/grype/distro"
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+type Matcher struct {
+}
+
+func (m *Matcher) PackageTypes() []syftPkg.Type {
+	return []syftPkg.Type{syftPkg.GoModulePkg}
+}
+
+func (m *Matcher) Type() match.MatcherType {
+	return match.GoModuleMatcher
+}
+
+func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Package) ([]match.Match, error) {
+	matches := make([]match.Match, 0)
+	return matches, nil
+}

--- a/grype/matcher/matchers.go
+++ b/grype/matcher/matchers.go
@@ -1,6 +1,7 @@
 package matcher
 
 import (
+	"github.com/anchore/grype/grype/matcher/golang"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
 
@@ -45,6 +46,7 @@ func NewDefaultMatchers(mc Config) []Matcher {
 		java.NewJavaMatcher(mc.Java),
 		&javascript.Matcher{},
 		&apk.Matcher{},
+		&golang.Matcher{},
 		&msrc.Matcher{},
 	}
 }

--- a/grype/matcher/matchers.go
+++ b/grype/matcher/matchers.go
@@ -1,7 +1,6 @@
 package matcher
 
 import (
-	"github.com/anchore/grype/grype/matcher/golang"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/anchore/grype/grype/matcher/apk"
 	"github.com/anchore/grype/grype/matcher/dotnet"
 	"github.com/anchore/grype/grype/matcher/dpkg"
+	"github.com/anchore/grype/grype/matcher/golang"
 	"github.com/anchore/grype/grype/matcher/java"
 	"github.com/anchore/grype/grype/matcher/javascript"
 	"github.com/anchore/grype/grype/matcher/msrc"

--- a/grype/pkg/golang_bin_metadata.go
+++ b/grype/pkg/golang_bin_metadata.go
@@ -1,0 +1,9 @@
+package pkg
+
+type GolangBinMetadata struct {
+	BuildSettings     map[string]string `json:"goBuildSettings,omitempty"`
+	GoCompiledVersion string            `json:"goCompiledVersion"`
+	Architecture      string            `json:"architecture"`
+	H1Digest          string            `json:"h1Digest,omitempty"`
+	MainModule        string            `json:"mainModule,omitempty"`
+}

--- a/grype/pkg/metadata.go
+++ b/grype/pkg/metadata.go
@@ -6,7 +6,8 @@ type MetadataType string
 const (
 	// this is the full set of data shapes that can be represented within the pkg.Package.Metadata field
 
-	UnknownMetadataType MetadataType = "UnknownMetadata"
-	JavaMetadataType    MetadataType = "JavaMetadata"
-	RpmdbMetadataType   MetadataType = "RpmdbMetadata"
+	UnknownMetadataType   MetadataType = "UnknownMetadata"
+	JavaMetadataType      MetadataType = "JavaMetadata"
+	RpmdbMetadataType     MetadataType = "RpmdbMetadata"
+	GolangBinMetadataType MetadataType = "GolangBinMetadata"
 )

--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -89,6 +89,11 @@ func dataFromPkg(p pkg.Package) (MetadataType, interface{}, []UpstreamPackage) {
 	var metadataType MetadataType
 
 	switch p.MetadataType {
+	case pkg.GolangBinMetadataType:
+		if m := golangBinDataFromPkg(p); m != nil {
+			metadata = *m
+			metadataType = GolangBinMetadataType
+		}
 	case pkg.DpkgMetadataType:
 		upstreams = dpkgDataFromPkg(p)
 	case pkg.RpmdbMetadataType:
@@ -107,6 +112,20 @@ func dataFromPkg(p pkg.Package) (MetadataType, interface{}, []UpstreamPackage) {
 		upstreams = apkDataFromPkg(p)
 	}
 	return metadataType, metadata, upstreams
+}
+
+func golangBinDataFromPkg(p pkg.Package) (m *GolangBinMetadata) {
+	metadata := &GolangBinMetadata{}
+	if value, ok := p.Metadata.(pkg.GolangBinMetadata); ok {
+		if value.BuildSettings != nil {
+			metadata.BuildSettings = value.BuildSettings
+		}
+		metadata.GoCompiledVersion = value.GoCompiledVersion
+		metadata.Architecture = value.Architecture
+		metadata.H1Digest = value.H1Digest
+		metadata.MainModule = value.MainModule
+	}
+	return metadata
 }
 
 func dpkgDataFromPkg(p pkg.Package) (upstreams []UpstreamPackage) {

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -251,9 +251,17 @@ func TestNew(t *testing.T) {
 			syftPkg: syftPkg.Package{
 				MetadataType: syftPkg.GolangBinMetadataType,
 				Metadata: syftPkg.GolangBinMetadata{
+					BuildSettings:     map[string]string{},
 					GoCompiledVersion: "1.0.0",
 					H1Digest:          "a",
+					MainModule:        "myMainModule",
 				},
+			},
+			metadata: GolangBinMetadata{
+				BuildSettings:     map[string]string{},
+				GoCompiledVersion: "1.0.0",
+				H1Digest:          "a",
+				MainModule:        "myMainModule",
 			},
 		},
 		{

--- a/test/integration/db_mock_test.go
+++ b/test/integration/db_mock_test.go
@@ -70,6 +70,22 @@ func newMockDbStore() *mockStore {
 					},
 				},
 			},
+			"github:language:go": {
+				"github.com/anchore/coverage": []grypeDB.Vulnerability{
+					{
+						ID:                "CVE-coverage-main-module-vuln",
+						VersionConstraint: "< 1.4.0",
+						VersionFormat:     "unknown",
+					},
+				},
+				"github.com/google/uuid": []grypeDB.Vulnerability{
+					{
+						ID:                "CVE-uuid-vuln",
+						VersionConstraint: "< 1.4.0",
+						VersionFormat:     "unknown",
+					},
+				},
+			},
 			"github:language:javascript": {
 				"npm": []grypeDB.Vulnerability{
 					{

--- a/test/integration/match_by_image_test.go
+++ b/test/integration/match_by_image_test.go
@@ -190,6 +190,44 @@ func addRubyMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Cata
 	})
 }
 
+func addGolangMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Catalog, theStore *mockStore, theResult *match.Matches) {
+	packages := catalog.PackagesByPath("/go-app")
+	if len(packages) != 2 {
+		t.Logf("Golang Packages: %+v", packages)
+		t.Fatalf("problem with upstream syft cataloger (golang)")
+	}
+
+	for _, p := range packages {
+		thePkg := pkg.New(p)
+		theVuln := theStore.backend["github:language:go"][p.Name][0]
+		vulnObj, err := vulnerability.NewVulnerability(theVuln)
+		if err != nil {
+			t.Fatalf("failed to create vuln obj: %+v", err)
+		}
+
+		// no vuln match supported for main module
+		if p.Name != "github.com/anchore/coverage" {
+			theResult.Add(match.Match{
+				Vulnerability: *vulnObj,
+				Package:       thePkg,
+				Details: []match.Detail{
+					{
+						Type:       match.ExactDirectMatch,
+						Confidence: 1.0,
+						SearchedBy: map[string]interface{}{
+							"langauge": "go",
+						},
+						Found: map[string]interface{}{
+							"constraint": " < 1.4.0 (golang)",
+						},
+						Matcher: match.GoModuleMatcher,
+					},
+				},
+			})
+		}
+	}
+}
+
 func addJavaMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Catalog, theStore *mockStore, theResult *match.Matches) {
 	packages := make([]syftPkg.Package, 0)
 	for p := range catalog.Enumerate(syftPkg.JavaPkg) {
@@ -314,7 +352,6 @@ func addSlesMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Cata
 		t.Fatalf("failed to create vuln obj: %+v", err)
 	}
 	theResult.Add(match.Match{
-
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
 		Details: []match.Detail{
@@ -337,7 +374,6 @@ func addSlesMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Cata
 }
 
 func TestMatchByImage(t *testing.T) {
-
 	observedMatchers := internal.NewStringSet()
 	definedMatchers := internal.NewStringSet()
 	for _, l := range match.AllMatcherTypes {
@@ -358,6 +394,7 @@ func TestMatchByImage(t *testing.T) {
 				addDpkgMatches(t, theSource, catalog, theStore, &expectedMatches)
 				addJavascriptMatches(t, theSource, catalog, theStore, &expectedMatches)
 				addDotnetMatches(t, theSource, catalog, theStore, &expectedMatches)
+				addGolangMatches(t, theSource, catalog, theStore, &expectedMatches)
 				return expectedMatches
 			},
 		},

--- a/test/integration/test-fixtures/image-debian-match-coverage/Dockerfile
+++ b/test/integration/test-fixtures/image-debian-match-coverage/Dockerfile
@@ -1,2 +1,8 @@
+FROM golang:1.16
+WORKDIR /go/src/github.com/anchore/test/
+COPY golang/ ./
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o go-app .
+
 FROM scratch
+COPY --from=0 /go/src/github.com/anchore/test/go-app ./
 COPY . .

--- a/test/integration/test-fixtures/image-debian-match-coverage/golang/go.mod
+++ b/test/integration/test-fixtures/image-debian-match-coverage/golang/go.mod
@@ -1,0 +1,5 @@
+module github.com/anchore/coverage
+
+go 1.18
+
+require github.com/google/uuid v1.3.0

--- a/test/integration/test-fixtures/image-debian-match-coverage/golang/go.sum
+++ b/test/integration/test-fixtures/image-debian-match-coverage/golang/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/test/integration/test-fixtures/image-debian-match-coverage/golang/main.go
+++ b/test/integration/test-fixtures/image-debian-match-coverage/golang/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+func main() {
+	fmt.Println(uuid.New())
+}


### PR DESCRIPTION
## Description

This PR drops match support in grype on the MAIN golang module to reduce the false positives being reported.

This drop is done by adding a custom Golang matcher that does a `search.ByCriteria` only if `package.Name` does not equal `package.Metadata.MainModule`

## Context:
4 months ago syft introduced including the main golang module for a given package into the SBOM
-myApp (devel) <------------- Main Golang Module
   - dependency1 (v1.0.0)
   - dependency2 (v0.5.0)
   - ...

This month we enhanced the reporting on that main module by building in package information compiled with the go binary:
Ex: devel ===> v0.0.0-20220606222826-f59ce19ec6b6

Problem: 
We have no way currently of updating the `v0.0.0` portion of the tag since currently there is no standard way to inject the latest VCS tags into the compile process. 

See https://github.com/golang/go/issues/50603 for more details.

Binaries optionally inject the latest VCS tag at build time as flags to different locations depending on the project.

Because of this, MAIN module matching does not have the opportunity or information to be accurate.

Thus, dropping matching support when `DEVEL` seems to be the best path option forward to reduce FP. The number of FP reduced is higher than the number of FN(false negatives) introduced in this case.

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>