### PR TITLE
additional readOptions added  per 855

### DIFF
--- a/grype/db/internal/gormadapter/open.go
+++ b/grype/db/internal/gormadapter/open.go
@@ -16,10 +16,6 @@ var writerStatements = []string{
 	`PRAGMA journal_mode = MEMORY`,
 }
 
-var readerStatments = []string{
-	`PRAGMA journal_mode = WAL`,
-}
-
 var readOptions = []string{
 	"&immutable=1",
 	"&cache=shared",
@@ -52,13 +48,6 @@ func Open(path string, write bool) (*gorm.DB, error) {
 
 	if write {
 		for _, sqlStmt := range writerStatements {
-			dbObj.Exec(sqlStmt)
-			if dbObj.Error != nil {
-				return nil, fmt.Errorf("unable to execute (%s): %w", sqlStmt, dbObj.Error)
-			}
-		}
-	} else {
-		for _, sqlStmt := range readerStatments {
 			dbObj.Exec(sqlStmt)
 			if dbObj.Error != nil {
 				return nil, fmt.Errorf("unable to execute (%s): %w", sqlStmt, dbObj.Error)

--- a/grype/db/internal/gormadapter/open.go
+++ b/grype/db/internal/gormadapter/open.go
@@ -16,6 +16,13 @@ var writerStatements = []string{
 	`PRAGMA journal_mode = MEMORY`,
 }
 
+var readOptions = []string{
+	"&immutable=1",
+	"&cache=shared",
+	"&mode=ro",
+	"&_journal_mode=WAL",
+}
+
 // Open a new connection to a sqlite3 database file
 func Open(path string, write bool) (*gorm.DB, error) {
 	if write {
@@ -29,7 +36,10 @@ func Open(path string, write bool) (*gorm.DB, error) {
 	}
 
 	if !write {
-		connStr += "&immutable=1"
+		// &immutable=1&cache=shared&mode=ro&_journal_mode=WAL
+		for _, o := range readOptions {
+			connStr += o
+		}
 	}
 
 	dbObj, err := gorm.Open(sqlite.Open(connStr), &gorm.Config{Logger: newLogger()})

--- a/grype/db/internal/gormadapter/open.go
+++ b/grype/db/internal/gormadapter/open.go
@@ -16,11 +16,14 @@ var writerStatements = []string{
 	`PRAGMA journal_mode = MEMORY`,
 }
 
+var readerStatments = []string{
+	`PRAGMA journal_mode = WAL`,
+}
+
 var readOptions = []string{
 	"&immutable=1",
 	"&cache=shared",
 	"&mode=ro",
-	"&_journal_mode=WAL",
 }
 
 // Open a new connection to a sqlite3 database file
@@ -49,6 +52,13 @@ func Open(path string, write bool) (*gorm.DB, error) {
 
 	if write {
 		for _, sqlStmt := range writerStatements {
+			dbObj.Exec(sqlStmt)
+			if dbObj.Error != nil {
+				return nil, fmt.Errorf("unable to execute (%s): %w", sqlStmt, dbObj.Error)
+			}
+		}
+	} else {
+		for _, sqlStmt := range readerStatments {
 			dbObj.Exec(sqlStmt)
 			if dbObj.Error != nil {
 				return nil, fmt.Errorf("unable to execute (%s): %w", sqlStmt, dbObj.Error)

--- a/grype/db/internal/gormadapter/open.go
+++ b/grype/db/internal/gormadapter/open.go
@@ -17,9 +17,9 @@ var writerStatements = []string{
 }
 
 var readOptions = []string{
-	"&immutable=1",
-	"&cache=shared",
-	"&mode=ro",
+	"immutable=1",
+	"cache=shared",
+	"mode=ro",
 }
 
 // Open a new connection to a sqlite3 database file
@@ -37,7 +37,7 @@ func Open(path string, write bool) (*gorm.DB, error) {
 	if !write {
 		// &immutable=1&cache=shared&mode=ro&_journal_mode=WAL
 		for _, o := range readOptions {
-			connStr += o
+			connStr += fmt.Sprintf("&%s", o)
 		}
 	}
 

--- a/grype/db/internal/gormadapter/open.go
+++ b/grype/db/internal/gormadapter/open.go
@@ -35,7 +35,7 @@ func Open(path string, write bool) (*gorm.DB, error) {
 	}
 
 	if !write {
-		// &immutable=1&cache=shared&mode=ro&_journal_mode=WAL
+		// &immutable=1&cache=shared&mode=ro
 		for _, o := range readOptions {
 			connStr += fmt.Sprintf("&%s", o)
 		}


### PR DESCRIPTION
Solves #855 

The only one I don't see here is `_journal_mode=WAL`
https://www.sqlite.org/uri.html#uri_filenames_in_sqlite

https://www.sqlite.org/c3ref/open.html <-- Immutable ref
https://www.sqlite.org/wal.html <-- WAL ref
https://www.sqlite.org/sharedcache.html#sqlite_shared_cache_mode <-- Cache ref
https://www.sqlite.org/uri.html#uri_filenames_in_sqlite <-- mode=ro ref

```
immutable=1
cache=shared
mode=ro
_journal_mode=WAL
```

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>