### PR TITLE
fix: add linux and libc-dev headers ignore rules for debian packages

### DIFF
--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -100,7 +100,9 @@ var ignoreVEXFixedNotAffected = []match.IgnoreRule{
 }
 
 var ignoreLinuxKernelHeaders = []match.IgnoreRule{
-	{Package: match.IgnoreRulePackage{Name: "kernel-headers", UpstreamName: "kernel", Type: "rpm"}, MatchType: match.ExactIndirectMatch},
+	{Package: match.IgnoreRulePackage{Name: "kernel-headers", UpstreamName: "kernel", Type: string(syftPkg.RpmPkg)}, MatchType: match.ExactIndirectMatch},
+	{Package: match.IgnoreRulePackage{Name: "linux-headers-.*", UpstreamName: "linux", Type: string(syftPkg.DebPkg)}, MatchType: match.ExactIndirectMatch},
+	{Package: match.IgnoreRulePackage{Name: "linux-libc-dev", UpstreamName: "linux", Type: string(syftPkg.DebPkg)}, MatchType: match.ExactIndirectMatch},
 }
 
 //nolint:funlen

--- a/grype/match/ignore.go
+++ b/grype/match/ignore.go
@@ -1,6 +1,8 @@
 package match
 
 import (
+	"regexp"
+
 	"github.com/bmatcuk/doublestar/v2"
 )
 
@@ -167,9 +169,22 @@ func ifNamespaceApplies(namespace string) ignoreCondition {
 	}
 }
 
+func packageNameRegex(packageName string) (*regexp.Regexp, error) {
+	pattern := packageName
+	if packageName[0] != '$' || packageName[len(packageName)-1] != '^' {
+		pattern = "^" + packageName + "$"
+	}
+	return regexp.Compile(pattern)
+}
+
 func ifPackageNameApplies(name string) ignoreCondition {
+	pattern, err := packageNameRegex(name)
+	if err != nil {
+		return func(Match) bool { return false }
+	}
+
 	return func(match Match) bool {
-		return name == match.Package.Name
+		return pattern.MatchString(match.Package.Name)
 	}
 }
 

--- a/grype/match/ignore_test.go
+++ b/grype/match/ignore_test.go
@@ -594,6 +594,82 @@ func TestApplyIgnoreRules(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "ignore on name regex",
+			allMatches: kernelHeadersMatches,
+			ignoreRules: []IgnoreRule{
+				{
+					Package: IgnoreRulePackage{
+						Name: "kernel-headers.*",
+					},
+				},
+			},
+			expectedRemainingMatches: []Match{
+				kernelHeadersMatches[1],
+			},
+			expectedIgnoredMatches: []IgnoredMatch{
+				{
+					Match: kernelHeadersMatches[0],
+					AppliedIgnoreRules: []IgnoreRule{
+						{
+							Package: IgnoreRulePackage{
+								Name: "kernel-headers.*",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "ignore on name regex, no matches",
+			allMatches: kernelHeadersMatches,
+			ignoreRules: []IgnoreRule{
+				{
+					Package: IgnoreRulePackage{
+						Name: "foo.*",
+					},
+				},
+			},
+			expectedRemainingMatches: kernelHeadersMatches,
+			expectedIgnoredMatches:   nil,
+		},
+		{
+			name:       "ignore on name regex, line termination verification",
+			allMatches: kernelHeadersMatches,
+			ignoreRules: []IgnoreRule{
+				{
+					Package: IgnoreRulePackage{
+						Name: "^kernel-header$",
+					},
+				},
+			},
+			expectedRemainingMatches: kernelHeadersMatches,
+			expectedIgnoredMatches:   nil,
+		},
+		{
+			name:       "ignore on name regex, line termination test match",
+			allMatches: kernelHeadersMatches,
+			ignoreRules: []IgnoreRule{
+				{
+					Package: IgnoreRulePackage{
+						Name: "^kernel-headers$",
+					},
+				},
+			},
+			expectedRemainingMatches: []Match{kernelHeadersMatches[1]},
+			expectedIgnoredMatches: []IgnoredMatch{
+				{
+					Match: kernelHeadersMatches[0],
+					AppliedIgnoreRules: []IgnoreRule{
+						{
+							Package: IgnoreRulePackage{
+								Name: "^kernel-headers$",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range cases {


### PR DESCRIPTION
Follow up on #1787 for debian packages, not just rpms.

Adds ignore rules for indirect matches on "linux" upstream package if the binary package is the linux-headers-* or linux-libc-dev packages since those are just headers files not the code that has the linux source that is vulnerable.