### PR TITLE
feat: disable CPE-based matching for GHSA ecosystems by default

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -53,6 +53,7 @@ jobs:
         run: make quality
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GRYPE_BY_CVE: "true"
 
   Integration-Test:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline

--- a/cmd/grype/cli/options/match.go
+++ b/cmd/grype/cli/options/match.go
@@ -8,6 +8,7 @@ type matchConfig struct {
 	Javascript matcherConfig `yaml:"javascript" json:"javascript" mapstructure:"javascript"` // settings for the javascript matcher
 	Python     matcherConfig `yaml:"python" json:"python" mapstructure:"python"`             // settings for the python matcher
 	Ruby       matcherConfig `yaml:"ruby" json:"ruby" mapstructure:"ruby"`                   // settings for the ruby matcher
+	Rust       matcherConfig `yaml:"rust" json:"rust" mapstructure:"rust"`                   // settings for the rust matcher
 	Stock      matcherConfig `yaml:"stock" json:"stock" mapstructure:"stock"`                // settings for the default/stock matcher
 }
 
@@ -17,13 +18,15 @@ type matcherConfig struct {
 
 func defaultMatchConfig() matchConfig {
 	useCpe := matcherConfig{UseCPEs: true}
+	dontUseCpe := matcherConfig{UseCPEs: false}
 	return matchConfig{
-		Java:       useCpe,
-		Dotnet:     useCpe,
-		Golang:     useCpe,
-		Javascript: useCpe,
-		Python:     useCpe,
-		Ruby:       useCpe,
+		Java:       dontUseCpe,
+		Dotnet:     dontUseCpe,
+		Golang:     dontUseCpe,
+		Javascript: dontUseCpe,
+		Python:     dontUseCpe,
+		Ruby:       dontUseCpe,
+		Rust:       dontUseCpe,
 		Stock:      useCpe,
 	}
 }

--- a/grype/db/v5/namespace/index_test.go
+++ b/grype/db/v5/namespace/index_test.go
@@ -30,6 +30,8 @@ func TestFromStringSlice(t *testing.T) {
 				"nvd:cpe",
 				"github:language:ruby",
 				"abc.xyz:language:ruby",
+				"github:language:rust",
+				"something:language:rust",
 				"1234.4567:language:unknown",
 				"---:cpe",
 				"another-provider:distro:alpine:3.15",
@@ -43,6 +45,10 @@ func TestFromStringSlice(t *testing.T) {
 				syftPkg.Ruby: {
 					language.NewNamespace("github", syftPkg.Ruby, ""),
 					language.NewNamespace("abc.xyz", syftPkg.Ruby, ""),
+				},
+				syftPkg.Rust: {
+					language.NewNamespace("github", syftPkg.Rust, ""),
+					language.NewNamespace("something", syftPkg.Rust, ""),
 				},
 				syftPkg.Language("unknown"): {
 					language.NewNamespace("1234.4567", syftPkg.Language("unknown"), ""),

--- a/grype/db/v5/namespace/language/namespace_test.go
+++ b/grype/db/v5/namespace/language/namespace_test.go
@@ -26,6 +26,10 @@ func TestFromString(t *testing.T) {
 			result:          NewNamespace("github", syftPkg.Java, ""),
 		},
 		{
+			namespaceString: "github:language:rust",
+			result:          NewNamespace("github", syftPkg.Rust, ""),
+		},
+		{
 			namespaceString: "abc.xyz:language:something",
 			result:          NewNamespace("abc.xyz", syftPkg.Language("something"), ""),
 		},

--- a/grype/match/matcher_type.go
+++ b/grype/match/matcher_type.go
@@ -15,6 +15,7 @@ const (
 	PortageMatcher     MatcherType = "portage-matcher"
 	GoModuleMatcher    MatcherType = "go-module-matcher"
 	OpenVexMatcher     MatcherType = "openvex-matcher"
+	RustMatcher        MatcherType = "rust-matcher"
 )
 
 var AllMatcherTypes = []MatcherType{
@@ -30,6 +31,7 @@ var AllMatcherTypes = []MatcherType{
 	PortageMatcher,
 	GoModuleMatcher,
 	OpenVexMatcher,
+	RustMatcher,
 }
 
 type MatcherType string

--- a/grype/matcher/matchers.go
+++ b/grype/matcher/matchers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/anchore/grype/grype/matcher/python"
 	"github.com/anchore/grype/grype/matcher/rpm"
 	"github.com/anchore/grype/grype/matcher/ruby"
+	"github.com/anchore/grype/grype/matcher/rust"
 	"github.com/anchore/grype/grype/matcher/stock"
 )
 
@@ -23,6 +24,7 @@ type Config struct {
 	Dotnet     dotnet.MatcherConfig
 	Javascript javascript.MatcherConfig
 	Golang     golang.MatcherConfig
+	Rust       rust.MatcherConfig
 	Stock      stock.MatcherConfig
 }
 
@@ -39,6 +41,7 @@ func NewDefaultMatchers(mc Config) []Matcher {
 		golang.NewGolangMatcher(mc.Golang),
 		&msrc.Matcher{},
 		&portage.Matcher{},
+		rust.NewRustMatcher(mc.Rust),
 		stock.NewStockMatcher(mc.Stock),
 	}
 }

--- a/grype/matcher/rust/matcher.go
+++ b/grype/matcher/rust/matcher.go
@@ -1,0 +1,40 @@
+package rust
+
+import (
+	"github.com/anchore/grype/grype/distro"
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/search"
+	"github.com/anchore/grype/grype/vulnerability"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+type Matcher struct {
+	cfg MatcherConfig
+}
+
+type MatcherConfig struct {
+	UseCPEs bool
+}
+
+func NewRustMatcher(cfg MatcherConfig) *Matcher {
+	return &Matcher{
+		cfg: cfg,
+	}
+}
+
+func (m *Matcher) PackageTypes() []syftPkg.Type {
+	return []syftPkg.Type{syftPkg.RustPkg}
+}
+
+func (m *Matcher) Type() match.MatcherType {
+	return match.RustMatcher
+}
+
+func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Package) ([]match.Match, error) {
+	criteria := search.CommonCriteria
+	if m.cfg.UseCPEs {
+		criteria = append(criteria, search.ByCPE)
+	}
+	return search.ByCriteria(store, d, p, m.Type(), criteria...)
+}

--- a/test/grype-test-config.yaml
+++ b/test/grype-test-config.yaml
@@ -1,1 +1,2 @@
 check-for-app-update: false
+

--- a/test/integration/db_mock_test.go
+++ b/test/integration/db_mock_test.go
@@ -163,6 +163,22 @@ func newMockDbStore() *mockStore {
 					},
 				},
 			},
+			"github:language:rust": {
+				"hello-auditable": []grypeDB.Vulnerability{
+					{
+						ID:                "CVE-rust-sample-1",
+						VersionConstraint: "< 0.2.0",
+						VersionFormat:     "unknown",
+					},
+				},
+				"auditable": []grypeDB.Vulnerability{
+					{
+						ID:                "CVE-rust-sample-2",
+						VersionConstraint: "< 0.2.0",
+						VersionFormat:     "unknown",
+					},
+				},
+			},
 			"debian:distro:debian:8": {
 				"apt-dev": []grypeDB.Vulnerability{
 					{

--- a/test/integration/test-fixtures/image-rust-auditable-match-coverage/Dockerfile
+++ b/test/integration/test-fixtures/image-rust-auditable-match-coverage/Dockerfile
@@ -1,0 +1,2 @@
+# An image containing the example hello-auditable binary from https://github.com/Shnatsel/rust-audit/tree/master/hello-auditable
+FROM docker.io/tofay/hello-rust-auditable:latest


### PR DESCRIPTION
Disables CPE-based matching for ecosystems which are covered by GitHub Security Advisories.  Also adds a separate rust matcher and related configuration to allow configuring CPE-based matching off for rust packages while still leaving it enabled for anything falling into the stock matcher.

Fixes: #811 