### PR TITLE
feat: implement secondary sorting for default json output

### DIFF
--- a/grype/presenter/json/presenter_test.go
+++ b/grype/presenter/json/presenter_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"regexp"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -124,6 +125,18 @@ func TestEmptyJsonPresenter(t *testing.T) {
 
 	assert.JSONEq(t, string(expected), string(actual))
 
+}
+
+func TestPresenter_Present_NewDocumentSorted(t *testing.T) {
+	matches, packages, context, metadataProvider, appConfig, dbStatus := internal.GenerateAnalysis(t, internal.ImageSource)
+	doc, err := models.NewDocument(packages, context, matches, nil, metadataProvider, appConfig, dbStatus)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !sort.IsSorted(models.MatchSort(doc.Matches)) {
+		t.Errorf("expected matches to be sorted")
+	}
 }
 
 func redact(content []byte) []byte {

--- a/grype/presenter/models/document.go
+++ b/grype/presenter/models/document.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/anchore/grype/grype/match"
@@ -42,6 +43,8 @@ func NewDocument(packages []pkg.Package, context pkg.Context, matches match.Matc
 
 		findings = append(findings, *matchModel)
 	}
+
+	sort.Sort(MatchSort(findings))
 
 	var src *source
 	if context.Source != nil {

--- a/grype/presenter/models/document_test.go
+++ b/grype/presenter/models/document_test.go
@@ -91,7 +91,7 @@ func TestPackagesAreSorted(t *testing.T) {
 		actualVulnerabilities = append(actualVulnerabilities, m.Vulnerability.ID)
 	}
 
-	assert.Equal(t, []string{"CVE-1999-0001", "CVE-1999-0002", "CVE-1999-0003"}, actualVulnerabilities)
+	assert.Equal(t, []string{"CVE-1999-0003", "CVE-1999-0002", "CVE-1999-0001"}, actualVulnerabilities)
 }
 
 func TestTimestampValidFormat(t *testing.T) {

--- a/grype/presenter/models/vulnerability_metadata.go
+++ b/grype/presenter/models/vulnerability_metadata.go
@@ -35,3 +35,23 @@ func NewVulnerabilityMetadata(id, namespace string, metadata *vulnerability.Meta
 		Cvss:        NewCVSS(metadata),
 	}
 }
+
+// returns severtiy score for presenter sorting purposes
+func SeverityScore(severtiy string) int {
+	switch severtiy {
+	case "Unknown":
+		return 0
+	case "Negligible":
+		return 1
+	case "Low":
+		return 2
+	case "Medium":
+		return 3
+	case "High":
+		return 4
+	case "Critical":
+		return 5
+	default:
+		return 0
+	}
+}

--- a/grype/presenter/table/presenter.go
+++ b/grype/presenter/table/presenter.go
@@ -109,12 +109,12 @@ func sortRows(rows [][]string) [][]string {
 		if rows[i][name] == rows[j][name] {
 			if rows[i][ver] == rows[j][ver] {
 				if rows[i][packageType] == rows[j][packageType] {
-					if sevScore(rows[i][sev]) == sevScore(rows[j][sev]) {
+					if models.SeverityScore(rows[i][sev]) == models.SeverityScore(rows[j][sev]) {
 						// we use > here to get the most recently filed vulnerabilities
 						// to show at the top of the severity
 						return rows[i][vuln] > rows[j][vuln]
 					}
-					return sevScore(rows[i][sev]) > sevScore(rows[j][sev])
+					return models.SeverityScore(rows[i][sev]) > models.SeverityScore(rows[j][sev])
 				}
 				return rows[i][packageType] < rows[j][packageType]
 			}
@@ -124,25 +124,6 @@ func sortRows(rows [][]string) [][]string {
 	})
 
 	return rows
-}
-
-func sevScore(sev string) int {
-	switch sev {
-	case "Unknown":
-		return 0
-	case "Negligible":
-		return 1
-	case "Low":
-		return 2
-	case "Medium":
-		return 3
-	case "High":
-		return 4
-	case "Critical":
-		return 5
-	default:
-		return 0
-	}
 }
 
 func removeDuplicateRows(items [][]string) [][]string {

--- a/grype/presenter/template/presenter.go
+++ b/grype/presenter/template/presenter.go
@@ -91,7 +91,7 @@ var FuncMap = func() template.FuncMap {
 			return collection
 		}
 
-		sort.Sort(models.ByName(matches))
+		sort.Sort(models.MatchSort(matches))
 		return matches
 	}
 	return f


### PR DESCRIPTION
## Follow up to https://github.com/anchore/grype/pull/1400

Another submission for #709 

Implements the new table sorting secondary sort for the default json output.

There is a small side effect which influences the template presenter since it uses the same sorting interface as the json output.

### For reviewer

Do you think we should do the same here for sarif and cyclonedx? I'm unsure here and only have made changes for formats we have agency over at the moment (table, json, template).