### PR TITLE
perf: avoid allocations with `(*regexp.Regexp).MatchString`

### DIFF
--- a/grype/db/v5/namespace/index.go
+++ b/grype/db/v5/namespace/index.go
@@ -151,7 +151,7 @@ func (i *Index) NamespacesForDistro(d *grypeDistro.Distro) []*distro.Namespace {
 
 func getAlpineNamespace(i *Index, d *grypeDistro.Distro, versionSegments []int) []*distro.Namespace {
 	// check if distro version matches x.y.z
-	if alpineVersionRegularExpression.Match([]byte(d.RawVersion)) {
+	if alpineVersionRegularExpression.MatchString(d.RawVersion) {
 		// Get the first two version components
 		// TODO: should we update the namespaces in db generation to match x.y.z here?
 		distroKey := fmt.Sprintf("%s:%d.%d", strings.ToLower(d.Type.String()), versionSegments[0], versionSegments[1])

--- a/grype/version/fuzzy_constraint.go
+++ b/grype/version/fuzzy_constraint.go
@@ -38,7 +38,7 @@ func newFuzzyConstraint(phrase, hint string) (*fuzzyConstraint, error) {
 check:
 	for _, units := range constraints.units {
 		for _, unit := range units {
-			if !pseudoSemverPattern.Match([]byte(unit.version)) {
+			if !pseudoSemverPattern.MatchString(unit.version) {
 				valid = false
 				break check
 			}
@@ -94,7 +94,7 @@ func (f *fuzzyConstraint) Satisfied(verObj *Version) (bool, error) {
 
 	// attempt semver first, then fallback to fuzzy part matching...
 	if f.semanticConstraint != nil {
-		if pseudoSemverPattern.Match([]byte(version)) {
+		if pseudoSemverPattern.MatchString(version) {
 			if semver, err := newSemanticVersion(version); err == nil && semver != nil {
 				return f.semanticConstraint.Check(semver.verObj), nil
 			}


### PR DESCRIPTION
We should use `(*regexp.Regexp).MatchString` instead of `(*regexp.Regexp).Match([]byte(...))` when matching string to avoid unnecessary `[]byte` conversions and reduce allocations. A one-line change for free performance improvement.

Example benchmark:

```go
func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := pseudoSemverPattern.Match([]byte("1.0.0-beta-prerelease")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := pseudoSemverPattern.MatchString("1.0.0-beta-prerelease"); !match {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/anchore/grype/grype/version
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 1378789	       889.7 ns/op	      24 B/op	       1 allocs/op
BenchmarkMatchString-16    	 2287442	       482.2 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/anchore/grype/grype/version	3.632s
```