### PR TITLE
Fix a cyclonedxvex typo and fix the schema document

### DIFF
--- a/schema/cyclonedxvex/Makefile
+++ b/schema/cyclonedxvex/Makefile
@@ -5,10 +5,10 @@ validate-schema: validate-schema-xml validate-schema-json
 
 .PHONY: validate-schema-xml
 validate-schema-xml:
-	go run ../../main.go -c ../../test/grype-test-config.yaml ubuntu:latest -vv -o embedded-cyclondex-vex-xml > bom.xml
+	go run ../../main.go -c ../../test/grype-test-config.yaml ubuntu:latest -vv -o embedded-cyclonedx-vex-xml > bom.xml
 	xmllint --noout --schema ./cyclonedx.xsd bom.xml
 
 .PHONY: validate-schema-json
 validate-schema-json:
-	go run ../../main.go -c ../../test/grype-test-config.yaml ubuntu:latest -vv -o embedded-cyclondex-vex-json > bom.json
+	go run ../../main.go -c ../../test/grype-test-config.yaml ubuntu:latest -vv -o embedded-cyclonedx-vex-json > bom.json
 	../../.tmp/yajsv -s cyclonedx.json bom.json

--- a/schema/cyclonedxvex/cyclonedx.xsd
+++ b/schema/cyclonedxvex/cyclonedx.xsd
@@ -2014,6 +2014,16 @@ limitations under the License.
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a key/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is OPTIONAL.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:sequence>
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>


### PR DESCRIPTION
The schema fix is from
https://github.com/CycloneDX/specification/issues/147

Signed-off-by: Josh Bressers <josh@bress.net>