### PR TITLE
feat: disable Java CPE matching by default

### DIFF
--- a/internal/config/match.go
+++ b/internal/config/match.go
@@ -20,7 +20,7 @@ type matcherConfig struct {
 }
 
 func (cfg matchConfig) loadDefaultValues(v *viper.Viper) {
-	v.SetDefault("match.java.using-cpes", true)
+	v.SetDefault("match.java.using-cpes", false)
 	v.SetDefault("match.dotnet.using-cpes", true)
 	v.SetDefault("match.golang.using-cpes", true)
 	v.SetDefault("match.javascript.using-cpes", false)


### PR DESCRIPTION
This PR disables CPE matching by default for Java.