### PR TITLE
Allow for pip extras

### DIFF
--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -45,6 +45,10 @@ type Package struct {
 func New(p pkg.Package) Package {
 	metadataType, metadata, upstreams := dataFromPkg(p)
 
+	if p.Type == "python" {
+		p.Name = pipCheckExtras(p.Name)
+	}
+
 	return Package{
 		ID:           ID(p.ID()),
 		Name:         p.Name,
@@ -282,4 +286,13 @@ func ByID(id ID, pkgs []Package) *Package {
 		}
 	}
 	return nil
+}
+
+// check if pip package has extras, if so remove it from package name
+func pipCheckExtras(packageName string) string {
+	pipExtrasRegex := regexp.MustCompile(`\[.*\]`)
+	if pipExtrasRegex.MatchString(packageName) {
+		return pipExtrasRegex.ReplaceAllString(packageName, "")
+	}
+	return packageName
 }


### PR DESCRIPTION
Allow for pip extras

- Allow pip packages to specify extras.
  - Syntax: package_name[extra1, extra2]
  - Using regex the extras will be removed from the package name.

Closes #1246

### Testing
Filename: `requirements.txt`
Content:

```txt
celery[redis, pytest]==4.4.7
starlette==0.17.1
```

Command: `go run main.go file:requirements.txt`

**Output Before**

```bash
 ✔ Vulnerability DB        [no update available]
 ✔ Indexed requirements.txt 
 ✔ Cataloged packages      [2 packages]
 ✔ Scanning image...       [1 vulnerabilities]
   ├── 0 critical, 0 high, 1 medium, 0 low, 0 negligible
   └── 1 fixed
NAME       INSTALLED  FIXED-IN  TYPE    VULNERABILITY        SEVERITY 
starlette  0.17.1     0.25.0    python  GHSA-74m5-2c7w-9w3x  Medium  
```

**Output After**

```bash
 ✔ Vulnerability DB        [no update available]
 ✔ Indexed requirements.txt 
 ✔ Cataloged packages      [2 packages]
 ✔ Scanning image...       [2 vulnerabilities]
   ├── 0 critical, 1 high, 1 medium, 0 low, 0 negligible
   └── 2 fixed
NAME       INSTALLED  FIXED-IN  TYPE    VULNERABILITY        SEVERITY 
celery     4.4.7      5.2.2     python  GHSA-q4xr-rc97-m4xx  High      
starlette  0.17.1     0.25.0    python  GHSA-74m5-2c7w-9w3x  Medium 
```