### PR TITLE
Add protobuf FPs to default ignore list

### DIFF
--- a/grype/match/explicit_ignores.go
+++ b/grype/match/explicit_ignores.go
@@ -16,9 +16,16 @@ func init() {
 	var explicitIgnores = []ignoreValues{
 		// Based on https://github.com/anchore/grype/issues/552, which includes a reference to the
 		// https://github.com/mergebase/log4j-samples collection, we want to filter these explicitly:
-		{"java-archive",
-			[]string{"CVE-2021-44228", "CVE-2021-45046", "GHSA-jfh8-c2jp-5v3q", "GHSA-7rjr-3q55-vv33"},
-			[]string{"log4j-api", "log4j-slf4j-impl", "log4j-to-slf4j", "log4j-1.2-api", "log4j-detector", "log4j-over-slf4j", "slf4j-log4j12"},
+		{
+			typ:             "java-archive",
+			vulnerabilities: []string{"CVE-2021-44228", "CVE-2021-45046", "GHSA-jfh8-c2jp-5v3q", "GHSA-7rjr-3q55-vv33"},
+			packages:        []string{"log4j-api", "log4j-slf4j-impl", "log4j-to-slf4j", "log4j-1.2-api", "log4j-detector", "log4j-over-slf4j", "slf4j-log4j12"},
+		},
+		// Based on https://github.com/anchore/grype/issues/558:
+		{
+			typ:             "go-module",
+			vulnerabilities: []string{"CVE-2015-5237", "CVE-2021-22570"},
+			packages:        []string{"google.golang.org/protobuf"},
 		},
 	}
 

--- a/grype/match/explicit_ignores_test.go
+++ b/grype/match/explicit_ignores_test.go
@@ -79,6 +79,23 @@ func Test_ApplyExplicitIgnoreRules(t *testing.T) {
 			},
 			expected: []string{},
 		},
+		{
+			name: "filters invalid CVEs for protobuf Go module",
+			typ:  "go-module",
+			matches: []cvePkg{
+				{"CVE-2015-5237", "google.golang.org/protobuf"},
+				{"CVE-2021-22570", "google.golang.org/protobuf"},
+			},
+			expected: []string{},
+		},
+		{
+			name: "keeps valid CVEs for protobuf Go module",
+			typ:  "go-module",
+			matches: []cvePkg{
+				{"CVE-1998-99999", "google.golang.org/protobuf"},
+			},
+			expected: []string{"google.golang.org/protobuf"},
+		},
 	}
 
 	p := newMockExclusionProvider()


### PR DESCRIPTION
Fixes #558 

Let me know if there's a better way to cancel these out in the code. I saw this method used for some log4j FPs so I continued that approach here.

One unfortunate drawback to this approach is the UI becomes a bit confusing:

```console
$ go run . anchore/grype   
 ✔ Vulnerability DB        [no update available]
 ✔ Parsed image            
 ✔ Cataloged packages      [212 packages]
 ✔ Scanned image           [2 vulnerabilities]
No vulnerabilities found
```

"2 vulnerabilities", and then "no vulnerabilities". Curious if anyone has thoughts to make this more straightforward.