### PR TITLE
fix: `if` with identical `then` and `else` blocks in `internal/format/writer_test.go`

### DIFF
--- a/internal/format/writer_test.go
+++ b/internal/format/writer_test.go
@@ -172,11 +172,7 @@ func Test_newSBOMMultiWriter(t *testing.T) {
 				switch w := mw.writers[i].(type) {
 				case *scanResultStreamWriter:
 					assert.Equal(t, string(w.format), e.format)
-					if e.file != "" {
-						assert.NotNil(t, w.out)
-					} else {
-						assert.NotNil(t, w.out)
-					}
+					assert.NotNil(t, w.out)
 					if e.file != "" {
 						assert.FileExists(t, tmp+e.file)
 					}


### PR DESCRIPTION
Closes #1534 by replacing the conditional with just the content of one of its branches.