### PR TITLE
docs: update README with newer data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,14 +491,16 @@ When Grype performs a scan for vulnerabilities, it does so using a vulnerability
 
 - Alpine Linux SecDB: https://secdb.alpinelinux.org/
 - Amazon Linux ALAS: https://alas.aws.amazon.com/AL2/alas.rss
-- RedHat RHSAs: https://www.redhat.com/security/data/oval/
+- Chainguard SecDB: https://packages.cgr.dev/chainguard/security.json
 - Debian Linux CVE Tracker: https://security-tracker.debian.org/tracker/data/json
-- Github GHSAs: https://github.com/advisories
+- GitHub Security Advisories (GHSAs): https://github.com/advisories
 - National Vulnerability Database (NVD): https://nvd.nist.gov/vuln/data-feeds
 - Oracle Linux OVAL: https://linux.oracle.com/security/oval/
 - RedHat Linux Security Data: https://access.redhat.com/hydra/rest/securitydata/
-- Suse Linux OVAL: https://ftp.suse.com/pub/projects/security/oval/
+- RedHat RHSAs: https://www.redhat.com/security/data/oval/
+- SUSE Linux OVAL: https://ftp.suse.com/pub/projects/security/oval/
 - Ubuntu Linux Security: https://people.canonical.com/~ubuntu-security/
+- Wolfi SecDB: https://packages.wolfi.dev/os/security.json
 
 By default, Grype automatically manages this database for you. Grype checks for new updates to the vulnerability database to make sure that every scan uses up-to-date vulnerability information. This behavior is configurable. For more information, see the [Managing Grype's database](#managing-grypes-database) section.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ For commercial support options with Syft or Grype, please [contact Anchore](http
   - Oracle Linux
   - Red Hat (RHEL)
   - Ubuntu
+  - Wolfi
 - Find vulnerabilities for language-specific packages:
   - Ruby (Gems)
   - Java (JAR, WAR, EAR, JPI, HPI)


### PR DESCRIPTION
- Adds data sources added since this list was last updated: Chainguard and Wolfi SecDBs
- Minor alphabetizing and case corrections