### PR TITLE
fix: version output including supported db schema

### DIFF
--- a/cmd/grype/cli/cli.go
+++ b/cmd/grype/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"github.com/anchore/grype/cmd/grype/cli/commands"
 	handler "github.com/anchore/grype/cmd/grype/cli/ui"
 	"github.com/anchore/grype/cmd/grype/internal/ui"
+	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal/bus"
 	"github.com/anchore/grype/internal/log"
 	"github.com/anchore/grype/internal/redact"
@@ -75,13 +76,13 @@ func create(id clio.Identification) (clio.Application, *cobra.Command) {
 		commands.DB(app),
 		commands.Completion(),
 		commands.Explain(app),
-		clio.VersionCommand(id, syftVersion),
+		clio.VersionCommand(id, syftVersion, dbVersion),
 	)
 
 	return app, rootCmd
 }
 
-func syftVersion() (string, string) {
+func syftVersion() (string, any) {
 	buildInfo, ok := debug.ReadBuildInfo()
 	if !ok {
 		log.Debug("unable to find the buildinfo section of the binary (syft version is unknown)")
@@ -90,10 +91,14 @@ func syftVersion() (string, string) {
 
 	for _, d := range buildInfo.Deps {
 		if d.Path == "github.com/anchore/syft" {
-			return "SyftVersion", d.Version
+			return "Syft Version", d.Version
 		}
 	}
 
 	log.Debug("unable to find 'github.com/anchore/syft' from the buildinfo section of the binary")
 	return "", ""
+}
+
+func dbVersion() (string, any) {
+	return "Supported DB Schema", vulnerability.SchemaVersion
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/adrg/xdg v0.4.0
 	github.com/anchore/bubbly v0.0.0-20230801194016-acdb4981b461
-	github.com/anchore/clio v0.0.0-20230823172630-c42d666061af
+	github.com/anchore/clio v0.0.0-20230915181724-f1acbce87918
 	github.com/anchore/go-logger v0.0.0-20230725134548-c21dafa1ec5a
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anchore/bubbly v0.0.0-20230801194016-acdb4981b461 h1:xGu4/uMWucwWV0YV3fpFIQZ6KVfS/Wfhmma8t0s0vRo=
 github.com/anchore/bubbly v0.0.0-20230801194016-acdb4981b461/go.mod h1:Ger02eh5NpPm2IqkPAy396HU1KlK3BhOeCljDYXySSk=
-github.com/anchore/clio v0.0.0-20230823172630-c42d666061af h1:dBVKZyMZeA0oZK0+aCCRoqxhxUvx/7xy/VEaLMMMnb0=
-github.com/anchore/clio v0.0.0-20230823172630-c42d666061af/go.mod h1:XryJ3CIF1T7SbacQV+OPykfKKIbfXnBssYfpjy2peUg=
+github.com/anchore/clio v0.0.0-20230915181724-f1acbce87918 h1:6OAq04XkelroCdjhjv54sMGNTaeNRf78LSSqAQKxId0=
+github.com/anchore/clio v0.0.0-20230915181724-f1acbce87918/go.mod h1:XryJ3CIF1T7SbacQV+OPykfKKIbfXnBssYfpjy2peUg=
 github.com/anchore/fangs v0.0.0-20230818131516-2186b10924fe h1:pVpLCGWdNeskAw7vGNdCAcGMezrNljHIqOc9HaOja5M=
 github.com/anchore/fangs v0.0.0-20230818131516-2186b10924fe/go.mod h1:82EGoxZTfBXSW0/zollEP+Qs3wkiKmip5yBT5j+eZpY=
 github.com/anchore/go-logger v0.0.0-20230725134548-c21dafa1ec5a h1:nJ2G8zWKASyVClGVgG7sfM5mwoZlZ2zYpIzN2OhjWkw=


### PR DESCRIPTION
This PR corrects an issue that the `grype version` command was not outputting the current db schema version.