### PR TITLE
chore: bump quality gate to use syft v0.89.0

### DIFF
--- a/test/quality/.yardstick.yaml
+++ b/test/quality/.yardstick.yaml
@@ -93,7 +93,7 @@ result-sets:
 
         - name: syft
           # note: we want to use a fixed version of syft for capturing all results (NOT "latest")
-          version: v0.87.1
+          version: v0.89.0
           produces: SBOM
           refresh: false
 


### PR DESCRIPTION
Should be merged after https://github.com/anchore/vulnerability-match-labels/pull/110