### PR TITLE
WIP: narrow golang match comparison for pseudo versions

### DIFF
--- a/grype/matcher/golang/matcher_test.go
+++ b/grype/matcher/golang/matcher_test.go
@@ -183,7 +183,7 @@ func (mp *mockProvider) populateData() {
 		// for TestMatcher_DropMainPackageIfNoVersion
 		"istio.io/istio": {
 			{
-				Constraint: version.MustGetConstraint("< 5.0.7", version.UnknownFormat),
+				Constraint: version.MustGetConstraint("< v0.0.0-20230606222826-f59ce19ec6b6", version.UnknownFormat),
 				ID:         "CVE-2013-fake-BAD",
 			},
 		},

--- a/grype/search/only_qualified_packages.go
+++ b/grype/search/only_qualified_packages.go
@@ -16,7 +16,6 @@ func onlyQualifiedPackages(d *distro.Distro, p pkg.Package, allVulns []vulnerabi
 
 		for _, q := range vuln.PackageQualifiers {
 			v, err := q.Satisfied(d, p)
-
 			if err != nil {
 				return nil, fmt.Errorf("failed to check package qualifier=%q for distro=%q package=%q: %w", q, d, p, err)
 			}

--- a/grype/version/golang_constraint.go
+++ b/grype/version/golang_constraint.go
@@ -56,14 +56,14 @@ func (g golangConstraint) Satisfied(version *Version) (bool, error) {
 }
 
 // PseudoVersionPattern is a regular expression pattern to match pseudo versions
-const PseudoVersionPattern = `^v0\.0\.0[-+].*$`
+const pseudoVersionPattern = `^v0\.0\.0[-+].*$`
+
+var pseudoVersionRegex = regexp.MustCompile(pseudoVersionPattern)
 
 // Check if a version string is a pseudo version
 func isPseudoVersion(version string) bool {
 	// List of prefixes commonly used for pseudo versions
-	regex := regexp.MustCompile(PseudoVersionPattern)
-
-	return regex.MatchString(strings.TrimSpace(version))
+	return pseudoVersionRegex.MatchString(strings.TrimSpace(version))
 }
 
 func newGolangComparator(unit constraintUnit) (Comparator, error) {

--- a/grype/version/golang_constraint_test.go
+++ b/grype/version/golang_constraint_test.go
@@ -38,6 +38,19 @@ func TestGolangConstraints(t *testing.T) {
 			constraint: "",
 			satisfied:  true,
 		},
+		{
+			name:       "pseudo version from package should not be considered as satisfied against semver constraint",
+			version:    "v0.0.0-0.20210101000000-abcdef123456",
+			constraint: "<v1.0.0",
+			satisfied:  false,
+		},
+		// https://github.com/anchore/grype/pull/1797
+		{
+			name:       "pseudo version from package should be considered as satisfied against pseudo version constraint",
+			version:    "0.0.0-20230131185645-0ae4915a9391",
+			constraint: "< 0.0.0-20240131185645-0ae4915a9391",
+			satisfied:  true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

This PR attempts to narrow the golang_constraint `Satisfied` logic as a follow up to #1797

#1797 allows grype to proceed with matches when it encounters a package with a `pseudo version`. This PR limits those pseudo versions to only be compared against constraints that also contain pseudo versions.

This eliminates a case of FP where an incomplete `pseudo version` (which doesn't have the correct main module information) is compared against a valid semver constraint.

Example of this FP:
```
syft -o json ollama/ollama:0.1.32 | go run cmd/grype/main.go

...

github.com/ollama/ollama    v0.0.0-20240414223325-7027f264fbb3  0.1.29             go-module  GHSA-5jx5-hqx5-2vrj  High
```

In the above case `v0.0.0-20240414223325-7027f264fbb3` is not < `0.1.29`. Syft is unable to determine the main module version for ollama. By comparing the incomplete pseudo version to the semver constraint grype produces a FP.

This PR makes it so that packages with versions like `v0.0.0-20240414223325-7027f264fbb3` should only be compared to constraints that also have a similar format.