### PR TITLE
config: add config opt in golang pseudo version main module comparison 

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,6 +838,7 @@ match:
     using-cpes: false
     # even if CPE matching is disabled, make an exception when scanning for "stdlib".
     always-use-cpe-for-stdlib: true
+    allow-main-module-pseudo-version-comparison: true
   stock:
     using-cpes: true
 ```

--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -291,8 +291,9 @@ func getMatchers(opts *options.Grype) []matcher.Matcher {
 			Dotnet:     dotnet.MatcherConfig(opts.Match.Dotnet),
 			Javascript: javascript.MatcherConfig(opts.Match.Javascript),
 			Golang: golang.MatcherConfig{
-				UseCPEs:               opts.Match.Golang.UseCPEs,
-				AlwaysUseCPEForStdlib: opts.Match.Golang.AlwaysUseCPEForStdlib,
+				UseCPEs:                                opts.Match.Golang.UseCPEs,
+				AlwaysUseCPEForStdlib:                  opts.Match.Golang.AlwaysUseCPEForStdlib,
+				AllowMainModulePseudoVersionComparison: opts.Match.Golang.AllowMainModulePseudoVersionComparison,
 			},
 			Stock: stock.MatcherConfig(opts.Match.Stock),
 		},

--- a/cmd/grype/cli/options/match.go
+++ b/cmd/grype/cli/options/match.go
@@ -17,8 +17,9 @@ type matcherConfig struct {
 }
 
 type golangConfig struct {
-	matcherConfig         `yaml:",inline" mapstructure:",squash"`
-	AlwaysUseCPEForStdlib bool `yaml:"always-use-cpe-for-stdlib" json:"always-use-cpe-for-stdlib" mapstructure:"always-use-cpe-for-stdlib"` // if CPEs should be used during matching
+	matcherConfig                          `yaml:",inline" mapstructure:",squash"`
+	AlwaysUseCPEForStdlib                  bool `yaml:"always-use-cpe-for-stdlib" json:"always-use-cpe-for-stdlib" mapstructure:"always-use-cpe-for-stdlib"`                                                       // if CPEs should be used during matching
+	AllowMainModulePseudoVersionComparison bool `yaml:"allow-main-module-pseudo-version-comparison" json:"allow-main-module-pseudo-version-comparison" mapstructure:"allow-main-module-pseudo-version-comparison"` // if pseudo versions should be compared
 }
 
 func defaultGolangConfig() golangConfig {
@@ -26,7 +27,8 @@ func defaultGolangConfig() golangConfig {
 		matcherConfig: matcherConfig{
 			UseCPEs: false,
 		},
-		AlwaysUseCPEForStdlib: true,
+		AlwaysUseCPEForStdlib:                  true,
+		AllowMainModulePseudoVersionComparison: true,
 	}
 }
 

--- a/grype/matcher/golang/matcher_test.go
+++ b/grype/matcher/golang/matcher_test.go
@@ -36,7 +36,9 @@ func TestMatcher_DropMainPackageIfNoVersion(t *testing.T) {
 	subjectWithMainModuleAsDevel := subjectWithMainModule
 	subjectWithMainModuleAsDevel.Version = "(devel)"
 
-	matcher := NewGolangMatcher(MatcherConfig{})
+	matcher := NewGolangMatcher(MatcherConfig{
+		AllowMainModulePseudoVersionComparison: true,
+	})
 	store := newMockProvider()
 
 	preTest, _ := matcher.Match(store, nil, subjectWithoutMainModule)


### PR DESCRIPTION
## Summary

Add a new config option for grype to NOT allow module comparison when there is a pseudo version and main module.

The default for this value is `true`, but users have the option to disable in case FP introductions are too high.

### Config Additions
```
match:
  golang:
    using-cpes: false
    # even if CPE matching is disabled, make an exception when scanning for "stdlib".
    always-use-cpe-for-stdlib: true
    allow-main-module-pseudo-version-comparison: true
```

### Env Variable Addition:
```
GRYPE_MATCH_GOLANG_ALLOW_MAIN_MODULE_PSEUDO_VERSION_COMPARISON
```

### Testing on your local
```
export GRYPE_MATCH_GOLANG_ALLOW_MAIN_MODULE_PSEUDO_VERSION_COMPARISON=true
syft -o json ollama/ollama:0.1.32 | go run cmd/grype/main.go

------

github.com/ollama/ollama    v0.0.0-20240414223325-7027f264fbb3  0.1.29             go-module  GHSA-5jx5-hqx5-2vrj  High
```

```
export GRYPE_MATCH_GOLANG_ALLOW_MAIN_MODULE_PSEUDO_VERSION_COMPARISON=false
syft -o json ollama/ollama:0.1.32 | go run cmd/grype/main.go

------

NO RESULT
```