### PR TITLE
feat: extract use cpes in matching logic to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,25 @@ log:
   # location to write the log file (default is not to have a log file)
   # same as GRYPE_LOG_FILE env var
   file: ""
+
+match:
+  # sets the matchers below to use cpes when trying to find 
+  # vulnerability matches. The stock matcher is the default
+  # when no primary matcher can be identified 
+  java:
+    using-cpes: true
+  python:
+    using-cpes: true
+  javascript:
+    using-cpes: true
+  ruby:
+    using-cpes: true
+  dotnet:
+    using-cpes: true
+  golang:
+    using-cpes: true
+  stock:
+    using-cpes: true
 ```
 
 ## Future plans

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,12 @@ import (
 	"github.com/anchore/grype/grype/grypeerr"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/matcher"
+	"github.com/anchore/grype/grype/matcher/dotnet"
+	"github.com/anchore/grype/grype/matcher/golang"
+	"github.com/anchore/grype/grype/matcher/javascript"
+	"github.com/anchore/grype/grype/matcher/python"
+	"github.com/anchore/grype/grype/matcher/ruby"
+	"github.com/anchore/grype/grype/matcher/stock"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/presenter"
 	"github.com/anchore/grype/grype/store"
@@ -351,7 +357,13 @@ func startWorker(userInput string, failOnSeverity *vulnerability.Severity) <-cha
 		applyDistroHint(packages, &context, appConfig)
 
 		matchers := matcher.NewDefaultMatchers(matcher.Config{
-			Java: appConfig.ExternalSources.ToJavaMatcherConfig(),
+			Java:       appConfig.ExternalSources.ToJavaMatcherConfig(appConfig.Match.Java),
+			Ruby:       ruby.MatcherConfig(appConfig.Match.Ruby),
+			Python:     python.MatcherConfig(appConfig.Match.Python),
+			Dotnet:     dotnet.MatcherConfig(appConfig.Match.Dotnet),
+			Javascript: javascript.MatcherConfig(appConfig.Match.Javascript),
+			Golang:     golang.MatcherConfig(appConfig.Match.Golang),
+			Stock:      stock.MatcherConfig(appConfig.Match.Stock),
 		})
 
 		allMatches := grype.FindVulnerabilitiesForPackage(*store, context.Distro, matchers, packages)

--- a/grype/matcher/dotnet/matcher.go
+++ b/grype/matcher/dotnet/matcher.go
@@ -10,6 +10,17 @@ import (
 )
 
 type Matcher struct {
+	UseCPEs bool
+}
+
+type MatcherConfig struct {
+	UseCPEs bool
+}
+
+func NewDotnetMatcher(cfg MatcherConfig) *Matcher {
+	return &Matcher{
+		UseCPEs: cfg.UseCPEs,
+	}
 }
 
 func (m *Matcher) PackageTypes() []syftPkg.Type {
@@ -21,5 +32,9 @@ func (m *Matcher) Type() match.MatcherType {
 }
 
 func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Package) ([]match.Match, error) {
-	return search.ByCriteria(store, d, p, m.Type(), search.CommonCriteria...)
+	criteria := search.CommonCriteria
+	if m.UseCPEs {
+		criteria = append(criteria, search.ByCPE)
+	}
+	return search.ByCriteria(store, d, p, m.Type(), criteria...)
 }

--- a/grype/matcher/golang/matcher.go
+++ b/grype/matcher/golang/matcher.go
@@ -12,6 +12,17 @@ import (
 )
 
 type Matcher struct {
+	UseCPEs bool
+}
+
+type MatcherConfig struct {
+	UseCPEs bool
+}
+
+func NewGolangMatcher(cfg MatcherConfig) *Matcher {
+	return &Matcher{
+		UseCPEs: cfg.UseCPEs,
+	}
 }
 
 func (m *Matcher) PackageTypes() []syftPkg.Type {
@@ -38,5 +49,9 @@ func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Pa
 		return matches, nil
 	}
 
-	return search.ByCriteria(store, d, p, m.Type(), search.CommonCriteria...)
+	criteria := search.CommonCriteria
+	if m.UseCPEs {
+		criteria = append(criteria, search.ByCPE)
+	}
+	return search.ByCriteria(store, d, p, m.Type(), criteria...)
 }

--- a/grype/matcher/javascript/matcher.go
+++ b/grype/matcher/javascript/matcher.go
@@ -10,6 +10,17 @@ import (
 )
 
 type Matcher struct {
+	UseCPEs bool
+}
+
+type MatcherConfig struct {
+	UseCPEs bool
+}
+
+func NewJavascriptMatcher(cfg MatcherConfig) *Matcher {
+	return &Matcher{
+		UseCPEs: cfg.UseCPEs,
+	}
 }
 
 func (m *Matcher) PackageTypes() []syftPkg.Type {
@@ -21,5 +32,9 @@ func (m *Matcher) Type() match.MatcherType {
 }
 
 func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Package) ([]match.Match, error) {
-	return search.ByCriteria(store, d, p, m.Type(), search.CommonCriteria...)
+	criteria := search.CommonCriteria
+	if m.UseCPEs {
+		criteria = append(criteria, search.ByCPE)
+	}
+	return search.ByCriteria(store, d, p, m.Type(), criteria...)
 }

--- a/grype/matcher/matchers.go
+++ b/grype/matcher/matchers.go
@@ -76,7 +76,7 @@ func trackMatcher() (*progress.Manual, *progress.Manual) {
 
 func newMatcherIndex(matchers []Matcher) (map[syftPkg.Type][]Matcher, Matcher) {
 	matcherIndex := make(map[syftPkg.Type][]Matcher)
-	var defaultMatcher Matcher = nil
+	var defaultMatcher Matcher
 	for _, m := range matchers {
 		if m.Type() == match.StockMatcher {
 			defaultMatcher = m

--- a/grype/matcher/python/matcher.go
+++ b/grype/matcher/python/matcher.go
@@ -10,6 +10,17 @@ import (
 )
 
 type Matcher struct {
+	UseCPEs bool
+}
+
+type MatcherConfig struct {
+	UseCPEs bool
+}
+
+func NewPythonMatcher(cfg MatcherConfig) *Matcher {
+	return &Matcher{
+		UseCPEs: cfg.UseCPEs,
+	}
 }
 
 func (m *Matcher) PackageTypes() []syftPkg.Type {
@@ -21,5 +32,9 @@ func (m *Matcher) Type() match.MatcherType {
 }
 
 func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Package) ([]match.Match, error) {
-	return search.ByCriteria(store, d, p, m.Type(), search.CommonCriteria...)
+	criteria := search.CommonCriteria
+	if m.UseCPEs {
+		criteria = append(criteria, search.ByCPE)
+	}
+	return search.ByCriteria(store, d, p, m.Type(), criteria...)
 }

--- a/grype/matcher/ruby/matcher.go
+++ b/grype/matcher/ruby/matcher.go
@@ -10,6 +10,17 @@ import (
 )
 
 type Matcher struct {
+	UseCPEs bool
+}
+
+type MatcherConfig struct {
+	UseCPEs bool
+}
+
+func NewRubyMatcher(cfg MatcherConfig) *Matcher {
+	return &Matcher{
+		UseCPEs: cfg.UseCPEs,
+	}
 }
 
 func (m *Matcher) PackageTypes() []syftPkg.Type {
@@ -21,5 +32,9 @@ func (m *Matcher) Type() match.MatcherType {
 }
 
 func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Package) ([]match.Match, error) {
-	return search.ByCriteria(store, d, p, m.Type(), search.CommonCriteria...)
+	criteria := search.CommonCriteria
+	if m.UseCPEs {
+		criteria = append(criteria, search.ByCPE)
+	}
+	return search.ByCriteria(store, d, p, m.Type(), criteria...)
 }

--- a/grype/matcher/stock/matcher.go
+++ b/grype/matcher/stock/matcher.go
@@ -10,6 +10,17 @@ import (
 )
 
 type Matcher struct {
+	UseCPEs bool
+}
+
+type MatcherConfig struct {
+	UseCPEs bool
+}
+
+func NewStockMatcher(cfg MatcherConfig) *Matcher {
+	return &Matcher{
+		UseCPEs: cfg.UseCPEs,
+	}
 }
 
 func (m *Matcher) PackageTypes() []syftPkg.Type {
@@ -21,5 +32,9 @@ func (m *Matcher) Type() match.MatcherType {
 }
 
 func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Package) ([]match.Match, error) {
-	return search.ByCriteria(store, d, p, m.Type(), search.CommonCriteria...)
+	criteria := search.CommonCriteria
+	if m.UseCPEs {
+		criteria = append(criteria, search.ByCPE)
+	}
+	return search.ByCriteria(store, d, p, m.Type(), criteria...)
 }

--- a/grype/search/criteria.go
+++ b/grype/search/criteria.go
@@ -14,7 +14,6 @@ var (
 	ByDistro       Criteria = "by-distro"
 	CommonCriteria          = []Criteria{
 		ByLanguage,
-		ByCPE,
 	}
 )
 

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -46,6 +46,7 @@ type Application struct {
 	Exclusions          []string                `yaml:"exclude" json:"exclude" mapstructure:"exclude"`
 	DB                  database                `yaml:"db" json:"db" mapstructure:"db"`
 	ExternalSources     externalSources         `yaml:"external-sources" json:"externalSources" mapstructure:"external-sources"`
+	Match               matchConfig             `yaml:"match" json:"match" mapstructure:"match"`
 	Dev                 development             `yaml:"dev" json:"dev" mapstructure:"dev"`
 	FailOn              string                  `yaml:"fail-on-severity" json:"fail-on-severity" mapstructure:"fail-on-severity"`
 	FailOnSeverity      *vulnerability.Severity `yaml:"-" json:"-"`

--- a/internal/config/datasources.go
+++ b/internal/config/datasources.go
@@ -26,7 +26,7 @@ func (cfg externalSources) loadDefaultValues(v *viper.Viper) {
 	v.SetDefault("external-sources.maven.base-url", defaultMavenBaseURL)
 }
 
-func (cfg externalSources) ToJavaMatcherConfig() java.MatcherConfig {
+func (cfg externalSources) ToJavaMatcherConfig(matchCfg matcherConfig) java.MatcherConfig {
 	// always respect if global config is disabled
 	smu := cfg.Maven.SearchUpstreamBySha1
 	if !cfg.Enable {
@@ -35,5 +35,6 @@ func (cfg externalSources) ToJavaMatcherConfig() java.MatcherConfig {
 	return java.MatcherConfig{
 		SearchMavenUpstream: smu,
 		MavenBaseURL:        cfg.Maven.BaseURL,
+		UseCPEs:             matchCfg.UseCPEs,
 	}
 }

--- a/internal/config/match.go
+++ b/internal/config/match.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"github.com/spf13/viper"
+)
+
+// matchConfig contains all matching-related configuration options available to the user via the application config.
+type matchConfig struct {
+	Java       matcherConfig `yaml:"java" json:"java" mapstructure:"java"`                   // settings for the java matcher
+	Dotnet     matcherConfig `yaml:"dotnet" json:"dotnet" mapstructure:"dotnet"`             // settings for the dotnet matcher
+	Golang     matcherConfig `yaml:"golang" json:"golang" mapstructure:"golang"`             // settings for the golang matcher
+	Javascript matcherConfig `yaml:"javascript" json:"javascript" mapstructure:"javascript"` // settings for the javascript matcher
+	Python     matcherConfig `yaml:"python" json:"python" mapstructure:"python"`             // settings for the python matcher
+	Ruby       matcherConfig `yaml:"ruby" json:"ruby" mapstructure:"ruby"`                   // settings for the ruby matcher
+	Stock      matcherConfig `yaml:"stock" json:"stock" mapstructure:"stock"`                // settings for the default/stock matcher
+}
+
+type matcherConfig struct {
+	UseCPEs bool `yaml:"using-cpes" json:"using-cpes" mapstructure:"using-cpes"` // if CPEs should be used during matching
+}
+
+func (cfg matchConfig) loadDefaultValues(v *viper.Viper) {
+	v.SetDefault("match.java.using-cpes", true)
+	v.SetDefault("match.dotnet.using-cpes", true)
+	v.SetDefault("match.golang.using-cpes", true)
+	v.SetDefault("match.javascript.using-cpes", true)
+	v.SetDefault("match.python.using-cpes", true)
+	v.SetDefault("match.ruby.using-cpes", true)
+	v.SetDefault("match.stock.using-cpes", true)
+}

--- a/test/integration/match_by_sbom_document_test.go
+++ b/test/integration/match_by_sbom_document_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/anchore/grype/grype"
 	"github.com/anchore/grype/grype/db"
 	"github.com/anchore/grype/grype/match"
-	"github.com/anchore/grype/grype/search"
 	"github.com/anchore/grype/grype/store"
 	"github.com/anchore/syft/syft/source"
 )
@@ -53,25 +52,8 @@ func TestMatchBySBOMDocument(t *testing.T) {
 		{
 			name:        "unknown package type",
 			fixture:     "test-fixtures/sbom/syft-sbom-with-unknown-packages.json",
-			expectedIDs: []string{"CVE-bogus-my-package-1", "CVE-bogus-my-package-2-python"},
+			expectedIDs: []string{"CVE-bogus-my-package-2-python"},
 			expectedDetails: []match.Detail{
-				{
-					Type: match.CPEMatch,
-					SearchedBy: search.CPEParameters{
-						Namespace: "nvd:cpe",
-						CPEs: []string{
-							"cpe:2.3:a:bogus:my-package:1.0.5:*:*:*:*:*:*:*",
-						},
-					},
-					Found: search.CPEResult{
-						VersionConstraint: "< 2.0 (unknown)",
-						CPEs: []string{
-							"cpe:2.3:a:bogus:my-package:*:*:*:*:*:*:something:*",
-						},
-					},
-					Matcher:    match.StockMatcher,
-					Confidence: 0.9,
-				},
 				{
 					Type: match.ExactDirectMatch,
 					SearchedBy: map[string]interface{}{


### PR DESCRIPTION
## 📝 Description
As discussed by @westonsteimel today, this pr puts the logic for turning on cpe matching for the language specific matchers & stock matcher into the config. Currently on by default, though this behavior will potentially change on the Gitlab data source is added