### PR TITLE
chore(test): update quality test grype db

### DIFF
--- a/test/install/Makefile
+++ b/test/install/Makefile
@@ -3,7 +3,7 @@ NAME=grype
 IMAGE_NAME=$(NAME)-install.sh-env
 UBUNTU_IMAGE=$(IMAGE_NAME):ubuntu-20.04
 ALPINE_IMAGE=$(IMAGE_NAME):alpine-3.6
-BUSYBOX_IMAGE=busybox:1.35
+BUSYBOX_IMAGE=busybox:1.36.1-musl
 
 ENVS=./environments
 DOCKER_RUN=docker run --rm -t -w /project/test/install -v $(shell pwd)/../../:/project
@@ -32,7 +32,7 @@ ci-test-mac: unit-local acceptance-local
 
 # note: do not add acceptance-local to this list
 .PHONY: acceptance
-acceptance: acceptance-ubuntu-20.04 acceptance-alpine-3.6 acceptance-busybox-1.35
+acceptance: acceptance-ubuntu-20.04 acceptance-alpine-3.6 acceptance-busybox
 
 .PHONY: unit
 unit: unit-ubuntu-20.04
@@ -55,7 +55,7 @@ acceptance-previous-release-local:
 	grype version | grep $(shell echo $(PREVIOUS_RELEASE)| tr -d "v")
 
 .PHONY: save
-save: ubuntu-20.04 alpine-3.6 busybox-1.35
+save: ubuntu-20.04 alpine-3.6 pull-busybox
 	@mkdir cache || true
 	docker image save -o cache/ubuntu-env.tar $(UBUNTU_IMAGE)
 	docker image save -o cache/alpine-env.tar $(ALPINE_IMAGE)
@@ -107,16 +107,16 @@ alpine-3.6:
 
 # note: busybox by default will not have cacerts, so you will get TLS warnings (we want to test under these conditions)
 
-.PHONY: acceptance-busybox-1.35
-acceptance-busybox-1.35: busybox-1.35
-	$(call title,busybox-1.35 - acceptance)
+.PHONY: acceptance-busybox
+acceptance-busybox: pull-busybox
+	$(call title,busybox - acceptance)
 	$(DOCKER_RUN) $(BUSYBOX_IMAGE) \
 		$(ACCEPTANCE_CMD)
 	@echo "\n*** test note: you should see grype spit out a 'x509: certificate signed by unknown authority' error --this is expected ***"
 
-.PHONY: busybox-1.35
-busybox-1.35:
-	$(call title,busybox-1.35 - build environment)
+.PHONY: pull-busybox
+pull-busybox:
+	$(call title,busybox - build environment)
 	docker pull $(BUSYBOX_IMAGE)
 
 ## For CI ########################################################

--- a/test/quality/Makefile
+++ b/test/quality/Makefile
@@ -8,7 +8,7 @@ VULNERABILITY_LABELS = ./vulnerability-labels
 RESULT_SET = pr_vs_latest_via_sbom
 
 # update periodically with values from "grype db list"
-TEST_DB_URL = https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v5_2023-10-25T01:27:28Z_fd5a911f9285633c57e3.tar.gz
+TEST_DB_URL = https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v5_2024-02-23T01:23:09Z_d8fbe227a9343b20a702.tar.gz
 TEST_DB = db.tar.gz
 LISTING_FILE = https://toolbox-data.anchore.io/grype/databases/listing.json
 


### PR DESCRIPTION
This PR updates the vulnerability database used in quality tests. And also applies [the fix from Syft](https://github.com/anchore/syft/pull/2663) for failing busybox install tests.