### PR TITLE
feat: add strong distro type for wolfi

### DIFF
--- a/grype/db/v3/namespace.go
+++ b/grype/db/v3/namespace.go
@@ -71,6 +71,8 @@ func NamespaceForDistro(d *distro.Distro) string {
 			return fmt.Sprintf("sles:%d.%d", versionSegments[0], versionSegments[1])
 		case distro.Windows:
 			return fmt.Sprintf("%s:%d", MSRCNamespacePrefix, versionSegments[0])
+		case distro.Wolfi:
+			return "wolfi:rolling"
 		}
 	}
 	return fmt.Sprintf("%s:%s", strings.ToLower(d.Type.String()), d.FullVersion())

--- a/grype/db/v3/namespace_test.go
+++ b/grype/db/v3/namespace_test.go
@@ -178,8 +178,13 @@ func Test_NamespaceForDistro(t *testing.T) {
 		},
 		{
 			dist:     distro.Gentoo,
-			version:  "", // Gentoo doesn't expose a version
+			version:  "", // Gentoo is a rolling release
 			expected: "gentoo:",
+		},
+		{
+			dist:     distro.Wolfi,
+			version:  "2022yzblah", // Wolfi is a rolling release
+			expected: "wolfi:rolling",
 		},
 	}
 

--- a/grype/db/v4/namespace/distro/namespace_test.go
+++ b/grype/db/v4/namespace/distro/namespace_test.go
@@ -37,6 +37,10 @@ func TestFromString(t *testing.T) {
 			namespaceString: "amazon:distro:amazonlinux:2",
 			result:          NewNamespace("amazon", grypeDistro.AmazonLinux, "2"),
 		},
+		{
+			namespaceString: "wolfi:distro:wolfi:rolling",
+			result:          NewNamespace("wolfi", grypeDistro.Wolfi, "rolling"),
+		},
 	}
 
 	for _, test := range successTests {

--- a/grype/db/v5/namespace/distro/namespace_test.go
+++ b/grype/db/v5/namespace/distro/namespace_test.go
@@ -37,6 +37,10 @@ func TestFromString(t *testing.T) {
 			namespaceString: "amazon:distro:amazonlinux:2",
 			result:          NewNamespace("amazon", grypeDistro.AmazonLinux, "2"),
 		},
+		{
+			namespaceString: "wolfi:distro:wolfi:rolling",
+			result:          NewNamespace("wolfi", grypeDistro.Wolfi, "rolling"),
+		},
 	}
 
 	for _, test := range successTests {

--- a/grype/distro/distro_test.go
+++ b/grype/distro/distro_test.go
@@ -204,6 +204,10 @@ func Test_NewDistroFromRelease_Coverage(t *testing.T) {
 			fixture: "test-fixtures/os/gentoo",
 			Type:    Gentoo,
 		},
+		{
+			fixture: "test-fixtures/os/wolfi",
+			Type:    Wolfi,
+		},
 	}
 
 	observedDistros := internal.NewStringSet()

--- a/grype/distro/test-fixtures/os/wolfi/etc/os-release
+++ b/grype/distro/test-fixtures/os/wolfi/etc/os-release
@@ -1,0 +1,5 @@
+ID=wolfi
+NAME="Wolfi"
+PRETTY_NAME="Wolfi"
+VERSION_ID="20220914"
+HOME_URL="https://wolfi.dev"

--- a/grype/distro/type.go
+++ b/grype/distro/type.go
@@ -28,6 +28,7 @@ const (
 	RockyLinux   Type = "rockylinux"
 	AlmaLinux    Type = "almalinux"
 	Gentoo       Type = "gentoo"
+	Wolfi        Type = "wolfi"
 )
 
 // All contains all Linux distribution options
@@ -50,6 +51,7 @@ var All = []Type{
 	RockyLinux,
 	AlmaLinux,
 	Gentoo,
+	Wolfi,
 }
 
 // IDMapping connects a distro ID like "ubuntu" to a Distro type
@@ -72,6 +74,7 @@ var IDMapping = map[string]Type{
 	"rocky":         RockyLinux,
 	"almalinux":     AlmaLinux,
 	"gentoo":        Gentoo,
+	"wolfi":         Wolfi,
 }
 
 func TypeFromRelease(release linux.Release) Type {


### PR DESCRIPTION
Adds a strong distro type for [Wolfi OS](https://github.com/wolfi-dev/).  Although we aren't yet populating a vulnerability feed namespace for it, because it is a rolling distro we will want to ignore mapping the version surfaced from the linux release and instead use a constant value like `rolling` or `live`.  We could also leave the version component of the namespace as an empty string, I just don't know if that's confusing.  So for a v5 namespace it'd be one of these:

- `wolfi:distro:wolfi:rolling`
- `wolfi:distro:wolfi:live`
- `wolfi:distro:wolfi:`
- something else?

