### PR TITLE
feat: add ability to ignore packages on pom properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,9 @@ Each rule can specify any combination of the following criteria:
 - package language (e.g. `"python"`; these values are defined [here](https://github.com/anchore/syft/blob/main/syft/pkg/language.go#L14-L23))
 - package type (e.g. `"npm"`; these values are defined [here](https://github.com/anchore/syft/blob/main/syft/pkg/type.go#L10-L24))
 - package location (e.g. `"/usr/local/lib/node_modules/**"`; supports glob patterns)
+- pom scope (e.g. `"test"`)
+- pom group id (e.g. `"org.springframework.boot"`)
+- pom artifact id (e.g. `"spring-boot-starter-webflux"`)
 
 Here's an example `~/.grype.yaml` that demonstrates the expected format for ignore rules:
 
@@ -336,6 +339,10 @@ ignore:
   # ...or just by a single package field:
   - package:
       type: gem
+
+  # ...or just by a single pom field:
+  - pom:
+      scope: test
 ```
 
 Vulnerability matches will be ignored if **any** rules apply to the match. A rule is considered to apply to a given vulnerability match only if **all** fields specified in the rule apply to the vulnerability match.

--- a/grype/match/ignore.go
+++ b/grype/match/ignore.go
@@ -2,6 +2,8 @@ package match
 
 import (
 	"github.com/bmatcuk/doublestar/v2"
+
+	"github.com/anchore/grype/grype/pkg"
 )
 
 // An IgnoredMatch is a vulnerability Match that has been ignored because one or more IgnoreRules applied to the match.
@@ -21,6 +23,7 @@ type IgnoreRule struct {
 	Namespace     string            `yaml:"namespace" json:"namespace" mapstructure:"namespace"`
 	FixState      string            `yaml:"fix-state" json:"fix-state" mapstructure:"fix-state"`
 	Package       IgnoreRulePackage `yaml:"package" json:"package" mapstructure:"package"`
+	Pom           IgnoreRulePom     `yaml:"pom" json:"pom" mapstructure:"pom"`
 }
 
 // IgnoreRulePackage describes the Package-specific fields that comprise the IgnoreRule.
@@ -30,6 +33,13 @@ type IgnoreRulePackage struct {
 	Language string `yaml:"language" json:"language" mapstructure:"language"`
 	Type     string `yaml:"type" json:"type" mapstructure:"type"`
 	Location string `yaml:"location" json:"location" mapstructure:"location"`
+}
+
+// IgnoreRulePom describes the Pom-specific fields that comprise the IgnoreRule.
+type IgnoreRulePom struct {
+	Scope      string `yaml:"scope" json:"scope" mapstructure:"scope"`
+	GroupID    string `yaml:"group-id" json:"group-id" mapstructure:"group-id"`
+	ArtifactID string `yaml:"artifact-id" json:"artifact-id" mapstructure:"artifact-id"`
 }
 
 // ApplyIgnoreRules iterates through the provided matches and, for each match,
@@ -123,6 +133,18 @@ func getIgnoreConditionsForRule(rule IgnoreRule) []ignoreCondition {
 		ignoreConditions = append(ignoreConditions, ifFixStateApplies(fs))
 	}
 
+	if s := rule.Pom.Scope; s != "" {
+		ignoreConditions = append(ignoreConditions, ifPomScopeApplies(s))
+	}
+
+	if gi := rule.Pom.GroupID; gi != "" {
+		ignoreConditions = append(ignoreConditions, ifPomGroupIDApplies(gi))
+	}
+
+	if ai := rule.Pom.ArtifactID; ai != "" {
+		ignoreConditions = append(ignoreConditions, ifPomArtifactIDApplies(ai))
+	}
+
 	return ignoreConditions
 }
 
@@ -171,6 +193,33 @@ func ifPackageTypeApplies(t string) ignoreCondition {
 func ifPackageLocationApplies(location string) ignoreCondition {
 	return func(match Match) bool {
 		return ruleLocationAppliesToMatch(location, match)
+	}
+}
+
+func ifPomScopeApplies(scope string) ignoreCondition {
+	return func(match Match) bool {
+		if metadata, ok := match.Package.Metadata.(pkg.JavaMetadata); ok {
+			return scope == metadata.PomScope
+		}
+		return false
+	}
+}
+
+func ifPomGroupIDApplies(groupID string) ignoreCondition {
+	return func(match Match) bool {
+		if metadata, ok := match.Package.Metadata.(pkg.JavaMetadata); ok {
+			return groupID == metadata.PomGroupID
+		}
+		return false
+	}
+}
+
+func ifPomArtifactIDApplies(artifactID string) ignoreCondition {
+	return func(match Match) bool {
+		if metadata, ok := match.Package.Metadata.(pkg.JavaMetadata); ok {
+			return artifactID == metadata.PomArtifactID
+		}
+		return false
 	}
 }
 

--- a/grype/match/ignore_test.go
+++ b/grype/match/ignore_test.go
@@ -70,19 +70,22 @@ var (
 		{
 			Vulnerability: vulnerability.Vulnerability{
 				ID:        "CVE-458",
-				Namespace: "ruby-vulns",
+				Namespace: "java-vulns",
 				Fix: vulnerability.Fix{
 					State: grypeDb.UnknownFixState,
 				},
 			},
 			Package: pkg.Package{
 				ID:       pkg.ID(uuid.NewString()),
-				Name:     "speach",
-				Version:  "100.0.52",
-				Language: syftPkg.Ruby,
-				Type:     syftPkg.GemPkg,
-				Locations: source.NewLocationSet(source.NewVirtualLocation("/real/path/with/speach",
-					"/virtual/path/that/has/speach")),
+				Name:     "log4j",
+				Version:  "1.1.1",
+				Language: syftPkg.Java,
+				Type:     syftPkg.JavaPkg,
+				Metadata: pkg.JavaMetadata{
+					PomGroupID:    "log4j",
+					PomArtifactID: "log4j-core",
+					PomScope:      "test",
+				},
 			},
 		},
 	}
@@ -235,6 +238,7 @@ func TestApplyIgnoreRules(t *testing.T) {
 			},
 			expectedRemainingMatches: []Match{
 				allMatches[0],
+				allMatches[3],
 			},
 			expectedIgnoredMatches: []IgnoredMatch{
 				{
@@ -247,14 +251,6 @@ func TestApplyIgnoreRules(t *testing.T) {
 				},
 				{
 					Match: allMatches[2],
-					AppliedIgnoreRules: []IgnoreRule{
-						{
-							Namespace: "ruby-vulns",
-						},
-					},
-				},
-				{
-					Match: allMatches[3],
 					AppliedIgnoreRules: []IgnoreRule{
 						{
 							Namespace: "ruby-vulns",
@@ -275,6 +271,7 @@ func TestApplyIgnoreRules(t *testing.T) {
 			},
 			expectedRemainingMatches: []Match{
 				allMatches[0],
+				allMatches[3],
 			},
 			expectedIgnoredMatches: []IgnoredMatch{
 				{
@@ -297,12 +294,86 @@ func TestApplyIgnoreRules(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		{
+			name:       "ignore matches on pom scope",
+			allMatches: allMatches,
+			ignoreRules: []IgnoreRule{
+				{
+					Pom: IgnoreRulePom{
+						Scope: "test",
+					},
+				},
+			},
+			expectedRemainingMatches: []Match{
+				allMatches[0],
+				allMatches[1],
+				allMatches[2],
+			},
+			expectedIgnoredMatches: []IgnoredMatch{
 				{
 					Match: allMatches[3],
 					AppliedIgnoreRules: []IgnoreRule{
 						{
-							Package: IgnoreRulePackage{
-								Language: string(syftPkg.Ruby),
+							Pom: IgnoreRulePom{
+								Scope: "test",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "ignore matches on pom group id",
+			allMatches: allMatches,
+			ignoreRules: []IgnoreRule{
+				{
+					Pom: IgnoreRulePom{
+						GroupID: "log4j",
+					},
+				},
+			},
+			expectedRemainingMatches: []Match{
+				allMatches[0],
+				allMatches[1],
+				allMatches[2],
+			},
+			expectedIgnoredMatches: []IgnoredMatch{
+				{
+					Match: allMatches[3],
+					AppliedIgnoreRules: []IgnoreRule{
+						{
+							Pom: IgnoreRulePom{
+								GroupID: "log4j",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "ignore matches on pom artifact id",
+			allMatches: allMatches,
+			ignoreRules: []IgnoreRule{
+				{
+					Pom: IgnoreRulePom{
+						ArtifactID: "log4j-core",
+					},
+				},
+			},
+			expectedRemainingMatches: []Match{
+				allMatches[0],
+				allMatches[1],
+				allMatches[2],
+			},
+			expectedIgnoredMatches: []IgnoredMatch{
+				{
+					Match: allMatches[3],
+					AppliedIgnoreRules: []IgnoreRule{
+						{
+							Pom: IgnoreRulePom{
+								ArtifactID: "log4j-core",
 							},
 						},
 					},
@@ -342,6 +413,25 @@ var (
 				source.NewVirtualLocation("/some/path", "/some/virtual/path"),
 			),
 			Type: "rpm",
+		},
+	}
+)
+
+var (
+	exampleJavaMatch = Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2000-1234",
+		},
+		Package: pkg.Package{
+			ID:      pkg.ID(uuid.NewString()),
+			Name:    "a-pkg",
+			Version: "1.0",
+			Type:    "java-archive",
+			Metadata: pkg.JavaMetadata{
+				PomGroupID:    "example-group",
+				PomArtifactID: "example-artifact",
+				PomScope:      "test",
+			},
 		},
 	}
 )
@@ -449,6 +539,36 @@ func TestShouldIgnore(t *testing.T) {
 				},
 			},
 			expected: false,
+		},
+		{
+			name:  "rule applies via pom scope",
+			match: exampleJavaMatch,
+			rule: IgnoreRule{
+				Pom: IgnoreRulePom{
+					Scope: exampleJavaMatch.Package.Metadata.(pkg.JavaMetadata).PomScope,
+				},
+			},
+			expected: true,
+		},
+		{
+			name:  "rule applies via pom group id",
+			match: exampleJavaMatch,
+			rule: IgnoreRule{
+				Pom: IgnoreRulePom{
+					GroupID: exampleJavaMatch.Package.Metadata.(pkg.JavaMetadata).PomGroupID,
+				},
+			},
+			expected: true,
+		},
+		{
+			name:  "rule applies via pom artifact id",
+			match: exampleJavaMatch,
+			rule: IgnoreRule{
+				Pom: IgnoreRulePom{
+					ArtifactID: exampleJavaMatch.Package.Metadata.(pkg.JavaMetadata).PomArtifactID,
+				},
+			},
+			expected: true,
 		},
 	}
 

--- a/grype/pkg/java_metadata.go
+++ b/grype/pkg/java_metadata.go
@@ -4,6 +4,7 @@ type JavaMetadata struct {
 	VirtualPath    string   `json:"virtualPath"`
 	PomArtifactID  string   `json:"pomArtifactID"`
 	PomGroupID     string   `json:"pomGroupID"`
+	PomScope       string   `json:"pomScope"`
 	ManifestName   string   `json:"manifestName"`
 	ArchiveDigests []Digest `json:"archiveDigests"`
 }

--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -238,10 +238,11 @@ func getNameAndELVersion(sourceRpm string) (string, string) {
 
 func javaDataFromPkg(p pkg.Package) (metadata *JavaMetadata) {
 	if value, ok := p.Metadata.(pkg.JavaMetadata); ok {
-		var artifact, group, name string
+		var artifact, group, name, scope string
 		if value.PomProperties != nil {
 			artifact = value.PomProperties.ArtifactID
 			group = value.PomProperties.GroupID
+			scope = value.PomProperties.Scope
 		}
 		if value.Manifest != nil {
 			if n, ok := value.Manifest.Main["Name"]; ok {
@@ -263,6 +264,7 @@ func javaDataFromPkg(p pkg.Package) (metadata *JavaMetadata) {
 			VirtualPath:    value.VirtualPath,
 			PomArtifactID:  artifact,
 			PomGroupID:     group,
+			PomScope:       scope,
 			ManifestName:   name,
 			ArchiveDigests: archiveDigests,
 		}


### PR DESCRIPTION
This resolves #985 

I was 50/50 about adding GroupID and ArtifactID, happy to remove artifact ID as you could use package-name in the package ignore rules but opened the PR anyway just in case it added value.

The artifact ID ignore rules are dependant on https://github.com/anchore/syft/pull/1870 as currently it's blank

Group ID filter
<img width="1280" alt="image" src="https://github.com/anchore/grype/assets/14006260/18a16eb4-06a9-4623-bf6a-73b77e43fa6f">

Scope filter
<img width="1258" alt="image" src="https://github.com/anchore/grype/assets/14006260/f252572b-3f3a-4204-84f8-a68d8c72d258">

Pom used for testing:

```xml
<dependency>
        <groupId>log4j</groupId>
        <artifactId>log4j</artifactId>
        <version>1.2.17</version>
</dependency>		
<dependency>
	<groupId>org.springframework.boot</groupId>
	<artifactId>spring-boot-starter-webflux</artifactId>
	<scope>test</scope>
</dependency>
```