### PR TITLE
fix(install): return right exit codes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -695,5 +695,6 @@ set +u
 if [ -z "${TEST_INSTALL_SH}" ]; then
   set -u
   main "$@"
+  exit $?
 fi
 set -u


### PR DESCRIPTION
As the main function was not the last command, it did always return a zero status code. Exiting right after main allows us to return the actual return code instead.

Analogous to https://github.com/anchore/syft/pull/2664 .