### PR TITLE
fix: update sarif to pass microsoft validator

### DIFF
--- a/grype/presenter/sarif/presenter.go
+++ b/grype/presenter/sarif/presenter.go
@@ -230,7 +230,7 @@ func (pres *Presenter) locations(m match.Match) []*sarif.Location {
 		// so we just use a short path-compatible image name here, not the entire user input as it may include
 		// sha and/or tags which are likely to change between runs and aren't really necessary for a general
 		// path to find file where the package originated
-		physicalLocation = fmt.Sprintf("%s %s", imageShortPathName(pres.src), physicalLocation)
+		physicalLocation = fmt.Sprintf("%s/%s", imageShortPathName(pres.src), physicalLocation)
 	case source.FileMetadata:
 		locations := m.Package.Locations.ToSlice()
 		for _, l := range locations {

--- a/grype/presenter/sarif/test-fixtures/snapshot/TestSarifPresenter_image.golden
+++ b/grype/presenter/sarif/test-fixtures/snapshot/TestSarifPresenter_image.golden
@@ -58,7 +58,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "user-input somefile-1.txt"
+                  "uri": "user-input/somefile-1.txt"
                 },
                 "region": {
                   "startLine": 1,
@@ -88,7 +88,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "user-input somefile-2.txt"
+                  "uri": "user-input/somefile-2.txt"
                 },
                 "region": {
                   "startLine": 1,


### PR DESCRIPTION
This PR adjusts the SARIF output to pass the Microsoft JS validator and adds a validation step to the unit tests.

Fixes: #1833 