### PR TITLE
Ensure releases only use released versions of syft

### DIFF
--- a/.github/scripts/check-syft-version-is-release.sh
+++ b/.github/scripts/check-syft-version-is-release.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+version=$(grep -E "github.com/anchore/syft" go.mod | awk '{print $NF}')
+
+# ensure that the version is a release version (not a commit hash)
+# a release in this case means that the go tooling resolved the version to a tag
+# this does not guarantee that the tag has a github release associated with it
+if [[ ! $version =~ ^v[0-9]+\.[0-9]+\.[0-9]?$ ]]; then
+    echo "syft version in go.mod is not a release version: $version"
+    echo "please update the version in go.mod to a release version and try again"
+    exit 1
+else
+    echo "syft version in go.mod is a release version: $version"
+fi

--- a/.github/scripts/trigger-release.sh
+++ b/.github/scripts/trigger-release.sh
@@ -9,6 +9,9 @@ if ! [ -x "$(command -v gh)" ]; then
     exit 1
 fi
 
+# we want to stop the release as early as possible if the version is not a release version
+./.github/scripts/check-syft-version-is-release.sh
+
 gh auth status
 
 # we need all of the git state to determine the next version. Since tagging is done by

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+
+      - name: Check if pinned syft is a release version
+        run: .github/scripts/check-syft-version-is-release.sh
+
       - name: Check if tag already exists
         # note: this will fail if the tag already exists
         run: |


### PR DESCRIPTION
This is an extra protection that ensures the version of syft in the `go.mod` is a released version of syft (not a version that is for a commit on main). This is done in both the release workflow as well as the trigger for release -- this is done in both places to help balance ease (fail as early as possible) and safety (the source of truth for all release gates must be in the release workflow).

This should allow us to continually integrate syft changes in grype more often and not require a release of syft.