### PR TITLE
feat: match against debian unstable

### DIFF
--- a/grype/db/v5/namespace/index.go
+++ b/grype/db/v5/namespace/index.go
@@ -146,6 +146,13 @@ func (i *Index) NamespacesForDistro(d *grypeDistro.Distro) []*distro.Namespace {
 		}
 	}
 
+	if versionSegments == nil && d.Type == grypeDistro.Debian && d.RawVersion == "unstable" {
+		distroKey := fmt.Sprintf("%s:%s", strings.ToLower(d.Type.String()), "unstable")
+		if v, ok := i.byDistroKey[distroKey]; ok {
+			return v
+		}
+	}
+
 	return nil
 }
 

--- a/grype/db/v5/namespace/index_test.go
+++ b/grype/db/v5/namespace/index_test.go
@@ -128,6 +128,7 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 		"alpine:distro:alpine:3.16",
 		"alpine:distro:alpine:edge",
 		"debian:distro:debian:8",
+		"debian:distro:debian:unstable",
 		"amazon:distro:amazonlinux:2",
 		"amazon:distro:amazonlinux:2022",
 		"abc.xyz:distro:unknown:123.456",
@@ -345,6 +346,17 @@ func TestIndex_NamespacesForDistro(t *testing.T) {
 			name:       "Busybox minor semvar matches no namespace",
 			distro:     newDistro(t, osDistro.Busybox, "20.1", []string{}),
 			namespaces: nil,
+		},
+		{
+			name: "debian unstable",
+			distro: &osDistro.Distro{
+				Type:       osDistro.Debian,
+				RawVersion: "unstable",
+				Version:    nil,
+			},
+			namespaces: []*distro.Namespace{
+				distro.NewNamespace("debian", osDistro.Debian, "unstable"),
+			},
 		},
 	}
 

--- a/grype/distro/distro.go
+++ b/grype/distro/distro.go
@@ -57,6 +57,14 @@ func NewFromRelease(release linux.Release) (*Distro, error) {
 		}
 	}
 
+	if t == Debian && release.VersionID == "" && release.Version == "" && strings.Contains(release.PrettyName, "sid") {
+		return &Distro{
+			Type:       t,
+			RawVersion: "unstable",
+			IDLike:     release.IDLike,
+		}, nil
+	}
+
 	return New(t, selectedVersion, release.IDLike...)
 }
 

--- a/grype/distro/distro_test.go
+++ b/grype/distro/distro_test.go
@@ -66,6 +66,21 @@ func Test_NewDistroFromRelease(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			// syft -o json debian:testing | jq .distro
+			name: "unstable debian",
+			release: linux.Release{
+				ID:              "debian",
+				VersionID:       "",
+				Version:         "",
+				PrettyName:      "Debian GNU/Linux trixie/sid",
+				VersionCodename: "trixie",
+				Name:            "Debian GNU/Linux",
+			},
+			expectedType:       Debian,
+			expectedRawVersion: "unstable",
+			expectedVersion:    "",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #1446 

Works by special casing `debian:unstable` to skip semver creation / parsing in a couple of places.

## Manual testing done

(`go run cmd/grype/main.go` is this change, `grype` is v0.73.0 from homebrew)

### from the original issue

``` sh
❯ go run cmd/grype/main.go r-base:latest
 ✔ Vulnerability DB                [no update available]
 ✔ Loaded image                                                                                                                                                                                                                                                                                                                                           r-base:latest
 ✔ Parsed image                                                                                                                                                                                                                                                                                 sha256:b49a24a003b91ee33a171c5491fb3add7152c7bb5e928d9d69f0e7fde7bff638
 ✔ Cataloged packages              [301 packages]
 ✔ Scanned for vulnerabilities     [284 vulnerability matches]
   ├── by severity: 3 critical, 23 high, 22 medium, 5 low, 224 negligible (7 unknown)
   └── by status:   30 fixed, 254 not-fixed, 0 ignored
NAME                        INSTALLED          FIXED-IN      TYPE  VULNERABILITY     SEVERITY
apt                         2.7.6                            deb   CVE-2011-3374     Negligible
binutils                    2.41-5                           deb   CVE-2021-32256    Negligible
binutils                    2.41-5                           deb   CVE-2018-9996     Negligible
binutils                    2.41-5                           deb   CVE-2018-20712    Negligible
... snip

❯ go run cmd/grype/main.go r-base:latest | wc -l
... snip
     285
```

### testing against `debian:testing` directly

``` sh
❯ go run cmd/grype/main.go -q -o json debian:testing | jq '.matches[0].vulnerability.namespace'
"debian:distro:debian:unstable"
```

``` sh
❯ go run cmd/grype/main.go debian:testing
 ✔ Vulnerability DB                [no update available]
 ✔ Loaded image                                                                                                                                                                                                                                                                                                                                          debian:testing
 ✔ Parsed image                                                                                                                                                                                                                                                                                 sha256:0450fd13eb205233d4ad56781f0018843029ac48b8f40172a7378edd88562857
 ✔ Cataloged packages              [87 packages]
 ✔ Scanned for vulnerabilities     [46 vulnerability matches]
   ├── by severity: 1 critical, 1 high, 0 medium, 1 low, 43 negligible
   └── by status:   0 fixed, 46 not-fixed, 0 ignored
NAME           INSTALLED        FIXED-IN  TYPE  VULNERABILITY     SEVERITY
apt            2.7.6                      deb   CVE-2011-3374     Negligible
bsdutils       1:2.39.2-4                 deb   CVE-2022-0563     Negligible
coreutils      9.1-1                      deb   CVE-2016-2781     Low
... snip
```

As opposed to:

```
❯ grype debian:testing
 ✔ Vulnerability DB                [no update available]
 ✔ Loaded image                                                                                                                                                                                                                                                                                                                                          debian:testing
 ✔ Parsed image                                                                                                                                                                                                                                                                                 sha256:0450fd13eb205233d4ad56781f0018843029ac48b8f40172a7378edd88562857
 ✔ Cataloged packages              [87 packages]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored
No vulnerabilities found
```
