### PR TITLE
fix: only show distro warning if distro packages exist

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/matcher"
 	"github.com/anchore/grype/grype/pkg"
+	type "github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/grype/grype/presenter"
 	"github.com/anchore/grype/grype/store"
 	"github.com/anchore/grype/grype/vulnerability"
@@ -346,7 +347,7 @@ func startWorker(userInput string, failOnSeverity *vulnerability.Severity) <-cha
 			appConfig.Ignore = append(appConfig.Ignore, ignoreFixedMatches...)
 		}
 
-		applyDistroHint(&context, appConfig)
+		applyDistroHint(packages, &context, appConfig)
 
 		matchers := matcher.NewDefaultMatchers(matcher.Config{
 			Java: appConfig.ExternalSources.ToJavaMatcherConfig(),
@@ -374,7 +375,7 @@ func startWorker(userInput string, failOnSeverity *vulnerability.Severity) <-cha
 	return errs
 }
 
-func applyDistroHint(context *pkg.Context, appConfig *config.Application) {
+func applyDistroHint(pkgs []pkg.Package, context *pkg.Context, appConfig *config.Application) {
 	if appConfig.Distro != "" {
 		log.Infof("using distro: %s", appConfig.Distro)
 
@@ -396,8 +397,16 @@ func applyDistroHint(context *pkg.Context, appConfig *config.Application) {
 		}
 	}
 
-	if context.Distro == nil {
-		log.Debug("Unable to determine the OS distribution. This may result in missing vulnerabilities. " +
+	hasOSPackage := false
+	for _, p := range pkgs {
+		switch p.Type {
+		case type.AlpmPkg, type.DebPkg, type.RpmPkg, type.KbPkg:
+			hasOSPackage = true
+		}
+	}
+
+	if context.Distro == nil && hasOSPackage {
+		log.Warnf("Unable to determine the OS distribution. This may result in missing vulnerabilities. " +
 			"You may specify a distro using: --distro <distro>:<version>")
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,6 @@ import (
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/matcher"
 	"github.com/anchore/grype/grype/pkg"
-	type "github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/grype/grype/presenter"
 	"github.com/anchore/grype/grype/store"
 	"github.com/anchore/grype/grype/vulnerability"
@@ -33,6 +32,7 @@ import (
 	"github.com/anchore/grype/internal/version"
 	"github.com/anchore/stereoscope"
 	"github.com/anchore/syft/syft/linux"
+	syftPkg "github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/source"
 )
 
@@ -400,7 +400,7 @@ func applyDistroHint(pkgs []pkg.Package, context *pkg.Context, appConfig *config
 	hasOSPackage := false
 	for _, p := range pkgs {
 		switch p.Type {
-		case type.AlpmPkg, type.DebPkg, type.RpmPkg, type.KbPkg:
+		case syftPkg.AlpmPkg, syftPkg.DebPkg, syftPkg.RpmPkg, syftPkg.KbPkg:
 			hasOSPackage = true
 		}
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -123,12 +123,12 @@ func Test_applyDistroHint(t *testing.T) {
 	ctx := pkg.Context{}
 	cfg := config.Application{}
 
-	applyDistroHint(&ctx, &cfg)
+	applyDistroHint([]pkg.Package{}, &ctx, &cfg)
 	assert.Nil(t, ctx.Distro)
 
 	// works when distro is nil
 	cfg.Distro = "alpine:3.10"
-	applyDistroHint(&ctx, &cfg)
+	applyDistroHint([]pkg.Package{}, &ctx, &cfg)
 	assert.NotNil(t, ctx.Distro)
 
 	assert.Equal(t, "alpine", ctx.Distro.Name)
@@ -136,7 +136,7 @@ func Test_applyDistroHint(t *testing.T) {
 
 	// does override an existing distro
 	cfg.Distro = "ubuntu:latest"
-	applyDistroHint(&ctx, &cfg)
+	applyDistroHint([]pkg.Package{}, &ctx, &cfg)
 	assert.NotNil(t, ctx.Distro)
 
 	assert.Equal(t, "ubuntu", ctx.Distro.Name)
@@ -144,7 +144,7 @@ func Test_applyDistroHint(t *testing.T) {
 
 	// doesn't remove an existing distro when empty
 	cfg.Distro = ""
-	applyDistroHint(&ctx, &cfg)
+	applyDistroHint([]pkg.Package{}, &ctx, &cfg)
 	assert.NotNil(t, ctx.Distro)
 
 	assert.Equal(t, "ubuntu", ctx.Distro.Name)


### PR DESCRIPTION
## 📝 Description
This PR ensures that Grype first tries to uses the following logic for warning a user about a missing distribution

1. Try to use the app config for the distribution
2. Try to use the context which has a distribution produced by Syft for formats that support it
3. Check if any packages would require a distribution

If the final state is reached where there is no distribution known and a distribution package exists, then throw the warning, but return it to warning level

Closes https://github.com/anchore/grype/issues/748