### PR TITLE
docs: improve Singularity image source docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ Grype can scan a variety of sources beyond those found in Docker.
 # scan a container image archive (from the result of `docker image save ...`, `podman save ...`, or `skopeo copy` commands)
 grype path/to/image.tar
 
+# scan a Singularity Image Format (SIF) container
+syft path/to/image.sif
+
 # scan a directory
 grype dir:path/to/dir
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,7 +56,7 @@ var (
 
 Supports the following image sources:
     {{.appName}} yourrepo/yourimage:tag             defaults to using images from a Docker daemon
-    {{.appName}} path/to/yourproject                a Docker tar, OCI tar, OCI directory, or generic filesystem directory
+    {{.appName}} path/to/yourproject                a Docker tar, OCI tar, OCI directory, SIF container, or generic filesystem directory
     {{.appName}} attestation.json --key cosign.pub  extract and scan SBOM from attestation file
 
 You can also explicitly specify the scheme to use:


### PR DESCRIPTION
(Draft until https://github.com/anchore/syft/issues/1189 addressed, likely via https://github.com/anchore/stereoscope/pull/142)

Add Singularity example to "supported sources" in README, and to image sources in online help.