### PR TITLE
fix: only warn missing CPEs if CPEs wanted

### DIFF
--- a/grype/matcher/apk/matcher_test.go
+++ b/grype/matcher/apk/matcher_test.go
@@ -591,6 +591,9 @@ func TestDistroMatchBySourceIndirection(t *testing.T) {
 				Name: "musl",
 			},
 		},
+		CPEs: []cpe.CPE{
+			cpe.Must("cpe:2.3:a:musl-utils:musl-utils:*:*:*:*:*:*:*:*", cpe.GeneratedSource),
+		},
 	}
 
 	vulnFound, err := vulnerability.NewVulnerability(secDbVuln)

--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -76,7 +76,6 @@ func FromCollection(catalog *pkg.Collection, config SynthesisConfig) []Package {
 
 func FromPackages(syftpkgs []pkg.Package, config SynthesisConfig) []Package {
 	var pkgs []Package
-	var missingCPEs bool
 	for _, p := range syftpkgs {
 		if len(p.CPEs) == 0 {
 			// For SPDX (or any format, really) we may have no CPEs
@@ -84,14 +83,11 @@ func FromPackages(syftpkgs []pkg.Package, config SynthesisConfig) []Package {
 				p.CPEs = cpes.Generate(p)
 			} else {
 				log.Debugf("no CPEs for package: %s", p)
-				missingCPEs = true
 			}
 		}
 		pkgs = append(pkgs, New(p))
 	}
-	if missingCPEs {
-		log.Warnf("some package(s) are missing CPEs. This may result in missing vulnerabilities. You may autogenerate these using: --add-cpes-if-none")
-	}
+
 	return pkgs
 }
 

--- a/grype/search/criteria.go
+++ b/grype/search/criteria.go
@@ -1,6 +1,8 @@
 package search
 
 import (
+	"errors"
+
 	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
@@ -25,7 +27,10 @@ func ByCriteria(store vulnerability.Provider, d *distro.Distro, p pkg.Package, u
 		switch c {
 		case ByCPE:
 			m, err := ByPackageCPE(store, d, p, upstreamMatcher)
-			if err != nil {
+			if errors.Is(err, ErrEmptyCPEMatch) {
+				log.Warnf("attempted CPE search on %s, which has no CPEs. Consider re-running with --add-cpes-if-none", p.Name)
+				continue
+			} else if err != nil {
 				log.Warnf("could not match by package CPE (package=%+v): %v", p, err)
 				continue
 			}


### PR DESCRIPTION
Previously, a warning would be logged about missing CPEs even when processing packages for which CPEs would never be generated. Instead, return a specific error when attempting to match by CPEs on a package with no CPEs.

This change improves the user experience in 2 ways:
1. The user will only see a warning about missing CPEs if Grype actually tries to search by CPE on a package that has no CPEs, which means the warning is only ever shown if it's affecting matchign
2. The warning contains the package name, so the user has a better ability to try to investigate.

But with the following tradeoff:
1. If the user has a lot of packages missing CPEs for a matcher that has CPE matching turned on, they will see this log line a lot of times.

Fixes #1634 

## Example runs

Before, even with CPE matching disabled 

``` sh
❯ grype cgr.dev/chainguard/go                                                             
...
[0009]  WARN some package(s) are missing CPEs. This may result in missing vulnerabilities. You may autogenerate these using: --add-cpes-if-none
NAME                INSTALLED  FIXED-IN  TYPE  VULNERABILITY        SEVERITY 
...
```

After this change, with CPE matching disabled, no warning is printed.

After this change, if when Grype attempts to match on a package by CPEs that has no CPEs, the flag is still suggested:

``` sh
❯ GRYPE_MATCH_GOLANG_USING_CPES=true go run cmd/grype/main.go willtmp/chainguard.syft.json
...
[0000]  WARN attempted CPE search on cmd/addr2line, which has no CPEs. Consider re-running with --add-cpes-if-none
NAME                INSTALLED  FIXED-IN  TYPE  VULNERABILITY        SEVERITY 
...
```