### PR TITLE
feat: add timestamp to json output (#1170)

### DIFF
--- a/grype/presenter/json/presenter_test.go
+++ b/grype/presenter/json/presenter_test.go
@@ -37,14 +37,15 @@ func TestJsonImgsPresenter(t *testing.T) {
 		t.Fatal(err)
 	}
 	actual := buffer.Bytes()
+	actual = redact(actual)
+
 	if *update {
 		testutils.UpdateGoldenFileContents(t, actual)
 	}
 
 	var expected = testutils.GetGoldenFileContents(t)
-	actualString := redactTimestamp(string(actual))
 
-	assert.JSONEq(t, string(expected), actualString)
+	assert.JSONEq(t, string(expected), string(actual))
 
 	// TODO: add me back in when there is a JSON schema
 	// validateAgainstDbSchema(t, string(actual))
@@ -69,15 +70,15 @@ func TestJsonDirsPresenter(t *testing.T) {
 		t.Fatal(err)
 	}
 	actual := buffer.Bytes()
+	actual = redact(actual)
 
 	if *update {
 		testutils.UpdateGoldenFileContents(t, actual)
 	}
 
 	var expected = testutils.GetGoldenFileContents(t)
-	actualString := redactTimestamp(string(actual))
 
-	assert.JSONEq(t, string(expected), actualString)
+	assert.JSONEq(t, string(expected), string(actual))
 
 	// TODO: add me back in when there is a JSON schema
 	// validateAgainstDbSchema(t, string(actual))
@@ -112,17 +113,18 @@ func TestEmptyJsonPresenter(t *testing.T) {
 		t.Fatal(err)
 	}
 	actual := buffer.Bytes()
+	actual = redact(actual)
+
 	if *update {
 		testutils.UpdateGoldenFileContents(t, actual)
 	}
 
 	var expected = testutils.GetGoldenFileContents(t)
-	actualString := redactTimestamp(string(actual))
 
-	assert.JSONEq(t, string(expected), actualString)
+	assert.JSONEq(t, string(expected), string(actual))
 
 }
 
-func redactTimestamp(s string) string {
-	return timestampRegexp.ReplaceAllString(s, `"timestamp":""`)
+func redact(content []byte) []byte {
+	return timestampRegexp.ReplaceAll(content, []byte(`"timestamp":""`))
 }

--- a/grype/presenter/json/presenter_test.go
+++ b/grype/presenter/json/presenter_test.go
@@ -2,8 +2,11 @@ package json
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -40,8 +43,23 @@ func TestJsonImgsPresenter(t *testing.T) {
 	}
 
 	var expected = testutils.GetGoldenFileContents(t)
+	var expectedJSON, actualJSON models.Document
 
-	assert.JSONEq(t, string(expected), string(actual))
+	if err := json.Unmarshal(expected, &expectedJSON); err != nil {
+		assert.Fail(t, fmt.Sprintf("Expected value ('%s') is not valid json.\nJSON parsing error: '%s'", expected, err.Error()))
+	}
+
+	if err := json.Unmarshal(actual, &actualJSON); err != nil {
+		assert.Fail(t, fmt.Sprintf("Input ('%s') is not valid json.\nJSON parsing error: '%s'", actual, err.Error()))
+	}
+
+	assert.NotEmpty(t, actualJSON.Descriptor.Timestamp)
+	// Check format is RFC3339 compatible e.g. 2023-04-21T00:22:06.491137+01:00
+	_, err := time.Parse(time.RFC3339, actualJSON.Descriptor.Timestamp)
+	if assert.NoError(t, err) {
+		actualJSON.Descriptor.Timestamp = expectedJSON.Descriptor.Timestamp
+		assert.Equal(t, expectedJSON, actualJSON)
+	}
 
 	// TODO: add me back in when there is a JSON schema
 	// validateAgainstDbSchema(t, string(actual))
@@ -72,8 +90,23 @@ func TestJsonDirsPresenter(t *testing.T) {
 	}
 
 	var expected = testutils.GetGoldenFileContents(t)
+	var expectedJSON, actualJSON models.Document
 
-	assert.JSONEq(t, string(expected), string(actual))
+	if err := json.Unmarshal(expected, &expectedJSON); err != nil {
+		assert.Fail(t, fmt.Sprintf("Expected value ('%s') is not valid json.\nJSON parsing error: '%s'", expected, err.Error()))
+	}
+
+	if err := json.Unmarshal(actual, &actualJSON); err != nil {
+		assert.Fail(t, fmt.Sprintf("Input ('%s') is not valid json.\nJSON parsing error: '%s'", actual, err.Error()))
+	}
+
+	assert.NotEmpty(t, actualJSON.Descriptor.Timestamp)
+	// Check format is RFC3339 compatible e.g. 2023-04-21T00:22:06.491137+01:00
+	_, err := time.Parse(time.RFC3339, actualJSON.Descriptor.Timestamp)
+	if assert.NoError(t, err) {
+		actualJSON.Descriptor.Timestamp = expectedJSON.Descriptor.Timestamp
+		assert.Equal(t, expectedJSON, actualJSON)
+	}
 
 	// TODO: add me back in when there is a JSON schema
 	// validateAgainstDbSchema(t, string(actual))
@@ -113,6 +146,22 @@ func TestEmptyJsonPresenter(t *testing.T) {
 	}
 
 	var expected = testutils.GetGoldenFileContents(t)
+	var expectedJSON, actualJSON models.Document
 
-	assert.JSONEq(t, string(expected), string(actual))
+	if err := json.Unmarshal(expected, &expectedJSON); err != nil {
+		assert.Fail(t, fmt.Sprintf("Expected value ('%s') is not valid json.\nJSON parsing error: '%s'", expected, err.Error()))
+	}
+
+	if err := json.Unmarshal(actual, &actualJSON); err != nil {
+		assert.Fail(t, fmt.Sprintf("Input ('%s') is not valid json.\nJSON parsing error: '%s'", actual, err.Error()))
+	}
+
+	assert.NotEmpty(t, actualJSON.Descriptor.Timestamp)
+	// Check format is RFC3339 compatible e.g. 2023-04-21T00:22:06.491137+01:00
+	_, err := time.Parse(time.RFC3339, actualJSON.Descriptor.Timestamp)
+	if assert.NoError(t, err) {
+		actualJSON.Descriptor.Timestamp = expectedJSON.Descriptor.Timestamp
+		assert.Equal(t, expectedJSON, actualJSON)
+	}
+
 }

--- a/grype/presenter/json/test-fixtures/snapshot/TestEmptyJsonPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestEmptyJsonPresenter.golden
@@ -13,6 +13,7 @@
  },
  "descriptor": {
   "name": "grype",
-  "version": "[not provided]"
+  "version": "[not provided]",
+  "timestamp": "2023-04-21T00:24:03.183136+01:00"
  }
 }

--- a/grype/presenter/json/test-fixtures/snapshot/TestEmptyJsonPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestEmptyJsonPresenter.golden
@@ -14,6 +14,6 @@
  "descriptor": {
   "name": "grype",
   "version": "[not provided]",
-  "timestamp": "2023-04-21T00:24:03.183136+01:00"
+  "timestamp": ""
  }
 }

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
@@ -145,6 +145,7 @@
  },
  "descriptor": {
   "name": "grype",
-  "version": "[not provided]"
+  "version": "[not provided]",
+  "timestamp": "2023-04-21T00:24:03.183136+01:00"
  }
 }

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
@@ -146,6 +146,6 @@
  "descriptor": {
   "name": "grype",
   "version": "[not provided]",
-  "timestamp": "2023-04-21T00:24:03.183136+01:00"
+  "timestamp": ""
  }
 }

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
@@ -175,6 +175,6 @@
  "descriptor": {
   "name": "grype",
   "version": "[not provided]",
-  "timestamp": "2023-04-21T00:24:03.183136+01:00"
+  "timestamp": ""
  }
 }

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
@@ -174,6 +174,7 @@
  },
  "descriptor": {
   "name": "grype",
-  "version": "[not provided]"
+  "version": "[not provided]",
+  "timestamp": "2023-04-21T00:24:03.183136+01:00"
  }
 }

--- a/grype/presenter/models/descriptor.go
+++ b/grype/presenter/models/descriptor.go
@@ -6,4 +6,5 @@ type descriptor struct {
 	Version               string      `json:"version"`
 	Configuration         interface{} `json:"configuration,omitempty"`
 	VulnerabilityDBStatus interface{} `json:"db,omitempty"`
+	Timestamp             string      `json:"timestamp"`
 }

--- a/grype/presenter/models/document.go
+++ b/grype/presenter/models/document.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
@@ -21,6 +22,11 @@ type Document struct {
 
 // NewDocument creates and populates a new Document struct, representing the populated JSON document.
 func NewDocument(packages []pkg.Package, context pkg.Context, matches match.Matches, ignoredMatches []match.IgnoredMatch, metadataProvider vulnerability.MetadataProvider, appConfig interface{}, dbStatus interface{}) (Document, error) {
+	timestamp, timestampErr := time.Now().Local().MarshalText()
+	if timestampErr != nil {
+		return Document{}, timestampErr
+	}
+
 	// we must preallocate the findings to ensure the JSON document does not show "null" when no matches are found
 	var findings = make([]Match, 0)
 	for _, m := range matches.Sorted() {
@@ -75,6 +81,7 @@ func NewDocument(packages []pkg.Package, context pkg.Context, matches match.Matc
 			Version:               version.FromBuild().Version,
 			Configuration:         appConfig,
 			VulnerabilityDBStatus: dbStatus,
+			Timestamp:             string(timestamp),
 		},
 	}, nil
 }

--- a/grype/presenter/models/document_test.go
+++ b/grype/presenter/models/document_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -92,4 +93,27 @@ func TestPackagesAreSorted(t *testing.T) {
 	}
 
 	assert.Equal(t, []string{"CVE-1999-0001", "CVE-1999-0002", "CVE-1999-0003"}, actualVulnerabilities)
+}
+
+func TestTimestampValidFormat(t *testing.T) {
+
+	matches := match.NewMatches()
+
+	ctx := pkg.Context{
+		Source: nil,
+		Distro: nil,
+	}
+
+	doc, err := NewDocument(nil, ctx, matches, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unable to get document: %+v", err)
+	}
+
+	assert.NotEmpty(t, doc.Descriptor.Timestamp)
+	// Check format is RFC3339 compatible e.g. 2023-04-21T00:22:06.491137+01:00
+	_, timeErr := time.Parse(time.RFC3339, doc.Descriptor.Timestamp)
+	if timeErr != nil {
+		t.Fatalf("unable to parse time: %+v", timeErr)
+	}
+
 }


### PR DESCRIPTION
Adds timestamp into the JSON Output, timestamp is a new field inside Descriptor.

Unit tests were a little fiddly because the timestamp changes so first check the value is not nil and is in RFC 3339 format, then essentially use the normal assert.JSONEq to check the rest of the document(s).