### PR TITLE
chore: use latest yardstick

### DIFF
--- a/test/quality/.yardstick.yaml
+++ b/test/quality/.yardstick.yaml
@@ -99,6 +99,8 @@ result-sets:
 
         - name: grype
           version: git:current-commit
+          # for local build of grype, use for example:
+          # version: path:../../
           takes: SBOM
 
         - name: grype

--- a/test/quality/gate.py
+++ b/test/quality/gate.py
@@ -72,6 +72,13 @@ def guess_tool_orientation(tools: list[str]):
         current_tool = tool
 
     if latest_release_tool is None:
+        for tool in tools:
+            if "@path:" in tool:
+                current_tool = tool
+                continue
+            latest_release_tool = tool
+
+    if latest_release_tool is None:
         # "latest" value isn't accessible, so we do a best guess at which version is latest
         latest_release_tool, current_tool = sorted(tools)
 

--- a/test/quality/requirements.txt
+++ b/test/quality/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/anchore/yardstick@v0.7.0
+git+https://github.com/anchore/yardstick@v0.8.0
 # ../../../yardstick
 tabulate==0.9.0


### PR DESCRIPTION
Include changes to gate.py to correctly guess that local builds of grype are considered the changed version, not the latest release.