### PR TITLE
chore: add top level permissions to new workflow

### DIFF
--- a/.github/workflows/release-version-file.yaml
+++ b/.github/workflows/release-version-file.yaml
@@ -1,5 +1,8 @@
 name: "Release"
 
+permissions:
+  contents: read
+
 on:
 
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Best practices for github workflows detail that top level permissions should be declarative `read`.

This PR updates the top level permissions for the `release-version-file` to `contents:read`