### PR TITLE
fix: terminal clobbering when commands return errors

### DIFF
--- a/cmd/grype/cli/commands/db_check.go
+++ b/cmd/grype/cli/commands/db_check.go
@@ -9,7 +9,6 @@ import (
 	"github.com/anchore/clio"
 	"github.com/anchore/grype/cmd/grype/cli/options"
 	"github.com/anchore/grype/grype/db"
-	"github.com/anchore/grype/internal/bus"
 )
 
 const (
@@ -30,8 +29,6 @@ func DBCheck(app clio.Application) *cobra.Command {
 }
 
 func runDBCheck(opts options.Database) error {
-	defer bus.Exit()
-
 	dbCurator, err := db.NewCurator(opts.ToCuratorConfig())
 	if err != nil {
 		return err

--- a/cmd/grype/cli/commands/db_delete.go
+++ b/cmd/grype/cli/commands/db_delete.go
@@ -8,7 +8,6 @@ import (
 	"github.com/anchore/clio"
 	"github.com/anchore/grype/cmd/grype/cli/options"
 	"github.com/anchore/grype/grype/db"
-	"github.com/anchore/grype/internal/bus"
 )
 
 func DBDelete(app clio.Application) *cobra.Command {
@@ -25,8 +24,6 @@ func DBDelete(app clio.Application) *cobra.Command {
 }
 
 func runDBDelete(opts options.Database) error {
-	defer bus.Exit()
-
 	dbCurator, err := db.NewCurator(opts.ToCuratorConfig())
 	if err != nil {
 		return err

--- a/cmd/grype/cli/commands/db_diff.go
+++ b/cmd/grype/cli/commands/db_diff.go
@@ -65,8 +65,6 @@ func DBDiff(app clio.Application) *cobra.Command {
 }
 
 func runDBDiff(opts *dbDiffOptions, base string, target string) (errs error) {
-	defer bus.Exit()
-
 	d, err := differ.NewDiffer(opts.DB.ToCuratorConfig())
 	if err != nil {
 		return err

--- a/cmd/grype/cli/commands/db_import.go
+++ b/cmd/grype/cli/commands/db_import.go
@@ -9,7 +9,6 @@ import (
 	"github.com/anchore/grype/cmd/grype/cli/options"
 	"github.com/anchore/grype/grype/db"
 	"github.com/anchore/grype/internal"
-	"github.com/anchore/grype/internal/bus"
 )
 
 func DBImport(app clio.Application) *cobra.Command {
@@ -27,8 +26,6 @@ func DBImport(app clio.Application) *cobra.Command {
 }
 
 func runDBImport(opts options.Database, dbArchivePath string) error {
-	defer bus.Exit()
-
 	dbCurator, err := db.NewCurator(opts.ToCuratorConfig())
 	if err != nil {
 		return err

--- a/cmd/grype/cli/commands/db_list.go
+++ b/cmd/grype/cli/commands/db_list.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/anchore/clio"
 	"github.com/anchore/grype/grype/db"
-	"github.com/anchore/grype/internal/bus"
 )
 
 type dbListOptions struct {
@@ -40,8 +39,6 @@ func DBList(app clio.Application) *cobra.Command {
 }
 
 func runDBList(opts *dbListOptions) error {
-	defer bus.Exit()
-
 	dbCurator, err := db.NewCurator(opts.DB.ToCuratorConfig())
 	if err != nil {
 		return err

--- a/cmd/grype/cli/commands/db_status.go
+++ b/cmd/grype/cli/commands/db_status.go
@@ -8,7 +8,6 @@ import (
 	"github.com/anchore/clio"
 	"github.com/anchore/grype/cmd/grype/cli/options"
 	"github.com/anchore/grype/grype/db"
-	"github.com/anchore/grype/internal/bus"
 )
 
 func DBStatus(app clio.Application) *cobra.Command {
@@ -25,8 +24,6 @@ func DBStatus(app clio.Application) *cobra.Command {
 }
 
 func runDBStatus(opts options.Database) error {
-	defer bus.Exit()
-
 	dbCurator, err := db.NewCurator(opts.ToCuratorConfig())
 	if err != nil {
 		return err

--- a/cmd/grype/cli/commands/db_update.go
+++ b/cmd/grype/cli/commands/db_update.go
@@ -26,8 +26,6 @@ func DBUpdate(app clio.Application) *cobra.Command {
 }
 
 func runDBUpdate(opts options.Database) error {
-	defer bus.Exit()
-
 	dbCurator, err := db.NewCurator(opts.ToCuratorConfig())
 	if err != nil {
 		return err

--- a/cmd/grype/cli/commands/update.go
+++ b/cmd/grype/cli/commands/update.go
@@ -15,7 +15,7 @@ var latestAppVersionURL = struct {
 	path string
 }{
 	host: "https://toolbox-data.anchore.io",
-	path: fmt.Sprintf("/%s/releases/latest/VERSION", internal.Grype),
+	path: "/grype/releases/latest/VERSION",
 }
 
 func isProductionBuild(version string) bool {

--- a/cmd/grype/cli/commands/util.go
+++ b/cmd/grype/cli/commands/util.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
+
+	"github.com/hashicorp/go-multierror"
+	"golang.org/x/exp/maps"
 )
 
 func stderrPrintLnf(message string, args ...interface{}) error {
@@ -12,4 +16,53 @@ func stderrPrintLnf(message string, args ...interface{}) error {
 	}
 	_, err := fmt.Fprintf(os.Stderr, message, args...)
 	return err
+}
+
+// parallel takes a set of functions and runs them in parallel, capturing all errors returned and
+// returning the single error returned by one of the parallel funcs, or a multierror.Error with all
+// the errors if more than one
+func parallel(funcs ...func() error) error {
+	errs := parallelMapped(funcs...)
+	if len(errs) > 0 {
+		values := maps.Values(errs)
+		if len(values) == 1 {
+			return values[0]
+		}
+		return multierror.Append(nil, values...)
+	}
+	return nil
+}
+
+// parallelMapped takes a set of functions and runs them in parallel, capturing all errors returned in
+// a map indicating which func, by index returned which error
+func parallelMapped(funcs ...func() error) map[int]error {
+	errs := map[int]error{}
+	errorLock := &sync.Mutex{}
+	wg := &sync.WaitGroup{}
+	wg.Add(len(funcs))
+	for i, fn := range funcs {
+		go func(i int, fn func() error) {
+			defer wg.Done()
+			err := fn()
+			if err != nil {
+				errorLock.Lock()
+				defer errorLock.Unlock()
+				errs[i] = err
+			}
+		}(i, fn)
+	}
+	wg.Wait()
+	return errs
+}
+
+func appendErrors(errs error, err ...error) error {
+	if errs == nil {
+		switch len(err) {
+		case 0:
+			return nil
+		case 1:
+			return err[0]
+		}
+	}
+	return multierror.Append(errs, err...)
 }

--- a/cmd/grype/cli/commands/util_test.go
+++ b/cmd/grype/cli/commands/util_test.go
@@ -1,0 +1,165 @@
+package commands
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/stretchr/testify/require"
+)
+
+const lotsaParallel = 100
+
+func Test_lotsaLotsaParallel(t *testing.T) {
+	funcs := []func() error{}
+	for i := 0; i < lotsaParallel; i++ {
+		funcs = append(funcs, func() error {
+			Test_lotsaParallel(t)
+			return nil
+		})
+	}
+	err := parallel(funcs...)
+	require.NoError(t, err)
+}
+
+func Test_lotsaParallel(t *testing.T) {
+	for i := 0; i < lotsaParallel; i++ {
+		Test_parallel(t)
+	}
+}
+
+// Test_parallel tests the parallel function by executing a set of functions that can only execute in a specific
+// order if they are actually running in parallel.
+func Test_parallel(t *testing.T) {
+	count := atomic.Int32{}
+	count.Store(0)
+
+	wg1 := sync.WaitGroup{}
+	wg1.Add(1)
+
+	wg2 := sync.WaitGroup{}
+	wg2.Add(1)
+
+	wg3 := sync.WaitGroup{}
+	wg3.Add(1)
+
+	err1 := fmt.Errorf("error-1")
+	err2 := fmt.Errorf("error-2")
+	err3 := fmt.Errorf("error-3")
+
+	order := ""
+
+	got := parallel(
+		func() error {
+			wg1.Wait()
+			count.Add(1)
+			order = order + "_0"
+			return nil
+		},
+		func() error {
+			wg3.Wait()
+			defer wg2.Done()
+			count.Add(10)
+			order = order + "_1"
+			return err1
+		},
+		func() error {
+			wg2.Wait()
+			defer wg1.Done()
+			count.Add(100)
+			order = order + "_2"
+			return err2
+		},
+		func() error {
+			defer wg3.Done()
+			count.Add(1000)
+			order = order + "_3"
+			return err3
+		},
+	)
+	require.Equal(t, int32(1111), count.Load())
+	require.Equal(t, "_3_1_2_0", order)
+
+	errs := got.(*multierror.Error).Errors
+
+	// cannot check equality to a slice with err1,2,3 because the functions above are running in parallel, for example:
+	// after func()#4 returns and the `wg3.Done()` has executed, the thread could immediately pause
+	// and the remaining functions execute first and err3 becomes the last in the list instead of the first
+	require.Contains(t, errs, err1)
+	require.Contains(t, errs, err2)
+	require.Contains(t, errs, err3)
+}
+
+func Test_parallelMapped(t *testing.T) {
+	err0 := fmt.Errorf("error-0")
+	err1 := fmt.Errorf("error-1")
+	err2 := fmt.Errorf("error-2")
+
+	tests := []struct {
+		name     string
+		funcs    []func() error
+		expected map[int]error
+	}{
+		{
+			name: "basic",
+			funcs: []func() error{
+				func() error {
+					return nil
+				},
+				func() error {
+					return err1
+				},
+				func() error {
+					return nil
+				},
+				func() error {
+					return err2
+				},
+			},
+			expected: map[int]error{
+				1: err1,
+				3: err2,
+			},
+		},
+		{
+			name: "no errors",
+			funcs: []func() error{
+				func() error {
+					return nil
+				},
+				func() error {
+					return nil
+				},
+			},
+			expected: map[int]error{},
+		},
+		{
+			name: "all errors",
+			funcs: []func() error{
+				func() error {
+					return err0
+				},
+				func() error {
+					return err1
+				},
+				func() error {
+					return err2
+				},
+			},
+			expected: map[int]error{
+				0: err0,
+				1: err1,
+				2: err2,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := parallelMapped(test.funcs...)
+			require.Equal(t, test.expected, got)
+		})
+	}
+}

--- a/cmd/grype/internal/constants.go
+++ b/cmd/grype/internal/constants.go
@@ -1,6 +1,5 @@
 package internal
 
 const (
-	Grype       = "grype"
 	NotProvided = "[not provided]"
 )

--- a/cmd/grype/internal/ui/no_ui.go
+++ b/cmd/grype/internal/ui/no_ui.go
@@ -33,8 +33,6 @@ func (n *NoUI) Handle(e partybus.Event) error {
 	case event.CLIReport, event.CLINotification:
 		// keep these for when the UI is terminated to show to the screen (or perform other events)
 		n.finalizeEvents = append(n.finalizeEvents, e)
-	case event.CLIExit:
-		return n.subscription.Unsubscribe()
 	}
 	return nil
 }

--- a/cmd/grype/internal/ui/ui.go
+++ b/cmd/grype/internal/ui/ui.go
@@ -72,20 +72,6 @@ func (m *UI) Handle(e partybus.Event) error {
 	return nil
 }
 
-func runWithTimeout(timeout time.Duration, fn func() error) (err error) {
-	c := make(chan struct{}, 1)
-	go func() {
-		err = fn()
-		c <- struct{}{}
-	}()
-	select {
-	case <-c:
-	case <-time.After(timeout):
-		return fmt.Errorf("timed out after %v", timeout)
-	}
-	return err
-}
-
 func (m *UI) Teardown(force bool) error {
 	if !force {
 		m.handler.Wait()
@@ -184,4 +170,18 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m UI) View() string {
 	return m.frame.View()
+}
+
+func runWithTimeout(timeout time.Duration, fn func() error) (err error) {
+	c := make(chan struct{}, 1)
+	go func() {
+		err = fn()
+		c <- struct{}{}
+	}()
+	select {
+	case <-c:
+	case <-time.After(timeout):
+		return fmt.Errorf("timed out after %v", timeout)
+	}
+	return err
 }

--- a/cmd/grype/main.go
+++ b/cmd/grype/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 // applicationName is the non-capitalized name of the application (do not change this)
-const applicationName = internal.Grype
+const applicationName = "grype"
 
 // all variables here are provided as build-time arguments, with clear default values
 var (

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,8 @@ require (
 	modernc.org/sqlite v1.25.0 // indirect
 )
 
+require golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63
+
 require (
 	cloud.google.com/go v0.110.2 // indirect
 	cloud.google.com/go/compute v1.20.1 // indirect
@@ -199,11 +201,11 @@ require (
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
+	github.com/zyedidia/generic v1.2.2-0.20230320175451-4410d2372cb1 // indirect
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/goleak v1.2.0 // indirect
 	golang.org/x/crypto v0.13.0 // indirect
-	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.15.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -945,6 +945,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
+github.com/zyedidia/generic v1.2.2-0.20230320175451-4410d2372cb1 h1:V+UsotZpAVvfj3X/LMoEytoLzSiP6Lg0F7wdVyu9gGg=
+github.com/zyedidia/generic v1.2.2-0.20230320175451-4410d2372cb1/go.mod h1:ly2RBz4mnz1yeuVbQA/VFwGjK3mnHGRj1JuoG336Bis=
 go.etcd.io/etcd/api/v3 v3.5.1/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=

--- a/grype/event/event.go
+++ b/grype/event/event.go
@@ -24,7 +24,4 @@ const (
 
 	// CLINotification is a partybus event that occurs when auxiliary information is ready for presentation to stderr
 	CLINotification partybus.EventType = cliTypePrefix + "-notification"
-
-	// CLIExit is a partybus event that occurs when an analysis result is ready for final presentation
-	CLIExit partybus.EventType = cliTypePrefix + "-exit-event"
 )

--- a/grype/vulnerability_matcher.go
+++ b/grype/vulnerability_matcher.go
@@ -61,19 +61,25 @@ func (m *VulnerabilityMatcher) WithIgnoreRules(ignoreRules []match.IgnoreRule) *
 	return m
 }
 
-func (m *VulnerabilityMatcher) FindMatches(pkgs []pkg.Package, context pkg.Context) (*match.Matches, []match.IgnoredMatch, error) {
+func (m *VulnerabilityMatcher) FindMatches(pkgs []pkg.Package, context pkg.Context) (remainingMatches *match.Matches, ignoredMatches []match.IgnoredMatch, err error) {
 	progressMonitor := trackMatcher(len(pkgs))
 
-	defer progressMonitor.SetCompleted()
+	defer func() {
+		progressMonitor.SetCompleted()
+		if err != nil {
+			progressMonitor.MatchesDiscovered.SetError(err)
+		}
+	}()
 
-	remainingMatches, ignoredMatches, err := m.findDBMatches(pkgs, context, progressMonitor)
+	remainingMatches, ignoredMatches, err = m.findDBMatches(pkgs, context, progressMonitor)
 	if err != nil {
 		return remainingMatches, ignoredMatches, err
 	}
 
 	remainingMatches, ignoredMatches, err = m.findVEXMatches(context, remainingMatches, ignoredMatches, progressMonitor)
 	if err != nil {
-		return remainingMatches, ignoredMatches, fmt.Errorf("unable to find matches against VEX sources: %w", err)
+		err = fmt.Errorf("unable to find matches against VEX sources: %w", err)
+		return remainingMatches, ignoredMatches, err
 	}
 
 	logListSummary(progressMonitor)

--- a/internal/bus/helpers.go
+++ b/internal/bus/helpers.go
@@ -3,14 +3,17 @@ package bus
 import (
 	"github.com/wagoodman/go-partybus"
 
+	"github.com/anchore/clio"
 	"github.com/anchore/grype/grype/event"
 	"github.com/anchore/grype/internal/redact"
 )
 
 func Exit() {
-	Publish(partybus.Event{
-		Type: event.CLIExit,
-	})
+	Publish(clio.ExitEvent(false))
+}
+
+func ExitWithInterrupt() {
+	Publish(clio.ExitEvent(true))
 }
 
 func Report(report string) {


### PR DESCRIPTION
This PR corrects an issue where the terminal cursor wasn't being restored after certain errors occur. For example, running:
```
grype docker:asdf.asdf
```
or 
```
grype alpine:3.15 --fail-on high
```
... both resulted in an error being returned from the command, resulting in the terminal getting clobbered _most of the time_, but this was actually due to a race condition, so occasionally it did not happen.

Additionally, this PR:
* Cleans up a few items from the CLIO port
* Restores the TUI elements for showing image / cataloging progress
* Reworks the `runGrype` function a bit to be easier to understand
* Removes the `internal.Grype` constant altogether

Fixes: #1492