### PR TITLE
feat: vulnerability namespacing support for rolling distros

### DIFF
--- a/grype/db/v3/namespace.go
+++ b/grype/db/v3/namespace.go
@@ -49,6 +49,10 @@ func NamespaceForDistro(d *distro.Distro) string {
 		return ""
 	}
 
+	if d.IsRolling() {
+		return fmt.Sprintf("%s:%s", strings.ToLower(d.Type.String()), "rolling")
+	}
+
 	var versionSegments []int
 	if d.Version != nil {
 		versionSegments = d.Version.Segments()
@@ -71,8 +75,6 @@ func NamespaceForDistro(d *distro.Distro) string {
 			return fmt.Sprintf("sles:%d.%d", versionSegments[0], versionSegments[1])
 		case distro.Windows:
 			return fmt.Sprintf("%s:%d", MSRCNamespacePrefix, versionSegments[0])
-		case distro.Wolfi:
-			return "wolfi:rolling"
 		}
 	}
 	return fmt.Sprintf("%s:%s", strings.ToLower(d.Type.String()), d.FullVersion())

--- a/grype/db/v3/namespace_test.go
+++ b/grype/db/v3/namespace_test.go
@@ -142,7 +142,7 @@ func Test_NamespaceForDistro(t *testing.T) {
 			// TODO: this is not correct. This should be mapped to a feed source.
 			dist:     distro.ArchLinux,
 			version:  "", // ArchLinux doesn't expose a version
-			expected: "archlinux:",
+			expected: "archlinux:rolling",
 		},
 		{
 			// TODO: this is not correct. This should be mapped to a feed source.
@@ -179,7 +179,7 @@ func Test_NamespaceForDistro(t *testing.T) {
 		{
 			dist:     distro.Gentoo,
 			version:  "", // Gentoo is a rolling release
-			expected: "gentoo:",
+			expected: "gentoo:rolling",
 		},
 		{
 			dist:     distro.Wolfi,
@@ -204,7 +204,7 @@ func Test_NamespaceForDistro(t *testing.T) {
 			d, err := distro.New(test.dist, test.version, "")
 			assert.NoError(t, err)
 			observedDistros.Add(d.Type.String())
-			assert.Equal(t, NamespaceForDistro(d), test.expected)
+			assert.Equal(t, test.expected, NamespaceForDistro(d))
 		})
 	}
 

--- a/grype/db/v4/namespace/index.go
+++ b/grype/db/v4/namespace/index.go
@@ -79,6 +79,13 @@ func (i *Index) NamespacesForDistro(d *grypeDistro.Distro) []*distro.Namespace {
 		return nil
 	}
 
+	if d.IsRolling() {
+		distroKey := fmt.Sprintf("%s:%s", strings.ToLower(d.Type.String()), "rolling")
+		if v, ok := i.byDistroKey[distroKey]; ok {
+			return v
+		}
+	}
+
 	var versionSegments []int
 	if d.Version != nil {
 		versionSegments = d.Version.Segments()

--- a/grype/db/v4/namespace/index_test.go
+++ b/grype/db/v4/namespace/index_test.go
@@ -132,6 +132,8 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 		"msrc:distro:windows:471816",
 		"ubuntu:distro:ubuntu:18.04",
 		"oracle:distro:oraclelinux:8",
+		"wolfi:distro:wolfi:rolling",
+		"archlinux:distro:archlinux:rolling",
 	})
 
 	assert.NoError(t, err)
@@ -236,7 +238,15 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 			},
 		},
 		{
-			distro:     newDistro(t, osDistro.ArchLinux, "", []string{}),
+			distro: newDistro(t, osDistro.ArchLinux, "", []string{}),
+			namespaces: []*distro.Namespace{
+				distro.NewNamespace("archlinux", osDistro.ArchLinux, "rolling"),
+			},
+		},
+		{
+			// Gentoo is a rolling distro; however, because we currently have no namespaces populated for it in the
+			// index fixture, we expect to get nil
+			distro:     newDistro(t, osDistro.Gentoo, "", []string{}),
 			namespaces: nil,
 		},
 		{
@@ -250,6 +260,12 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 		{
 			distro:     newDistro(t, osDistro.Busybox, "20.1", []string{}),
 			namespaces: nil,
+		},
+		{
+			distro: newDistro(t, osDistro.Wolfi, "20221011", []string{}),
+			namespaces: []*distro.Namespace{
+				distro.NewNamespace("wolfi", osDistro.Wolfi, "rolling"),
+			},
 		},
 	}
 

--- a/grype/db/v5/namespace/index.go
+++ b/grype/db/v5/namespace/index.go
@@ -77,9 +77,17 @@ func (i *Index) NamespacesForLanguage(l syftPkg.Language) []*language.Namespace 
 	return nil
 }
 
+//nolint:funlen,gocognit
 func (i *Index) NamespacesForDistro(d *grypeDistro.Distro) []*distro.Namespace {
 	if d == nil {
 		return nil
+	}
+
+	if d.IsRolling() {
+		distroKey := fmt.Sprintf("%s:%s", strings.ToLower(d.Type.String()), "rolling")
+		if v, ok := i.byDistroKey[distroKey]; ok {
+			return v
+		}
 	}
 
 	var versionSegments []int

--- a/grype/db/v5/namespace/index_test.go
+++ b/grype/db/v5/namespace/index_test.go
@@ -133,6 +133,8 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 		"msrc:distro:windows:471816",
 		"ubuntu:distro:ubuntu:18.04",
 		"oracle:distro:oraclelinux:8",
+		"wolfi:distro:wolfi:rolling",
+		"archlinux:distro:archlinux:rolling",
 	})
 
 	assert.NoError(t, err)
@@ -294,8 +296,24 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 		},
 		{
 
-			name:       "Arch Linux matches no namespace",
-			distro:     newDistro(t, osDistro.ArchLinux, "", []string{}),
+			name:   "Arch Linux matches archlinux rolling namespace",
+			distro: newDistro(t, osDistro.ArchLinux, "", []string{}),
+			namespaces: []*distro.Namespace{
+				distro.NewNamespace("archlinux", osDistro.ArchLinux, "rolling"),
+			},
+		},
+		{
+
+			name:   "Wolfi matches wolfi rolling namespace",
+			distro: newDistro(t, osDistro.Wolfi, "20221011", []string{}),
+			namespaces: []*distro.Namespace{
+				distro.NewNamespace("wolfi", osDistro.Wolfi, "rolling"),
+			},
+		},
+		{
+
+			name:       "Gentoo doesn't match any namespace since the gentoo rolling namespace doesn't exist in index",
+			distro:     newDistro(t, osDistro.Gentoo, "", []string{}),
 			namespaces: nil,
 		},
 		{

--- a/grype/distro/distro.go
+++ b/grype/distro/distro.go
@@ -85,3 +85,7 @@ func (d Distro) String() string {
 	}
 	return fmt.Sprintf("%s %s", d.Type, versionStr)
 }
+
+func (d Distro) IsRolling() bool {
+	return d.Type == Wolfi || d.Type == ArchLinux || d.Type == Gentoo
+}


### PR DESCRIPTION
Adds support for building the correct vulnerability namespaces for rolling distros.  This will allow matching against distro-specific feeds once a namespace is populated within the grype database.  It will only return the new rolling namespace for a distro once it is being populated in the loaded index from the grype database, so will ensure fallback to CPE-based matching until the corresponding vuln drivers are implemented and released