### PR TITLE
fix: update case for alpine:edge correct vuln feed

### DIFF
--- a/grype/db/v5/namespace/index.go
+++ b/grype/db/v5/namespace/index.go
@@ -119,20 +119,8 @@ func (i *Index) NamespacesForDistro(d *grypeDistro.Distro) []*distro.Namespace {
 				return v
 			}
 		case grypeDistro.Alpine:
-			// Check if the alpine raw version matches x.y.z
-			if alpineVersionRegularExpression.Match([]byte(d.RawVersion)) {
-				// Get the first two version components
-				distroKey = fmt.Sprintf("%s:%d.%d", strings.ToLower(d.Type.String()), versionSegments[0], versionSegments[1])
-				if v, ok := i.byDistroKey[distroKey]; ok {
-					return v
-				}
-			}
-
-			// If the version does not match x.y.z then it is edge
-			// In this case it would have - or _ alpha,beta,etc
-			// https://github.com/anchore/grype/issues/964#issuecomment-1290888755
-			distroKey := fmt.Sprintf("%s:%s", strings.ToLower(d.Type.String()), "edge")
-			if v, ok := i.byDistroKey[distroKey]; ok {
+			v := getAlpineNamespace(i, d, versionSegments)
+			if v != nil {
 				return v
 			}
 		}
@@ -145,6 +133,27 @@ func (i *Index) NamespacesForDistro(d *grypeDistro.Distro) []*distro.Namespace {
 		if v, ok := i.byDistroKey[distroKey]; ok {
 			return v
 		}
+	}
+
+	return nil
+}
+
+func getAlpineNamespace(i *Index, d *grypeDistro.Distro, versionSegments []int) []*distro.Namespace {
+	// check if distro version matches x.y.z
+	if alpineVersionRegularExpression.Match([]byte(d.RawVersion)) {
+		// Get the first two version components
+		distroKey := fmt.Sprintf("%s:%d.%d", strings.ToLower(d.Type.String()), versionSegments[0], versionSegments[1])
+		if v, ok := i.byDistroKey[distroKey]; ok {
+			return v
+		}
+	}
+
+	// If the version does not match x.y.z then it is edge
+	// In this case it would have - or _ alpha,beta,etc
+	// https://github.com/anchore/grype/issues/964#issuecomment-1290888755
+	distroKey := fmt.Sprintf("%s:%s", strings.ToLower(d.Type.String()), "edge")
+	if v, ok := i.byDistroKey[distroKey]; ok {
+		return v
 	}
 
 	return nil

--- a/grype/db/v5/namespace/index.go
+++ b/grype/db/v5/namespace/index.go
@@ -120,7 +120,7 @@ func (i *Index) NamespacesForDistro(d *grypeDistro.Distro) []*distro.Namespace {
 
 	// Fall back to alpine:edge if no version segments found
 	// alpine:edge is labeled as alpine-x.x_alphaYYYYMMDD
-	if versionSegments == nil && d.Type.String() == "alpine" {
+	if versionSegments == nil && d.Type == grypeDistro.Alpine {
 		distroKey := fmt.Sprintf("%s:%s", strings.ToLower(d.Type.String()), "edge")
 		if v, ok := i.byDistroKey[distroKey]; ok {
 			return v

--- a/grype/db/v5/namespace/index.go
+++ b/grype/db/v5/namespace/index.go
@@ -118,6 +118,15 @@ func (i *Index) NamespacesForDistro(d *grypeDistro.Distro) []*distro.Namespace {
 		}
 	}
 
+	// Fall back to alpine:edge if no version segments found
+	// alpine:edge is labeled as alpine-x.x_alphaYYYYMMDD
+	if versionSegments == nil && d.Type.String() == "alpine" {
+		distroKey := fmt.Sprintf("%s:%s", strings.ToLower(d.Type.String()), "edge")
+		if v, ok := i.byDistroKey[distroKey]; ok {
+			return v
+		}
+	}
+
 	return nil
 }
 

--- a/grype/db/v5/namespace/index_test.go
+++ b/grype/db/v5/namespace/index_test.go
@@ -150,12 +150,20 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 			},
 		},
 		{
-			name:   "alpine minor version matches minor version namespace",
+			name:   "alpine minor version with no patch should match edge",
 			distro: newDistro(t, osDistro.Alpine, "3.16", []string{}),
 			namespaces: []*distro.Namespace{
-				distro.NewNamespace("alpine", osDistro.Alpine, "3.16"),
+				distro.NewNamespace("alpine", osDistro.Alpine, "edge"),
 			},
 		},
+		{
+			name:   "alpine rc version with no patch should match edge",
+			distro: newDistro(t, osDistro.Alpine, "3.16.4-r4", []string{}),
+			namespaces: []*distro.Namespace{
+				distro.NewNamespace("alpine", osDistro.Alpine, "edge"),
+			},
+		},
+
 		{
 			name:   "alpine edge version matches edge namespace",
 			distro: &osDistro.Distro{Type: osDistro.Alpine, Version: nil, RawVersion: "3.17.1_alpha20221002", IDLike: []string{"alpine"}},

--- a/grype/db/v5/namespace/index_test.go
+++ b/grype/db/v5/namespace/index_test.go
@@ -158,36 +158,39 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 		},
 		{
 			name:   "alpine edge version matches edge namespace",
-			distro: &osDistro.Distro{Type: osDistro.Alpine, Version: nil, RawVersion: "3.17_alpha20221002", IDLike: []string{"alpine"}},
+			distro: &osDistro.Distro{Type: osDistro.Alpine, Version: nil, RawVersion: "3.17.1_alpha20221002", IDLike: []string{"alpine"}},
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("alpine", osDistro.Alpine, "edge"),
 			},
 		},
 		{
 			name:   "alpine raw version matches edge with - character",
-			distro: &osDistro.Distro{Type: osDistro.Alpine, Version: nil, RawVersion: "3.17-alpha20221002", IDLike: []string{"alpine"}},
+			distro: &osDistro.Distro{Type: osDistro.Alpine, Version: nil, RawVersion: "3.17.1-alpha20221002", IDLike: []string{"alpine"}},
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("alpine", osDistro.Alpine, "edge"),
 			},
 		},
 		{
 			name:   "alpine raw version matches edge with - character no sha",
-			distro: &osDistro.Distro{Type: osDistro.Alpine, Version: nil, RawVersion: "3.17-alpha", IDLike: []string{"alpine"}},
+			distro: newDistro(t, osDistro.Alpine, "3.17.1-alpha", []string{"alpine"}),
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("alpine", osDistro.Alpine, "edge"),
 			},
 		},
 		{
-			name:   "alpine raw version matches edge with _ character no sha",
-			distro: &osDistro.Distro{Type: osDistro.Alpine, Version: nil, RawVersion: "3.17_alpha", IDLike: []string{"alpine"}},
+			name: "alpine raw version matches edge with _ character no sha",
+			// we don't create a newDistro from this since parsing the version fails
+			distro: &osDistro.Distro{Type: osDistro.Alpine, Version: nil, RawVersion: "3.17.1_alpha", IDLike: []string{"alpine"}},
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("alpine", osDistro.Alpine, "edge"),
 			},
 		},
 		{
-			name:       "alpine malformed version matches no namespace",
-			distro:     newDistro(t, osDistro.Alpine, "3.16.4.5", []string{}),
-			namespaces: nil,
+			name:   "alpine malformed version matches no namespace",
+			distro: newDistro(t, osDistro.Alpine, "3.16.4.5", []string{}),
+			namespaces: []*distro.Namespace{
+				distro.NewNamespace("alpine", osDistro.Alpine, "edge"),
+			},
 		},
 		{
 			name:   "Debian minor version matches debian and other-provider namespaces",

--- a/grype/db/v5/namespace/index_test.go
+++ b/grype/db/v5/namespace/index_test.go
@@ -120,6 +120,7 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 	namespaceIndex, err := FromStrings([]string{
 		"alpine:distro:alpine:3.15",
 		"alpine:distro:alpine:3.16",
+		"alpine:distro:alpine:edge",
 		"debian:distro:debian:8",
 		"amazon:distro:amazonlinux:2",
 		"amazon:distro:amazonlinux:2022",
@@ -137,26 +138,38 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 	assert.NoError(t, err)
 
 	tests := []struct {
+		name       string
 		distro     *osDistro.Distro
 		namespaces []*distro.Namespace
 	}{
 		{
+			name:   "alpine patch version matches minor version namespace",
 			distro: newDistro(t, osDistro.Alpine, "3.15.4", []string{"alpine"}),
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("alpine", osDistro.Alpine, "3.15"),
 			},
 		},
 		{
+			name:   "alpine minor version matches minor version namespace",
 			distro: newDistro(t, osDistro.Alpine, "3.16", []string{}),
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("alpine", osDistro.Alpine, "3.16"),
 			},
 		},
 		{
+			name:   "alpine edge version matches edge namespace",
+			distro: &osDistro.Distro{Type: osDistro.Alpine, Version: nil, RawVersion: "3.17_alpha20221002", IDLike: []string{"alpine"}},
+			namespaces: []*distro.Namespace{
+				distro.NewNamespace("alpine", osDistro.Alpine, "edge"),
+			},
+		},
+		{
+			name:       "alpine malformed version matches no namespace",
 			distro:     newDistro(t, osDistro.Alpine, "3.16.4.5", []string{}),
 			namespaces: nil,
 		},
 		{
+			name:   "Debian minor version matches debian and other-provider namespaces",
 			distro: newDistro(t, osDistro.Debian, "8.5", []string{}),
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("debian", osDistro.Debian, "8"),
@@ -164,6 +177,7 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 			},
 		},
 		{
+			name:   "Redhat minor version matches redhat and other-provider namespaces",
 			distro: newDistro(t, osDistro.RedHat, "9.5", []string{}),
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("redhat", osDistro.RedHat, "9"),
@@ -171,6 +185,7 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 			},
 		},
 		{
+			name:   "Centos minor version matches redhat and other-provider namespaces",
 			distro: newDistro(t, osDistro.CentOS, "9.5", []string{}),
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("redhat", osDistro.RedHat, "9"),
@@ -178,6 +193,7 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 			},
 		},
 		{
+			name:   "Alma Linux minor version matches redhat and other-provider namespaces",
 			distro: newDistro(t, osDistro.AlmaLinux, "9.5", []string{}),
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("redhat", osDistro.RedHat, "9"),
@@ -185,6 +201,7 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 			},
 		},
 		{
+			name:   "Rocky Linux minor version matches redhat and other-provider namespaces",
 			distro: newDistro(t, osDistro.RockyLinux, "9.5", []string{}),
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("redhat", osDistro.RedHat, "9"),
@@ -192,69 +209,84 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 			},
 		},
 		{
+			name:   "SLES minor version matches suse namespace",
 			distro: newDistro(t, osDistro.SLES, "12.5", []string{}),
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("suse", osDistro.SLES, "12.5"),
 			},
 		},
 		{
+			name:   "Windows version object matches msrc namespace with exact version",
 			distro: newDistro(t, osDistro.Windows, "471816", []string{}),
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("msrc", osDistro.Windows, "471816"),
 			},
 		},
 		{
+			name:   "Ubuntu minor semvar matches ubuntu namespace with exact version",
 			distro: newDistro(t, osDistro.Ubuntu, "18.04", []string{}),
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("ubuntu", osDistro.Ubuntu, "18.04"),
 			},
 		},
 		{
+			name:       "Fedora minor semvar will not match a namespace",
 			distro:     newDistro(t, osDistro.Fedora, "31.4", []string{}),
 			namespaces: nil,
 		},
 		{
+			name:   "Amazon Linux Major semvar matches amazon namespace with exact version",
 			distro: newDistro(t, osDistro.AmazonLinux, "2", []string{}),
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("amazon", osDistro.AmazonLinux, "2"),
 			},
 		},
 		{
+			name:   "Amazon Linux year version matches amazon namespace with exact uear",
 			distro: newDistro(t, osDistro.AmazonLinux, "2022", []string{}),
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("amazon", osDistro.AmazonLinux, "2022"),
 			},
 		},
 		{
+			name:       "Mariner minor semvar matches no namespace",
 			distro:     newDistro(t, osDistro.Mariner, "20.1", []string{}),
 			namespaces: nil,
 		},
 		{
+			name:   "Oracle Linux Major semvar matches oracle namespace with exact version",
 			distro: newDistro(t, osDistro.OracleLinux, "8", []string{}),
 			namespaces: []*distro.Namespace{
 				distro.NewNamespace("oracle", osDistro.OracleLinux, "8"),
 			},
 		},
 		{
+
+			name:       "Arch Linux matches no namespace",
 			distro:     newDistro(t, osDistro.ArchLinux, "", []string{}),
 			namespaces: nil,
 		},
 		{
+			name:       "Open Suse Leap semvar matches no namespace",
 			distro:     newDistro(t, osDistro.OpenSuseLeap, "100", []string{}),
 			namespaces: nil,
 		},
 		{
+			name:       "Photon minor semvar no namespace",
 			distro:     newDistro(t, osDistro.Photon, "20.1", []string{}),
 			namespaces: nil,
 		},
 		{
+			name:       "Busybox minor semvar matches no namespace",
 			distro:     newDistro(t, osDistro.Busybox, "20.1", []string{}),
 			namespaces: nil,
 		},
 	}
 
 	for _, test := range tests {
-		result := namespaceIndex.NamespacesForDistro(test.distro)
-		assert.ElementsMatch(t, result, test.namespaces)
+		t.Run(test.name, func(t *testing.T) {
+			namespaces := namespaceIndex.NamespacesForDistro(test.distro)
+			assert.Equal(t, test.namespaces, namespaces)
+		})
 	}
 }

--- a/grype/db/v5/namespace/index_test.go
+++ b/grype/db/v5/namespace/index_test.go
@@ -164,6 +164,27 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 			},
 		},
 		{
+			name:   "alpine raw version matches edge with - character",
+			distro: &osDistro.Distro{Type: osDistro.Alpine, Version: nil, RawVersion: "3.17-alpha20221002", IDLike: []string{"alpine"}},
+			namespaces: []*distro.Namespace{
+				distro.NewNamespace("alpine", osDistro.Alpine, "edge"),
+			},
+		},
+		{
+			name:   "alpine raw version matches edge with - character no sha",
+			distro: &osDistro.Distro{Type: osDistro.Alpine, Version: nil, RawVersion: "3.17-alpha", IDLike: []string{"alpine"}},
+			namespaces: []*distro.Namespace{
+				distro.NewNamespace("alpine", osDistro.Alpine, "edge"),
+			},
+		},
+		{
+			name:   "alpine raw version matches edge with _ character no sha",
+			distro: &osDistro.Distro{Type: osDistro.Alpine, Version: nil, RawVersion: "3.17_alpha", IDLike: []string{"alpine"}},
+			namespaces: []*distro.Namespace{
+				distro.NewNamespace("alpine", osDistro.Alpine, "edge"),
+			},
+		},
+		{
 			name:       "alpine malformed version matches no namespace",
 			distro:     newDistro(t, osDistro.Alpine, "3.16.4.5", []string{}),
 			namespaces: nil,

--- a/grype/db/vulnerability_provider.go
+++ b/grype/db/vulnerability_provider.go
@@ -48,7 +48,7 @@ func (pr *VulnerabilityProvider) GetByDistro(d *distro.Distro, p pkg.Package) ([
 	namespaces := pr.namespaceIndex.NamespacesForDistro(d)
 
 	if len(namespaces) == 0 {
-		log.Warnf("no vulnerability namespaces found for distro=%s", d.String())
+		log.Debugf("no vulnerability namespaces found in grype database for distro=%s package=%s", d.String(), p.Name)
 		return vulnerabilities, nil
 	}
 
@@ -82,7 +82,7 @@ func (pr *VulnerabilityProvider) GetByLanguage(l syftPkg.Language, p pkg.Package
 	namespaces := pr.namespaceIndex.NamespacesForLanguage(l)
 
 	if len(namespaces) == 0 {
-		log.Warnf("no vulnerability namespaces found for language=%s", l)
+		log.Debugf("no vulnerability namespaces found in grype database for language=%s package=%s", l, p.Name)
 		return vulnerabilities, nil
 	}
 
@@ -116,7 +116,7 @@ func (pr *VulnerabilityProvider) GetByCPE(requestCPE syftPkg.CPE) ([]vulnerabili
 	namespaces := pr.namespaceIndex.CPENamespaces()
 
 	if len(namespaces) == 0 {
-		log.Warn("no vulnerability namespaces found for arbitrary CPEs")
+		log.Debugf("no vulnerability namespaces found for arbitrary CPEs in grype database")
 		return nil, nil
 	}
 

--- a/grype/matcher/apk/matcher.go
+++ b/grype/matcher/apk/matcher.go
@@ -160,6 +160,9 @@ func (m *Matcher) matchBySourceIndirection(store vulnerability.Provider, d *dist
 	var matches []match.Match
 
 	for _, indirectPackage := range pkg.UpstreamPackages(p) {
+		if indirectPackage.Name == "openssl" {
+			indirectPackage.Name = "openssl1.1-compact"
+		}
 		indirectMatches, err := m.findApkPackage(store, d, indirectPackage)
 		if err != nil {
 			return nil, fmt.Errorf("failed to find vulnerabilities for apk upstream source package: %w", err)

--- a/grype/matcher/apk/matcher.go
+++ b/grype/matcher/apk/matcher.go
@@ -160,9 +160,6 @@ func (m *Matcher) matchBySourceIndirection(store vulnerability.Provider, d *dist
 	var matches []match.Match
 
 	for _, indirectPackage := range pkg.UpstreamPackages(p) {
-		if indirectPackage.Name == "openssl" {
-			indirectPackage.Name = "openssl1.1-compact"
-		}
 		indirectMatches, err := m.findApkPackage(store, d, indirectPackage)
 		if err != nil {
 			return nil, fmt.Errorf("failed to find vulnerabilities for apk upstream source package: %w", err)

--- a/grype/matcher/matchers.go
+++ b/grype/matcher/matchers.go
@@ -120,11 +120,11 @@ func FindMatches(store interface {
 		packagesProcessed.N++
 		log.Debugf("searching for vulnerability matches for pkg=%s", p)
 
-		matchers, ok := matcherIndex[p.Type]
+		matchAgainst, ok := matcherIndex[p.Type]
 		if !ok {
-			matchers = []Matcher{defaultMatcher}
+			matchAgainst = []Matcher{defaultMatcher}
 		}
-		for _, m := range matchers {
+		for _, m := range matchAgainst {
 			matches, err := m.Match(store, d, p)
 			if err != nil {
 				log.Warnf("matcher failed for pkg=%s: %+v", p, err)


### PR DESCRIPTION
Partial Fix for #964 

## Summary
When scanning `alpine:edge` with grype the incorrect vulnerability namespace would be used causing false positives that would already be fixed in the upstream source:

https://security.alpinelinux.org/branch/edge-main
https://gitlab.alpinelinux.org/ariadne/secfixes-tracker

This fix treats nil distro version segments (a product of a version string that could not be parsed), when distro is of type `alpine`, as the signal for returning the `alpine:edge` namespace.

### Notes

Please read the related issue for upstream recommendations on reducing the false positives produced by this PR. 

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>