### PR TITLE
fix: use Go main module version when possible

### DIFF
--- a/grype/matcher/golang/matcher.go
+++ b/grype/matcher/golang/matcher.go
@@ -42,11 +42,14 @@ func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Pa
 		mainModule = m.MainModule
 	}
 
-	// Golang currently does not have a standard way of incorporating the vcs version
-	// into the compiled binary: https://github.com/golang/go/issues/50603
-	// current version information for the main module is incomplete leading to multiple FP
-	// TODO: remove this exclusion when vcs information is included in future go version
-	isNotCorrected := strings.HasPrefix(p.Version, "v0.0.0-") || strings.HasPrefix(p.Version, "(devel)")
+	// Golang currently does not have a standard way of incorporating the main
+	// module's version into the compiled binary:
+	// https://github.com/golang/go/issues/50603.
+	//
+	// Syft has some fallback mechanisms to come up with a more sane version value
+	// depending on the scenario. But if none of these apply, the Go-set value of
+	// "(devel)" is used, which is altogether unhelpful for vulnerability matching.
+	isNotCorrected := strings.HasPrefix(p.Version, "(devel)")
 	if p.Name == mainModule && isNotCorrected {
 		return matches, nil
 	}

--- a/grype/matcher/golang/matcher_test.go
+++ b/grype/matcher/golang/matcher_test.go
@@ -15,7 +15,7 @@ import (
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
-func TestMatcher_DropMainPackage(t *testing.T) {
+func TestMatcher_DropMainPackageIfNoVersion(t *testing.T) {
 
 	mainModuleMetadata := pkg.GolangBinMetadata{
 		MainModule: "istio.io/istio",
@@ -43,7 +43,7 @@ func TestMatcher_DropMainPackage(t *testing.T) {
 	assert.Len(t, preTest, 1, "should have matched the package when there is not a main module")
 
 	actual, _ := matcher.Match(store, nil, subjectWithMainModule)
-	assert.Len(t, actual, 0, "unexpected match count; should not match main module")
+	assert.Len(t, actual, 1, "should match the main module (i.e. 1 match)")
 
 	actual, _ = matcher.Match(store, nil, subjectWithMainModuleAsDevel)
 	assert.Len(t, actual, 0, "unexpected match count; should not match main module (devel)")
@@ -174,13 +174,13 @@ type mockProvider struct {
 }
 
 func (mp *mockProvider) Get(id, namespace string) ([]vulnerability.Vulnerability, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (mp *mockProvider) populateData() {
 	mp.data[syftPkg.Go] = map[string][]vulnerability.Vulnerability{
-		// for TestMatcher_DropMainPackage
+		// for TestMatcher_DropMainPackageIfNoVersion
 		"istio.io/istio": {
 			{
 				Constraint: version.MustGetConstraint("< 5.0.7", version.UnknownFormat),

--- a/grype/version/golang_version_test.go
+++ b/grype/version/golang_version_test.go
@@ -132,6 +132,18 @@ func TestCompareGolangVersions(t *testing.T) {
 			want:         1,
 		},
 		{
+			name:         "pseudoversion less than other pseudoversion",
+			thisVersion:  "v0.0.0-20170116102854-1ef0e047d5a7",
+			otherVersion: "v0.0.0-20180116102854-5a71ef0e047d",
+			want:         -1,
+		},
+		{
+			name:         "pseudoversion greater than other pseudoversion",
+			thisVersion:  "v0.0.0-20190116102854-8a3f0e047d5a",
+			otherVersion: "v0.0.0-20180116102854-5a71ef0e047d",
+			want:         1,
+		},
+		{
 			name:         "+incompatible doesn't break equality",
 			thisVersion:  "v3.2.0",
 			otherVersion: "v3.2.0+incompatible",


### PR DESCRIPTION
Previously, if Grype saw a Go binary's main module package version was set to a string prefixed by `v0.0.0-`, it would **avoid any kind of vulnerability matching** for that package.

Meanwhile, Syft makes [several reasonable attempts](https://github.com/anchore/syft/blob/main/syft/pkg/cataloger/golang/parse_go_binary.go#L132-L149) to find a sane version to use as this main module's version. In the case of VCS information being embedded in the Go binary, Syft has enough information to produce a Go pseudoversion.

The "no vulnerability matching at all" approach may have been to avoid some false positive edge cases, or it may have predated some of the enhancements to Syft's version computation. But in any case, we were seeing this behavior result in false negatives, because many Go projects produce Go binaries (and are thus the main module for that binary), and when Syft can compute a pseudoversion from VCS data, and these projects have GHSAs filed for them using pseudoversions (e.g. GHSA-xx8w-mq23-29g4), Grype was missing these matches 100% of the time.

To be upfront, I do expect this change to yield an increase in false positives. But I expect this change to yield a _much bigger_ decrease in false negatives. If I understand the current Grype philosophy, distros with "comprehensive feeds" aren't even subject to this kind of matching, so it's really just the distros that are left (Wolfi, Chainguard, and Alpine), and then non-distro Go binaries where the developer is likely in much more control of the version information embedded in the binary.

For context, this change was discussed in advance in Anchore's community slack with @kzantow. ([thread link](https://anchorecommunity.slack.com/archives/C027JE5M345/p1712697730521309))

Let me know if I can answer any questions!