### PR TITLE
chore: log unsupported package qualifier as debug

### DIFF
--- a/grype/db/v5/pkg/qualifier/from_json.go
+++ b/grype/db/v5/pkg/qualifier/from_json.go
@@ -43,7 +43,7 @@ func FromJSON(data []byte) ([]Qualifier, error) {
 			}
 			qualifiers = append(qualifiers, q)
 		default:
-			log.Warn("Skipping unsupported package qualifier: %s", k)
+			log.Debug("Skipping unsupported package qualifier: %s", k)
 			continue
 		}
 	}


### PR DESCRIPTION
Logs unsupported package qualifiers at `debug` level rather than `warning`.  The message is only meant to convey that there are new qualifiers available in grype-db that the version of grype being used cannot take advantage of to improve matching behavior; however, the warning is confusing to users and may make it seem like grype is in a broken state.