### PR TITLE
chore: pin actions; pin images; add top level action permissions

### DIFF
--- a/.github/workflows/oss-project-board-add.yaml
+++ b/.github/workflows/oss-project-board-add.yaml
@@ -1,5 +1,8 @@
 name: Add to OSS board
 
+permissions:
+  contents: read
+
 on:
   issues:
     types:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,13 +9,15 @@ on:
 env:
   GO_VERSION: "1.21.x"
 
+permissions:
+  contents: read
+
 jobs:
   quality-gate:
     environment: release
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
       - name: Check if tag already exists
         # note: this will fail if the tag already exists
         run: |
@@ -94,7 +96,7 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v2.5.0
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           fetch-depth: 0
 
@@ -105,13 +107,13 @@ jobs:
           build-cache-key-prefix: "snapshot"
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d  #v3.0.0
         with:
           username: ${{ secrets.TOOLBOX_DOCKER_USER }}
           password: ${{ secrets.TOOLBOX_DOCKER_PASS }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d  #v3.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -110,17 +110,17 @@ jobs:
     needs: [Build-Snapshot-Artifacts]
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
 
       - name: Download snapshot build
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
         with:
           path: snapshot
           key: snapshot-build-${{ github.run_id }}
 
       - name: Restore install.sh test image cache
         id: install-test-image-cache
-        uses: actions/cache@v3
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
         with:
           path: ${{ github.workspace }}/test/install/cache
           key: ${{ runner.os }}-install-test-image-cache-${{ hashFiles('test/install/cache.fingerprint') }}
@@ -142,17 +142,17 @@ jobs:
     needs: [Build-Snapshot-Artifacts]
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
 
       - name: Download snapshot build
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
         with:
           path: snapshot
           key: snapshot-build-${{ github.run_id }}
 
       - name: Restore docker image cache for compare testing
         id: mac-compare-testing-cache
-        uses: actions/cache@v3
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
         with:
           path: image.tar
           key: ${{ runner.os }}-${{ hashFiles('test/compare/mac.sh') }}
@@ -167,19 +167,19 @@ jobs:
     needs: [Build-Snapshot-Artifacts]
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
 
       - name: Bootstrap environment
         uses: ./.github/actions/bootstrap
 
       - name: Restore CLI test-fixture cache
-        uses: actions/cache@v3
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
         with:
           path: ${{ github.workspace }}/test/cli/test-fixtures/cache
           key: ${{ runner.os }}-cli-test-cache-${{ hashFiles('test/cli/test-fixtures/cache.fingerprint') }}
 
       - name: Download snapshot build
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
         with:
           path: snapshot
           key: snapshot-build-${{ github.run_id }}

--- a/test/cli/test-fixtures/image-java-subprocess/Dockerfile
+++ b/test/cli/test-fixtures/image-java-subprocess/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:15-slim-buster
+FROM openjdk:15-slim-buster@sha256:1e069bf1c5c23adde58b29b82281b862e473d698ce7cc4e164194a0a2a1c044a
 COPY app.java /
 ENV PATH="/app/bin:${PATH}"
 WORKDIR /

--- a/test/cli/test-fixtures/image-node-subprocess/Dockerfile
+++ b/test/cli/test-fixtures/image-node-subprocess/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-stretch
+FROM node:16-stretch@sha256:5810de52349af302a2c5dddf0a3f31174ef65d0eed8985959a5e83bb1084b79b
 COPY app.js /
 ENV PATH="/app/bin:${PATH}"
 WORKDIR /

--- a/test/install/environments/Dockerfile-alpine-3.6
+++ b/test/install/environments/Dockerfile-alpine-3.6
@@ -1,2 +1,2 @@
-FROM alpine:3.6
+FROM alpine:3.6@sha256:66790a2b79e1ea3e1dabac43990c54aca5d1ddf268d9a5a0285e4167c8b24475
 RUN apk update && apk add python3 wget unzip make ca-certificates

--- a/test/install/environments/Dockerfile-ubuntu-20.04
+++ b/test/install/environments/Dockerfile-ubuntu-20.04
@@ -1,2 +1,2 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.04@sha256:33a5cc25d22c45900796a1aca487ad7a7cb09f09ea00b779e3b2026b4fc2faba
 RUN apt update -y && apt install make python3 curl unzip -y


### PR DESCRIPTION
## Summary

This PR takes a few steps on the github actions side of our code to protect against potential security threats.

- Updates All Github Actions to be pinned by sha (please double check there are no shortened commit sha here)
- Updates container images to be pinned by sha256
- Updates top level security permissions of workflows to be default `READ` (writes can still be scoped to individual steps eg: releases)

### Methodology
For the Audit I used https://github.com/ossf/scorecard#basic-usage with the `--show-details` flag. The sections I looked at for this PR were:

[Dangerous-Workflow](https://github.com/ossf/scorecard/blob/main/docs/checks.md#dangerous-workflow)
[Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
[Token-Permissions](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)