### PR TITLE
revert: "fix: use Go main module version when possible"

### DIFF
--- a/grype/matcher/golang/matcher.go
+++ b/grype/matcher/golang/matcher.go
@@ -42,14 +42,11 @@ func (m *Matcher) Match(store vulnerability.Provider, d *distro.Distro, p pkg.Pa
 		mainModule = m.MainModule
 	}
 
-	// Golang currently does not have a standard way of incorporating the main
-	// module's version into the compiled binary:
-	// https://github.com/golang/go/issues/50603.
-	//
-	// Syft has some fallback mechanisms to come up with a more sane version value
-	// depending on the scenario. But if none of these apply, the Go-set value of
-	// "(devel)" is used, which is altogether unhelpful for vulnerability matching.
-	isNotCorrected := strings.HasPrefix(p.Version, "(devel)")
+	// Golang currently does not have a standard way of incorporating the vcs version
+	// into the compiled binary: https://github.com/golang/go/issues/50603
+	// current version information for the main module is incomplete leading to multiple FP
+	// TODO: remove this exclusion when vcs information is included in future go version
+	isNotCorrected := strings.HasPrefix(p.Version, "v0.0.0-") || strings.HasPrefix(p.Version, "(devel)")
 	if p.Name == mainModule && isNotCorrected {
 		return matches, nil
 	}

--- a/grype/matcher/golang/matcher_test.go
+++ b/grype/matcher/golang/matcher_test.go
@@ -15,7 +15,7 @@ import (
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
-func TestMatcher_DropMainPackageIfNoVersion(t *testing.T) {
+func TestMatcher_DropMainPackage(t *testing.T) {
 
 	mainModuleMetadata := pkg.GolangBinMetadata{
 		MainModule: "istio.io/istio",
@@ -43,7 +43,7 @@ func TestMatcher_DropMainPackageIfNoVersion(t *testing.T) {
 	assert.Len(t, preTest, 1, "should have matched the package when there is not a main module")
 
 	actual, _ := matcher.Match(store, nil, subjectWithMainModule)
-	assert.Len(t, actual, 1, "should match the main module (i.e. 1 match)")
+	assert.Len(t, actual, 0, "unexpected match count; should not match main module")
 
 	actual, _ = matcher.Match(store, nil, subjectWithMainModuleAsDevel)
 	assert.Len(t, actual, 0, "unexpected match count; should not match main module (devel)")
@@ -174,13 +174,13 @@ type mockProvider struct {
 }
 
 func (mp *mockProvider) Get(id, namespace string) ([]vulnerability.Vulnerability, error) {
-	// TODO implement me
+	//TODO implement me
 	panic("implement me")
 }
 
 func (mp *mockProvider) populateData() {
 	mp.data[syftPkg.Go] = map[string][]vulnerability.Vulnerability{
-		// for TestMatcher_DropMainPackageIfNoVersion
+		// for TestMatcher_DropMainPackage
 		"istio.io/istio": {
 			{
 				Constraint: version.MustGetConstraint("< 5.0.7", version.UnknownFormat),

--- a/grype/version/golang_version_test.go
+++ b/grype/version/golang_version_test.go
@@ -132,18 +132,6 @@ func TestCompareGolangVersions(t *testing.T) {
 			want:         1,
 		},
 		{
-			name:         "pseudoversion less than other pseudoversion",
-			thisVersion:  "v0.0.0-20170116102854-1ef0e047d5a7",
-			otherVersion: "v0.0.0-20180116102854-5a71ef0e047d",
-			want:         -1,
-		},
-		{
-			name:         "pseudoversion greater than other pseudoversion",
-			thisVersion:  "v0.0.0-20190116102854-8a3f0e047d5a",
-			otherVersion: "v0.0.0-20180116102854-5a71ef0e047d",
-			want:         1,
-		},
-		{
 			name:         "+incompatible doesn't break equality",
 			thisVersion:  "v3.2.0",
 			otherVersion: "v3.2.0+incompatible",


### PR DESCRIPTION
Reverts anchore/grype#1797

We still plan to move forward with this change, but the main branch of grype should be released today with the following fixes:
- https://github.com/anchore/grype/pull/1809
- https://github.com/anchore/grype/pull/1787

The FP impact for this change was greater than expected. We're working on a resolution in: https://github.com/anchore/grype/pull/1810

This requires a bit more code re architecture on the matchers than time will permit before going into another release.