### PR TITLE
chore: explicitly test maven suffixes

### DIFF
--- a/grype/version/maven_constraint_test.go
+++ b/grype/version/maven_constraint_test.go
@@ -29,6 +29,8 @@ func TestVersionConstraintJava(t *testing.T) {
 		{version: "2.0.1", constraint: "< 2.0.1-123", satisfied: true},
 		{version: "2.0.1-xyz", constraint: "< 2.0.1-123", satisfied: true},
 		{version: "2.414.2-cb-5", constraint: "> 2.414.2", satisfied: true},
+		{version: "5.2.25.RELEASE", constraint: "< 5.2.25", satisfied: false},
+		{version: "5.2.25.RELEASE", constraint: "<= 5.2.25", satisfied: true},
 	}
 
 	for _, test := range tests {

--- a/grype/version/maven_version_test.go
+++ b/grype/version/maven_version_test.go
@@ -32,6 +32,36 @@ func Test_javaVersion_Compare(t *testing.T) {
 			compare: "2.414.2",
 			want:    1,
 		},
+		{
+			name:    "5.2.25.RELEASE", // see https://mvnrepository.com/artifact/org.springframework/spring-web
+			compare: "5.2.25",
+			want:    0,
+		},
+		{
+			name:    "5.2.25.release",
+			compare: "5.2.25",
+			want:    0,
+		},
+		{
+			name:    "5.2.25.FINAL",
+			compare: "5.2.25",
+			want:    0,
+		},
+		{
+			name:    "5.2.25.final",
+			compare: "5.2.25",
+			want:    0,
+		},
+		{
+			name:    "5.2.25.GA",
+			compare: "5.2.25",
+			want:    0,
+		},
+		{
+			name:    "5.2.25.ga",
+			compare: "5.2.25",
+			want:    0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Some older Maven releases include a suffix like .RELEASE on the version number. Grype's behavior with regard to these versions has been suggested as a source of false positives. Pin the behavior with tests to make it easier to reason about how Grype will compare maven versions and to guard against this behavior accidentally changing.