### PR TITLE
fix: empty descriptor name and version

### DIFF
--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -182,6 +182,7 @@ func runGrype(app clio.Application, opts *options.Grype, userInput string) (errs
 	}
 
 	if err = writer.Write(models.PresenterConfig{
+		ID:               app.ID(),
 		Matches:          *remainingMatches,
 		IgnoredMatches:   ignoredMatches,
 		Packages:         packages,

--- a/test/cli/cmd_test.go
+++ b/test/cli/cmd_test.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCmd(t *testing.T) {
@@ -77,4 +80,21 @@ func TestCmd(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_descriptorNameAndVersionSet(t *testing.T) {
+	_, output, _ := runGrype(t, nil, "-o", "json", getFixtureImage(t, "image-bare"))
+
+	parsed := map[string]any{}
+	err := json.Unmarshal([]byte(output), &parsed)
+	require.NoError(t, err)
+
+	desc, _ := parsed["descriptor"].(map[string]any)
+	require.NotNil(t, desc)
+
+	name := desc["name"]
+	require.Equal(t, "grype", name)
+
+	version := desc["version"]
+	require.NotEmpty(t, version)
 }


### PR DESCRIPTION
This PR corrects an oversight that the `descriptor` block was empty (and analogous other locations in other formats).

Fixes: #1538