### PR TITLE
Pass correct output file

### DIFF
--- a/cmd/grype/cli/legacy/root.go
+++ b/cmd/grype/cli/legacy/root.go
@@ -289,8 +289,7 @@ func startWorker(userInput string, failOnSeverity *vulnerability.Severity) <-cha
 		defer close(errs)
 		defer bus.Exit()
 
-		// TODO: appConfig.File
-		writer, err := format.MakeScanResultWriter(appConfig.Outputs, appConfig.OutputTemplateFile, format.PresentationConfig{
+		writer, err := format.MakeScanResultWriter(appConfig.Outputs, appConfig.File, format.PresentationConfig{
 			TemplateFilePath: appConfig.OutputTemplateFile,
 			ShowSuppressed:   appConfig.ShowSuppressed,
 		})


### PR DESCRIPTION
Previously, the wrong path would get passed, and the template file would get truncated.

Fixes https://github.com/anchore/grype/issues/1388

Manual testing done:

```
❯ go run cmd/grype/main.go -o template=foo.csv -o json -t templates/csv.tmpl alpine:latest
 ✔ Vulnerability DB                [no update available]  
 ✔ Loaded image                                                                                                                                                                                               alpine:latest
 ✔ Parsed image                                                                                                                                     sha256:5053b247d78b5e43b5543fec77c856ce70b8dc705d9f38336fa77736f25ff47c
 ✔ Cataloged packages              [16 packages]  
 ✔ Scanned for vulnerabilities     [2 vulnerabilities]  
   ├── 0 critical, 0 high, 0 medium, 0 low, 0 negligible (2 unknown)
   └── 2 fixed
# json got written to stdout:
{
 "matches": [
  {
   "vulnerability": {
    "id": "CVE-2023-2975",
    "dataSource": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2975",
    "namespace": "alpine:distro:alpine:3.18",
    "severity": "Unknown",
    "urls": [
... snip
# csv got written
❯ cat foo.csv 
"Package","Version Installed","Vulnerability ID","Severity"
"libcrypto3","3.1.1-r1","CVE-2023-2975","Unknown"
"libssl3","3.1.1-r1","CVE-2023-2975","Unknown"
# template file used did not get truncated
❯ cat templates/csv.tmpl 
"Package","Version Installed","Vulnerability ID","Severity"
{{- range .Matches}}
"{{.Artifact.Name}}","{{.Artifact.Version}}","{{.Vulnerability.ID}}","{{.Vulnerability.Severity}}"
{{- end}}
```

Testing that `--file` still works

```
 go run cmd/grype/main.go -o template=foo.csv -o json --file test.json -t templates/csv.tmpl alpine:latest
 ✔ Vulnerability DB                [no update available]  
 ✔ Loaded image                                                                                                                                                                                               alpine:latest
 ✔ Parsed image                                                                                                                                     sha256:5053b247d78b5e43b5543fec77c856ce70b8dc705d9f38336fa77736f25ff47c
 ✔ Cataloged packages              [16 packages]  
 ✔ Scanned for vulnerabilities     [2 vulnerabilities]  
   ├── 0 critical, 0 high, 0 medium, 0 low, 0 negligible (2 unknown)
   └── 2 fixed

❯ head test.json 
{
 "matches": [
  {
   "vulnerability": {
    "id": "CVE-2023-2975",
    "dataSource": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2975",
    "namespace": "alpine:distro:alpine:3.18",
    "severity": "Unknown",
    "urls": [
     "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2975"

❯ head foo.csv 
"Package","Version Installed","Vulnerability ID","Severity"
"libcrypto3","3.1.1-r1","CVE-2023-2975","Unknown"
"libssl3","3.1.1-r1","CVE-2023-2975","Unknown"
```
