### PR TITLE
chore: add github token to quality tests

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -155,6 +155,8 @@ jobs:
 
       - name: Run quality tests
         run: make quality
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   Integration-Test:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline


### PR DESCRIPTION
This PR adds the `GITHUB_TOKEN` to the quality test environment to attempt to solve intermittent failures to access the GitHub API to get the latest version of Grype.