### PR TITLE
chore: bump to syft v0.87.1 in quality gate

### DIFF
--- a/test/quality/.yardstick.yaml
+++ b/test/quality/.yardstick.yaml
@@ -93,7 +93,7 @@ result-sets:
 
         - name: syft
           # note: we want to use a fixed version of syft for capturing all results (NOT "latest")
-          version: v0.86.1
+          version: v0.87.1
           produces: SBOM
           refresh: false
 


### PR DESCRIPTION
To take into account recent maven PURL generation improvements.  https://github.com/anchore/vulnerability-match-labels/pull/101 should be merged first to ensure the sbom cache is updated