### PR TITLE
feat: disable CPE-based matching by default for javascript

### DIFF
--- a/internal/config/match.go
+++ b/internal/config/match.go
@@ -23,7 +23,7 @@ func (cfg matchConfig) loadDefaultValues(v *viper.Viper) {
 	v.SetDefault("match.java.using-cpes", true)
 	v.SetDefault("match.dotnet.using-cpes", true)
 	v.SetDefault("match.golang.using-cpes", true)
-	v.SetDefault("match.javascript.using-cpes", true)
+	v.SetDefault("match.javascript.using-cpes", false)
 	v.SetDefault("match.python.using-cpes", true)
 	v.SetDefault("match.ruby.using-cpes", true)
 	v.SetDefault("match.stock.using-cpes", true)


### PR DESCRIPTION
CPE-based matching leads to a large amount of false positives, and disabling it by default for the javascript matcher seems like a reasonable first step since GitHub owns NPM and already has coverage of NPM-related security advisories in the Github Security Advisory dataset