### PR TITLE
Suppress warnings when matching go packages with `devel` version

### DIFF
--- a/grype/matcher/apk/matcher.go
+++ b/grype/matcher/apk/matcher.go
@@ -1,6 +1,7 @@
 package apk
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/anchore/grype/grype/distro"
@@ -9,6 +10,7 @@ import (
 	"github.com/anchore/grype/grype/search"
 	"github.com/anchore/grype/grype/version"
 	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/grype/internal/log"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
@@ -63,6 +65,10 @@ func (m *Matcher) cpeMatchesWithoutSecDBFixes(store vulnerability.Provider, d *d
 
 	verObj, err := version.NewVersionFromPkg(p)
 	if err != nil {
+		if errors.Is(err, version.ErrUnsupportedVersion) {
+			log.WithFields("error", err).Tracef("skipping package '%s@%s'", p.Name, p.Version)
+			return nil, nil
+		}
 		return nil, fmt.Errorf("matcher failed to parse version pkg='%s' ver='%s': %w", p.Name, p.Version, err)
 	}
 

--- a/grype/search/distro.go
+++ b/grype/search/distro.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/anchore/grype/grype/distro"
@@ -8,6 +9,7 @@ import (
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/version"
 	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/grype/internal/log"
 )
 
 func ByPackageDistro(store vulnerability.ProviderByDistro, d *distro.Distro, p pkg.Package, upstreamMatcher match.MatcherType) ([]match.Match, error) {
@@ -17,6 +19,10 @@ func ByPackageDistro(store vulnerability.ProviderByDistro, d *distro.Distro, p p
 
 	verObj, err := version.NewVersionFromPkg(p)
 	if err != nil {
+		if errors.Is(err, version.ErrUnsupportedVersion) {
+			log.WithFields("error", err).Tracef("skipping package '%s@%s'", p.Name, p.Version)
+			return nil, nil
+		}
 		return nil, fmt.Errorf("matcher failed to parse version pkg=%q ver=%q: %w", p.Name, p.Version, err)
 	}
 

--- a/grype/search/language.go
+++ b/grype/search/language.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/anchore/grype/grype/distro"
@@ -8,11 +9,16 @@ import (
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/version"
 	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/grype/internal/log"
 )
 
 func ByPackageLanguage(store vulnerability.ProviderByLanguage, d *distro.Distro, p pkg.Package, upstreamMatcher match.MatcherType) ([]match.Match, error) {
 	verObj, err := version.NewVersionFromPkg(p)
 	if err != nil {
+		if errors.Is(err, version.ErrUnsupportedVersion) {
+			log.WithFields("error", err).Tracef("skipping package '%s@%s'", p.Name, p.Version)
+			return nil, nil
+		}
 		return nil, fmt.Errorf("matcher failed to parse version pkg=%q ver=%q: %w", p.Name, p.Version, err)
 	}
 

--- a/grype/version/golang_version.go
+++ b/grype/version/golang_version.go
@@ -45,6 +45,9 @@ func (g golangVersion) compare(o golangVersion) int {
 }
 
 func newGolangVersion(v string) (*golangVersion, error) {
+	if v == "(devel)" {
+		return nil, ErrUnsupportedVersion
+	}
 	// go stdlib is reported by syft as a go package with version like "go1.24.1"
 	// other versions have "v" as a prefix, which the semver lib handles automatically
 	semver, err := hashiVer.NewSemver(strings.TrimPrefix(v, "go"))

--- a/grype/version/golang_version_test.go
+++ b/grype/version/golang_version_test.go
@@ -150,3 +150,42 @@ func TestCompareGolangVersions(t *testing.T) {
 		})
 	}
 }
+
+func Test_newGolangVersion_UnsupportedVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		v       string
+		want    *golangVersion
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "devel",
+			v:    "(devel)",
+			wantErr: func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
+				return assert.ErrorIs(t, err, ErrUnsupportedVersion)
+			},
+		},
+		{
+			name:    "invalid",
+			v:       "invalid",
+			wantErr: assert.Error,
+		},
+		{
+			name: "valid",
+			v:    "v1.2.3",
+			want: &golangVersion{
+				raw:    "v1.2.3",
+				semVer: hashiVer.Must(hashiVer.NewSemver("v1.2.3")),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newGolangVersion(tt.v)
+			if tt.wantErr != nil {
+				tt.wantErr(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/grype/version/version.go
+++ b/grype/version/version.go
@@ -7,6 +7,10 @@ import (
 	"github.com/anchore/syft/syft/cpe"
 )
 
+// ErrUnsupportedVersion is returned when a version string cannot be parsed into a rich version object
+// for a known unsupported case (e.g. golang "devel" version).
+var ErrUnsupportedVersion = fmt.Errorf("unsupported version value")
+
 type Version struct {
 	Raw    string
 	Format Format


### PR DESCRIPTION
Today when you are matching against a golang package with a devel version, you see this warning:
```
[0000]  WARN could not match by package language (package=Pkg(type=go-module, name=./staging/src/k8s.io/api, version=(devel), upstreams=0)): matcher failed to parse version pkg="./staging/src/k8s.io/api" ver="(devel)": Malformed version: (devel)
```

However, this case is quite common, and there is nothing the user can do about this so we should not be showing this warning.

This PR makes the following changes:
- an explicit error case that other version constructors can use in the future
- changes this to a trace log
