### PR TITLE
fix: golang version parsing

### DIFF
--- a/grype/search/cpe_test.go
+++ b/grype/search/cpe_test.go
@@ -484,8 +484,8 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 				},
 				Name:     "sw",
 				Version:  "0.1",
-				Language: syftPkg.Go,
-				Type:     syftPkg.GoModulePkg,
+				Language: syftPkg.Erlang,
+				Type:     syftPkg.HexPkg,
 			},
 			expected: []match.Match{
 				{
@@ -498,8 +498,8 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 						},
 						Name:     "sw",
 						Version:  "0.1",
-						Language: syftPkg.Go,
-						Type:     syftPkg.GoModulePkg,
+						Language: syftPkg.Erlang,
+						Type:     syftPkg.HexPkg,
 					},
 					Details: []match.Detail{
 						{

--- a/grype/version/constraint.go
+++ b/grype/version/constraint.go
@@ -17,6 +17,8 @@ func GetConstraint(constStr string, format Format) (Constraint, error) {
 		return newSemanticConstraint(constStr)
 	case DebFormat:
 		return newDebConstraint(constStr)
+	case GolangFormat:
+		return newGolangConstraint(constStr)
 	case MavenFormat:
 		return newMavenConstraint(constStr)
 	case RpmFormat:

--- a/grype/version/format.go
+++ b/grype/version/format.go
@@ -33,6 +33,7 @@ var formatStr = []string{
 	"KB",
 	"Gem",
 	"Portage",
+	"Go",
 }
 
 var Formats = []Format{

--- a/grype/version/format.go
+++ b/grype/version/format.go
@@ -17,6 +17,7 @@ const (
 	KBFormat
 	GemFormat
 	PortageFormat
+	GolangFormat
 )
 
 type Format int
@@ -54,6 +55,8 @@ func ParseFormat(userStr string) Format {
 		return ApkFormat
 	case strings.ToLower(DebFormat.String()), "dpkg":
 		return DebFormat
+	case strings.ToLower(GolangFormat.String()), "go":
+		return GolangFormat
 	case strings.ToLower(MavenFormat.String()), "maven":
 		return MavenFormat
 	case strings.ToLower(RpmFormat.String()), "rpm":
@@ -89,6 +92,8 @@ func FormatFromPkgType(t pkg.Type) Format {
 		format = KBFormat
 	case pkg.PortagePkg:
 		format = PortageFormat
+	case pkg.GoModulePkg:
+		format = GolangFormat
 	default:
 		format = UnknownFormat
 	}

--- a/grype/version/golang_constraint.go
+++ b/grype/version/golang_constraint.go
@@ -1,0 +1,1 @@
+package version

--- a/grype/version/golang_constraint.go
+++ b/grype/version/golang_constraint.go
@@ -21,7 +21,10 @@ func newGolangConstraint(raw string) (golangConstraint, error) {
 }
 
 func (g golangConstraint) String() string {
-	panic("implement me")
+	if g.raw == "" {
+		return "none (go)"
+	}
+	return fmt.Sprintf("%s (go)", g.raw)
 }
 
 func (g golangConstraint) Satisfied(version *Version) (bool, error) {

--- a/grype/version/golang_constraint.go
+++ b/grype/version/golang_constraint.go
@@ -1,1 +1,40 @@
 package version
+
+import "fmt"
+
+var _ Constraint = (*golangConstraint)(nil)
+
+type golangConstraint struct {
+	raw        string
+	expression constraintExpression
+}
+
+func newGolangConstraint(raw string) (golangConstraint, error) {
+	constraints, err := newConstraintExpression(raw, newGolangComparator)
+	if err != nil {
+		return golangConstraint{}, nil
+	}
+	return golangConstraint{
+		expression: constraints,
+		raw:        raw,
+	}, nil
+}
+
+func (g golangConstraint) String() string {
+	panic("implement me")
+}
+
+func (g golangConstraint) Satisfied(version *Version) (bool, error) {
+	if g.raw == "" {
+		return true, nil // the empty constraint is always satisfied
+	}
+	return g.expression.satisfied(version)
+}
+
+func newGolangComparator(unit constraintUnit) (Comparator, error) {
+	ver, err := newGolangVersion("v" + unit.version)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse constraint version (%s): %w", unit.version, err)
+	}
+	return ver, nil
+}

--- a/grype/version/golang_constraint.go
+++ b/grype/version/golang_constraint.go
@@ -35,7 +35,7 @@ func (g golangConstraint) Satisfied(version *Version) (bool, error) {
 }
 
 func newGolangComparator(unit constraintUnit) (Comparator, error) {
-	ver, err := newGolangVersion("v" + unit.version)
+	ver, err := newGolangVersion(unit.version)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse constraint version (%s): %w", unit.version, err)
 	}

--- a/grype/version/golang_constraint.go
+++ b/grype/version/golang_constraint.go
@@ -12,7 +12,7 @@ type golangConstraint struct {
 func newGolangConstraint(raw string) (golangConstraint, error) {
 	constraints, err := newConstraintExpression(raw, newGolangComparator)
 	if err != nil {
-		return golangConstraint{}, nil
+		return golangConstraint{}, err
 	}
 	return golangConstraint{
 		expression: constraints,

--- a/grype/version/golang_constraint_test.go
+++ b/grype/version/golang_constraint_test.go
@@ -1,0 +1,29 @@
+package version
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestIncompatibleFlagIsSameVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		version    string
+		constraint string
+		satisfied  bool
+	}{}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := newGolangConstraint(tc.constraint)
+			require.NoError(t, err)
+			v, err := NewVersion(tc.version, GolangFormat)
+			require.NoError(t, err)
+			sat, err := c.Satisfied(v)
+			require.NoError(t, err)
+			assert.Equal(t, tc.satisfied, sat)
+		})
+	}
+
+}

--- a/grype/version/golang_constraint_test.go
+++ b/grype/version/golang_constraint_test.go
@@ -1,9 +1,10 @@
 package version
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestIncompatibleFlagIsSameVersion(t *testing.T) {
@@ -12,7 +13,32 @@ func TestIncompatibleFlagIsSameVersion(t *testing.T) {
 		version    string
 		constraint string
 		satisfied  bool
-	}{}
+	}{
+		{
+			name:       "regular semantic version satisfied",
+			version:    "v1.2.3",
+			constraint: "< 1.2.4",
+			satisfied:  true,
+		},
+		{
+			name:       "regular semantic version unsatisfied",
+			version:    "v1.2.3",
+			constraint: "> 1.2.4",
+			satisfied:  false,
+		},
+		{
+			name:       "+incompatible added to version", // see grype#1581
+			version:    "v3.2.0+incompatible",
+			constraint: "<=3.2.0",
+			satisfied:  true,
+		},
+		{
+			name:       "the empty constraint is always satisfied",
+			version:    "v1.0.0",
+			constraint: "",
+			satisfied:  true,
+		},
+	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -25,5 +51,20 @@ func TestIncompatibleFlagIsSameVersion(t *testing.T) {
 			assert.Equal(t, tc.satisfied, sat)
 		})
 	}
+}
 
+func TestString(t *testing.T) {
+	tests := []struct {
+		name       string
+		constraint string
+		expected   string
+	}{}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := newGolangConstraint(tc.constraint)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, c.String())
+		})
+	}
 }

--- a/grype/version/golang_constraint_test.go
+++ b/grype/version/golang_constraint_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIncompatibleFlagIsSameVersion(t *testing.T) {
+func TestGolangConstraints(t *testing.T) {
 	tests := []struct {
 		name       string
 		version    string
@@ -58,7 +58,18 @@ func TestString(t *testing.T) {
 		name       string
 		constraint string
 		expected   string
-	}{}
+	}{
+		{
+			name:       "empty string",
+			constraint: "",
+			expected:   "none (go)",
+		},
+		{
+			name:       "basic constraint",
+			constraint: "< 1.3.4",
+			expected:   "< 1.3.4 (go)",
+		},
+	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/grype/version/golang_version.go
+++ b/grype/version/golang_version.go
@@ -8,12 +8,40 @@ import (
 	hashiVer "github.com/anchore/go-version"
 )
 
+var _ Comparator = (*golangVersion)(nil)
+
 type golangVersion struct {
 	raw              string
 	semVer           *hashiVer.Version
 	timestamp        string
 	commitSHA        string
 	incompatibleFlag bool
+}
+
+func (g golangVersion) Compare(version *Version) (int, error) {
+	if version.Format != GolangFormat {
+		return -1, fmt.Errorf("cannot compare %v to golang version", version.Format)
+	}
+	if version.rich.golangVersion == nil {
+		return -1, fmt.Errorf("cannot compare version with nil golang version to golang version")
+	}
+	if version.rich.golangVersion.raw == g.raw {
+		return 0, nil
+	}
+	if version.rich.golangVersion.semVer != nil && g.semVer != nil {
+		return g.semVer.Compare(version.rich.golangVersion.semVer), nil
+	}
+	if version.rich.golangVersion.semVer != nil && g.semVer == nil {
+		// semvers are greater than tag versions
+		return -1, nil
+	}
+	if g.semVer != nil && version.rich.golangVersion.semVer == nil {
+		return 1, nil
+	}
+	if version.rich.golangVersion.timestamp != "" && g.timestamp != "" {
+		return strings.Compare(g.timestamp, version.rich.golangVersion.timestamp), nil
+	}
+	return 0, nil
 }
 
 var startsWithSemver = regexp.MustCompile(`v\d+\.\d+\.\d+`)

--- a/grype/version/golang_version.go
+++ b/grype/version/golang_version.go
@@ -48,6 +48,9 @@ func (g golangVersion) compare(o golangVersion) int {
 var startsWithSemver = regexp.MustCompile(`(v|go){0,1}\d+\.\d+\.\d+`)
 
 func newGolangVersion(v string) (*golangVersion, error) {
+	if v == "(devel)" {
+		return &golangVersion{raw: v}, nil
+	}
 	if !startsWithSemver.MatchString(v) {
 		return nil, fmt.Errorf("%s is not a go version", v)
 	}
@@ -69,7 +72,13 @@ func newGolangVersion(v string) (*golangVersion, error) {
 
 	if semver, err := hashiVer.NewSemver(strings.TrimPrefix(version, "v")); err == nil {
 		result.semVer = semver
+		return result, nil
 	}
 
+	// go stdlib is reported by syft as a go package with version like "go1.24.1"
+	if semver, err := hashiVer.NewSemver(strings.TrimPrefix(version, "go")); err == nil {
+		result.semVer = semver
+		return result, nil
+	}
 	return result, nil
 }

--- a/grype/version/golang_version.go
+++ b/grype/version/golang_version.go
@@ -45,7 +45,7 @@ func (g golangVersion) compare(o golangVersion) int {
 	}
 }
 
-var startsWithSemver = regexp.MustCompile(`v\d+\.\d+\.\d+`)
+var startsWithSemver = regexp.MustCompile(`(v|go){0,1}\d+\.\d+\.\d+`)
 
 func newGolangVersion(v string) (*golangVersion, error) {
 	if !startsWithSemver.MatchString(v) {

--- a/grype/version/golang_version.go
+++ b/grype/version/golang_version.go
@@ -1,18 +1,46 @@
 package version
 
 import (
-	hashiVer "github.com/anchore/go-version"
+	"fmt"
+	"regexp"
 	"strings"
+
+	hashiVer "github.com/anchore/go-version"
 )
 
 type golangVersion struct {
-	verObj           *hashiVer.Version
+	raw              string
+	semVer           *hashiVer.Version
+	timestamp        string
+	commitSHA        string
 	incompatibleFlag bool
 }
 
-func newGolangVersion(v string) (*golangVersion, error) {
-	if strings.HasSuffix(v, "+incompatible") {
+var startsWithSemver = regexp.MustCompile(`v\d+\.\d+\.\d+`)
 
+func newGolangVersion(v string) (*golangVersion, error) {
+	if !startsWithSemver.MatchString(v) {
+		return nil, fmt.Errorf("%s is not a go version", v)
 	}
-	return &golangVersion{}, nil
+	result := &golangVersion{
+		raw: v,
+	}
+	version, incompatible := strings.CutSuffix(v, "+incompatible")
+	zeroZeroSuffix, untagged := strings.CutPrefix(v, "v0.0.0-")
+	if untagged {
+		parts := strings.Split(zeroZeroSuffix, "-")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("%s is not a valid golang version", v)
+		}
+		result.timestamp = parts[0]
+		result.commitSHA = parts[1]
+		return result, nil
+	}
+	result.incompatibleFlag = incompatible
+
+	if semver, err := hashiVer.NewSemver(strings.TrimPrefix(version, "v")); err == nil {
+		result.semVer = semver
+	}
+
+	return result, nil
 }

--- a/grype/version/golang_version.go
+++ b/grype/version/golang_version.go
@@ -1,0 +1,18 @@
+package version
+
+import (
+	hashiVer "github.com/anchore/go-version"
+	"strings"
+)
+
+type golangVersion struct {
+	verObj           *hashiVer.Version
+	incompatibleFlag bool
+}
+
+func newGolangVersion(v string) (*golangVersion, error) {
+	if strings.HasSuffix(v, "+incompatible") {
+
+	}
+	return &golangVersion{}, nil
+}

--- a/grype/version/golang_version.go
+++ b/grype/version/golang_version.go
@@ -28,20 +28,21 @@ func (g golangVersion) Compare(version *Version) (int, error) {
 	if version.rich.golangVersion.raw == g.raw {
 		return 0, nil
 	}
-	if version.rich.golangVersion.semVer != nil && g.semVer != nil {
-		return g.semVer.Compare(version.rich.golangVersion.semVer), nil
+
+	return version.rich.golangVersion.compare(g), nil
+}
+
+func (g golangVersion) compare(o golangVersion) int {
+	switch {
+	case g.semVer != nil && o.semVer != nil:
+		return g.semVer.Compare(o.semVer)
+	case g.semVer != nil && o.semVer == nil:
+		return 1
+	case g.semVer == nil && o.semVer != nil:
+		return -1
+	default:
+		return strings.Compare(g.timestamp, o.timestamp)
 	}
-	if version.rich.golangVersion.semVer != nil && g.semVer == nil {
-		// semvers are greater than tag versions
-		return -1, nil
-	}
-	if g.semVer != nil && version.rich.golangVersion.semVer == nil {
-		return 1, nil
-	}
-	if version.rich.golangVersion.timestamp != "" && g.timestamp != "" {
-		return strings.Compare(g.timestamp, version.rich.golangVersion.timestamp), nil
-	}
-	return 0, nil
 }
 
 var startsWithSemver = regexp.MustCompile(`v\d+\.\d+\.\d+`)

--- a/grype/version/golang_version_test.go
+++ b/grype/version/golang_version_test.go
@@ -43,6 +43,21 @@ func TestNewGolangVersion(t *testing.T) {
 			},
 		},
 		{
+			name:  "standard library",
+			input: "go1.21.4",
+			expected: golangVersion{
+				raw:    "go1.21.4",
+				semVer: hashiVer.Must(hashiVer.NewSemver("1.21.4")),
+			},
+		},
+		{
+			name:  "devel",
+			input: "(devel)",
+			expected: golangVersion{
+				raw: "(devel)",
+			},
+		},
+		{
 			name:    "invalid input",
 			input:   "some nonsense",
 			wantErr: true,

--- a/grype/version/golang_version_test.go
+++ b/grype/version/golang_version_test.go
@@ -128,10 +128,9 @@ func TestCompareGolangVersions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			a, err := newGolangVersion(tc.thisVersion)
 			require.NoError(t, err)
-			other, err := NewVersion(tc.otherVersion, GolangFormat)
+			other, err := newGolangVersion(tc.otherVersion)
 			require.NoError(t, err)
-			got, err := a.Compare(other)
-			require.NoError(t, err)
+			got := a.compare(*other)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/grype/version/golang_version_test.go
+++ b/grype/version/golang_version_test.go
@@ -60,3 +60,79 @@ func TestNewGolangVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestCompareGolangVersions(t *testing.T) {
+	tests := []struct {
+		name         string
+		thisVersion  string
+		otherVersion string
+		want         int
+	}{
+		{
+			name:         "semver this version less",
+			thisVersion:  "v1.2.3",
+			otherVersion: "v1.2.4",
+			want:         -1,
+		},
+		{
+			name:         "semver this version more",
+			thisVersion:  "v1.3.4",
+			otherVersion: "v1.2.4",
+			want:         1,
+		},
+		{
+			name:         "semver equal",
+			thisVersion:  "v1.2.4",
+			otherVersion: "v1.2.4",
+			want:         0,
+		},
+		{
+			name:         "commit-sha this version less",
+			thisVersion:  "v0.0.0-20180116102854-5a71ef0e047d",
+			otherVersion: "v0.0.0-20190116102854-somehash",
+			want:         -1,
+		},
+		{
+			name:         "commit-sha this version more",
+			thisVersion:  "v0.0.0-20180216102854-5a71ef0e047d",
+			otherVersion: "v0.0.0-20180116102854-somehash",
+			want:         1,
+		},
+		{
+			name:         "commit-sha this version equal",
+			thisVersion:  "v0.0.0-20180116102854-5a71ef0e047d",
+			otherVersion: "v0.0.0-20180116102854-5a71ef0e047d",
+			want:         0,
+		},
+		{
+			name:         "this pre-semver is less than any semver",
+			thisVersion:  "v0.0.0-20180116102854-5a71ef0e047d",
+			otherVersion: "v0.0.1",
+			want:         -1,
+		},
+		{
+			name:         "semver is greater than timestamp",
+			thisVersion:  "v2.1.0",
+			otherVersion: "v0.0.0-20180116102854-5a71ef0e047d",
+			want:         1,
+		},
+		{
+			name:         "+incompatible doesn't break equality",
+			thisVersion:  "v3.2.0",
+			otherVersion: "v3.2.0+incompatible",
+			want:         0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a, err := newGolangVersion(tc.thisVersion)
+			require.NoError(t, err)
+			other, err := NewVersion(tc.otherVersion, GolangFormat)
+			require.NoError(t, err)
+			got, err := a.Compare(other)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/grype/version/golang_version_test.go
+++ b/grype/version/golang_version_test.go
@@ -21,25 +21,23 @@ func TestNewGolangVersion(t *testing.T) {
 			input: "v1.8.0",
 			expected: golangVersion{
 				raw:    "v1.8.0",
-				semVer: hashiVer.Must(hashiVer.NewSemver("1.8.0")),
+				semVer: hashiVer.Must(hashiVer.NewSemver("v1.8.0")),
 			},
 		},
 		{
 			name:  "v0.0.0 date and hash version",
 			input: "v0.0.0-20180116102854-5a71ef0e047d",
 			expected: golangVersion{
-				raw:       "v0.0.0-20180116102854-5a71ef0e047d",
-				timestamp: "20180116102854",
-				commitSHA: "5a71ef0e047d",
+				raw:    "v0.0.0-20180116102854-5a71ef0e047d",
+				semVer: hashiVer.Must(hashiVer.NewSemver("v0.0.0-20180116102854-5a71ef0e047d")),
 			},
 		},
 		{
 			name:  "semver with +incompatible",
 			input: "v24.0.7+incompatible",
 			expected: golangVersion{
-				raw:              "v24.0.7+incompatible",
-				semVer:           hashiVer.Must(hashiVer.NewSemver("24.0.7")),
-				incompatibleFlag: true,
+				raw:    "v24.0.7+incompatible",
+				semVer: hashiVer.Must(hashiVer.NewSemver("v24.0.7+incompatible")),
 			},
 		},
 		{
@@ -51,11 +49,9 @@ func TestNewGolangVersion(t *testing.T) {
 			},
 		},
 		{
-			name:  "devel",
-			input: "(devel)",
-			expected: golangVersion{
-				raw: "(devel)",
-			},
+			name:    "devel",
+			input:   "(devel)",
+			wantErr: true,
 		},
 		{
 			name:    "invalid input",

--- a/grype/version/golang_version_test.go
+++ b/grype/version/golang_version_test.go
@@ -1,0 +1,62 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	hashiVer "github.com/anchore/go-version"
+)
+
+func TestNewGolangVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected golangVersion
+		wantErr  bool
+	}{
+		{
+			name:  "normal semantic version",
+			input: "v1.8.0",
+			expected: golangVersion{
+				raw:    "v1.8.0",
+				semVer: hashiVer.Must(hashiVer.NewSemver("1.8.0")),
+			},
+		},
+		{
+			name:  "v0.0.0 date and hash version",
+			input: "v0.0.0-20180116102854-5a71ef0e047d",
+			expected: golangVersion{
+				raw:       "v0.0.0-20180116102854-5a71ef0e047d",
+				timestamp: "20180116102854",
+				commitSHA: "5a71ef0e047d",
+			},
+		},
+		{
+			name:  "semver with +incompatible",
+			input: "v24.0.7+incompatible",
+			expected: golangVersion{
+				raw:              "v24.0.7+incompatible",
+				semVer:           hashiVer.Must(hashiVer.NewSemver("24.0.7")),
+				incompatibleFlag: true,
+			},
+		},
+		{
+			name:    "invalid input",
+			input:   "some nonsense",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := newGolangVersion(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			assert.Equal(t, tc.expected, *v)
+		})
+	}
+}

--- a/grype/version/golang_version_test.go
+++ b/grype/version/golang_version_test.go
@@ -49,6 +49,10 @@ func TestNewGolangVersion(t *testing.T) {
 			},
 		},
 		{
+			// "(devel)" is the main module of a go program.
+			// If we get a package with this version, it means the SBOM
+			// doesn't have a real version number for the built package, so
+			// we can't compare it and should just return an error.
 			name:    "devel",
 			input:   "(devel)",
 			wantErr: true,

--- a/grype/version/version.go
+++ b/grype/version/version.go
@@ -18,6 +18,7 @@ type rich struct {
 	semVer        *semanticVersion
 	apkVer        *apkVersion
 	debVer        *debVersion
+	golangVersion *golangVersion
 	mavenVer      *mavenVersion
 	rpmVer        *rpmVersion
 	kbVer         *kbVersion
@@ -62,6 +63,10 @@ func (v *Version) populate() error {
 	case DebFormat:
 		ver, err := newDebVersion(v.Raw)
 		v.rich.debVer = ver
+		return err
+	case GolangFormat:
+		ver, err := newGolangVersion(v.Raw)
+		v.rich.golangVersion = ver
 		return err
 	case MavenFormat:
 		ver, err := newMavenVersion(v.Raw)


### PR DESCRIPTION
Resolves https://github.com/anchore/grype/issues/1581

Right now, go versions are handled by generic semantic version comparison (or fall through to fuzzy version comparison sometimes). There are a few ways in which the version found in a `go.mod` for example is not exactly a semver string:

1. Sometimes, the go tooling appends `+incompatible` to a version string. This causes the comparison to fall through from semantic version to fuzzy version, which is the root cause of #1581.
2. Versions of the go standard library itself start with `go` (e.g. `go1.24.1`) instead of `v`.
3. Go dependencies can be declared based on commits, rather than semver tags, which results in a string that looks like `v0.0.0-20180116102854-5a71ef0e047d`. Right now, these are working because the lexicographical sorting of the strings gives the right order, which is great, but a bit of a coincidence since we're letting them fall through to the "just guessing based on strings" part of the version comparison logic.
4. Sometimes syft emits `(devel)` for a go version.

This change introduces a golangVersion and golangConstraint structs in the grype/version package, so that we have a single place to write down rules like "`v3.2.0+incompatible` should compare as equal to `v3.2.0`".

Note that this change does not yet specify how `(devel)` should compare to other go versions. All the answer have potential pitfalls (e.g. saying `(devel)` is greater than `v1.2.3` might not be true; someone could check out `v1.2.2` and build it, and get `(devel)` as the version number, or vice versa if we say `(devel)` is less than `v1.2.3`).

This also changes a CPE test that, as far as I can tell, was relying on go being a language without specific versioning logic. I've changed this test to use erlang which, for the moment, does not have specific versioning logic.

It could also be that there's a nice go library somewhere for parsing and comparing go versions, and we shouldn't maintain this code (in fact, something like this code must exist in Go's own build tools), but I haven't been able to find it, and this is a pretty thin wrapper around semver anyway.

TODO:
- [x] decide how to handle `(devel)` in comparison