### PR TITLE
fix: improve sarif descriptive text and fingerprint

### DIFF
--- a/grype/presenter/sarif/presenter.go
+++ b/grype/presenter/sarif/presenter.go
@@ -1,6 +1,7 @@
 package sarif
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -215,18 +216,18 @@ func (pres *Presenter) locations(m match.Match) []*sarif.Location {
 		img := metadata.UserInput
 		locations := m.Package.Locations.ToSlice()
 		for _, l := range locations {
-			trimmedPath := strings.TrimPrefix(pres.locationPath(l), "/")
+			trimmedPath := strings.TrimLeft(pres.locationPath(l), "/")
 			logicalLocations = append(logicalLocations, &sarif.LogicalLocation{
 				FullyQualifiedName: sp(fmt.Sprintf("%s@%s:/%s", img, l.FileSystemID, trimmedPath)),
 				Name:               sp(l.RealPath),
 			})
 		}
 
-		// this is a hack to get results to show up in GitHub, as it requires relative paths for the location
-		// but we really won't have any information about what Dockerfile on the filesystem was used to build the image
-		// TODO we could add configuration to specify the prefix, a user might want to specify an image name and architecture
-		// in the case of multiple vuln scans, for example
-		physicalLocation = fmt.Sprintf("image/%s", physicalLocation)
+		// GitHub requires relative paths for the location, but we really don't have any information about what
+		// file(s) these originated from in the repository. e.g. which Dockerfile was used to build an image
+		// just use the image name here, the user input may be sha-based, tags updating, but we
+		// want to track effectively the same built artifact
+		physicalLocation = fmt.Sprintf("%s %s", pres.src.Name, physicalLocation)
 	case source.FileSourceMetadata:
 		locations := m.Package.Locations.ToSlice()
 		for _, l := range locations {
@@ -387,11 +388,12 @@ func (pres *Presenter) sarifResults() []*sarif.Result {
 		out = append(out, &sarif.Result{
 			RuleID:  sp(pres.ruleID(m)),
 			Message: pres.resultMessage(m),
-			// According to the SARIF spec, I believe we should be using AnalysisTarget.URI to indicate a logical
+			// According to the SARIF spec, it may be correct to use AnalysisTarget.URI to indicate a logical
 			// file such as a "Dockerfile" but GitHub does not work well with this
-			// FIXME github "requires" partialFingerprints
-			// PartialFingerprints: ???
-			Locations: pres.locations(m),
+			// GitHub requires partialFingerprints to upload to the API; these are automatically filled in
+			// when using the CodeQL upload action. See: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#providing-data-to-track-code-scanning-alerts-across-runs
+			PartialFingerprints: pres.partialFingerprints(m),
+			Locations:           pres.locations(m),
 		})
 	}
 	return out
@@ -409,16 +411,33 @@ func sp(sarif string) *string {
 
 func (pres *Presenter) resultMessage(m match.Match) sarif.Message {
 	path := pres.packagePath(m.Package)
-	message := fmt.Sprintf("The path %s reports %s at version %s ", path, m.Package.Name, m.Package.Version)
-
-	if _, ok := pres.src.Metadata.(source.DirectorySourceMetadata); ok {
-		message = fmt.Sprintf("%s which would result in a vulnerable (%s) package installed", message, m.Package.Type)
-	} else {
-		message = fmt.Sprintf("%s which is a vulnerable (%s) package installed in the container", message, m.Package.Type)
+	src := pres.inputPath()
+	switch meta := pres.src.Metadata.(type) {
+	case source.StereoscopeImageSourceMetadata:
+		src = fmt.Sprintf("in image %s at: %s", meta.UserInput, path)
+	case source.FileSourceMetadata, source.DirectorySourceMetadata:
+		src = fmt.Sprintf("at: %s", path)
 	}
+	message := fmt.Sprintf("A %s vulnerability in %s package: %s, version %s was found %s",
+		pres.severityText(m), m.Package.Type, m.Package.Name, m.Package.Version, src)
 
 	return sarif.Message{
 		Text: &message,
+	}
+}
+
+func (pres *Presenter) partialFingerprints(m match.Match) map[string]any {
+	prefix := ""
+	if meta, ok := pres.src.Metadata.(source.StereoscopeImageSourceMetadata); ok {
+		prefix = fmt.Sprintf("%s/%s/%s", pres.src.Name, meta.Architecture, meta.OS)
+	}
+	p := m.Package
+	path := pres.packagePath(p)
+	line := 1
+	hash := fmt.Sprintf("%s/%s/%s/%s/%s:%d", prefix, path, p.Type, p.Name, p.Version, line)
+	hash = fmt.Sprintf("%x", sha256.Sum256([]byte(hash)))
+	return map[string]any{
+		"primaryLocationLineHash": fmt.Sprintf("%s:%v", hash, line),
 	}
 }
 

--- a/grype/presenter/sarif/presenter_test.go
+++ b/grype/presenter/sarif/presenter_test.go
@@ -418,3 +418,38 @@ func Test_cvssScore(t *testing.T) {
 		})
 	}
 }
+
+func Test_imageShortPathName(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		expected string
+	}{
+		{
+			name:     "valid single name",
+			in:       "simple.-_name",
+			expected: "simple.-_name",
+		},
+		{
+			name:     "valid name in org",
+			in:       "some-org/some-image",
+			expected: "some-image",
+		},
+		{
+			name:     "name and org with many invalid chars",
+			in:       "some/*^&$#%$#@*(}{<><./,valid-()(#)@!(~@#$#%^&**[]{-chars",
+			expected: "valid--chars",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := imageShortPathName(&source.Description{
+				Name:     test.in,
+				Metadata: nil,
+			})
+
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}

--- a/grype/presenter/sarif/presenter_test.go
+++ b/grype/presenter/sarif/presenter_test.go
@@ -227,8 +227,8 @@ func TestToSarifReport(t *testing.T) {
 			name:   "image",
 			scheme: internal.ImageSource,
 			locations: map[string]string{
-				"CVE-1999-0001-package-1": "image/somefile-1.txt",
-				"CVE-1999-0002-package-2": "image/somefile-2.txt",
+				"CVE-1999-0001-package-1": "user-input somefile-1.txt",
+				"CVE-1999-0002-package-2": "user-input somefile-2.txt",
 			},
 		},
 	}

--- a/grype/presenter/sarif/test-fixtures/snapshot/TestSarifPresenter_directory.golden
+++ b/grype/presenter/sarif/test-fixtures/snapshot/TestSarifPresenter_directory.golden
@@ -52,7 +52,7 @@
         {
           "ruleId": "CVE-1999-0001-package-1",
           "message": {
-            "text": "The path /some/path/somefile-1.txt reports package-1 at version 1.1.1  which would result in a vulnerable (rpm) package installed"
+            "text": "A low vulnerability in rpm package: package-1, version 1.1.1 was found at: /some/path/somefile-1.txt"
           },
           "locations": [
             {
@@ -68,12 +68,15 @@
                 }
               }
             }
-          ]
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "10042ee410e5436e32faadfdddc8b578ed580feb0f234972babdd58b051eac94:1"
+          }
         },
         {
           "ruleId": "CVE-1999-0002-package-2",
           "message": {
-            "text": "The path /some/path/somefile-2.txt reports package-2 at version 2.2.2  which would result in a vulnerable (deb) package installed"
+            "text": "A critical vulnerability in deb package: package-2, version 2.2.2 was found at: /some/path/somefile-2.txt"
           },
           "locations": [
             {
@@ -89,7 +92,10 @@
                 }
               }
             }
-          ]
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "b4f7108e5957a87e4b52740601a12cba7e81435f76c4f3b93f3ea1087adf22e6:1"
+          }
         }
       ]
     }

--- a/grype/presenter/sarif/test-fixtures/snapshot/TestSarifPresenter_directory.golden
+++ b/grype/presenter/sarif/test-fixtures/snapshot/TestSarifPresenter_directory.golden
@@ -70,7 +70,7 @@
             }
           ],
           "partialFingerprints": {
-            "primaryLocationLineHash": "10042ee410e5436e32faadfdddc8b578ed580feb0f234972babdd58b051eac94:1"
+            "primaryLocationLineHash": "0eefd3962fe456b80e5ddad4ec777c7f75b3c0586db887eff1c98f376fff60ba:1"
           }
         },
         {
@@ -94,7 +94,7 @@
             }
           ],
           "partialFingerprints": {
-            "primaryLocationLineHash": "b4f7108e5957a87e4b52740601a12cba7e81435f76c4f3b93f3ea1087adf22e6:1"
+            "primaryLocationLineHash": "0d4ef10dce50e71641e9314195020cea18febe4c6a4a8145a485154383d4fe0b:1"
           }
         }
       ]

--- a/grype/presenter/sarif/test-fixtures/snapshot/TestSarifPresenter_image.golden
+++ b/grype/presenter/sarif/test-fixtures/snapshot/TestSarifPresenter_image.golden
@@ -52,13 +52,13 @@
         {
           "ruleId": "CVE-1999-0001-package-1",
           "message": {
-            "text": "The path somefile-1.txt reports package-1 at version 1.1.1  which is a vulnerable (rpm) package installed in the container"
+            "text": "A low vulnerability in rpm package: package-1, version 1.1.1 was found in image user-input at: somefile-1.txt"
           },
           "locations": [
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "image/somefile-1.txt"
+                  "uri": "user-input somefile-1.txt"
                 },
                 "region": {
                   "startLine": 1,
@@ -74,18 +74,21 @@
                 }
               ]
             }
-          ]
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "7ad58f20b703f8b1b77a242dfb07964ef7c99177eb1dec53141120c274519b5a:1"
+          }
         },
         {
           "ruleId": "CVE-1999-0002-package-2",
           "message": {
-            "text": "The path somefile-2.txt reports package-2 at version 2.2.2  which is a vulnerable (deb) package installed in the container"
+            "text": "A critical vulnerability in deb package: package-2, version 2.2.2 was found in image user-input at: somefile-2.txt"
           },
           "locations": [
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "image/somefile-2.txt"
+                  "uri": "user-input somefile-2.txt"
                 },
                 "region": {
                   "startLine": 1,
@@ -101,7 +104,10 @@
                 }
               ]
             }
-          ]
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "4fed3aeadddb35b91dfbd7ebe10ab463c9198c207348ff26374f4a7c2c9f38b0:1"
+          }
         }
       ]
     }

--- a/grype/presenter/sarif/test-fixtures/snapshot/TestSarifPresenter_image.golden
+++ b/grype/presenter/sarif/test-fixtures/snapshot/TestSarifPresenter_image.golden
@@ -76,7 +76,7 @@
             }
           ],
           "partialFingerprints": {
-            "primaryLocationLineHash": "7ad58f20b703f8b1b77a242dfb07964ef7c99177eb1dec53141120c274519b5a:1"
+            "primaryLocationLineHash": "efe125c0a2b4bdafe476b69ba51a49734780c62b93803950319056acebe4323f:1"
           }
         },
         {
@@ -106,7 +106,7 @@
             }
           ],
           "partialFingerprints": {
-            "primaryLocationLineHash": "4fed3aeadddb35b91dfbd7ebe10ab463c9198c207348ff26374f4a7c2c9f38b0:1"
+            "primaryLocationLineHash": "bafe9890c7cda00bf4d1b1a57d1d20b08e27162e718235a3d38a9a8d2f449ed1:1"
           }
         }
       ]


### PR DESCRIPTION
This PR improves the descriptive text when outputting SARIF to display more information to the user including the image/ and tag or sha that was specified. [An example of what this looks like in GitHub can be seen here](https://github.com/kzantow-anchore/test-sarif/security/code-scanning/38).

Fixes #1715 