### PR TITLE
fix: db diff default has flipped base/target url

### DIFF
--- a/cmd/db_diff.go
+++ b/cmd/db_diff.go
@@ -143,7 +143,7 @@ func getDefaultURL() (defaultURL []*url.URL, err error) {
 
 	recent := available[:2]
 	for _, entry := range recent {
-		defaultURL = append(defaultURL, entry.URL)
+		defaultURL = append([]*url.URL{entry.URL}, defaultURL...)
 	}
 
 	return defaultURL, nil


### PR DESCRIPTION
## 📝 Description
Just flips the base/target urls back the correct direction for the default case of no urls provided

Closes: https://github.com/anchore/grype/issues/844