### PR TITLE
fix: by-cpe pivot by vuln metadata rather than vulnerability record

### DIFF
--- a/grype/vulnerability_matcher.go
+++ b/grype/vulnerability_matcher.go
@@ -109,20 +109,13 @@ func (m *VulnerabilityMatcher) normalizeByCVE(match match.Match) match.Match {
 
 	ref := effectiveCVERecordRefs[0]
 
-	upstreamVulnRecords, err := m.Store.Get(ref.ID, ref.Namespace)
+	upstreamMetadata, err := m.Store.GetMetadata(ref.ID, ref.Namespace)
 	if err != nil {
-		log.Warnf("unable to fetch effective CVE record for id=%q namespace=%q : %v", ref.ID, ref.Namespace, err)
+		log.Warnf("unable to fetch effective CVE metadata for id=%q namespace=%q : %v", ref.ID, ref.Namespace, err)
 		return match
 	}
 
-	switch len(upstreamVulnRecords) {
-	case 0:
-		// TODO: trace logging
-		return match
-	case 1:
-		break
-	default:
-		// TODO: trace logging
+	if upstreamMetadata == nil {
 		return match
 	}
 
@@ -130,8 +123,10 @@ func (m *VulnerabilityMatcher) normalizeByCVE(match match.Match) match.Match {
 		ID:        match.Vulnerability.ID,
 		Namespace: match.Vulnerability.Namespace,
 	}
-	match.Vulnerability = upstreamVulnRecords[0]
-	match.Vulnerability.RelatedVulnerabilities = append(match.Vulnerability.RelatedVulnerabilities, originalRef)
+
+	match.Vulnerability.ID = upstreamMetadata.ID
+	match.Vulnerability.Namespace = upstreamMetadata.Namespace
+	match.Vulnerability.RelatedVulnerabilities = []vulnerability.Reference{originalRef}
 
 	return match
 }

--- a/grype/vulnerability_matcher_test.go
+++ b/grype/vulnerability_matcher_test.go
@@ -56,13 +56,25 @@ func (d *mockStore) stub() {
 	// METADATA /////////////////////////////////////////////////////////////////////////////////
 	d.metadata["CVE-2014-fake-1"] = map[string]*grypeDB.VulnerabilityMetadata{
 		"debian:distro:debian:8": {
-			Severity: "medium",
+			ID:        "CVE-2014-fake-1",
+			Namespace: "debian:distro:debian:8",
+			Severity:  "medium",
 		},
 	}
 
 	d.metadata["GHSA-2014-fake-3"] = map[string]*grypeDB.VulnerabilityMetadata{
 		"github:language:ruby": {
-			Severity: "medium",
+			ID:        "GHSA-2014-fake-3",
+			Namespace: "github:language:ruby",
+			Severity:  "medium",
+		},
+	}
+
+	d.metadata["CVE-2014-fake-3"] = map[string]*grypeDB.VulnerabilityMetadata{
+		"nvd:cpe": {
+			ID:        "CVE-2014-fake-3",
+			Namespace: "nvd:cpe",
+			Severity:  "critical",
 		},
 	}
 


### PR DESCRIPTION
This changes the `--by-cve` logic to only reorient the vulnerability metadata around NVD data rather than attempting to get the corresponding vulnerability table record.  This will address performance concerns since their was no index on `id, namespace` on the vulnerabilities table, but there is on the `vulnerability_metadata` table.  This also preserves the fixed in information from the actual match rather than losing it since the NVD data has no fix info.  It also correctly returns the CVE identifier in cases where there is more than one vulnerability record for a given `id, namespace` since that is the primary key on the `vulnerability_metadata` table.

Fixes #1185 