### PR TITLE
feat: fix summary output (#1312)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -391,7 +391,7 @@ func startWorker(userInput string, failOnSeverity *vulnerability.Severity) <-cha
 		}
 
 		bus.Publish(partybus.Event{
-			Type:  event.VulnerabilityScanningFinished,
+			Type:  event.PresentationStarted,
 			Value: presenter.GetPresenter(presenterConfig, pb),
 		})
 	}()

--- a/grype/event/event.go
+++ b/grype/event/event.go
@@ -9,4 +9,5 @@ const (
 	VulnerabilityScanningFinished partybus.EventType = "grype-vulnerability-scanning-finished"
 	NonRootCommandFinished        partybus.EventType = "grype-non-root-command-finished"
 	DatabaseDiffingStarted        partybus.EventType = "grype-database-diffing-started"
+	PresentationStarted           partybus.EventType = "grype-presentation-started"
 )

--- a/grype/event/parsers/parsers.go
+++ b/grype/event/parsers/parsers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
 
+	"github.com/anchore/grype/grype"
 	diffEvents "github.com/anchore/grype/grype/differ/events"
 	"github.com/anchore/grype/grype/event"
 	"github.com/anchore/grype/grype/matcher"
@@ -76,8 +77,21 @@ func ParseVulnerabilityScanningStarted(e partybus.Event) (*matcher.Monitor, erro
 	return &monitor, nil
 }
 
-func ParseVulnerabilityScanningFinished(e partybus.Event) (presenter.Presenter, error) {
+func ParseVulnerabilityScanningFinished(e partybus.Event) (*grype.MatcherResults, error) {
 	if err := checkEventType(e.Type, event.VulnerabilityScanningFinished); err != nil {
+		return nil, err
+	}
+
+	matcherResults, ok := e.Value.(grype.MatcherResults)
+	if !ok {
+		return nil, newPayloadErr(e.Type, "Value", e.Value)
+	}
+
+	return &matcherResults, nil
+}
+
+func ParsePresentationStarted(e partybus.Event) (presenter.Presenter, error) {
+	if err := checkEventType(e.Type, event.PresentationStarted); err != nil {
 		return nil, err
 	}
 

--- a/grype/matcher/matchers.go
+++ b/grype/matcher/matchers.go
@@ -4,7 +4,6 @@ import (
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
 
-	grypeDb "github.com/anchore/grype/grype/db/v5"
 	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/event"
 	"github.com/anchore/grype/grype/match"
@@ -31,51 +30,29 @@ import (
 type Monitor struct {
 	PackagesProcessed         progress.Monitorable
 	VulnerabilitiesDiscovered progress.Monitorable
-	Fixed                     progress.Monitorable
-	BySeverity                map[vulnerability.Severity]progress.Monitorable
 }
 
 type monitor struct {
 	PackagesProcessed         *progress.Manual
 	VulnerabilitiesDiscovered *progress.Manual
-	Fixed                     *progress.Manual
-	BySeverity                map[vulnerability.Severity]*progress.Manual
 }
 
 func newMonitor() (monitor, Monitor) {
-	manualBySev := make(map[vulnerability.Severity]*progress.Manual)
-	for _, severity := range vulnerability.AllSeverities() {
-		manualBySev[severity] = progress.NewManual(-1)
-	}
-	manualBySev[vulnerability.UnknownSeverity] = progress.NewManual(-1)
 
 	m := monitor{
 		PackagesProcessed:         progress.NewManual(-1),
 		VulnerabilitiesDiscovered: progress.NewManual(-1),
-		Fixed:                     progress.NewManual(-1),
-		BySeverity:                manualBySev,
-	}
-
-	monitorableBySev := make(map[vulnerability.Severity]progress.Monitorable)
-	for sev, manual := range manualBySev {
-		monitorableBySev[sev] = manual
 	}
 
 	return m, Monitor{
 		PackagesProcessed:         m.PackagesProcessed,
 		VulnerabilitiesDiscovered: m.VulnerabilitiesDiscovered,
-		Fixed:                     m.Fixed,
-		BySeverity:                monitorableBySev,
 	}
 }
 
 func (m *monitor) SetCompleted() {
 	m.PackagesProcessed.SetCompleted()
 	m.VulnerabilitiesDiscovered.SetCompleted()
-	m.Fixed.SetCompleted()
-	for _, v := range m.BySeverity {
-		v.SetCompleted()
-	}
 }
 
 // Config contains values used by individual matcher structs for advanced configuration
@@ -180,61 +157,16 @@ func FindMatches(store interface {
 				logMatches(p, matches)
 				res.Add(matches...)
 				progressMonitor.VulnerabilitiesDiscovered.Add(int64(len(matches)))
-				updateVulnerabilityList(progressMonitor, matches, store)
 			}
 		}
 	}
 
 	progressMonitor.SetCompleted()
 
-	logListSummary(progressMonitor)
-
 	// Filter out matches based off of the records in the exclusion table in the database or from the old hard-coded rules
 	res = match.ApplyExplicitIgnoreRules(store, res)
 
 	return res
-}
-
-func logListSummary(vl *monitor) {
-	log.Infof("found %d vulnerabilities for %d packages", vl.VulnerabilitiesDiscovered.Current(), vl.PackagesProcessed.Current())
-	log.Debugf("  ├── fixed: %d", vl.Fixed.Current())
-	log.Debugf("  └── matched: %d", vl.VulnerabilitiesDiscovered.Current())
-
-	var unknownCount int64
-	if count, ok := vl.BySeverity[vulnerability.UnknownSeverity]; ok {
-		unknownCount = count.Current()
-	}
-	log.Debugf("      ├── %s: %d", vulnerability.UnknownSeverity.String(), unknownCount)
-
-	allSeverities := vulnerability.AllSeverities()
-	for idx, sev := range allSeverities {
-		branch := "├"
-		if idx == len(allSeverities)-1 {
-			branch = "└"
-		}
-		log.Debugf("      %s── %s: %d", branch, sev.String(), vl.BySeverity[sev].Current())
-	}
-}
-
-func updateVulnerabilityList(list *monitor, matches []match.Match, metadataProvider vulnerability.MetadataProvider) {
-	for _, m := range matches {
-		metadata, err := metadataProvider.GetMetadata(m.Vulnerability.ID, m.Vulnerability.Namespace)
-		if err != nil || metadata == nil {
-			list.BySeverity[vulnerability.UnknownSeverity].Increment()
-			continue
-		}
-
-		sevManualProgress, ok := list.BySeverity[vulnerability.ParseSeverity(metadata.Severity)]
-		if !ok {
-			list.BySeverity[vulnerability.UnknownSeverity].Increment()
-			continue
-		}
-		sevManualProgress.Increment()
-
-		if m.Vulnerability.Fix.State == grypeDb.FixedState {
-			list.Fixed.Increment()
-		}
-	}
 }
 
 func logMatches(p pkg.Package, matches []match.Match) {

--- a/grype/vulnerability_matcher.go
+++ b/grype/vulnerability_matcher.go
@@ -3,13 +3,16 @@ package grype
 import (
 	"strings"
 
+	"github.com/anchore/grype/grype/event"
 	"github.com/anchore/grype/grype/grypeerr"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/matcher"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/store"
 	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/grype/internal/bus"
 	"github.com/anchore/grype/internal/log"
+	"github.com/wagoodman/go-partybus"
 )
 
 type VulnerabilityMatcher struct {
@@ -18,6 +21,12 @@ type VulnerabilityMatcher struct {
 	IgnoreRules    []match.IgnoreRule
 	FailSeverity   *vulnerability.Severity
 	NormalizeByCVE bool
+}
+
+type MatcherResults struct {
+	Matches        *match.Matches
+	IgnoredMatches []match.IgnoredMatch
+	Store          store.Store
 }
 
 func DefaultVulnerabilityMatcher(store store.Store) *VulnerabilityMatcher {
@@ -60,6 +69,15 @@ func (m *VulnerabilityMatcher) FindMatches(pkgs []pkg.Package, context pkg.Conte
 		// vulnerability ID, we wantMatches to ensure that the rule is honored.
 		matches, ignoredMatches = m.applyIgnoreRules(normalizedMatches)
 	}
+
+	bus.Publish(partybus.Event{
+		Type: event.VulnerabilityScanningFinished,
+		Value: MatcherResults{
+			Matches:        &matches,
+			IgnoredMatches: ignoredMatches,
+			Store:          m.Store,
+		},
+	})
 
 	var err error
 	if m.FailSeverity != nil && HasSeverityAtOrAbove(m.Store, *m.FailSeverity, matches) {

--- a/internal/ui/common_event_handlers.go
+++ b/internal/ui/common_event_handlers.go
@@ -9,11 +9,11 @@ import (
 	grypeEventParsers "github.com/anchore/grype/grype/event/parsers"
 )
 
-func handleVulnerabilityScanningFinished(event partybus.Event, reportOutput io.Writer) error {
+func handlePresentationStarted(event partybus.Event, reportOutput io.Writer) error {
 	// show the report to stdout
-	pres, err := grypeEventParsers.ParseVulnerabilityScanningFinished(event)
+	pres, err := grypeEventParsers.ParsePresentationStarted(event)
 	if err != nil {
-		return fmt.Errorf("bad CatalogerFinished event: %w", err)
+		return fmt.Errorf("bad PresentationStarted event: %w", err)
 	}
 
 	if err := pres.Present(reportOutput); err != nil {

--- a/internal/ui/ephemeral_terminal_ui.go
+++ b/internal/ui/ephemeral_terminal_ui.go
@@ -83,12 +83,12 @@ func (h *ephemeralTerminalUI) Handle(event partybus.Event) error {
 			log.Errorf("unable to show %s event: %+v", event.Type, err)
 		}
 
-	case event.Type == grypeEvent.VulnerabilityScanningFinished:
+	case event.Type == grypeEvent.PresentationStarted:
 		// we need to close the screen now since signaling the the presenter is ready means that we
 		// are about to write bytes to stdout, so we should reset the terminal state first
 		h.closeScreen(false)
 
-		if err := handleVulnerabilityScanningFinished(event, h.reportOutput); err != nil {
+		if err := handlePresentationStarted(event, h.reportOutput); err != nil {
 			log.Errorf("unable to show %s event: %+v", event.Type, err)
 		}
 

--- a/internal/ui/logger_ui.go
+++ b/internal/ui/logger_ui.go
@@ -28,9 +28,9 @@ func (l *loggerUI) Setup(unsubscribe func() error) error {
 
 func (l loggerUI) Handle(event partybus.Event) error {
 	switch event.Type {
-	case grypeEvent.VulnerabilityScanningFinished:
-		if err := handleVulnerabilityScanningFinished(event, l.reportOutput); err != nil {
-			log.Warnf("unable to show catalog image finished event: %+v", err)
+	case grypeEvent.PresentationStarted:
+		if err := handlePresentationStarted(event, l.reportOutput); err != nil {
+			log.Warnf("unable to show presentation started event: %+v", err)
 		}
 	case grypeEvent.NonRootCommandFinished:
 		if err := handleNonRootCommandFinished(event, l.reportOutput); err != nil {

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -24,6 +24,7 @@ func NewHandler() *Handler {
 func (r *Handler) RespondsTo(event partybus.Event) bool {
 	switch event.Type {
 	case grypeEvent.VulnerabilityScanningStarted,
+		grypeEvent.VulnerabilityScanningFinished,
 		grypeEvent.UpdateVulnerabilityDatabase,
 		grypeEvent.DatabaseDiffingStarted:
 		return true
@@ -36,6 +37,8 @@ func (r *Handler) Handle(ctx context.Context, fr *frame.Frame, event partybus.Ev
 	switch event.Type {
 	case grypeEvent.VulnerabilityScanningStarted:
 		return r.VulnerabilityScanningStartedHandler(ctx, fr, event, wg)
+	case grypeEvent.VulnerabilityScanningFinished:
+		return r.VulnerabilityScanningFinishedHandler(ctx, fr, event, wg)
 	case grypeEvent.UpdateVulnerabilityDatabase:
 		return r.UpdateVulnerabilityDatabaseHandler(ctx, fr, event, wg)
 	case grypeEvent.DatabaseDiffingStarted:


### PR DESCRIPTION
This resolves #1312 

Opening the PR slightly earlier than normal, just to get peoples views on the proposed output:

![image](https://github.com/anchore/grype/assets/14006260/0395a991-2dff-4b10-9037-08c47ed0e99c)

And then with supressed/ignored vulns

![image](https://github.com/anchore/grype/assets/14006260/156121ed-3a61-466d-9a1e-48cebca17d1e)

Happy to hear any thoughts on the above.

- TODO
I removed the log summary so need to add that back in once I find a nice way of handling it e.g.
![image](https://github.com/anchore/grype/assets/14006260/9dd4d2c6-ee2f-4cc0-9b42-bfb79fe0c854)

Signed-off-by: James Neate <jamesmneate@gmail.com>
