### PR TITLE
add new line for help block

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,6 +68,7 @@ You can also explicitly specify the scheme to use:
     {{.appName}} sbom:path/to/syft.json                 read Syft JSON from path on disk
     {{.appName}} registry:yourrepo/yourimage:tag        pull image directly from a registry (no container runtime required)
     {{.appName}} att:attestation.json --key cosign.pub  explicitly use the input as an attestation
+
 You can also pipe in Syft JSON directly:
 	syft yourimage:tag -o json | {{.appName}}
 


### PR DESCRIPTION
Small help menu update to space out relevant syft instructions

Before:
![Screen Shot 2022-07-19 at 10 36 34 AM](https://user-images.githubusercontent.com/32073428/179777212-03b11fcd-f440-4401-9f0b-bdc55c2d065b.png)

After:
![Screen Shot 2022-07-19 at 10 37 15 AM](https://user-images.githubusercontent.com/32073428/179777351-9613fbd0-11b7-4975-8727-42dca6f95175.png)

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>