### PR TITLE
Add SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,3 +100,8 @@ $ make integration
 ## Document your changes
 
 When proposed changes are modifying user-facing functionality or output, it is expected the PR will include updates to the documentation as well.
+
+
+## Security Vulnerabilities
+
+Found a security vulnerability? See in our [Security Policy](SECURITY.md) to see how to report it to be solved as soon as possible. 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+<!-- Use this section to tell people about which versions of your project are
+currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 5.1.x   | :white_check_mark: |
+| 5.0.x   | :x:                |
+| 4.0.x   | :white_check_mark: |
+| < 4.0   | :x:                |
+
+-->
+
+Security updates are applied only to the most recent release, try to always be up to date.
+
+## Reporting a Vulnerability
+
+<!-- Use this section to tell people how to report a vulnerability.
+
+Tell them where to go, how often they can expect to get an update on a
+reported vulnerability, what to expect if the vulnerability is accepted or
+declined, etc. -->
+
+To report a security issue, please email
+[your-email@example.com](mailto:your-email@example.com)
+with a description of the issue, the steps you took to create the issue,
+affected versions, and, if known, mitigations for the issue.
+
+All support will be made on the best effort base, so please indicate the "urgency level" of the vulnerability as Critical, High, Medium or Low.


### PR DESCRIPTION
Closes #982 

I've created the document following a template, we should personalize with an email or the best way for your team to receive security vulnerability reports.

Also I've defined it as if the only version supported with security updates would always be the latest ones, but if you have a list or range of versions you give that kind of support we can use the "table of content" template.