### PR TITLE
[Example] ci: add grype image bundled with db for ci

### DIFF
--- a/.github/workflows/republish-ci-container.yml
+++ b/.github/workflows/republish-ci-container.yml
@@ -1,0 +1,19 @@
+name: "Republish grype:ci Container"
+on:
+  repository_dispatch:
+    types: [republish-ci-image]
+env:
+  GO_VERSION: "1.18.x"
+  GO_STABLE_VERSION: true
+
+jobs:
+  republish-ci-container:
+    environment: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: 
+        run: make republish-ci-container
+        env:
+          DOCKER_USERNAME: ${{ secrets.TOOLBOX_DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.TOOLBOX_DOCKER_PASS }}

--- a/.goreleaser.ci.yaml
+++ b/.goreleaser.ci.yaml
@@ -1,0 +1,23 @@
+release:
+  prerelease: auto
+  draft: false
+
+env:
+  # required to support multi architecture docker builds
+  - DOCKER_CLI_EXPERIMENTAL=enabled
+
+dockers:
+  - image_templates:
+      - anchore/grype:ci
+      - ghcr.io/anchore/grype:ci
+    goarch: amd64
+    dockerfile: Dockerfile.ci
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+
+docker_manifests:
+  - name_template: anchore/grype:ci
+    image_templates:
+      - anchore/grype:ci

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,34 @@
+FROM gcr.io/distroless/static-debian11:debug AS build
+
+FROM scratch
+# needed for version check HTTPS request
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# create the /tmp dir, which is needed for image content cache
+WORKDIR /tmp
+
+FROM grype:latest AS grype
+COPY --from=grype /grype /grype
+
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG VCS_REF
+ARG VCS_URL
+
+LABEL org.opencontainers.image.created=$BUILD_DATE
+LABEL org.opencontainers.image.title="grype"
+LABEL org.opencontainers.image.description="A vulnerability scanner for container images and filesystems"
+LABEL org.opencontainers.image.source=$VCS_URL
+LABEL org.opencontainers.image.revision=$VCS_REF
+LABEL org.opencontainers.image.vendor="Anchore, Inc."
+LABEL org.opencontainers.image.version=$BUILD_VERSION
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL io.artifacthub.package.readme-url="https://raw.githubusercontent.com/anchore/grype/main/README.md"
+LABEL io.artifacthub.package.logo-url="https://user-images.githubusercontent.com/5199289/136855393-d0a9eef9-ccf1-4e2b-9d7c-7aad16a567e5.png"
+LABEL io.artifacthub.package.license="Apache-2.0"
+
+# download grype database
+RUN ["/grype", "db", "update"]
+ENV GRYPE_DB_AUTO_UPDATE=false
+
+ENTRYPOINT ["/grype"]

--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,11 @@ release: clean-dist CHANGELOG.md  ## Build and publish final binaries and packag
 	# upload the version file that supports the application version update check (excluding pre-releases)
 	.github/scripts/update-version-file.sh "$(DISTDIR)" "$(VERSION)"
 
+.PHONY: republish-ci-container
+republish-ci-container:
+	cat .goreleaser.ci.yaml >> $(TEMPDIR)/goreleaser.yaml
+	bash -c "$(RELEASE_CMD) --config $(TEMPDIR)/goreleaser.yaml"
+
 .PHONY: clean
 clean: clean-dist clean-snapshot  ## Remove previous builds and result reports
 	$(call safe_rm_rf_children,$(RESULTSDIR))


### PR DESCRIPTION
Just an example idea https://github.com/anchore/grype/issues/837

Issues:
- doesn't tag with the version, giturl, or commit inside using goreleaser
- adds additional goreleaser config / would also need added to current goreleaser setup
- hard to handle if you want pegged version ex. 34.7, need to republish every image as part of the re-release job