### PR TITLE
Allow generic sprig functions

### DIFF
--- a/grype/presenter/template/presenter.go
+++ b/grype/presenter/template/presenter.go
@@ -77,7 +77,7 @@ func (pres *Presenter) Present(output io.Writer) error {
 
 // FuncMap is a function that returns template.FuncMap with custom functions available to template authors.
 var FuncMap = func() template.FuncMap {
-	f := sprig.HermeticTxtFuncMap()
+	f := sprig.GenericFuncMap()
 	f["getLastIndex"] = func(collection interface{}) int {
 		if v := reflect.ValueOf(collection); v.Kind() == reflect.Slice {
 			return v.Len() - 1

--- a/grype/presenter/template/presenter_test.go
+++ b/grype/presenter/template/presenter_test.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"os"
 	"path"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,4 +49,34 @@ func TestPresenter_Present(t *testing.T) {
 	expected := testutils.GetGoldenFileContents(t)
 
 	assert.Equal(t, string(expected), string(actual))
+}
+
+func TestPresenter_SprigDate(t *testing.T) {
+	matches, packages, context, metadataProvider, appConfig, dbStatus := models.GenerateAnalysis(t, source.ImageScheme)
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	templateFilePath := path.Join(workingDirectory, "./test-fixtures/test.template.sprig")
+
+	pb := models.PresenterConfig{
+		Matches:          matches,
+		Packages:         packages,
+		Context:          context,
+		MetadataProvider: metadataProvider,
+		AppConfig:        appConfig,
+		DBStatus:         dbStatus,
+	}
+
+	templatePresenter := NewPresenter(pb, templateFilePath)
+
+	var buffer bytes.Buffer
+	if err := templatePresenter.Present(&buffer); err != nil {
+		t.Fatal(err)
+	}
+
+	actual := string(buffer.Bytes())
+	dateRexexp := regexp.MustCompile("\\d{4}-\\d{2}-\\d{2}")
+
+	assert.True(t, dateRexexp.MatchString(actual))
 }

--- a/grype/presenter/template/test-fixtures/test.template.sprig
+++ b/grype/presenter/template/test-fixtures/test.template.sprig
@@ -1,0 +1,11 @@
+Identified distro as {{.Distro.Name}} version {{.Distro.Version}}.
+Date: {{ now | date "2006-01-02" }}
+{{- range .Matches}}
+    Vulnerability: {{.Vulnerability.ID}}
+    Severity: {{.Vulnerability.Severity}}
+    Package: {{.Artifact.Name}} version {{.Artifact.Version}} ({{.Artifact.Type}})
+    CPEs: {{ toJson .Artifact.CPEs }}
+    {{- range .MatchDetails}}
+    Matched by: {{.Matcher}}
+    {{- end}}
+{{- end}}


### PR DESCRIPTION
Previously, functions that could return different results at different times, such as `now`, were not allowed in sprig templates. Allow them.

Fixes https://github.com/anchore/grype/issues/1243