### PR TITLE
chore: Update go declaration to have point version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/anchore/grype
 
-go 1.21
-
-toolchain go1.21.0
+go 1.21.1
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.7.1


### PR DESCRIPTION
Our understanding is that without the patch version, every run of "go mod tidy" will write a toolchain directive in the file, which will result in a diff from contributors with different point versions of go, which is noisy and prone to breaking CI.

Thanks to https://github.com/golang/go/issues/62278#issuecomment-1698829945 for the concise explanation of what seems to be going on with the changes to go.mod.