### PR TITLE
chore: exclude yardstick store from filename rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ lint:  ## Run gofmt + golangci lint checks
 	@[ -z "$(shell $(GOIMPORTS_CMD) -d .)" ] || (echo "goimports needs to be fixed" && false)
 
 	# go tooling does not play well with certain filename characters, ensure the common cases don't result in future "go get" failures
-	$(eval MALFORMED_FILENAMES := $(shell find . | grep -e ':'))
+	$(eval MALFORMED_FILENAMES := $(shell find . | grep -e ':' | grep -v -e "test/quality/.yardstick" -e "test/quality/vulnerability-match-labels"))
 	@bash -c "[[ '$(MALFORMED_FILENAMES)' == '' ]] || (printf '\nfound unsupported filename characters:\n$(MALFORMED_FILENAMES)\n\n' && false)"
 
 .PHONY: format


### PR DESCRIPTION
Enables "make lint" to be run after "make quality". Previously, the linter rules that prohibit ":" in any filename would fail if the yardstick or vulnerability-match-labels directories had been initialized (e.g. if "make quality" had been run), since they have filenames like "sha256:abcd" in them. Exclude them from this lint, since they are not go files.

## Manual testing done

Test case where repo has yardstick state, and thus files with ":":

1. Run `make` in test/quality to get some yardstick state in the workspace
2. Prove that there are a lot of files with `:` in the name: `find . | grep -e ":" | wc -l` prints ~17k.
3. Run `make lint` from the root of this workspace; it succeeds.

Running `make lint` on main, before this change, if the yardstick state is initialized, fails like this:

```
❯ make lint
Running linters
# ensure there are no go fmt differences
files with gofmt issues: []
# run all golangci-lint rules
./.tmp/golangci-lint run --tests=false
# go tooling does not play well with certain filename characters, ensure the common cases don't result in future "go get" failures
make: /bin/sh: Argument list too long
make: *** [lint] Error 1
```

Test case where this state hasn't existed (to make sure the subshell exiting differently because of the grep or whatever doesn't break something):

```
git clone -b ignore-label-and-image-dirs git@github.com:anchore/grype grype-test && cd grype-test && make bootstrap && make lint
```
exits zero.