### PR TITLE
chore: update yardstick to diagnose intermittent quality gate test failures

### DIFF
--- a/test/quality/requirements.txt
+++ b/test/quality/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/anchore/yardstick@bc1ec40841295f2b8e8c1971aab57e0f0859d932
+git+https://github.com/anchore/yardstick@10d2c34d7033c5f9ac5188bce3ec07b09771df4b
 # ../../../yardstick
 tabulate==0.8.10


### PR DESCRIPTION
This PR updates the quality gate yardstick to print more errors if unable to get the latest grype version from the github api.