### PR TITLE
feat: allow grype db diff to specify local db directories

### DIFF
--- a/grype/differ/differ_test.go
+++ b/grype/differ/differ_test.go
@@ -3,6 +3,7 @@ package differ
 import (
 	"bytes"
 	"flag"
+	"strconv"
 	"testing"
 
 	"github.com/sergi/go-diff/diffmatchpatch"
@@ -11,6 +12,7 @@ import (
 	"github.com/anchore/go-testutils"
 	"github.com/anchore/grype/grype/db"
 	v5 "github.com/anchore/grype/grype/db/v5"
+	"github.com/anchore/grype/grype/vulnerability"
 )
 
 var update = flag.Bool("update", false, "update the *.golden files for diff presenter")
@@ -25,6 +27,25 @@ func TestNewDiffer(t *testing.T) {
 	//THEN
 	require.NoError(t, err)
 	require.NotNil(t, differ.baseCurator)
+}
+
+func Test_DifferDirectory(t *testing.T) {
+	d, err := NewDiffer(db.Config{
+		DBRootDir: "root-dir",
+	})
+	require.NoError(t, err)
+
+	err = d.SetBaseDB("test-fixtures/dbs/base")
+	require.NoError(t, err)
+
+	baseStatus := d.baseCurator.Status()
+	require.Equal(t, "test-fixtures/dbs/base/"+strconv.Itoa(vulnerability.SchemaVersion), baseStatus.Location)
+
+	err = d.SetTargetDB("test-fixtures/dbs/target")
+	require.NoError(t, err)
+
+	targetStatus := d.targetCurator.Status()
+	require.Equal(t, "test-fixtures/dbs/target/"+strconv.Itoa(vulnerability.SchemaVersion), targetStatus.Location)
 }
 
 func TestPresent_Json(t *testing.T) {

--- a/grype/differ/test-fixtures/dbs/base/5/metadata.json
+++ b/grype/differ/test-fixtures/dbs/base/5/metadata.json
@@ -1,0 +1,5 @@
+{
+ "built": "2022-12-18T08:18:18Z",
+ "version": 5,
+ "checksum": "sha256:9d979f7320c575e7ac41c4384e9f55d578cdddd701822563cabc6b913fde7b80"
+}

--- a/grype/differ/test-fixtures/dbs/base/5/vulnerability.db
+++ b/grype/differ/test-fixtures/dbs/base/5/vulnerability.db
@@ -1,0 +1,1 @@
+an older vulnerability db

--- a/grype/differ/test-fixtures/dbs/target/5/metadata.json
+++ b/grype/differ/test-fixtures/dbs/target/5/metadata.json
@@ -1,0 +1,5 @@
+{
+ "built": "2022-12-18T08:18:18Z",
+ "version": 5,
+ "checksum": "sha256:da2141ae7415abe5cf5390faeed60e164c5a919370ee823c8cc3ad9f4698f56e"
+}

--- a/grype/differ/test-fixtures/dbs/target/5/vulnerability.db
+++ b/grype/differ/test-fixtures/dbs/target/5/vulnerability.db
@@ -1,0 +1,1 @@
+a vulnerability db


### PR DESCRIPTION
This change allows both URLs and local file directories to be used with the `grype db diff` command, e.g.

```shell
grype db diff db-1 db-2
```

Where `db-1` and `db-2` are both directories containing a grype db. This means each db must have the following structure:

```
<dir>/
  <db-version>/
    metadata.json
    vulnerability.db
```

currently, `db-1` would then be:

```
db-1/
  5/
    metadata.json
    vulnerability.db
```

Fixes: #1059
