### PR TITLE
chore: enable dependabot on gomod and GitHub actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
Signed-off-by: Weston Steimel <weston.steimel@anchore.com>