### PR TITLE
New version notice only showing the version and no text

### DIFF
--- a/cmd/grype/internal/ui/__snapshots__/post_ui_event_writer_test.snap
+++ b/cmd/grype/internal/ui/__snapshots__/post_ui_event_writer_test.snap
@@ -27,12 +27,7 @@ report 1!!>
                     
 <notification 2>
 <notification 3>
-                        
-                        
-<my app can be updated!!
-...to this version>     
-                        
-                        
+A newer version of grype is available for download: v0.33.0 (installed version is [not provided])
 
 ---
 

--- a/cmd/grype/internal/ui/post_ui_event_writer.go
+++ b/cmd/grype/internal/ui/post_ui_event_writer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/anchore/grype/grype/event"
 	"github.com/anchore/grype/grype/event/parsers"
 	"github.com/anchore/grype/internal/log"
+	"github.com/anchore/grype/internal/version"
 )
 
 type postUIEventWriter struct {
@@ -118,11 +119,17 @@ func writeAppUpdate(writer io.Writer, events ...partybus.Event) error {
 	style := lipgloss.NewStyle().Foreground(lipgloss.Color("13")).Italic(true)
 
 	for _, e := range events {
-		notice, err := parsers.ParseCLIAppUpdateAvailable(e)
+		newVersion, err := parsers.ParseCLIAppUpdateAvailable(e)
 		if err != nil {
 			log.WithFields("error", err).Warn("failed to parse app update notification")
 			continue
 		}
+
+		if newVersion == "" {
+			continue
+		}
+
+		notice := fmt.Sprintf("A newer version of grype is available for download: %s (installed version is %s)", newVersion, version.FromBuild().Version)
 
 		if _, err := fmt.Fprintln(writer, style.Render(notice)); err != nil {
 			// don't let this be fatal

--- a/cmd/grype/internal/ui/post_ui_event_writer_test.go
+++ b/cmd/grype/internal/ui/post_ui_event_writer_test.go
@@ -35,7 +35,7 @@ func Test_postUIEventWriter_write(t *testing.T) {
 				},
 				{
 					Type:  event.CLIAppUpdateAvailable,
-					Value: "\n\n<my app can be updated!!\n...to this version>\n\n",
+					Value: "v0.33.0",
 				},
 				{
 					Type:  event.CLINotification,


### PR DESCRIPTION
Currently when running grype and there is a new version available the version is shown with no other context:

<img width="582" alt="Screenshot 2023-08-18 at 1 36 05 PM" src="https://github.com/anchore/grype/assets/590471/f2ffcefe-01d2-4369-b9f8-62377bac3987">

This PR addresses this by filling in the notice text:

<img width="887" alt="Screenshot 2023-08-18 at 1 35 01 PM" src="https://github.com/anchore/grype/assets/590471/71e7ea12-8539-40df-a512-1921fbf43e35">
