### PR TITLE
fix: vulnerabilities should be printed when `--fail-on` fails

### DIFF
--- a/cmd/grype/cli/legacy/event_loop.go
+++ b/cmd/grype/cli/legacy/event_loop.go
@@ -43,12 +43,12 @@ func eventLoop(workerErrs <-chan error, signals <-chan os.Signal, subscription *
 				// if the error is not a severity threshold error, then it is unexpected and we should start to tear down the UI
 				if !errors.Is(err, grypeerr.ErrAboveSeverityThreshold) {
 					// capture the error from the worker and unsubscribe to complete a graceful shutdown
-					retErr = multierror.Append(retErr, err)
 					_ = subscription.Unsubscribe()
 					// the worker has exited, we may have been mid-handling events for the UI which should now be
 					// ignored, in which case forcing a teardown of the UI irregardless of the state is required.
 					forceTeardown = true
 				}
+				retErr = multierror.Append(retErr, err)
 			}
 		case e, isOpen := <-events:
 			if !isOpen {

--- a/cmd/grype/cli/legacy/event_loop.go
+++ b/cmd/grype/cli/legacy/event_loop.go
@@ -16,7 +16,7 @@ import (
 // eventLoop listens to worker errors (from execution path), worker events (from a partybus subscription), and
 // signal interrupts. Is responsible for handling each event relative to a given UI an to coordinate eventing until
 // an eventual graceful exit.
-func eventLoop(workerErrs <-chan error, signals <-chan os.Signal, subscription *partybus.Subscription, cleanupFn func(), uxs ...clio.UI) error {
+func eventLoop(workerErrs <-chan error, signals <-chan os.Signal, subscription *partybus.Subscription, cleanupFn func(), uxs ...clio.UI) error { //nolint:gocognit
 	defer cleanupFn()
 	events := subscription.Events()
 	var err error

--- a/test/cli/cmd_test.go
+++ b/test/cli/cmd_test.go
@@ -59,6 +59,7 @@ func TestCmd(t *testing.T) {
 			args: []string{"registry:busybox:1.31", "-f", "high", "--platform", "linux/amd64"},
 			assertions: []traitAssertion{
 				assertInOutput("CVE-2021-42379"),
+				assertFailingReturnCode,
 			},
 		},
 	}

--- a/test/cli/cmd_test.go
+++ b/test/cli/cmd_test.go
@@ -56,9 +56,9 @@ func TestCmd(t *testing.T) {
 		},
 		{
 			name: "vulnerabilities in output on -f with failure",
-			args: strings.Split("alpine:3.12.11 -f critical --only-fixed --platform linux/amd64", " "),
+			args: []string{"registry:busybox:1.31", "-f", "high", "--platform", "linux/amd64"},
 			assertions: []traitAssertion{
-				assertInOutput("CVE-2022-37434"), // a known vulnerability in the alpine:3.12.11 image
+				assertInOutput("CVE-2021-42379"),
 			},
 		},
 	}

--- a/test/cli/cmd_test.go
+++ b/test/cli/cmd_test.go
@@ -54,6 +54,13 @@ func TestCmd(t *testing.T) {
 				assertInOutput("scope: all-layers"),
 			},
 		},
+		{
+			name: "vulnerabilities in output on -f with failure",
+			args: strings.Split("alpine:3.12.11 -f critical --only-fixed --platform linux/amd64", " "),
+			assertions: []traitAssertion{
+				assertInOutput("CVE-2022-37434"), // a known vulnerability in the alpine:3.12.11 image
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes https://github.com/anchore/grype/issues/1392.