### PR TITLE
fix: table format sorting

### DIFF
--- a/grype/presenter/table/presenter.go
+++ b/grype/presenter/table/presenter.go
@@ -69,7 +69,7 @@ func (pres *Presenter) Present(output io.Writer) error {
 	// sort by name, version, then type
 	sort.SliceStable(rows, func(i, j int) bool {
 		for col := 0; col < len(columns); col++ {
-			if rows[i][0] != rows[j][0] {
+			if rows[i][col] != rows[j][col] {
 				return rows[i][col] < rows[j][col]
 			}
 		}


### PR DESCRIPTION
If the same package is found with different versions, table output is not stable. This PR corrects the issue. E.g.:

Before:
```
busybox       1.23.2-r3             apk     CVE-2016-2148     Critical
busybox       1.23.2                binary  CVE-2021-42381    High
busybox       1.23.2                binary  CVE-2016-2148     Critical
busybox       1.23.2-r3             apk     CVE-2018-20679    High
busybox       1.23.2                binary  CVE-2021-42384    High
busybox       1.23.2                binary  CVE-2017-16544    High
busybox       1.23.2                binary  CVE-2018-20679    High
busybox       1.23.2                binary  CVE-2021-42385    High
busybox       1.23.2-r3             apk     CVE-2021-42385    High
busybox       1.23.2                binary  CVE-2016-2147     High
busybox       1.23.2-r3             apk     CVE-2022-28391    High
busybox       1.23.2                binary  CVE-2015-9261     Medium
busybox       1.23.2-r3             apk     CVE-2016-2147     High
busybox       1.23.2                binary  CVE-2016-6301     High
busybox       1.23.2-r3             apk     CVE-2018-1000517  Critical
busybox       1.23.2-r3             apk     CVE-2017-16544    High
busybox       1.23.2-r3             apk     CVE-2021-42381    High
busybox       1.23.2-r3             apk     CVE-2021-42386    High
busybox       1.23.2                binary  CVE-2018-1000500  High
busybox       1.23.2                binary  CVE-2019-5747     High
busybox       1.23.2-r3             apk     CVE-2021-42376    Medium
busybox       1.23.2-r3             apk     CVE-2021-42379    High
busybox       1.23.2-r3             apk     CVE-2019-5747     High
busybox       1.23.2                binary  CVE-2021-42379    High
busybox       1.23.2-r3             apk     CVE-2018-1000500  High
busybox       1.23.2-r3             apk     CVE-2021-42378    High
busybox       1.23.2                binary  CVE-2021-42386    High
busybox       1.23.2                binary  CVE-2018-1000517  Critical
busybox       1.23.2                binary  CVE-2021-42376    Medium
busybox       1.23.2                binary  CVE-2022-28391    High
busybox       1.23.2                binary  CVE-2021-42378    High
busybox       1.23.2-r3             apk     CVE-2021-42384    High
busybox       1.23.2-r3             apk     CVE-2015-9261     Medium
busybox       1.23.2-r3  1.24.2-r1  apk     CVE-2016-6301     High
```

After:
```
busybox       1.23.2                binary  CVE-2015-9261     Medium    
busybox       1.23.2                binary  CVE-2016-2147     High      
busybox       1.23.2                binary  CVE-2016-2148     Critical  
busybox       1.23.2                binary  CVE-2016-6301     High      
busybox       1.23.2                binary  CVE-2017-16544    High      
busybox       1.23.2                binary  CVE-2018-1000500  High      
busybox       1.23.2                binary  CVE-2018-1000517  Critical  
busybox       1.23.2                binary  CVE-2018-20679    High      
busybox       1.23.2                binary  CVE-2019-5747     High      
busybox       1.23.2                binary  CVE-2021-42376    Medium    
busybox       1.23.2                binary  CVE-2021-42378    High      
busybox       1.23.2                binary  CVE-2021-42379    High      
busybox       1.23.2                binary  CVE-2021-42381    High      
busybox       1.23.2                binary  CVE-2021-42384    High      
busybox       1.23.2                binary  CVE-2021-42385    High      
busybox       1.23.2                binary  CVE-2021-42386    High      
busybox       1.23.2                binary  CVE-2022-28391    High      
busybox       1.23.2-r3             apk     CVE-2015-9261     Medium    
busybox       1.23.2-r3             apk     CVE-2016-2147     High      
busybox       1.23.2-r3             apk     CVE-2016-2148     Critical  
busybox       1.23.2-r3             apk     CVE-2017-16544    High      
busybox       1.23.2-r3             apk     CVE-2018-1000500  High      
busybox       1.23.2-r3             apk     CVE-2018-1000517  Critical  
busybox       1.23.2-r3             apk     CVE-2018-20679    High      
busybox       1.23.2-r3             apk     CVE-2019-5747     High      
busybox       1.23.2-r3             apk     CVE-2021-42376    Medium    
busybox       1.23.2-r3             apk     CVE-2021-42378    High      
busybox       1.23.2-r3             apk     CVE-2021-42379    High      
busybox       1.23.2-r3             apk     CVE-2021-42381    High      
busybox       1.23.2-r3             apk     CVE-2021-42384    High      
busybox       1.23.2-r3             apk     CVE-2021-42385    High      
busybox       1.23.2-r3             apk     CVE-2021-42386    High      
busybox       1.23.2-r3             apk     CVE-2022-28391    High      
busybox       1.23.2-r3  1.24.2-r1  apk     CVE-2016-6301     High      
```