### PR TITLE
Hide suppressed vulnerabilities when --show-suppressed is not given

### DIFF
--- a/grype/presenter/presenter.go
+++ b/grype/presenter/presenter.go
@@ -24,10 +24,7 @@ func GetPresenter(c Config, pb models.PresenterConfig) Presenter {
 	case jsonFormat:
 		return json.NewPresenter(pb)
 	case tableFormat:
-		if c.showSuppressed {
-			return table.NewPresenter(pb)
-		}
-		return table.NewPresenter(pb)
+		return table.NewPresenter(pb, c.showSuppressed)
 
 	// NOTE: cyclonedx is identical to embeddedVEXJSON
 	// The cyclonedx library only provides two BOM formats: JSON and XML

--- a/grype/presenter/table/presenter.go
+++ b/grype/presenter/table/presenter.go
@@ -25,15 +25,17 @@ type Presenter struct {
 	ignoredMatches   []match.IgnoredMatch
 	packages         []pkg.Package
 	metadataProvider vulnerability.MetadataProvider
+	showSuppressed   bool
 }
 
 // NewPresenter is a *Presenter constructor
-func NewPresenter(pb models.PresenterConfig) *Presenter {
+func NewPresenter(pb models.PresenterConfig, showSuppressed bool) *Presenter {
 	return &Presenter{
 		results:          pb.Matches,
 		ignoredMatches:   pb.IgnoredMatches,
 		packages:         pb.Packages,
 		metadataProvider: pb.MetadataProvider,
+		showSuppressed:   showSuppressed,
 	}
 }
 
@@ -53,13 +55,15 @@ func (pres *Presenter) Present(output io.Writer) error {
 	}
 
 	// Generate rows for suppressed vulnerabilities
-	for _, m := range pres.ignoredMatches {
-		row, err := createRow(m.Match, pres.metadataProvider, appendSuppressed)
+	if pres.showSuppressed {
+		for _, m := range pres.ignoredMatches {
+			row, err := createRow(m.Match, pres.metadataProvider, appendSuppressed)
 
-		if err != nil {
-			return err
+			if err != nil {
+				return err
+			}
+			rows = append(rows, row)
 		}
-		rows = append(rows, row)
 	}
 
 	if len(rows) == 0 {

--- a/grype/presenter/table/test-fixtures/snapshot/TestDisplaysIgnoredMatches.golden
+++ b/grype/presenter/table/test-fixtures/snapshot/TestDisplaysIgnoredMatches.golden
@@ -1,0 +1,5 @@
+NAME       INSTALLED  FIXED-IN          TYPE  VULNERABILITY  SEVERITY              
+package-1  1.1.1                        rpm   CVE-1999-0002  Critical               
+package-1  1.1.1      the-next-version  rpm   CVE-1999-0001  Low                    
+package-2  2.2.2                        deb   CVE-1999-0001  Low (suppressed)       
+package-2  2.2.2                        deb   CVE-1999-0002  Critical (suppressed)  

--- a/grype/presenter/table/test-fixtures/snapshot/TestHidesIgnoredMatches.golden
+++ b/grype/presenter/table/test-fixtures/snapshot/TestHidesIgnoredMatches.golden
@@ -1,0 +1,3 @@
+NAME       INSTALLED  FIXED-IN          TYPE  VULNERABILITY  SEVERITY 
+package-1  1.1.1                        rpm   CVE-1999-0002  Critical  
+package-1  1.1.1      the-next-version  rpm   CVE-1999-0001  Low       


### PR DESCRIPTION
Closes https://github.com/anchore/grype/issues/1053

This PR fixes a bug where suppressed vulnerabilities are displayed even though the `--show-suppressed` flag is not provided. The fix is made by checking the value of the `showSuppressed` option before including the suppressed vulns in the result. This PR also adds tests to assert the behaviour with/without `--show-suppressed`.