### PR TITLE
Add test for running Grype concurrently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ DISTDIR=./dist
 SNAPSHOTDIR=./snapshot
 OS=$(shell uname | tr '[:upper:]' '[:lower:]')
 SYFT_VERSION=$(shell go list -m all | grep github.com/anchore/syft | awk '{print $$2}')
-SNAPSHOT_BIN=$(shell realpath $(shell pwd)/$(SNAPSHOTDIR)/$(OS)-build_$(OS)_amd64_v1/$(BIN))
+SNAPSHOT_BIN=$(realpath $(shell pwd)/$(SNAPSHOTDIR)/$(OS)-build_$(OS)_amd64_v1/$(BIN))
 
 
 ## Variable assertions
@@ -95,8 +95,8 @@ bootstrap-tools: $(TEMPDIR)
 	curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMPDIR)/ v0.4.0
 	curl -sSfL https://raw.githubusercontent.com/anchore/chronicle/main/install.sh | sh -s -- -b $(TEMPDIR)/ v0.3.0
 	# the only difference between goimports and gosimports is that gosimports removes extra whitespace between import blocks (see https://github.com/golang/go/issues/20818)
-	GOBIN="$(shell realpath $(TEMPDIR))" go install github.com/rinchsan/gosimports/cmd/gosimports@v0.1.5
-	GOBIN="$(shell realpath $(TEMPDIR))" go install github.com/neilpa/yajsv@v1.4.0
+	GOBIN="$(realpath $(TEMPDIR))" go install github.com/rinchsan/gosimports/cmd/gosimports@v0.1.5
+	GOBIN="$(realpath $(TEMPDIR))" go install github.com/neilpa/yajsv@v1.4.0
 	.github/scripts/goreleaser-install.sh -b $(TEMPDIR)/ v1.10.3
 
 .PHONY: bootstrap-go

--- a/test/cli/concurrent_test.go
+++ b/test/cli/concurrent_test.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ConcurrentAccess(t *testing.T) {
+	wg := sync.WaitGroup{}
+	iterations := 10
+	wg.Add(iterations)
+	for i := 0; i < iterations; i++ {
+		go func() {
+			defer wg.Done()
+			cmd, _, _ := runGrype(t, nil, "alpine:3.15", "-vv")
+			require.Equal(t, 0, cmd.ProcessState.ExitCode())
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
This PR adds a test to run Grype concurrently and validate there are no database locking or other related issues.