### PR TITLE
chore: break assumption that syft cpe.CPE is wfn.Attributes

### DIFF
--- a/grype/cpe/cpe.go
+++ b/grype/cpe/cpe.go
@@ -1,9 +1,10 @@
 package cpe
 
 import (
+	"github.com/facebookincubator/nvdtools/wfn"
+
 	"github.com/anchore/grype/internal/log"
 	"github.com/anchore/syft/syft/cpe"
-	"github.com/facebookincubator/nvdtools/wfn"
 )
 
 func NewSlice(cpeStrs ...string) ([]cpe.CPE, error) {
@@ -22,9 +23,9 @@ func NewSlice(cpeStrs ...string) ([]cpe.CPE, error) {
 
 func MatchWithoutVersion(c cpe.CPE, candidates []cpe.CPE) []cpe.CPE {
 	matches := make([]cpe.CPE, 0)
-	a := wfn.Attributes(c)
+	a := wfn.Attributes(c) // nolint:unconvert // TODO: remove nolint when syft upgrade in grype
 	for _, candidate := range candidates {
-		canCopy := wfn.Attributes(candidate)
+		canCopy := wfn.Attributes(candidate) // nolint:unconvert // TODO: remove nolint when syft upgrade in grype
 		if a.MatchWithoutVersion(&canCopy) {
 			matches = append(matches, candidate)
 		}

--- a/grype/cpe/cpe.go
+++ b/grype/cpe/cpe.go
@@ -3,6 +3,7 @@ package cpe
 import (
 	"github.com/anchore/grype/internal/log"
 	"github.com/anchore/syft/syft/cpe"
+	"github.com/facebookincubator/nvdtools/wfn"
 )
 
 func NewSlice(cpeStrs ...string) ([]cpe.CPE, error) {
@@ -21,9 +22,10 @@ func NewSlice(cpeStrs ...string) ([]cpe.CPE, error) {
 
 func MatchWithoutVersion(c cpe.CPE, candidates []cpe.CPE) []cpe.CPE {
 	matches := make([]cpe.CPE, 0)
+	a := wfn.Attributes(c)
 	for _, candidate := range candidates {
-		canCopy := candidate
-		if c.MatchWithoutVersion(&canCopy) {
+		canCopy := wfn.Attributes(candidate)
+		if a.MatchWithoutVersion(&canCopy) {
 			matches = append(matches, candidate)
 		}
 	}

--- a/grype/pkg/purl_provider.go
+++ b/grype/pkg/purl_provider.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/facebookincubator/nvdtools/wfn"
 	"github.com/mitchellh/go-homedir"
 
 	"github.com/anchore/packageurl-go"
@@ -53,7 +52,7 @@ func decodePurlFile(reader io.Reader) ([]Package, error) {
 			return nil, fmt.Errorf("unable to decode purl %s: %w", rawLine, err)
 		}
 
-		cpes := []wfn.Attributes{}
+		cpes := []cpe.CPE{}
 		epoch := "0"
 		for _, qualifier := range purl.Qualifiers {
 			if qualifier.Key == cpesQualifierKey {

--- a/test/integration/match_by_image_test.go
+++ b/test/integration/match_by_image_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/facebookincubator/nvdtools/wfn"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
@@ -23,6 +22,7 @@ import (
 	"github.com/anchore/stereoscope/pkg/imagetest"
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
+	"github.com/anchore/syft/syft/cpe"
 	"github.com/anchore/syft/syft/linux"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/source"
@@ -142,7 +142,6 @@ func addPythonMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Co
 	require.NoError(t, err)
 
 	theResult.Add(match.Match{
-
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
 		Details: []match.Detail{
@@ -183,7 +182,6 @@ func addDotnetMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Co
 	require.NoError(t, err)
 
 	theResult.Add(match.Match{
-
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
 		Details: []match.Detail{
@@ -220,7 +218,6 @@ func addRubyMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 	require.NoError(t, err)
 
 	theResult.Add(match.Match{
-
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
 		Details: []match.Detail{
@@ -363,7 +360,6 @@ func addDpkgMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 	require.NoError(t, err)
 
 	theResult.Add(match.Match{
-
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
 		Details: []match.Detail{
@@ -442,7 +438,6 @@ func addRhelMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 	require.NoError(t, err)
 
 	theResult.Add(match.Match{
-
 		Vulnerability: *vulnObj,
 		Package:       thePkg,
 		Details: []match.Detail{
@@ -764,7 +759,6 @@ func TestMatchByImage(t *testing.T) {
 
 		t.Log(cmp.Diff(defs, obs))
 	}
-
 }
 
 // testIgnoredMatches returns an list of ignored matches to test the vex
@@ -783,7 +777,7 @@ func testIgnoredMatches() []match.IgnoredMatch {
 					Version:  "0.9.9",
 					Licenses: []string{"GPL-2.0-or-later"},
 					Type:     "apk",
-					CPEs: []wfn.Attributes{
+					CPEs: []cpe.CPE{
 						{
 							Part:    "a",
 							Vendor:  "libvncserver",
@@ -858,7 +852,7 @@ func vexMatches(t *testing.T, ignoredMatches []match.IgnoredMatch, vexStatus vex
 
 func assertMatches(t *testing.T, expected, actual []match.Match) {
 	t.Helper()
-	var opts = []cmp.Option{
+	opts := []cmp.Option{
 		cmpopts.IgnoreFields(vulnerability.Vulnerability{}, "Constraint"),
 		cmpopts.IgnoreFields(pkg.Package{}, "Locations"),
 		cmpopts.SortSlices(func(a, b match.Match) bool {


### PR DESCRIPTION
Previously, Syft's cpe.CPE type was an alias for wfn.Attributes. Fix a couple places where Grype's compilation depended on that fact, since it will stop being true in the next Syft release.

See anchore/syft#2529