### PR TITLE
fix: always include severity in cyclonedx output

### DIFF
--- a/grype/presenter/cyclonedx/vulnerability.go
+++ b/grype/presenter/cyclonedx/vulnerability.go
@@ -104,6 +104,13 @@ func generateCDXRatings(metadata *vulnerability.Metadata) []cyclonedx.Vulnerabil
 		ratings = append(ratings, rating)
 	}
 
+	// ensure the severity is always included
+	if len(ratings) == 0 {
+		ratings = append(ratings, cyclonedx.VulnerabilityRating{
+			Severity: severity,
+		})
+	}
+
 	return ratings
 }
 

--- a/grype/presenter/cyclonedx/vulnerability_test.go
+++ b/grype/presenter/cyclonedx/vulnerability_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
@@ -132,12 +133,14 @@ func TestNewVulnerability_AlwaysIncludesSeverity(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual, err := NewVulnerability(test.match, test.metadataProvider)
-			assert.NoError(t, err)
-			if !assert.NotNil(t, actual.Ratings, "cyclonedx document ratings should not be nil") {
-				t.Fatal("could not process nil ratings")
-			}
-			for i, rating := range *actual.Ratings {
-				assert.Equal(t, test.metadataProvider.cvss[i].Metrics.BaseScore, *rating.Score)
+			require.NoError(t, err)
+			require.NotNil(t, actual.Ratings, "cyclonedx document ratings should not be nil")
+			require.NotEmpty(t, actual.Ratings)
+			require.Equal(t, cdxSeverityFromGrypeSeverity(test.metadataProvider.severity), (*actual.Ratings)[0].Severity)
+			if len(test.metadataProvider.cvss) > 0 {
+				for i, rating := range *actual.Ratings {
+					require.Equal(t, test.metadataProvider.cvss[i].Metrics.BaseScore, *rating.Score)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
This PR restores previous behavior that severity is always output in CycloneDX format.

Fixes #1066 