### PR TITLE
PURL input results in incorrect artifact in JSON output

### DIFF
--- a/grype/pkg/purl_provider.go
+++ b/grype/pkg/purl_provider.go
@@ -67,6 +67,7 @@ func decodePurlFile(reader io.Reader) ([]Package, error) {
 		}
 
 		packages = append(packages, Package{
+			ID:       ID(purl.String()),
 			CPEs:     cpes,
 			Name:     purl.Name,
 			Version:  purl.Version,

--- a/grype/pkg/purl_provider_test.go
+++ b/grype/pkg/purl_provider_test.go
@@ -35,7 +35,7 @@ func Test_PurlProvider_Fails(t *testing.T) {
 
 func Test_CsvProvide(t *testing.T) {
 	//GIVEN
-	expected := []string{"curl"}
+	expected := []string{"curl", "ant", "log4j-core"}
 
 	//WHEN
 	packages, _, err := purlProvider("purl:test-fixtures/valid-purl.txt")
@@ -43,6 +43,7 @@ func Test_CsvProvide(t *testing.T) {
 	//THEN
 	packageNames := []string{}
 	for _, pkg := range packages {
+		assert.NotEmpty(t, pkg.ID)
 		packageNames = append(packageNames, pkg.Name)
 	}
 	assert.NoError(t, err)

--- a/grype/pkg/test-fixtures/valid-purl.txt
+++ b/grype/pkg/test-fixtures/valid-purl.txt
@@ -1,1 +1,3 @@
 pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie&cpes=cpe%3A2.3%3Aa%3Abenjamin_curtis%3Aphpbugtracker%3A1.0.3%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A
+pkg:maven/org.apache.ant/ant@1.10.8
+pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1


### PR DESCRIPTION
This PR fixes incorrect JSON output when using PURL input, which was caused by all Packages having an empty ID.

Fixes #967 