### PR TITLE
fix: prevent hang if stderr is tty but stdout is not

### DIFF
--- a/cmd/grype/internal/ui/select.go
+++ b/cmd/grype/internal/ui/select.go
@@ -19,7 +19,7 @@ import (
 func Select(verbose, quiet bool) (uis []clio.UI) {
 	isStdoutATty := term.IsTerminal(int(os.Stdout.Fd()))
 	isStderrATty := term.IsTerminal(int(os.Stderr.Fd()))
-	notATerminal := !isStderrATty && !isStdoutATty
+	notATerminal := !isStderrATty || !isStdoutATty
 
 	switch {
 	case runtime.GOOS == "windows" || verbose || quiet || notATerminal || !isStderrATty:


### PR DESCRIPTION
Previously, invocations of grype could hang if, for example, stdout was redirect but stderr was a TTY. Fall back to non-fancy GUI if either stdout or stderr is not a TTY, instead of only when both are directed.

## Manual testing done

```
# hangs forever:
❯ cat <(grype alpine:latest | head -n 1) <(grype alpine:latest | rg binary)
^C
# runs correctly:
❯ cat <(go run cmd/grype/main.go alpine:latest | head -n 1) <(go run cmd/grype/main.go alpine:latest | rg binary)
NAME        INSTALLED  FIXED-IN  TYPE  VULNERABILITY  SEVERITY
```

I believe this is same problem that affects syft, see https://github.com/anchore/syft/issues/1439 and https://github.com/anchore/syft/pull/1977