### PR TITLE
feat: default image source config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ check-for-app-update: true
 
 # allows users to specify which image source should be used to generate the sbom
 # valid values are: registry, docker, podman
+# same as GRYPE_DEFAULT_IMAGE_PULL_SOURCE env var
 default-image-pull-source: ""
 
 # same as --name; set the name of the target being analyzed

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ sbom:path/to/syft.json                 read Syft JSON from path on disk
 registry:yourrepo/yourimage:tag        pull image directly from a registry (no container runtime required)
 ```
 
+If an image source is not provided and cannot be detected from the given reference it is assumed the image should be pulled from the Docker daemon.
+If docker is not present, then the Podman daemon is attempted next, followed by reaching out directly to the image registry last.
+
+
+This default behavior can be overridden with the `default-image-pull-source` configuration option (See [Configuration](https://github.com/anchore/grype#configuration) for more details).
+
 Use SBOMs for even faster vulnerability scanning in Grype:
 
 ```
@@ -546,6 +552,10 @@ Configuration options (example values are the default):
 # enable/disable checking for application updates on startup
 # same as GRYPE_CHECK_FOR_APP_UPDATE env var
 check-for-app-update: true
+
+# allows users to specify which image source should be used to generate the sbom
+# valid values are: registry, docker, podman
+default-image-pull-source: ""
 
 # upon scanning, if a severity is found at or above the given severity then the return code will be 1
 # default is unset which will skip this validation (options: negligible, low, medium, high, critical)

--- a/README.md
+++ b/README.md
@@ -557,6 +557,9 @@ check-for-app-update: true
 # valid values are: registry, docker, podman
 default-image-pull-source: ""
 
+# same as --name; set the name of the target being analyzed
+name: ""
+
 # upon scanning, if a severity is found at or above the given severity then the return code will be 1
 # default is unset which will skip this validation (options: negligible, low, medium, high, critical)
 # same as --fail-on ; GRYPE_FAIL_ON_SEVERITY env var

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -466,10 +466,12 @@ func getMatchers() []matcher.Matcher {
 func getProviderConfig() pkg.ProviderConfig {
 	return pkg.ProviderConfig{
 		SyftProviderConfig: pkg.SyftProviderConfig{
-			RegistryOptions:   appConfig.Registry.ToOptions(),
-			Exclusions:        appConfig.Exclusions,
-			CatalogingOptions: appConfig.Search.ToConfig(),
-			Platform:          appConfig.Platform,
+			RegistryOptions:        appConfig.Registry.ToOptions(),
+			Exclusions:             appConfig.Exclusions,
+			CatalogingOptions:      appConfig.Search.ToConfig(),
+			Platform:               appConfig.Platform,
+			Name:                   appConfig.Name,
+			DefaultImagePullSource: appConfig.DefaultImagePullSource,
 		},
 		SynthesisConfig: pkg.SynthesisConfig{
 			GenerateMissingCPEs: appConfig.GenerateMissingCPEs,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,6 +141,11 @@ func setRootFlags(flags *pflag.FlagSet) {
 	)
 
 	flags.StringP(
+		"name", "", "",
+		"set the name of the target being analyzed",
+	)
+
+	flags.StringP(
 		"distro", "", "",
 		"distro to match against in the format: <distro>:<version>",
 	)
@@ -240,6 +245,10 @@ func bindRootConfigOptions(flags *pflag.FlagSet) error {
 	}
 
 	if err := viper.BindPFlag("platform", flags.Lookup("platform")); err != nil {
+		return err
+	}
+
+	if err := viper.BindPFlag("name", flags.Lookup("name")); err != nil {
 		return err
 	}
 

--- a/grype/pkg/provider_config.go
+++ b/grype/pkg/provider_config.go
@@ -11,10 +11,12 @@ type ProviderConfig struct {
 }
 
 type SyftProviderConfig struct {
-	CatalogingOptions cataloger.Config
-	RegistryOptions   *image.RegistryOptions
-	Platform          string
-	Exclusions        []string
+	CatalogingOptions      cataloger.Config
+	RegistryOptions        *image.RegistryOptions
+	Platform               string
+	Exclusions             []string
+	Name                   string
+	DefaultImagePullSource string
 }
 
 type SynthesisConfig struct {

--- a/grype/pkg/syft_provider.go
+++ b/grype/pkg/syft_provider.go
@@ -11,7 +11,7 @@ func syftProvider(userInput string, config ProviderConfig) ([]Package, Context, 
 		return nil, Context{}, nil, errDoesNotProvide
 	}
 
-	sourceInput, err := source.ParseInputWithName(userInput, config.Platform, "", config.DefaultImagePullSource)
+	sourceInput, err := source.ParseInputWithName(userInput, config.Platform, config.Name, config.DefaultImagePullSource)
 	if err != nil {
 		return nil, Context{}, nil, err
 	}

--- a/grype/pkg/syft_provider.go
+++ b/grype/pkg/syft_provider.go
@@ -11,7 +11,7 @@ func syftProvider(userInput string, config ProviderConfig) ([]Package, Context, 
 		return nil, Context{}, nil, errDoesNotProvide
 	}
 
-	sourceInput, err := source.ParseInput(userInput, config.Platform)
+	sourceInput, err := source.ParseInputWithName(userInput, config.Platform, "", "")
 	if err != nil {
 		return nil, Context{}, nil, err
 	}

--- a/grype/pkg/syft_provider.go
+++ b/grype/pkg/syft_provider.go
@@ -11,7 +11,7 @@ func syftProvider(userInput string, config ProviderConfig) ([]Package, Context, 
 		return nil, Context{}, nil, errDoesNotProvide
 	}
 
-	sourceInput, err := source.ParseInputWithName(userInput, config.Platform, "", config.DefaultImagePullSrouce)
+	sourceInput, err := source.ParseInputWithName(userInput, config.Platform, "", config.DefaultImagePullSource)
 	if err != nil {
 		return nil, Context{}, nil, err
 	}

--- a/grype/pkg/syft_provider.go
+++ b/grype/pkg/syft_provider.go
@@ -11,7 +11,7 @@ func syftProvider(userInput string, config ProviderConfig) ([]Package, Context, 
 		return nil, Context{}, nil, errDoesNotProvide
 	}
 
-	sourceInput, err := source.ParseInputWithName(userInput, config.Platform, "", "")
+	sourceInput, err := source.ParseInputWithName(userInput, config.Platform, "", config.DefaultImagePullSrouce)
 	if err != nil {
 		return nil, Context{}, nil, err
 	}

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -29,32 +29,33 @@ type parser interface {
 }
 
 type Application struct {
-	ConfigPath          string                  `yaml:",omitempty" json:"configPath"` // the location where the application config was read from (either from -c or discovered while loading)
-	Verbosity           uint                    `yaml:"verbosity,omitempty" json:"verbosity" mapstructure:"verbosity"`
-	Output              string                  `yaml:"output" json:"output" mapstructure:"output"`                                           // -o, the Presenter hint string to use for report formatting
-	File                string                  `yaml:"file" json:"file" mapstructure:"file"`                                                 // --file, the file to write report output to
-	Distro              string                  `yaml:"distro" json:"distro" mapstructure:"distro"`                                           // --distro, specify a distro to explicitly use
-	GenerateMissingCPEs bool                    `yaml:"add-cpes-if-none" json:"add-cpes-if-none" mapstructure:"add-cpes-if-none"`             // --add-cpes-if-none, automatically generate CPEs if they are not present in import (e.g. from a 3rd party SPDX document)
-	OutputTemplateFile  string                  `yaml:"output-template-file" json:"output-template-file" mapstructure:"output-template-file"` // -t, the template file to use for formatting the final report
-	Quiet               bool                    `yaml:"quiet" json:"quiet" mapstructure:"quiet"`                                              // -q, indicates to not show any status output to stderr (ETUI or logging UI)
-	CheckForAppUpdate   bool                    `yaml:"check-for-app-update" json:"check-for-app-update" mapstructure:"check-for-app-update"` // whether to check for an application update on start up or not
-	OnlyFixed           bool                    `yaml:"only-fixed" json:"only-fixed" mapstructure:"only-fixed"`                               // only fail if detected vulns have a fix
-	OnlyNotFixed        bool                    `yaml:"only-notfixed" json:"only-notfixed" mapstructure:"only-notfixed"`                      // only fail if detected vulns don't have a fix
-	Platform            string                  `yaml:"platform" json:"platform" mapstructure:"platform"`                                     // --platform, override the target platform for a container image
-	CliOptions          CliOnlyOptions          `yaml:"-" json:"-"`
-	Search              search                  `yaml:"search" json:"search" mapstructure:"search"`
-	Ignore              []match.IgnoreRule      `yaml:"ignore" json:"ignore" mapstructure:"ignore"`
-	Exclusions          []string                `yaml:"exclude" json:"exclude" mapstructure:"exclude"`
-	DB                  database                `yaml:"db" json:"db" mapstructure:"db"`
-	ExternalSources     externalSources         `yaml:"external-sources" json:"externalSources" mapstructure:"external-sources"`
-	Match               matchConfig             `yaml:"match" json:"match" mapstructure:"match"`
-	Dev                 development             `yaml:"dev" json:"dev" mapstructure:"dev"`
-	FailOn              string                  `yaml:"fail-on-severity" json:"fail-on-severity" mapstructure:"fail-on-severity"`
-	FailOnSeverity      *vulnerability.Severity `yaml:"-" json:"-"`
-	Registry            registry                `yaml:"registry" json:"registry" mapstructure:"registry"`
-	Log                 logging                 `yaml:"log" json:"log" mapstructure:"log"`
-	ShowSuppressed      bool                    `yaml:"show-suppressed" json:"show-suppressed" mapstructure:"show-suppressed"`
-	ByCVE               bool                    `yaml:"by-cve" json:"by-cve" mapstructure:"by-cve"` // --by-cve, indicates if the original match vulnerability IDs should be preserved or the CVE should be used instead
+	ConfigPath             string                  `yaml:",omitempty" json:"configPath"` // the location where the application config was read from (either from -c or discovered while loading)
+	Verbosity              uint                    `yaml:"verbosity,omitempty" json:"verbosity" mapstructure:"verbosity"`
+	Output                 string                  `yaml:"output" json:"output" mapstructure:"output"`                                           // -o, the Presenter hint string to use for report formatting
+	File                   string                  `yaml:"file" json:"file" mapstructure:"file"`                                                 // --file, the file to write report output to
+	Distro                 string                  `yaml:"distro" json:"distro" mapstructure:"distro"`                                           // --distro, specify a distro to explicitly use
+	GenerateMissingCPEs    bool                    `yaml:"add-cpes-if-none" json:"add-cpes-if-none" mapstructure:"add-cpes-if-none"`             // --add-cpes-if-none, automatically generate CPEs if they are not present in import (e.g. from a 3rd party SPDX document)
+	OutputTemplateFile     string                  `yaml:"output-template-file" json:"output-template-file" mapstructure:"output-template-file"` // -t, the template file to use for formatting the final report
+	Quiet                  bool                    `yaml:"quiet" json:"quiet" mapstructure:"quiet"`                                              // -q, indicates to not show any status output to stderr (ETUI or logging UI)
+	CheckForAppUpdate      bool                    `yaml:"check-for-app-update" json:"check-for-app-update" mapstructure:"check-for-app-update"` // whether to check for an application update on start up or not
+	OnlyFixed              bool                    `yaml:"only-fixed" json:"only-fixed" mapstructure:"only-fixed"`                               // only fail if detected vulns have a fix
+	OnlyNotFixed           bool                    `yaml:"only-notfixed" json:"only-notfixed" mapstructure:"only-notfixed"`                      // only fail if detected vulns don't have a fix
+	Platform               string                  `yaml:"platform" json:"platform" mapstructure:"platform"`                                     // --platform, override the target platform for a container image
+	CliOptions             CliOnlyOptions          `yaml:"-" json:"-"`
+	Search                 search                  `yaml:"search" json:"search" mapstructure:"search"`
+	Ignore                 []match.IgnoreRule      `yaml:"ignore" json:"ignore" mapstructure:"ignore"`
+	Exclusions             []string                `yaml:"exclude" json:"exclude" mapstructure:"exclude"`
+	DB                     database                `yaml:"db" json:"db" mapstructure:"db"`
+	ExternalSources        externalSources         `yaml:"external-sources" json:"externalSources" mapstructure:"external-sources"`
+	Match                  matchConfig             `yaml:"match" json:"match" mapstructure:"match"`
+	Dev                    development             `yaml:"dev" json:"dev" mapstructure:"dev"`
+	FailOn                 string                  `yaml:"fail-on-severity" json:"fail-on-severity" mapstructure:"fail-on-severity"`
+	FailOnSeverity         *vulnerability.Severity `yaml:"-" json:"-"`
+	Registry               registry                `yaml:"registry" json:"registry" mapstructure:"registry"`
+	Log                    logging                 `yaml:"log" json:"log" mapstructure:"log"`
+	ShowSuppressed         bool                    `yaml:"show-suppressed" json:"show-suppressed" mapstructure:"show-suppressed"`
+	ByCVE                  bool                    `yaml:"by-cve" json:"by-cve" mapstructure:"by-cve"` // --by-cve, indicates if the original match vulnerability IDs should be preserved or the CVE should be used instead
+	DefaultImagePullSource string                  `yaml:"default-image-pull-source" json:"default-image-pull-source" mapstructure:"default-image-pull-source"`
 }
 
 func newApplicationConfig(v *viper.Viper, cliOpts CliOnlyOptions) *Application {
@@ -90,6 +91,7 @@ func LoadApplicationConfig(v *viper.Viper, cliOpts CliOnlyOptions) (*Application
 func (cfg Application) loadDefaultValues(v *viper.Viper) {
 	// set the default values for primitive fields in this struct
 	v.SetDefault("check-for-app-update", true)
+	v.SetDefault("default-image-pull-source", "")
 
 	// for each field in the configuration struct, see if the field implements the defaultValueLoader interface and invoke it if it does
 	value := reflect.ValueOf(cfg)

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -55,6 +55,7 @@ type Application struct {
 	Log                    logging                 `yaml:"log" json:"log" mapstructure:"log"`
 	ShowSuppressed         bool                    `yaml:"show-suppressed" json:"show-suppressed" mapstructure:"show-suppressed"`
 	ByCVE                  bool                    `yaml:"by-cve" json:"by-cve" mapstructure:"by-cve"` // --by-cve, indicates if the original match vulnerability IDs should be preserved or the CVE should be used instead
+	Name                   string                  `yaml:"name" json:"name" mapstructure:"name"`
 	DefaultImagePullSource string                  `yaml:"default-image-pull-source" json:"default-image-pull-source" mapstructure:"default-image-pull-source"`
 }
 


### PR DESCRIPTION
Follow up to https://github.com/anchore/syft/pull/1703

## Add config option to allow user to select the default image source location

https://github.com/anchore/grype/issues/1204 surfaces the need for allowing a user to express a preference over the `default-image-pull-source` to be used when building an SBOM for vulnerability scanning.

This adds a config option into grype to consume the new syft behavior.

There is also a small boy scout change that includes the `name` flag (it was part of the function signature being edited for pull source) which was introduced into syft recently. `name` is used to provide users an override for naming the source. `name` and `default-image-pull-source` have been added into the syft provider config.