### PR TITLE
distro: Disable support for Arch Linux

### DIFF
--- a/grype/distro/distro.go
+++ b/grype/distro/distro.go
@@ -89,3 +89,13 @@ func (d Distro) String() string {
 func (d Distro) IsRolling() bool {
 	return d.Type == Wolfi || d.Type == ArchLinux || d.Type == Gentoo
 }
+
+// Unsupported Linux distributions
+func (d Distro) Disabled() bool {
+	switch {
+	case d.Type == ArchLinux:
+		return true
+	default:
+		return false
+	}
+}

--- a/grype/matcher/matchers.go
+++ b/grype/matcher/matchers.go
@@ -109,7 +109,7 @@ func FindMatches(store interface {
 		if err != nil {
 			log.Warnf("unable to determine linux distribution: %+v", err)
 		}
-		if d.Disabled() {
+		if d != nil && d.Disabled() {
 			log.Warnf("unsupported linux distribution: %s", d.Name())
 			return match.Matches{}
 		}

--- a/grype/matcher/matchers.go
+++ b/grype/matcher/matchers.go
@@ -109,6 +109,10 @@ func FindMatches(store interface {
 		if err != nil {
 			log.Warnf("unable to determine linux distribution: %+v", err)
 		}
+		if d.Disabled() {
+			log.Warnf("unsupported linux distribution: %s", d.Name())
+			return match.Matches{}
+		}
 	}
 
 	packagesProcessed, vulnerabilitiesDiscovered := trackMatcher()


### PR DESCRIPTION
Support for Arch Linux was added without parsing the vulnerability tracker from Arch Linux, resulting in false positives.

Disabled until proper coverage can be done.

Example:

     $ grype archlinux
     ✔ Vulnerability DB        [updated]
     ✔ Parsed image
     ✔ Cataloged packages      [113 packages]
     ✔ Scanned image           [5 vulnerabilities]
    NAME        INSTALLED   FIXED-IN  TYPE  VULNERABILITY   SEVERITY
    gnupg       2.2.40-1              alpm  CVE-2022-34903  Medium
    gnupg       2.2.40-1              alpm  CVE-2022-3515   Critical
    libarchive  3.6.2-2               alpm  CVE-2022-36227  Critical
    zlib        1:1.2.13-2            alpm  CVE-2018-25032  High
    zlib        1:1.2.13-2            alpm  CVE-2022-37434  Critical

Where CVE-2022-37434 is fixed by zlib version 1:1.2.12-3.

https://github.com/archlinux/svntogit-packages/commit/842507fff025b6e7f447082988051155d932cd49