### PR TITLE
Install skopeo during bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ GORELEASER_VERSION := v1.17.2
 YAJSV_VERSION := v1.4.1
 QUILL_VERSION := v0.2.0
 GLOW_VERSION := v1.5.0
+SKOPEO_VERSION := v1.12.0
 
 # Formatting variables ############################
 BOLD := $(shell tput -T linux bold)
@@ -117,6 +118,7 @@ bootstrap-tools: $(TEMP_DIR)
 	GOBIN="$(realpath $(TEMP_DIR))" go install github.com/rinchsan/gosimports/cmd/gosimports@$(GOSIMPORTS_VERSION)
 	GOBIN="$(realpath $(TEMP_DIR))" go install github.com/neilpa/yajsv@$(YAJSV_VERSION)
 	GOBIN="$(realpath $(TEMP_DIR))" go install github.com/charmbracelet/glow@$(GLOW_VERSION)
+	GOBIN="$(realpath $(TEMP_DIR))" CGO_ENABLED=0 GO_DYN_FLAGS="" go install -tags "containers_image_openpgp" github.com/containers/skopeo/cmd/skopeo@$(SKOPEO_VERSION)
 
 .PHONY: bootstrap-go
 bootstrap-go:

--- a/test/integration/test-fixtures/skopeo-policy.json
+++ b/test/integration/test-fixtures/skopeo-policy.json
@@ -1,0 +1,16 @@
+{
+  "default": [
+    {
+      "type": "insecureAcceptAnything"
+    }
+  ],
+  "transports": {
+    "docker-daemon": {
+      "": [
+        {
+          "type": "insecureAcceptAnything"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The "make integration" target assumes that skopeo will be available on PATH, but this wasn't documented. Install it during bootstrap when other utilities are installed. (See ./test/integration/utils_test.go:50). Include a sample skopeo policy.json, otherwise skopeo will look for a missing policy doc a /etc/containers/policy.json and exit with an error. The sample policy document matches the one included by default with "brew install skopeo".

## Discussion

1. Is `./test/integration/test-fixtures/skopeo-policy.json` the right place for this file?
2. Are the contents of `skopeo-policy.json` what we want?
3. Should the test fall back to `skopeo` on path if it's available? IMO no, since it would make the test depend more on the environment where it was run, but wanted to call out this behavior change.
4. I duplicated `repoRoot` from elsewhere in the test suite. Is it worth extracting anywhere?

## Why?

On current main, initial test run fails without skopeo:

```
 % git clone https://github.com/anchore/grype.git && cd grype && make integration
Cloning into 'grype'...
remote: Enumerating objects: 8291, done.
remote: Counting objects: 100% (930/930), done.
remote: Compressing objects: 100% (186/186), done.
remote: Total 8291 (delta 851), reused 767 (delta 744), pack-reused 7361
Receiving objects: 100% (8291/8291), 3.59 MiB | 25.86 MiB/s, done.
Resolving deltas: 100% (5433/5433), done.
Running integration tests
go test -v ./test/integration
=== RUN   TestCompareSBOMInputToLibResults
    utils_test.go:39: Cache miss for image anchore/test_images:vulnerabilities-alpine; copying to archive at /tmp/grype/test/integration/test-fixtures/cache/anchore-test_images-vulnerabilities-alpine.tar
    utils_test.go:58: exec: "skopeo": executable file not found in $PATH
--- FAIL: TestCompareSBOMInputToLibResults (5.43s)
```

## Testing

```
% cat repro.sh
#!/usr/bin/env sh
set -euxo pipefail
# prove we don't have skopeo on path
which skopeo && false
# clean up integration tests, because before I got false positive
make clean-test-cache
# remove bootstrap dependencies, since we're testing changes to how they're installed
rm -rf ./.tmp || true
# reinstall test dependencies
make bootstrap
# actually test
make integration
```

On this branch, `./repro.sh` (not committed; just part of working on the issue) passes, but on main, it fails.