### PR TITLE
Add Packaged Dockerfile (#1652)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -205,6 +205,60 @@ dockers:
       - "--build-arg=VCS_REF={{.FullCommit}}"
       - "--build-arg=VCS_URL={{.GitURL}}"
 
+  - image_templates:
+      - anchore/grype:packaged
+      - anchore/grype:{{.Tag}}-packaged
+      - ghcr.io/anchore/grype:packaged
+      - ghcr.io/anchore/grype:{{.Tag}}-packaged
+    goarch: amd64
+    dockerfile: Dockerfile.packaged
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
+  - image_templates:
+      - anchore/grype:{{.Tag}}-packaged-arm64v8
+      - ghcr.io/anchore/grype:{{.Tag}}-packaged-arm64v8
+    goarch: arm64
+    dockerfile: Dockerfile.packaged
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
+  - image_templates:
+      - anchore/grype:{{.Tag}}-packaged-ppc64le
+      - ghcr.io/anchore/grype:{{.Tag}}-packaged-ppc64le
+    goarch: ppc64le
+    dockerfile: Dockerfile.packaged
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/ppc64le"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
+  - image_templates:
+      - anchore/grype:{{.Tag}}-packaged-s390x
+      - ghcr.io/anchore/grype:{{.Tag}}-packaged-s390x
+    goarch: s390x
+    dockerfile: Dockerfile.packaged
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/s390x"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
 docker_manifests:
   - name_template: anchore/grype:latest
     image_templates:
@@ -218,6 +272,12 @@ docker_manifests:
       - anchore/grype:{{.Tag}}-debug-arm64v8
       - anchore/grype:{{.Tag}}-debug-ppc64le
       - anchore/grype:{{.Tag}}-debug-s390x
+
+  - name_template: anchore/grype:packaged
+      - anchore/grype:{{.Tag}}-packaged
+      - anchore/grype:{{.Tag}}-packaged-arm64v8
+      - anchore/grype:{{.Tag}}-packaged-ppc64le
+      - anchore/grype:{{.Tag}}-packaged-s390x
 
   - name_template: anchore/grype:{{.Tag}}
     image_templates:
@@ -239,6 +299,13 @@ docker_manifests:
       - ghcr.io/anchore/grype:{{.Tag}}-debug-arm64v8
       - ghcr.io/anchore/grype:{{.Tag}}-debug-ppc64le
       - ghcr.io/anchore/grype:{{.Tag}}-debug-s390x
+
+  - name_template: ghcr.io/anchore/grype:packaged
+    image_templates:
+      - ghcr.io/anchore/grype:{{.Tag}}-packaged
+      - ghcr.io/anchore/grype:{{.Tag}}-packaged-arm64v8
+      - ghcr.io/anchore/grype:{{.Tag}}-packaged-ppc64le
+      - ghcr.io/anchore/grype:{{.Tag}}-packaged-s390x
 
   - name_template: ghcr.io/anchore/grype:{{.Tag}}
     image_templates:

--- a/Dockerfile.packaged
+++ b/Dockerfile.packaged
@@ -1,0 +1,39 @@
+FROM gcr.io/distroless/static-debian11@sha256:5759d194607e472ff80fff5833442d3991dd89b219c96552837a2c8f74058617 AS build
+
+
+FROM scratch
+
+# Needed for version check HTTPS request
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Create the /tmp dir, which is needed for image content cache
+WORKDIR /tmp
+
+COPY grype /
+
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG VCS_REF
+ARG VCS_URL
+
+LABEL org.opencontainers.image.created=$BUILD_DATE
+LABEL org.opencontainers.image.title="grype"
+LABEL org.opencontainers.image.description="A vulnerability scanner for container images and filesystems"
+LABEL org.opencontainers.image.source=$VCS_URL
+LABEL org.opencontainers.image.revision=$VCS_REF
+LABEL org.opencontainers.image.vendor="Anchore, Inc."
+LABEL org.opencontainers.image.version=$BUILD_VERSION
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL io.artifacthub.package.readme-url="https://raw.githubusercontent.com/anchore/grype/main/README.md"
+LABEL io.artifacthub.package.logo-url="https://user-images.githubusercontent.com/5199289/136855393-d0a9eef9-ccf1-4e2b-9d7c-7aad16a567e5.png"
+LABEL io.artifacthub.package.license="Apache-2.0"
+
+# Disable the automatic database update by default
+ENV GRYPE_DB_AUTO_UPDATE=false
+
+# Run the update to get the latest vulnerability database. This is done here so that the database can be cached without
+# requiring internet access, though the update can still optionally be run at runtime
+RUN ["/grype", "db", "update"]
+
+
+ENTRYPOINT ["/grype"]


### PR DESCRIPTION
This addresses #1652 to build a Docker image that has the vulnerability database packaged in the image.