### PR TITLE
chore: remove outdated comment about fuzzy matching python versions

### DIFF
--- a/grype/version/constraint.go
+++ b/grype/version/constraint.go
@@ -20,11 +20,6 @@ func GetConstraint(constStr string, format Format) (Constraint, error) {
 	case RpmFormat:
 		return newRpmConstraint(constStr)
 	case PythonFormat:
-		// This is specific to PythonFormat so that it adheres to PEP440 and its odd corner-cases
-		// It is significantly odd enough, that the fuzzyConstraint is the best bet to compare versions.
-		// Although this will work in most cases, some oddities aren't supported, like:
-		// 1.0b2.post345.dev456 which is allowed by the spec. In that case (a dev release of a post release)
-		// the comparator will fail. See https://www.python.org/dev/peps/pep-0440
 		return newPep440Constraint(constStr)
 	case KBFormat:
 		return newKBConstraint(constStr)


### PR DESCRIPTION
Now that we're using a real PEP440 library, there's no need for this comment.

Was pointed out at https://github.com/anchore/grype/pull/1510#discussion_r1337007669