### PR TITLE
Fix logging configuration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,10 +683,6 @@ fail-on-severity: ""
 # same as -o ; GRYPE_OUTPUT env var
 output: "table"
 
-# suppress all output (except for the vulnerability list)
-# same as -q ; GRYPE_QUIET env var
-quiet: false
-
 # write output report to a file (default is to write to stdout)
 # same as --file; GRYPE_FILE env var
 file: ""
@@ -794,9 +790,13 @@ registry:
 
 
 log:
-  # use structured logging
-  # same as GRYPE_LOG_STRUCTURED env var
-  structured: false
+	# suppress all output (except for the vulnerability list)
+	# same as -q ; GRYPE_LOG_QUIET env var
+	quiet: false
+
+  # increase verbosity
+  # same as GRYPE_LOG_VERBOSITY env var
+  verbosity: 0
 
   # the log level; note: detailed logging suppress the ETUI
   # same as GRYPE_LOG_LEVEL env var

--- a/README.md
+++ b/README.md
@@ -577,12 +577,12 @@ An example `config.json` looks something like this:
 ```
 // config.json
 {
-	"auths": {
-		"registry.example.com": {
-			"username": "AzureDiamond",
-			"password": "hunter2"
-		}
-	}
+  "auths": {
+    "registry.example.com": {
+      "username": "AzureDiamond",
+      "password": "hunter2"
+    }
+  }
 }
 ```
 
@@ -790,9 +790,9 @@ registry:
 
 
 log:
-	# suppress all output (except for the vulnerability list)
-	# same as -q ; GRYPE_LOG_QUIET env var
-	quiet: false
+  # suppress all output (except for the vulnerability list)
+  # same as -q ; GRYPE_LOG_QUIET env var
+  quiet: false
 
   # increase verbosity
   # same as GRYPE_LOG_VERBOSITY env var


### PR DESCRIPTION
After porting to CLIO, README was not updated to reflect changes in the logging configuration. The file is now updated based on `grype --help` output which is already up to date.

This closes #1645 