### PR TITLE
Add exception for go stdlib search by CPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,19 +809,21 @@ log:
 match:
   # sets the matchers below to use cpes when trying to find 
   # vulnerability matches. The stock matcher is the default
-  # when no primary matcher can be identified 
+  # when no primary matcher can be identified.
   java:
-    using-cpes: true
+    using-cpes: false
   python:
-    using-cpes: true
+    using-cpes: false
   javascript:
-    using-cpes: true
+    using-cpes: false
   ruby:
-    using-cpes: true
+    using-cpes: false
   dotnet:
-    using-cpes: true
+    using-cpes: false
   golang:
-    using-cpes: true
+    using-cpes: false
+    # even if CPE matching is disabled, make an exception when scanning for "stdlib".
+    always-use-cpe-for-stdlib: true
   stock:
     using-cpes: true
 ```

--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -279,8 +279,11 @@ func getMatchers(opts *options.Grype) []matcher.Matcher {
 			Python:     python.MatcherConfig(opts.Match.Python),
 			Dotnet:     dotnet.MatcherConfig(opts.Match.Dotnet),
 			Javascript: javascript.MatcherConfig(opts.Match.Javascript),
-			Golang:     golang.MatcherConfig(opts.Match.Golang),
-			Stock:      stock.MatcherConfig(opts.Match.Stock),
+			Golang: golang.MatcherConfig{
+				UseCPEs:               opts.Match.Golang.UseCPEs,
+				AlwaysUseCPEForStdlib: opts.Match.Golang.AlwaysUseCPEForStdlib,
+			},
+			Stock: stock.MatcherConfig(opts.Match.Stock),
 		},
 	)
 }

--- a/cmd/grype/cli/options/match.go
+++ b/cmd/grype/cli/options/match.go
@@ -4,7 +4,7 @@ package options
 type matchConfig struct {
 	Java       matcherConfig `yaml:"java" json:"java" mapstructure:"java"`                   // settings for the java matcher
 	Dotnet     matcherConfig `yaml:"dotnet" json:"dotnet" mapstructure:"dotnet"`             // settings for the dotnet matcher
-	Golang     matcherConfig `yaml:"golang" json:"golang" mapstructure:"golang"`             // settings for the golang matcher
+	Golang     golangConfig  `yaml:"golang" json:"golang" mapstructure:"golang"`             // settings for the golang matcher
 	Javascript matcherConfig `yaml:"javascript" json:"javascript" mapstructure:"javascript"` // settings for the javascript matcher
 	Python     matcherConfig `yaml:"python" json:"python" mapstructure:"python"`             // settings for the python matcher
 	Ruby       matcherConfig `yaml:"ruby" json:"ruby" mapstructure:"ruby"`                   // settings for the ruby matcher
@@ -16,13 +16,27 @@ type matcherConfig struct {
 	UseCPEs bool `yaml:"using-cpes" json:"using-cpes" mapstructure:"using-cpes"` // if CPEs should be used during matching
 }
 
+type golangConfig struct {
+	matcherConfig         `yaml:",inline" mapstructure:",squash"`
+	AlwaysUseCPEForStdlib bool `yaml:"always-use-cpe-for-stdlib" json:"always-use-cpe-for-stdlib" mapstructure:"always-use-cpe-for-stdlib"` // if CPEs should be used during matching
+}
+
+func defaultGolangConfig() golangConfig {
+	return golangConfig{
+		matcherConfig: matcherConfig{
+			UseCPEs: false,
+		},
+		AlwaysUseCPEForStdlib: true,
+	}
+}
+
 func defaultMatchConfig() matchConfig {
 	useCpe := matcherConfig{UseCPEs: true}
 	dontUseCpe := matcherConfig{UseCPEs: false}
 	return matchConfig{
 		Java:       dontUseCpe,
 		Dotnet:     dontUseCpe,
-		Golang:     dontUseCpe,
+		Golang:     defaultGolangConfig(),
 		Javascript: dontUseCpe,
 		Python:     dontUseCpe,
 		Ruby:       dontUseCpe,

--- a/grype/matcher/golang/matcher.go
+++ b/grype/matcher/golang/matcher.go
@@ -16,7 +16,8 @@ type Matcher struct {
 }
 
 type MatcherConfig struct {
-	UseCPEs bool
+	UseCPEs               bool
+	AlwaysUseCPEForStdlib bool
 }
 
 func NewGolangMatcher(cfg MatcherConfig) *Matcher {
@@ -51,8 +52,17 @@ func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Pa
 	}
 
 	criteria := search.CommonCriteria
-	if m.cfg.UseCPEs {
+	if searchByCPE(p.Name, m.cfg) {
 		criteria = append(criteria, search.ByCPE)
 	}
+
 	return search.ByCriteria(store, d, p, m.Type(), criteria...)
+}
+
+func searchByCPE(name string, cfg MatcherConfig) bool {
+	if cfg.UseCPEs {
+		return true
+	}
+
+	return cfg.AlwaysUseCPEForStdlib && (name == "stdlib")
 }

--- a/grype/matcher/golang/matcher_test.go
+++ b/grype/matcher/golang/matcher_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/anchore/grype/grype/distro"
@@ -14,23 +15,150 @@ import (
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
-func TestMatcherGolang_DropMainPackage(t *testing.T) {
-	p := pkg.Package{
+func TestMatcher_DropMainPackage(t *testing.T) {
+
+	mainModuleMetadata := pkg.GolangBinMetadata{
+		MainModule: "istio.io/istio",
+	}
+
+	subjectWithoutMainModule := pkg.Package{
 		ID:           pkg.ID(uuid.NewString()),
 		Name:         "istio.io/istio",
 		Version:      "v0.0.0-20220606222826-f59ce19ec6b6",
 		Type:         syftPkg.GoModulePkg,
+		Language:     syftPkg.Go,
 		MetadataType: pkg.GolangBinMetadataType,
-		Metadata: pkg.GolangBinMetadata{
-			MainModule: "istio.io/istio",
+		Metadata:     pkg.GolangBinMetadata{},
+	}
+
+	subjectWithMainModule := subjectWithoutMainModule
+	subjectWithMainModule.Metadata = mainModuleMetadata
+
+	subjectWithMainModuleAsDevel := subjectWithMainModule
+	subjectWithMainModuleAsDevel.Version = "(devel)"
+
+	matcher := NewGolangMatcher(MatcherConfig{})
+	store := newMockProvider()
+
+	preTest, _ := matcher.Match(store, nil, subjectWithoutMainModule)
+	assert.Len(t, preTest, 1, "should have matched the package when there is not a main module")
+
+	actual, _ := matcher.Match(store, nil, subjectWithMainModule)
+	assert.Len(t, actual, 0, "unexpected match count; should not match main module")
+
+	actual, _ = matcher.Match(store, nil, subjectWithMainModuleAsDevel)
+	assert.Len(t, actual, 0, "unexpected match count; should not match main module (devel)")
+}
+
+func TestMatcher_SearchForStdlib(t *testing.T) {
+
+	// values derived from:
+	//   $ go version -m $(which grype)
+	//  /opt/homebrew/bin/grype: go1.21.1
+
+	subject := pkg.Package{
+		ID:       pkg.ID(uuid.NewString()),
+		Name:     "stdlib",
+		Version:  "go1.18.3",
+		Type:     syftPkg.GoModulePkg,
+		Language: syftPkg.Go,
+		CPEs: []cpe.CPE{
+			cpe.Must("cpe:2.3:a:golang:go:1.18.3:-:*:*:*:*:*:*"),
+		},
+		MetadataType: pkg.GolangBinMetadataType,
+		Metadata:     pkg.GolangBinMetadata{},
+	}
+
+	cases := []struct {
+		name         string
+		cfg          MatcherConfig
+		subject      pkg.Package
+		expectedCVEs []string
+	}{
+		// positive
+		{
+			name: "cpe enables, no override enabled",
+			cfg: MatcherConfig{
+				UseCPEs:               true,
+				AlwaysUseCPEForStdlib: false,
+			},
+			subject: subject,
+			expectedCVEs: []string{
+				"CVE-2022-27664",
+			},
+		},
+		{
+			name: "stdlib search, cpe enables, no override enabled",
+			cfg: MatcherConfig{
+				UseCPEs:               true,
+				AlwaysUseCPEForStdlib: true,
+			},
+			subject: subject,
+			expectedCVEs: []string{
+				"CVE-2022-27664",
+			},
+		},
+		{
+			name: "stdlib search, cpe enables, no override enabled",
+			cfg: MatcherConfig{
+				UseCPEs:               false,
+				AlwaysUseCPEForStdlib: true,
+			},
+			subject: subject,
+			expectedCVEs: []string{
+				"CVE-2022-27664",
+			},
+		},
+		{
+			name: "go package search should be found by cpe",
+			cfg: MatcherConfig{
+				UseCPEs:               true,
+				AlwaysUseCPEForStdlib: true,
+			},
+			subject: func() pkg.Package { p := subject; p.Name = "go"; return p }(),
+			expectedCVEs: []string{
+				"CVE-2022-27664",
+			}},
+		// negative
+		{
+			name: "stdlib search, cpe suppressed, no override enabled",
+			cfg: MatcherConfig{
+				UseCPEs:               false,
+				AlwaysUseCPEForStdlib: false,
+			},
+			subject:      subject,
+			expectedCVEs: nil,
+		},
+		{
+			name: "go package search should not be an exception (only the stdlib)",
+			cfg: MatcherConfig{
+				UseCPEs:               false,
+				AlwaysUseCPEForStdlib: true,
+			},
+			subject:      func() pkg.Package { p := subject; p.Name = "go"; return p }(),
+			expectedCVEs: nil,
 		},
 	}
 
-	matcher := Matcher{}
 	store := newMockProvider()
 
-	actual, _ := matcher.Match(store, nil, p)
-	assert.Len(t, actual, 0, "unexpected match count; should not match main module")
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			matcher := NewGolangMatcher(c.cfg)
+
+			actual, _ := matcher.Match(store, nil, c.subject)
+			actualCVEs := strset.New()
+			for _, m := range actual {
+				actualCVEs.Add(m.Vulnerability.ID)
+			}
+
+			expectedCVEs := strset.New(c.expectedCVEs...)
+
+			assert.ElementsMatch(t, expectedCVEs.List(), actualCVEs.List())
+
+		})
+	}
+
 }
 
 func newMockProvider() *mockProvider {
@@ -54,17 +182,28 @@ func (mp *mockProvider) Get(id, namespace string) ([]vulnerability.Vulnerability
 
 func (mp *mockProvider) populateData() {
 	mp.data[syftPkg.Go] = map[string][]vulnerability.Vulnerability{
+		// for TestMatcher_DropMainPackage
 		"istio.io/istio": {
 			{
-				Constraint: version.MustGetConstraint("<5.0.7", version.UnknownFormat),
+				Constraint: version.MustGetConstraint("< 5.0.7", version.UnknownFormat),
 				ID:         "CVE-2013-fake-BAD",
+			},
+		},
+	}
+
+	mp.data["nvd:cpe"] = map[string][]vulnerability.Vulnerability{
+		// for TestMatcher_SearchForStdlib
+		"cpe:2.3:a:golang:go:1.18.3:-:*:*:*:*:*:*": {
+			{
+				Constraint: version.MustGetConstraint("< 1.18.6 || = 1.19.0", version.UnknownFormat),
+				ID:         "CVE-2022-27664",
 			},
 		},
 	}
 }
 
 func (mp *mockProvider) GetByCPE(p cpe.CPE) ([]vulnerability.Vulnerability, error) {
-	return []vulnerability.Vulnerability{}, nil
+	return mp.data["nvd:cpe"][p.BindToFmtString()], nil
 }
 
 func (mp *mockProvider) GetByDistro(d *distro.Distro, p pkg.Package) ([]vulnerability.Vulnerability, error) {


### PR DESCRIPTION
Fixes #1562 

This PR introduces a new config option `match.golang.always-use-cpe-for-stdlib` (defaulting to true) allowing the golang matcher to search for the stdlib package by CPE even if CPE matching is disabled. 

We lean primarily on GHSA matching for the golang ecosystem, however, there are still cases specifically for the stdlib where the data in NVD is preferred for matching. Take for example [CVE-2023-24537](https://nvd.nist.gov/vuln/detail/CVE-2023-24537) , which matches to `golang:go` when `< 1.19.8` (and other ranges), however the [GHSA](https://github.com/advisories/GHSA-fp86-2355-v99r) data does not have a suggested package for this (yet) . This can lead to potential false positives, say  in the case of [CVE-2022-27664](https://nvd.nist.gov/vuln/detail/CVE-2022-27664) where the CPE is again for `golang:go`, however, the [GHSA](https://github.com/advisories/GHSA-69cg-p879-7622) correctly attributes this to `golang.org/x/net`. 

For this reason CPE matching for the stdlib is allowed as a special case, and can override the golang `using-cpes` configurable (as it does by default).