### PR TITLE
use "path/filepath" to build file path

### DIFF
--- a/internal/format/writer.go
+++ b/internal/format/writer.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -138,7 +138,7 @@ func newMultiWriter(options ...scanResultWriterDescription) (_ *scanResultMultiW
 			})
 		default:
 			// create any missing subdirectories
-			dir := path.Dir(option.Path)
+			dir := filepath.Dir(option.Path)
 			if dir != "" {
 				s, err := os.Stat(dir)
 				if err != nil {


### PR DESCRIPTION
I found `path.Dir()` which looks misuse.

package ["path"](https://pkg.go.dev/path) suggests:
> The path package should only be used for paths separated by forward slashes, such as the paths in URLs. This package does not deal with Windows paths with drive letters or backslashes; to manipulate operating system paths, use the [path/filepath](https://pkg.go.dev/path/filepath) package.

NOTE: I found this just scanning project statically. I haven't reproduced "real" problem. Even I don't have Windows environment.

This line looks to be covered by existing test.
https://github.com/anchore/grype/blob/548da9e7cb723816aea0740ff5f56dcf3a5a074f/internal/format/writer_test.go#L173-L178