### PR TITLE
fix: ask catalog for package, rather than type asserting

### DIFF
--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -113,6 +113,11 @@ func removePackagesByOverlap(catalog *pkg.Collection, relationships []artifact.R
 			if ok && excludePackage(comprehensiveDistroFeed, p, from) {
 				continue
 			}
+
+			fromPtr, ok := r.From.(*pkg.Package)
+			if ok && excludePackage(comprehensiveDistroFeed, p, *fromPtr) {
+				continue
+			}
 		}
 		out.Add(p)
 	}

--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -109,13 +109,8 @@ func removePackagesByOverlap(catalog *pkg.Collection, relationships []artifact.R
 	for p := range catalog.Enumerate() {
 		r, ok := byOverlap[p.ID()]
 		if ok {
-			from, ok := r.From.(pkg.Package)
-			if ok && excludePackage(comprehensiveDistroFeed, p, from) {
-				continue
-			}
-
-			fromPtr, ok := r.From.(*pkg.Package)
-			if ok && excludePackage(comprehensiveDistroFeed, p, *fromPtr) {
+			from := catalog.Package(r.From.ID())
+			if from != nil && excludePackage(comprehensiveDistroFeed, p, *from) {
 				continue
 			}
 		}

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -874,7 +874,7 @@ func catalogWithOverlaps(packages []string, overlaps []string) *sbom.SBOM {
 		pkgs = append(pkgs, p)
 	}
 
-	for _, overlap := range overlaps {
+	for i, overlap := range overlaps {
 		parts := strings.Split(overlap, "->")
 		if len(parts) < 2 {
 			panic("invalid overlap, use -> to specify, e.g.: pkg1->pkg2")
@@ -882,11 +882,24 @@ func catalogWithOverlaps(packages []string, overlaps []string) *sbom.SBOM {
 		from := toPkg(parts[0])
 		to := toPkg(parts[1])
 
-		relationships = append(relationships, artifact.Relationship{
-			From: &from,
-			To:   &to,
-			Type: artifact.OwnershipByFileOverlapRelationship,
-		})
+		// The catalog will type check whether To or From is a pkg.Package or a *pkg.Package.
+		// Previously, there was a bug where Grype assumed that From was always a pkg.Package.
+		// Therefore, intentionally mix pointer and non-pointer packages to prevent Grype from
+		// assuming which is which again. (The correct usage, calling catalog.Package, always
+		// returns a *pkg.Package, and doesn't rely on any type assertion.)
+		if i%2 == 0 {
+			relationships = append(relationships, artifact.Relationship{
+				From: &from,
+				To:   &to,
+				Type: artifact.OwnershipByFileOverlapRelationship,
+			})
+		} else {
+			relationships = append(relationships, artifact.Relationship{
+				From: from,
+				To:   to,
+				Type: artifact.OwnershipByFileOverlapRelationship,
+			})
+		}
 	}
 
 	catalog := syftPkg.NewCollection(pkgs...)

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -883,8 +883,8 @@ func catalogWithOverlaps(packages []string, overlaps []string) *sbom.SBOM {
 		to := toPkg(parts[1])
 
 		relationships = append(relationships, artifact.Relationship{
-			From: from,
-			To:   to,
+			From: &from,
+			To:   &to,
 			Type: artifact.OwnershipByFileOverlapRelationship,
 		})
 	}


### PR DESCRIPTION
## TODO

- [x] tests
- [x] research fixing in Syft instead - nothing to be done; grype wasn't using Syft's API very well.

## Explanation

Basically, when we're cataloging we remove some packages by ownership overlap, (e.g. if you're on redhat and do `yum install python3-urllib`, grype will drop the PyPI package `urllib` in favor of the RPM `python3-urllib`, because we have better match information for the distro package than for PyPI, e.g. because RedHad backported a fix to an old version of the python code or something).

We do this:
``` go
   		from, ok := r.From.(pkg.Package)
		if ok && excludePackage(comprehensiveDistroFeed, p, from) {
			continue
		}
```

Which seems fine, _however_, some relationships have a From of type `*pkg.Package`, not type `pkg.Package` (pointer vs struct). This causes the type assertion in grype to _always_ fail, resulting FPs.

The underlying reason is that the syft scanner does this:

``` go
		parent := catalog.Package(parentID)
		child := catalog.Package(childID)
```

when building the relationship. And catalog.Package(id) returns a `*Package`.

However, when we're decoding an SBOM, the relationship builder looks over `catalog.Sorted()`, which is a `[]Package`.

We can compensate for this in grype by trying to type assert to both `pkg.Package` and `*pkg.Package`. I think that's the easier way, and I feel like the "right" way (making Syft either always put a pointer in the To/From field of a relationship or never do so) might end up breaking the type signature of something exported, which we wanted to avoid in 1.0. Grype PR soon, but definitely open to feedback on the approach.