### PR TITLE
chore: change CVE example to official sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ ignore:
       location: "/usr/local/lib/node_modules/**"
 
   # We can make rules to match just by vulnerability ID:
-  - vulnerability: CVE-2017-41432
+  - vulnerability: CVE-2014-54321
 
   # ...or just by a single package field:
   - package:


### PR DESCRIPTION
CVE-2017-41432 is not a valid ID but in theory could be one day. Changed it to CVE-2014-54321 which is one of a number sample IDs used during the Syntax change in 2013/2014. References: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-54321 https://cve.mitre.org/data/board/archives/2013-04/msg00000.html

@attritionorg - updated the commit with a signature so it could pass CI. I was unable to modify your fork, but cherry-picked the commit here so your change still reflects your work:

Closing: #1025 and merging this - Thanks a million for the contribution!

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>