### PR TITLE
chore: update codeql to pinned v2 with correct write permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,8 @@ on:
     - cron: '0 14 * * 4'
 
 permissions:
-  contents: read
+  # required for all workflows
+  security-events: write
 
 jobs:
   analyze:
@@ -33,22 +34,22 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
+        # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -62,4 +63,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,7 +11,7 @@ on:
      - '**'
      - '!**.md'
      - '!LICENSE'
-     - 'test/**'
+     - '!test/**'
     branches: [ main ]
 
   schedule:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,8 +26,6 @@ jobs:
     permissions:
       # required for all workflows
       security-events: write
-      actions: read
-      contents: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,13 +3,16 @@
 #
 # You may wish to alter this file to override the set of languages analyzed,
 # or to provide custom queries or build logic.
-name: "CodeQL Security Scan"
+name: CodeQL Security Scan
 
 on:
   push:
-    branches:
-      # only run when there are pushes to the main branch (not on PRs)
-      - main
+    paths:
+     - '**'
+     - '!**.md'
+     - '!LICENSE'
+     - 'test/**'
+    branches: [ main ]
 
   schedule:
     - cron: '0 14 * * 4'
@@ -23,6 +26,8 @@ jobs:
     permissions:
       # required for all workflows
       security-events: write
+      actions: read
+      contents: read
 
     strategy:
       fail-fast: false
@@ -35,11 +40,27 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+
+    - name: Utilize Go Module Cache
+      uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Set correct version of Golang to use during CodeQL run
+      uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
+      with:
+        go-version: '1.18'
+        check-latest: true
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@c3b6fce4ee2ca25bc1066aa3bf73962fda0e8898 # v2.1.31
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -47,7 +68,6 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
@@ -64,4 +84,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@c3b6fce4ee2ca25bc1066aa3bf73962fda0e8898 # v2.1.31

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,13 +12,13 @@ on:
      - '!**.md'
      - '!LICENSE'
      - '!test/**'
-    branches: [ main, codeql-upgrade]
+    branches: [ main ]
 
   schedule:
     - cron: '0 14 * * 4'
 
 env:
-  CODEQL_EXTRACTOR_GO_BUILD_TRACING: true
+  CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
 
 jobs:
   analyze:
@@ -34,7 +34,7 @@ jobs:
       matrix:
         # Override automatic language detection by changing the below list
         # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        language: ['go']
+        language: ['go', 'python']
         # Learn more...
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,8 @@ on:
   schedule:
     - cron: '0 14 * * 4'
 
+env:
+  CODEQL_EXTRACTOR_GO_BUILD_TRACING: true
 
 jobs:
   analyze:
@@ -32,7 +34,7 @@ jobs:
       matrix:
         # Override automatic language detection by changing the below list
         # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        language: ['go', 'python']
+        language: ['go']
         # Learn more...
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,14 +14,15 @@ on:
   schedule:
     - cron: '0 14 * * 4'
 
-permissions:
-  # required for all workflows
-  security-events: write
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+
+    permissions:
+      # required for all workflows
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,7 @@ on:
      - '!**.md'
      - '!LICENSE'
      - '!test/**'
-    branches: [ main ]
+    branches: [ main, codeql-upgrade]
 
   schedule:
     - cron: '0 14 * * 4'
@@ -67,8 +67,8 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    # - name: Autobuild
+    # uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -76,10 +76,8 @@ jobs:
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - name: Build grype for CodeQL
+      run: make grype
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@c3b6fce4ee2ca25bc1066aa3bf73962fda0e8898 # v2.1.31

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ coverage.txt
 *.dll
 *.so
 *.dylib
+/grype/grype
+
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,11 @@ endef
 all: clean static-analysis test ## Run all checks (linting, license check, unit, integration, and linux acceptance tests tests)
 	@printf '$(SUCCESS)All checks pass!$(RESET)\n'
 
+.PHONY: grype
+grype: ## Build the grype binary
+	@printf '$(TITLE)Building grype$(RESET)\n'
+	CGO_ENABLED=0 go build -o $@ -trimpath -ldflags "-X main.version=$(VERSION) -X main.syftVersion=$(SYFT_VERSION)"
+
 .PHONY: test
 test: unit validate-cyclonedx-schema validate-cyclonedx-vex-schema integration cli ## Run all tests (unit, integration, linux acceptance, and CLI tests)
 


### PR DESCRIPTION
## Summary
After merging #988 it was observed that the codeql action needed to be upgraded as well as have its permissions refined a bit further. This PR adds:
```
    permissions:
      # required for all workflows
      security-events: write
```
Per the documentation found here:
https://github.com/github/codeql-action#usage

It also scopes it under the job rather than at the top level of the workflow file, but I am unsure if that has an effect on the OSS score-card. 

The versions have also been bumped and pinned to deal with the following warning found in this build:
https://github.com/anchore/grype/actions/runs/3461743751/jobs/5779738191

`Warning: CodeQL Action v1 will be deprecated on December 7th, 2022. Please upgrade to v2.`

Path awareness has also been added to save runs on docs, tests, or other nonmainline code changes.

The go module cache action has been added utilizing a `hashFile` for `go.sum` to implement the cache key
https://docs.github.com/en/actions/learn-github-actions/expressions#hashfiles

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>

Fixes: #991