### PR TITLE
feat: add source and type to CVSS information

### DIFF
--- a/grype/db/v5/vulnerability_metadata.go
+++ b/grype/db/v5/vulnerability_metadata.go
@@ -23,6 +23,8 @@ type Cvss struct {
 	Metrics        CvssMetrics `json:"metrics"`
 	Vector         string      `json:"vector"`  // A textual representation of the metric values used to determine the score
 	Version        string      `json:"version"` // The version of the CVSS spec, for example 2.0, 3.0, or 3.1
+	Source         string      `json:"source"`  // Identifies the organization that provided the score
+	Type           string      `json:"type"`    // Whether the source is a `primary` or `secondary` source
 }
 
 // CvssMetrics are the quantitative values that make up a CVSS score.

--- a/grype/presenter/models/cvss.go
+++ b/grype/presenter/models/cvss.go
@@ -3,6 +3,8 @@ package models
 import "github.com/anchore/grype/grype/vulnerability"
 
 type Cvss struct {
+	Source         string      `json:"source,omitempty"`
+	Type           string      `json:"type,omitempty"`
 	Version        string      `json:"version"`
 	Vector         string      `json:"vector"`
 	Metrics        CvssMetrics `json:"metrics"`
@@ -23,6 +25,8 @@ func NewCVSS(metadata *vulnerability.Metadata) []Cvss {
 			vendorMetadata = make(map[string]interface{})
 		}
 		cvss = append(cvss, Cvss{
+			Source:  score.Source,
+			Type:    score.Type,
 			Version: score.Version,
 			Vector:  score.Vector,
 			Metrics: CvssMetrics{

--- a/grype/vulnerability/metadata.go
+++ b/grype/vulnerability/metadata.go
@@ -15,6 +15,8 @@ type Metadata struct {
 }
 
 type Cvss struct {
+	Source         string
+	Type           string
 	Version        string
 	Vector         string
 	Metrics        CvssMetrics
@@ -47,6 +49,8 @@ func NewCvss(m []grypeDB.Cvss) []Cvss {
 	var cvss []Cvss
 	for _, score := range m {
 		cvss = append(cvss, Cvss{
+			Source:  score.Source,
+			Type:    score.Type,
 			Version: score.Version,
 			Vector:  score.Vector,
 			Metrics: CvssMetrics{


### PR DESCRIPTION
Adds source and type to the CVSS score information to allow identification of the organization that submitted the score and whether they are a primary or secondary source.