### PR TITLE
chore: Fix race conditions around stager, enable detector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,13 +170,14 @@ check-go-mod-tidy:
 .PHONY: unit
 unit: $(TEMP_DIR) ## Run unit tests (with coverage)
 	$(call title,Running unit tests)
-	go test -coverprofile $(TEMP_DIR)/unit-coverage-details.txt $(shell go list ./... | grep -v anchore/grype/test)
+	go test -race -coverprofile $(TEMP_DIR)/unit-coverage-details.txt $(shell go list ./... | grep -v anchore/grype/test)
 	@.github/scripts/coverage.py $(COVERAGE_THRESHOLD) $(TEMP_DIR)/unit-coverage-details.txt
 
 .PHONY: integration
 integration:  ## Run integration tests
 	$(call title,Running integration tests)
 	go test -v ./test/integration
+	go run cmd/grype/main.go alpine:latest
 
 .PHONY: quality
 quality: ## Run quality tests

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/wagoodman/go-partybus v0.0.0-20230516145632-8ccac152c651
 	github.com/wagoodman/go-presenter v0.0.0-20211015174752-f9c01afc824b
-	github.com/wagoodman/go-progress v0.0.0-20230301185719-21920a456ad5
+	github.com/wagoodman/go-progress v0.0.0-20230911172108-cf810b7e365c
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
 	golang.org/x/term v0.12.0 // indirect
 	gorm.io/gorm v1.23.10

--- a/go.sum
+++ b/go.sum
@@ -931,8 +931,8 @@ github.com/wagoodman/go-partybus v0.0.0-20230516145632-8ccac152c651 h1:jIVmlAFIq
 github.com/wagoodman/go-partybus v0.0.0-20230516145632-8ccac152c651/go.mod h1:b26F2tHLqaoRQf8DywqzVaV1MQ9yvjb0OMcNl7Nxu20=
 github.com/wagoodman/go-presenter v0.0.0-20211015174752-f9c01afc824b h1:uWNQ0khA6RdFzODOMwKo9XXu7fuewnnkHykUtuKru8s=
 github.com/wagoodman/go-presenter v0.0.0-20211015174752-f9c01afc824b/go.mod h1:ewlIKbKV8l+jCj8rkdXIs361ocR5x3qGyoCSca47Gx8=
-github.com/wagoodman/go-progress v0.0.0-20230301185719-21920a456ad5 h1:lwgTsTy18nYqASnH58qyfRW/ldj7Gt2zzBvgYPzdA4s=
-github.com/wagoodman/go-progress v0.0.0-20230301185719-21920a456ad5/go.mod h1:jLXFoL31zFaHKAAyZUh+sxiTDFe1L1ZHrcK2T1itVKA=
+github.com/wagoodman/go-progress v0.0.0-20230911172108-cf810b7e365c h1:mM8T8YhiD19d2wYv3vqZn8xpe1ZFJrUJCGlK4IV05xM=
+github.com/wagoodman/go-progress v0.0.0-20230911172108-cf810b7e365c/go.mod h1:jLXFoL31zFaHKAAyZUh+sxiTDFe1L1ZHrcK2T1itVKA=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/grype/differ/differ.go
+++ b/grype/differ/differ.go
@@ -100,9 +100,7 @@ func (d *Differ) setOrDownload(curator *db.Curator, filenameOrURL string) error 
 func download(curator *db.Curator, listing *db.ListingEntry) error {
 	// let consumers know of a monitorable event (download + import stages)
 	importProgress := progress.NewManual(1)
-	stage := &progress.Stage{
-		Current: "checking available databases",
-	}
+	stage := progress.NewAtomicStage("checking available databases")
 	downloadProgress := progress.NewManual(1)
 	aggregateProgress := progress.NewAggregator(progress.DefaultStrategy, downloadProgress, importProgress)
 


### PR DESCRIPTION
Fix the race conditions from setting stage.Current from multiple go routines by upgrading to a newer version of go-progress that includes an atomic version of stager and using that. Enable race detection on unit tests, and on a single invocation of the main command under the integration target.