### PR TITLE
Fix false positive for purl provider

### DIFF
--- a/grype/pkg/purl_provider.go
+++ b/grype/pkg/purl_provider.go
@@ -54,6 +54,7 @@ func decodePurlFile(reader io.Reader) ([]Package, error) {
 		}
 
 		cpes := []wfn.Attributes{}
+		epoch := "0"
 		for _, qualifier := range purl.Qualifiers {
 			if qualifier.Key == cpesQualifierKey {
 				rawCpes := strings.Split(qualifier.Value, ",")
@@ -65,6 +66,14 @@ func decodePurlFile(reader io.Reader) ([]Package, error) {
 					cpes = append(cpes, c)
 				}
 			}
+
+			if qualifier.Key == "epoch" {
+				epoch = qualifier.Value
+			}
+		}
+
+		if purl.Type == packageurl.TypeRPM && !strings.HasPrefix(purl.Version, fmt.Sprintf("%s:", epoch)) {
+			purl.Version = fmt.Sprintf("%s:%s", epoch, purl.Version)
 		}
 
 		packages = append(packages, Package{


### PR DESCRIPTION
Fix false positive for purl provider

- To fix this, updated the purl_provider to have an epoch variable:
  - defaults to 0
  - if epoch= set in the purl file it grabs that value
  - if epoch not in front of version it is added, version=epoch:version

Closes #1031

**Testing**:

purl file `dbus.purl`

```purl
pkg:rpm/dbus@1.12.8-18.el8?arch=x86_64&epoch=1
```

command used:

```bash
go run main.go purl:dbus.purl --distro rhel:8.6
```

output without fix:

```bash
 ✔ Vulnerability DB        [no update available]
 ✔ Scanning image...       [6 vulnerabilities]
   ├── 0 critical, 2 high, 3 medium, 1 low, 0 negligible
   └── 5 fixed
NAME  INSTALLED      FIXED-IN             TYPE  VULNERABILITY   SEVERITY 
dbus  1.12.8-18.el8  (won't fix)          rpm   CVE-2020-35512  Low       
dbus  1.12.8-18.el8  1:1.12.8-10.el8_2    rpm   CVE-2020-12049  High      
dbus  1.12.8-18.el8  1:1.12.8-23.el8_7.1  rpm   CVE-2022-42010  Medium    
dbus  1.12.8-18.el8  1:1.12.8-23.el8_7.1  rpm   CVE-2022-42011  Medium    
dbus  1.12.8-18.el8  1:1.12.8-23.el8_7.1  rpm   CVE-2022-42012  Medium    
dbus  1.12.8-18.el8  1:1.12.8-9.el8       rpm   CVE-2019-12749  High 
```

output with fix:

```bash
 ✔ Vulnerability DB        [no update available]
 ✔ Scanning image...       [4 vulnerabilities]
   ├── 0 critical, 0 high, 3 medium, 1 low, 0 negligible
   └── 3 fixed
NAME  INSTALLED        FIXED-IN             TYPE  VULNERABILITY   SEVERITY 
dbus  1:1.12.8-18.el8  (won't fix)          rpm   CVE-2020-35512  Low       
dbus  1:1.12.8-18.el8  1:1.12.8-23.el8_7.1  rpm   CVE-2022-42010  Medium    
dbus  1:1.12.8-18.el8  1:1.12.8-23.el8_7.1  rpm   CVE-2022-42011  Medium    
dbus  1:1.12.8-18.el8  1:1.12.8-23.el8_7.1  rpm   CVE-2022-42012  Medium 
```