### PR TITLE
bump yardstick to 2d30ea7429d0a59020e0176bba1b3b6b8b01b08a

### DIFF
--- a/test/quality/requirements.txt
+++ b/test/quality/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/anchore/yardstick@10d2c34d7033c5f9ac5188bce3ec07b09771df4b
+git+https://github.com/anchore/yardstick@2d30ea7429d0a59020e0176bba1b3b6b8b01b08a
 # ../../../yardstick
 tabulate==0.8.10


### PR DESCRIPTION
Incorporates https://github.com/anchore/yardstick/pull/24 into our quality gate checks as to alleviate the GitHub rate limits we're seeing in the pipeline. 