### PR TITLE
fix: update removing results based on ownership-by-file-overlap

### DIFF
--- a/grype/pkg/syft_provider.go
+++ b/grype/pkg/syft_provider.go
@@ -27,6 +27,8 @@ func syftProvider(userInput string, config ProviderConfig) ([]Package, Context, 
 		return nil, Context{}, nil, err
 	}
 
+	catalog = removePackagesByOverlap(catalog, relationships)
+
 	packages := FromCatalog(catalog, config.SynthesisConfig)
 	context := Context{
 		Source: &src.Metadata,

--- a/grype/pkg/syft_sbom_provider.go
+++ b/grype/pkg/syft_sbom_provider.go
@@ -42,7 +42,7 @@ func syftSBOMProvider(userInput string, config ProviderConfig) ([]Package, Conte
 	}
 
 	catalog := s.Artifacts.PackageCatalog
-	catalog = RemoveBinaryPackagesByOverlap(catalog, s.Relationships)
+	catalog = removePackagesByOverlap(catalog, s.Relationships)
 
 	return FromCatalog(catalog, config.SynthesisConfig), Context{
 		Source: &s.Source,


### PR DESCRIPTION
This PR adjust the package exclusions baesd on ownership-by-file-overlap relationships. Before:

```
$ grype cgr.dev/chainguard/wolfi-base:latest -q 
NAME        INSTALLED  FIXED-IN  TYPE  VULNERABILITY   SEVERITY 
busybox     1.35.0                     CVE-2022-28391  High      
busybox     1.35.0                     CVE-2022-30065  High      
libcrypto3  3.0.7-r0             apk   CVE-2022-3996   High      
libssl3     3.0.7-r0             apk   CVE-2022-3996   High 
```

After:

```
grype cgr.dev/chainguard/wolfi-base:latest -q 
NAME        INSTALLED  FIXED-IN  TYPE  VULNERABILITY  SEVERITY 
libcrypto3  3.0.7-r0             apk   CVE-2022-3996  High      
libssl3     3.0.7-r0             apk   CVE-2022-3996  High  
```

Fixes #1044 -- but NOTE: we are planning on moving some of this behavior into Syft, this is only a stopgap solution.