### PR TITLE
remove arch typo - add debug/reg s390x

### DIFF
--- a/.goreleaser_docker.yaml
+++ b/.goreleaser_docker.yaml
@@ -62,15 +62,15 @@ dockers:
       - "--build-arg=VCS_URL={{.GitURL}}"
 
   - image_templates:
-      - anchore/grype:debug-arm64v8
-      - anchore/grype:{{.Tag}}-debug-arm64v8
-      - ghcr.io/anchore/grype:debug-arm64v8
-      - ghcr.io/anchore/grype:{{.Tag}}-debug-arm64v8
+      - anchore/grype:debug-s390x
+      - anchore/grype:{{.Tag}}-debug-s390x
+      - ghcr.io/anchore/grype:debug-s390x
+      - ghcr.io/anchore/grype:{{.Tag}}-debug-s390x
     goarch: s390x
     dockerfile: Dockerfile.debug
     use: buildx
     build_flag_templates:
-      - "--platform=linux/arm64/v8"
+      - "--platform=linux/s390x"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -95,19 +95,6 @@ dockers:
       - anchore/grype:{{.Tag}}-arm64v8
       - ghcr.io/anchore/grype:{{.Tag}}-arm64v8
     goarch: arm64
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/grype:{{.Tag}}-arm64v8
-      - ghcr.io/anchore/grype:{{.Tag}}-arm64v8
-    goarch: s390x
     dockerfile: Dockerfile
     use: buildx
     build_flag_templates:

--- a/.goreleaser_docker.yaml
+++ b/.goreleaser_docker.yaml
@@ -104,13 +104,26 @@ dockers:
       - "--build-arg=VCS_REF={{.FullCommit}}"
       - "--build-arg=VCS_URL={{.GitURL}}"
 
+  - image_templates:
+      - anchore/grype:{{.Tag}}-s390x
+      - ghcr.io/anchore/grype:{{.Tag}}-s390x
+    goarch: s390x
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/s390x"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
+
 docker_manifests:
   - name_template: anchore/grype:latest
     image_templates:
       - anchore/grype:{{.Tag}}
       - anchore/grype:{{.Tag}}-arm64v8
       - anchore/grype:{{.Tag}}-s390x
-
 
   - name_template: anchore/grype:debug
       - anchore/grype:{{.Tag}}-debug


### PR DESCRIPTION
The current docker assets are not being published due to a bug in the go releaser templates:
https://github.com/anchore/grype/actions/runs/2973469646

This PR removes the old typos and adds a debug/reg image under the `dockers` config.

The addition of these two images resolves the manifest issue. These images can now be included as expected image templates since they are once again being published.

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>