### PR TITLE
feat: wordpress-plugin support

### DIFF
--- a/grype/search/only_vulnerable_targets.go
+++ b/grype/search/only_vulnerable_targets.go
@@ -21,11 +21,9 @@ func isUnknownTarget(targetSW string) bool {
 	// supported by syft but are signifcant sources of false positives and should be
 	// considered known for the purposes of filtering here
 	known := map[string]bool{
-		"wordpress":  true,
-		"wordpress_": true,
-		"joomla":     true,
-		"joomla\\!":  true,
-		"drupal":     true,
+		"joomla":    true,
+		"joomla\\!": true,
+		"drupal":    true,
 	}
 
 	if _, ok := known[targetSW]; ok {

--- a/grype/search/only_vulnerable_targets_test.go
+++ b/grype/search/only_vulnerable_targets_test.go
@@ -13,7 +13,7 @@ func Test_isUnknownTarget(t *testing.T) {
 		expected bool
 	}{
 		{name: "supported syft language", targetSW: "python", expected: false},
-		{name: "supported non-syft language CPE component", targetSW: "wordpress", expected: false},
+		{name: "supported non-syft language CPE component", targetSW: "joomla", expected: false},
 		{name: "unknown component", targetSW: "abc", expected: true},
 	}
 


### PR DESCRIPTION
Removed `wordpress` from `known` targets due to wordpress cataloger support (https://github.com/anchore/syft/pull/2218) in `Syft`