### PR TITLE
chore: update deprecated set-output calls

### DIFF
--- a/.github/workflows/update-syft-release.yml
+++ b/.github/workflows/update-syft-release.yml
@@ -32,7 +32,7 @@ jobs:
           go mod tidy
 
           # export the version for use with create-pull-request
-          echo "::set-output name=LATEST_VERSION::$LATEST_VERSION"
+          echo "LATEST_VERSION=$LATEST_VERSION" >> $GITHUB_OUTPUT
         id: latest-version
 
       - uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0


### PR DESCRIPTION
Update deprecated `::set-output` calls