### PR TITLE
chore: bump to syft v0.98.0 in quality gate tests

### DIFF
--- a/test/quality/.yardstick.yaml
+++ b/test/quality/.yardstick.yaml
@@ -93,7 +93,7 @@ result-sets:
 
         - name: syft
           # note: we want to use a fixed version of syft for capturing all results (NOT "latest")
-          version: v0.89.0
+          version: v0.98.0
           produces: SBOM
           refresh: false
 


### PR DESCRIPTION
Merge https://github.com/anchore/vulnerability-match-labels/pull/124 first and wait for sbom cache rebuild