### PR TITLE
fix: update grype version in ac tests to support darwin arm64

### DIFF
--- a/test/install/Makefile
+++ b/test/install/Makefile
@@ -14,7 +14,8 @@ UNIT=make unit-local
 # release)
 ACCEPTANCE_CMD=sh -c '../../install.sh -b /usr/local/bin  && grype version'
 # we also want to test against a previous release to ensure that install.sh defers execution to a former install.sh
-PREVIOUS_RELEASE=v0.24.0
+# this version should be at least as recent as when grype was publishing for darwin arm64 as that is what the github runner uses for osx validation
+PREVIOUS_RELEASE=v0.60.0
 ACCEPTANCE_PREVIOUS_RELEASE_CMD=sh -c "../../install.sh -b /usr/local/bin $(PREVIOUS_RELEASE) && grype version"
 
 # CI cache busting values; change these if you want CI to not use previous stored cache


### PR DESCRIPTION
## Summary

Github recently updated their runners for osx to use arm64 architecture. The previous version of grype v0.24.0 did not support this release so our AC would fail. I've updated this test to an older version of grype, but one that adopts the arch used by the default GH runner.