### PR TITLE
chore: Fix logger prefix

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -84,8 +84,8 @@ func initLogging() {
 		return
 	}
 	grype.SetLogger(logWrapper)
-	syft.SetLogger(logWrapper.Nested("form-lib", "syft"))
-	stereoscope.SetLogger(logWrapper.Nested("form-lib", "stereoscope"))
+	syft.SetLogger(logWrapper.Nested("from-lib", "syft"))
+	stereoscope.SetLogger(logWrapper.Nested("from-lib", "stereoscope"))
 }
 
 func logAppConfig() {


### PR DESCRIPTION
s/form-lib/from-lib

Reported as part of https://github.com/anchore/grype/issues/1244, but the main fix will need to be in Syft I believe, at https://github.com/anchore/syft/blob/75d625b697e85283b688c4d7cb7addf7e2854a58/syft/formats/syftjson/to_syft_model.go#L197

Note: I've added the `changelog-ignore` label because I don't think this needs to be in release notes.