### PR TITLE
feat: consider well-known false-positive generating CPE target SW components in match filtering logic

### DIFF
--- a/grype/search/only_vulnerable_targets_test.go
+++ b/grype/search/only_vulnerable_targets_test.go
@@ -1,0 +1,26 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_isUnknownTarget(t *testing.T) {
+	tests := []struct {
+		name     string
+		targetSW string
+		expected bool
+	}{
+		{name: "supported syft language", targetSW: "python", expected: false},
+		{name: "supported non-syft language CPE component", targetSW: "wordpress", expected: false},
+		{name: "unknown component", targetSW: "abc", expected: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			u := isUnknownTarget(test.targetSW)
+			assert.Equal(t, test.expected, u)
+		})
+	}
+}


### PR DESCRIPTION
Enhances the CPE target software component match filtering logic to consider ecosystems which aren't currently supported by syft cataloging but are well-known sources of false-positives. This currently adds support for filtering various permutations of `wordpress`, `joomla`, and `drupal`

Signed-off-by: Weston Steimel <weston.steimel@anchore.com>