### PR TITLE
fix: enable http timeout

### DIFF
--- a/cmd/grype/cli/options/database.go
+++ b/cmd/grype/cli/options/database.go
@@ -12,14 +12,22 @@ import (
 )
 
 type Database struct {
-	Dir                   string        `yaml:"cache-dir" json:"cache-dir" mapstructure:"cache-dir"`
-	UpdateURL             string        `yaml:"update-url" json:"update-url" mapstructure:"update-url"`
-	CACert                string        `yaml:"ca-cert" json:"ca-cert" mapstructure:"ca-cert"`
-	AutoUpdate            bool          `yaml:"auto-update" json:"auto-update" mapstructure:"auto-update"`
-	ValidateByHashOnStart bool          `yaml:"validate-by-hash-on-start" json:"validate-by-hash-on-start" mapstructure:"validate-by-hash-on-start"`
-	ValidateAge           bool          `yaml:"validate-age" json:"validate-age" mapstructure:"validate-age"`
-	MaxAllowedBuiltAge    time.Duration `yaml:"max-allowed-built-age" json:"max-allowed-built-age" mapstructure:"max-allowed-built-age"`
+	Dir                    string        `yaml:"cache-dir" json:"cache-dir" mapstructure:"cache-dir"`
+	UpdateURL              string        `yaml:"update-url" json:"update-url" mapstructure:"update-url"`
+	CACert                 string        `yaml:"ca-cert" json:"ca-cert" mapstructure:"ca-cert"`
+	AutoUpdate             bool          `yaml:"auto-update" json:"auto-update" mapstructure:"auto-update"`
+	ValidateByHashOnStart  bool          `yaml:"validate-by-hash-on-start" json:"validate-by-hash-on-start" mapstructure:"validate-by-hash-on-start"`
+	ValidateAge            bool          `yaml:"validate-age" json:"validate-age" mapstructure:"validate-age"`
+	MaxAllowedBuiltAge     time.Duration `yaml:"max-allowed-built-age" json:"max-allowed-built-age" mapstructure:"max-allowed-built-age"`
+	UpdateAvailableTimeout time.Duration `yaml:"update-available-timeout" json:"update-available-timeout" mapstructure:"update-available-timeout"`
+	UpdateDownloadTimeout  time.Duration `yaml:"update-download-timeout" json:"update-download-timeout" mapstructure:"update-download-timeout"`
 }
+
+const (
+	defaultMaxDBAge               time.Duration = time.Hour * 24 * 5
+	defaultUpdateAvailableTimeout               = time.Second * 30
+	defaultUpdateDownloadTimeout                = time.Second * 120
+)
 
 func DefaultDatabase(id clio.Identification) Database {
 	return Database{
@@ -28,7 +36,9 @@ func DefaultDatabase(id clio.Identification) Database {
 		AutoUpdate:  true,
 		ValidateAge: true,
 		// After this period (5 days) the db data is considered stale
-		MaxAllowedBuiltAge: time.Hour * 24 * 5,
+		MaxAllowedBuiltAge:     defaultMaxDBAge,
+		UpdateAvailableTimeout: defaultUpdateAvailableTimeout,
+		UpdateDownloadTimeout:  defaultUpdateDownloadTimeout,
 	}
 }
 
@@ -40,5 +50,7 @@ func (cfg Database) ToCuratorConfig() db.Config {
 		ValidateByHashOnGet: cfg.ValidateByHashOnStart,
 		ValidateAge:         cfg.ValidateAge,
 		MaxAllowedBuiltAge:  cfg.MaxAllowedBuiltAge,
+		ListingFileTimeout:  cfg.UpdateAvailableTimeout,
+		UpdateTimeout:       cfg.UpdateDownloadTimeout,
 	}
 }

--- a/grype/db/curator.go
+++ b/grype/db/curator.go
@@ -390,6 +390,7 @@ func (c Curator) ListingFromURL() (Listing, error) {
 
 func defaultHTTPClient(fs afero.Fs, caCertPath string) (*http.Client, error) {
 	httpClient := cleanhttp.DefaultClient()
+	httpClient.Timeout = 30 * time.Second
 	if caCertPath != "" {
 		rootCAs := x509.NewCertPool()
 

--- a/grype/db/curator.go
+++ b/grype/db/curator.go
@@ -37,11 +37,14 @@ type Config struct {
 	ValidateByHashOnGet bool
 	ValidateAge         bool
 	MaxAllowedBuiltAge  time.Duration
+	ListingFileTimeout  time.Duration
+	UpdateTimeout       time.Duration
 }
 
 type Curator struct {
 	fs                  afero.Fs
-	downloader          file.Getter
+	listingDownloader   file.Getter
+	updateDownloader    file.Getter
 	targetSchema        int
 	dbDir               string
 	dbPath              string
@@ -55,7 +58,14 @@ func NewCurator(cfg Config) (Curator, error) {
 	dbDir := path.Join(cfg.DBRootDir, strconv.Itoa(vulnerability.SchemaVersion))
 
 	fs := afero.NewOsFs()
-	httpClient, err := defaultHTTPClient(fs, cfg.CACert)
+	listingClient, err := defaultHTTPClient(fs, cfg.CACert)
+	listingClient.Timeout = cfg.ListingFileTimeout
+	if err != nil {
+		return Curator{}, err
+	}
+
+	dbClient, err := defaultHTTPClient(fs, cfg.CACert)
+	dbClient.Timeout = cfg.UpdateTimeout
 	if err != nil {
 		return Curator{}, err
 	}
@@ -63,7 +73,8 @@ func NewCurator(cfg Config) (Curator, error) {
 	return Curator{
 		fs:                  fs,
 		targetSchema:        vulnerability.SchemaVersion,
-		downloader:          file.NewGetter(httpClient),
+		listingDownloader:   file.NewGetter(listingClient),
+		updateDownloader:    file.NewGetter(dbClient),
 		dbDir:               dbDir,
 		dbPath:              path.Join(dbDir, FileName),
 		listingURL:          cfg.ListingURL,
@@ -283,7 +294,7 @@ func (c *Curator) download(listing *ListingEntry, downloadProgress *progress.Man
 	url.RawQuery = query.Encode()
 
 	// go-getter will automatically extract all files within the archive to the temp dir
-	err = c.downloader.GetToDir(tempDir, listing.URL.String(), downloadProgress)
+	err = c.updateDownloader.GetToDir(tempDir, listing.URL.String(), downloadProgress)
 	if err != nil {
 		return "", fmt.Errorf("unable to download db: %w", err)
 	}
@@ -375,7 +386,7 @@ func (c Curator) ListingFromURL() (Listing, error) {
 	}()
 
 	// download the listing file
-	err = c.downloader.GetFile(tempFile.Name(), c.listingURL)
+	err = c.listingDownloader.GetFile(tempFile.Name(), c.listingURL)
 	if err != nil {
 		return Listing{}, fmt.Errorf("unable to download listing: %w", err)
 	}

--- a/grype/db/curator.go
+++ b/grype/db/curator.go
@@ -59,16 +59,16 @@ func NewCurator(cfg Config) (Curator, error) {
 
 	fs := afero.NewOsFs()
 	listingClient, err := defaultHTTPClient(fs, cfg.CACert)
-	listingClient.Timeout = cfg.ListingFileTimeout
 	if err != nil {
 		return Curator{}, err
 	}
+	listingClient.Timeout = cfg.ListingFileTimeout
 
 	dbClient, err := defaultHTTPClient(fs, cfg.CACert)
-	dbClient.Timeout = cfg.UpdateTimeout
 	if err != nil {
 		return Curator{}, err
 	}
+	dbClient.Timeout = cfg.UpdateTimeout
 
 	return Curator{
 		fs:                  fs,

--- a/grype/db/curator_test.go
+++ b/grype/db/curator_test.go
@@ -74,7 +74,7 @@ func newTestCurator(tb testing.TB, fs afero.Fs, getter file.Getter, dbDir, metad
 	return c
 }
 
-func Test_defaultHTTPClient(t *testing.T) {
+func Test_defaultHTTPClientHasCert(t *testing.T) {
 	tests := []struct {
 		name    string
 		hasCert bool
@@ -105,9 +105,14 @@ func Test_defaultHTTPClient(t *testing.T) {
 			} else {
 				assert.Nil(t, httpClient.Transport.(*http.Transport).TLSClientConfig)
 			}
-
 		})
 	}
+}
+
+func Test_defaultHTTPClientTimeout(t *testing.T) {
+	c, err := defaultHTTPClient(afero.NewMemMapFs(), "")
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Second, c.Timeout)
 }
 
 func generateCertFixture(t *testing.T) string {

--- a/grype/db/curator_test.go
+++ b/grype/db/curator_test.go
@@ -68,7 +68,8 @@ func newTestCurator(tb testing.TB, fs afero.Fs, getter file.Getter, dbDir, metad
 
 	require.NoError(tb, err)
 
-	c.downloader = getter
+	c.listingDownloader = getter
+	c.updateDownloader = getter
 	c.fs = fs
 
 	return c


### PR DESCRIPTION
Otherwise grype db commands can hang if the CDN is having issues.

Related to https://github.com/anchore/grype/issues/1731

## Some notes

We don't want commands like `grype db update` to hang indefinitely, and we certain don't want `grype <some-source>` to hang indefinitely.

Grype is already intended to continue on error if db updates are not available: https://github.com/anchore/grype/blob/fix%2Foverall-http-timeout/grype/db/curator.go#L142, so after this change, a timeout error when checking for update or downloading the database will result in a logged warning.

30 seconds overall timeout seems be reasonable. The compressed grype db as of this writing is ~152MB .tar.gz file when downloaded. I've done a few `time curl -o /dev/null "${DB_URL}"` for grype dbs published on different days, and the highest I've seen is about 8 seconds.

## Questions

1. Do we want to expose the timeout as a config variable?
2. Do we want to use separate timeouts for downloading listing.json (small JSON doc) vs database (much larger tar.gz), maybe making a shorter timeout for the listing.json and a longer timeout for the database?

## Manual testing done:

With this change:
```
( run a server on localhost:5000 that accepts connections but never replies)
$ GRYPE_DB_UPDATE_URL=http://localhost:5000/listing.json go run cmd/grype/main.go alpine:latest
[0000]  INFO grype version: [not provided]
[0060]  WARN unable to check for vulnerability database update << prints warning about failed update, but continues
[0060]  INFO found 12 vulnerability matches across 15 packages
NAME           INSTALLED   FIXED-IN  TYPE  VULNERABILITY   SEVERITY
busybox        1.36.1-r15            apk   CVE-2023-42366  Medium
busybox        1.36.1-r15            apk   CVE-2023-42365  Medium
busybox        1.36.1-r15            apk   CVE-2023-42364  Medium
... snip ...
```