### PR TITLE
feat: update table sort to be name, version, type, severity, vulnerability

### DIFF
--- a/grype/presenter/table/presenter.go
+++ b/grype/presenter/table/presenter.go
@@ -47,7 +47,6 @@ func (pres *Presenter) Present(output io.Writer) error {
 	// Generate rows for matching vulnerabilities
 	for m := range pres.results.Enumerate() {
 		row, err := createRow(m, pres.metadataProvider, "")
-
 		if err != nil {
 			return err
 		}
@@ -71,8 +70,30 @@ func (pres *Presenter) Present(output io.Writer) error {
 		return err
 	}
 
-	rows = removeDuplicateRows(rows)
+	rows = sortRows(removeDuplicateRows(rows))
 
+	table := tablewriter.NewWriter(output)
+	table.SetHeader(columns)
+	table.SetAutoWrapText(false)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetTablePadding("  ")
+	table.SetNoWhiteSpace(true)
+
+	table.AppendBulk(rows)
+	table.Render()
+
+	return nil
+}
+
+func sortRows(rows [][]string) [][]string {
 	// sort
 	sort.SliceStable(rows, func(i, j int) bool {
 		var (
@@ -102,26 +123,7 @@ func (pres *Presenter) Present(output io.Writer) error {
 		return rows[i][name] < rows[j][name]
 	})
 
-	table := tablewriter.NewWriter(output)
-
-	table.SetHeader(columns)
-	table.SetAutoWrapText(false)
-	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
-	table.SetAlignment(tablewriter.ALIGN_LEFT)
-
-	table.SetHeaderLine(false)
-	table.SetBorder(false)
-	table.SetAutoFormatHeaders(true)
-	table.SetCenterSeparator("")
-	table.SetColumnSeparator("")
-	table.SetRowSeparator("")
-	table.SetTablePadding("  ")
-	table.SetNoWhiteSpace(true)
-
-	table.AppendBulk(rows)
-	table.Render()
-
-	return nil
+	return rows
 }
 
 func sevScore(sev string) int {

--- a/grype/presenter/table/presenter.go
+++ b/grype/presenter/table/presenter.go
@@ -71,16 +71,36 @@ func (pres *Presenter) Present(output io.Writer) error {
 		return err
 	}
 
-	// sort by name, version, then type
-	sort.SliceStable(rows, func(i, j int) bool {
-		for col := 0; col < len(columns); col++ {
-			if rows[i][col] != rows[j][col] {
-				return rows[i][col] < rows[j][col]
-			}
-		}
-		return false
-	})
 	rows = removeDuplicateRows(rows)
+
+	// sort
+	sort.SliceStable(rows, func(i, j int) bool {
+		var (
+			name        = 0
+			ver         = 1
+			packageType = 3
+			vuln        = 4
+			sev         = 5
+		)
+		// name, version, type, severity, vulnerability
+		// > is for numeric sorting like severity or year/number of vulnerability
+		// < is for alphabetical sorting like name, version, type
+		if rows[i][name] == rows[j][name] {
+			if rows[i][ver] == rows[j][ver] {
+				if rows[i][packageType] == rows[j][packageType] {
+					if sevScore(rows[i][sev]) == sevScore(rows[j][sev]) {
+						// we use > here to get the most recently filed vulnerabilities
+						// to show at the top of the severity
+						return rows[i][vuln] > rows[j][vuln]
+					}
+					return sevScore(rows[i][sev]) > sevScore(rows[j][sev])
+				}
+				return rows[i][packageType] < rows[j][packageType]
+			}
+			return rows[i][ver] < rows[j][ver]
+		}
+		return rows[i][name] < rows[j][name]
+	})
 
 	table := tablewriter.NewWriter(output)
 
@@ -102,6 +122,25 @@ func (pres *Presenter) Present(output io.Writer) error {
 	table.Render()
 
 	return nil
+}
+
+func sevScore(sev string) int {
+	switch sev {
+	case "Unknown":
+		return 0
+	case "Negligible":
+		return 1
+	case "Low":
+		return 2
+	case "Medium":
+		return 3
+	case "High":
+		return 4
+	case "Critical":
+		return 5
+	default:
+		return 0
+	}
 }
 
 func removeDuplicateRows(items [][]string) [][]string {

--- a/grype/presenter/table/presenter_test.go
+++ b/grype/presenter/table/presenter_test.go
@@ -19,7 +19,7 @@ import (
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
-var update = flag.Bool("update", true, "update the *.golden files for table presenters")
+var update = flag.Bool("update", false, "update the *.golden files for table presenters")
 
 func TestCreateRow(t *testing.T) {
 	pkg1 := pkg.Package{

--- a/grype/presenter/table/test-fixtures/snapshot/TestDisplaysIgnoredMatches.golden
+++ b/grype/presenter/table/test-fixtures/snapshot/TestDisplaysIgnoredMatches.golden
@@ -1,5 +1,5 @@
 NAME       INSTALLED  FIXED-IN          TYPE  VULNERABILITY  SEVERITY              
 package-1  1.1.1                        rpm   CVE-1999-0002  Critical               
 package-1  1.1.1      the-next-version  rpm   CVE-1999-0001  Low                    
-package-2  2.2.2                        deb   CVE-1999-0001  Low (suppressed)       
 package-2  2.2.2                        deb   CVE-1999-0002  Critical (suppressed)  
+package-2  2.2.2                        deb   CVE-1999-0001  Low (suppressed)       


### PR DESCRIPTION
## Update table sort in default presenter

This PR updates the table sort in the default table presenter with the following priority:
- name
- version
- type
- severity
- vulnerability

### Before the table output would have severities interleaved along with an unspecific ordering of CVE by date filed
<img width="917" alt="Screenshot 2023-07-25 at 1 58 33 PM" src="https://github.com/anchore/grype/assets/32073428/26fd4292-a135-43fa-826a-97b1811bc834">


### After the table output now collates the results by severity (highest to lowest), further sorting those by when the CVE was filed (most recent year/number at the top)
<img width="1016" alt="Screenshot 2023-07-25 at 1 58 45 PM" src="https://github.com/anchore/grype/assets/32073428/9a4216d4-c86d-4a0d-ae08-9fce7c828507">

TODO

- [x] Static Code linting
- [x] Update presenter tests to account for latest sort order