### PR TITLE
chore: use syft v0.86.1 in the quality gate tests

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -40,7 +40,7 @@ jobs:
   Quality-Test:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Quality tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04-4core-16gb
     steps:
       - uses: actions/checkout@v3
         with:

--- a/test/quality/.yardstick.yaml
+++ b/test/quality/.yardstick.yaml
@@ -93,7 +93,7 @@ result-sets:
 
         - name: syft
           # note: we want to use a fixed version of syft for capturing all results (NOT "latest")
-          version: v0.74.1
+          version: v0.86.1
           produces: SBOM
           refresh: false
 


### PR DESCRIPTION
This ensures the CPE dict enhancements are taken into account for future quality gate comparisons.  This should wait until https://github.com/anchore/vulnerability-match-labels/pull/92 makes it in