### PR TITLE
feat: upgrade golang to 1.19

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Set correct version of Golang to use during CodeQL run
       uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: '1.18'
+        go-version: '1.19'
         check-latest: true
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
       - "v*"
 
 env:
-  GO_VERSION: "1.18.x"
+  GO_VERSION: "1.19.x"
   GO_STABLE_VERSION: true
 
 permissions:

--- a/.github/workflows/update-bootstrap-tools.yml
+++ b/.github/workflows/update-bootstrap-tools.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.18.x"
+  GO_VERSION: "1.19.x"
   GO_STABLE_VERSION: true
 
 permissions:

--- a/.github/workflows/update-syft-release.yml
+++ b/.github/workflows/update-syft-release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.18.x"
+  GO_VERSION: "1.19.x"
   GO_STABLE_VERSION: true
 
 permissions:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.18.x"
+  GO_VERSION: "1.19.x"
   GO_STABLE_VERSION: true
   PYTHON_VERSION: "3.10"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/grype
 
-go 1.18
+go 1.19
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.7.1-0.20221222100750-41a1ac565cce


### PR DESCRIPTION
Go 1.18 will become EOL with the upcoming release of Go 1.20
