### PR TITLE
chore: in quality tests, only colorize quality ouput if in a tty

### DIFF
--- a/test/quality/gate.py
+++ b/test/quality/gate.py
@@ -90,6 +90,17 @@ class bcolors:
     UNDERLINE = '\033[4m'
     RESET = '\033[0m'
 
+if not sys.stdout.isatty():
+    bcolors.HEADER = ""
+    bcolors.OKBLUE = ""
+    bcolors.OKCYAN = ""
+    bcolors.OKGREEN = ""
+    bcolors.WARNING = ""
+    bcolors.FAIL = ""
+    bcolors.BOLD = ""
+    bcolors.UNDERLINE = ""
+    bcolors.RESET = ""
+
 def show_results_used(results: list[artifact.ScanResult]):
     print(f"   Results used:")
     for idx, result in enumerate(results):


### PR DESCRIPTION
Permit piping "make validate" to a file without filling it with control characters.