### PR TITLE
Disable TUI for simple commands

### DIFF
--- a/cmd/grype/cli/cli.go
+++ b/cmd/grype/cli/cli.go
@@ -79,7 +79,7 @@ func create(id clio.Identification) (clio.Application, *cobra.Command) {
 	// add sub-commands
 	rootCmd.AddCommand(
 		commands.DB(app),
-		commands.Completion(),
+		commands.Completion(app),
 		commands.Explain(app),
 		clio.VersionCommand(id, syftVersion, dbVersion),
 	)

--- a/cmd/grype/cli/commands/completion.go
+++ b/cmd/grype/cli/commands/completion.go
@@ -9,10 +9,12 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
+
+	"github.com/anchore/clio"
 )
 
 // Completion returns a command to provide completion to various terminal shells
-func Completion() *cobra.Command {
+func Completion(app clio.Application) *cobra.Command {
 	return &cobra.Command{
 		Use:   "completion [bash|zsh|fish]",
 		Short: "Generate a shell completion for Grype (listing local docker images)",
@@ -49,6 +51,7 @@ $ grype completion fish > ~/.config/fish/completions/grype.fish
 `,
 		DisableFlagsInUseLine: true,
 		ValidArgs:             []string{"bash", "fish", "zsh"},
+		PreRunE:               disableUI(app),
 		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error

--- a/cmd/grype/cli/commands/db_check.go
+++ b/cmd/grype/cli/commands/db_check.go
@@ -19,9 +19,10 @@ func DBCheck(app clio.Application) *cobra.Command {
 	opts := dbOptionsDefault(app.ID())
 
 	return app.SetupCommand(&cobra.Command{
-		Use:   "check",
-		Short: "check to see if there is a database update available",
-		Args:  cobra.ExactArgs(0),
+		Use:     "check",
+		Short:   "check to see if there is a database update available",
+		PreRunE: disableUI(app),
+		Args:    cobra.ExactArgs(0),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDBCheck(opts.DB)
 		},

--- a/cmd/grype/cli/commands/db_delete.go
+++ b/cmd/grype/cli/commands/db_delete.go
@@ -14,9 +14,10 @@ func DBDelete(app clio.Application) *cobra.Command {
 	opts := dbOptionsDefault(app.ID())
 
 	return app.SetupCommand(&cobra.Command{
-		Use:   "delete",
-		Short: "delete the vulnerability database",
-		Args:  cobra.ExactArgs(0),
+		Use:     "delete",
+		Short:   "delete the vulnerability database",
+		Args:    cobra.ExactArgs(0),
+		PreRunE: disableUI(app),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDBDelete(opts.DB)
 		},

--- a/cmd/grype/cli/commands/db_import.go
+++ b/cmd/grype/cli/commands/db_import.go
@@ -15,10 +15,11 @@ func DBImport(app clio.Application) *cobra.Command {
 	opts := dbOptionsDefault(app.ID())
 
 	return app.SetupCommand(&cobra.Command{
-		Use:   "import FILE",
-		Short: "import a vulnerability database archive",
-		Long:  fmt.Sprintf("import a vulnerability database archive from a local FILE.\nDB archives can be obtained from %q.", internal.DBUpdateURL),
-		Args:  cobra.ExactArgs(1),
+		Use:     "import FILE",
+		Short:   "import a vulnerability database archive",
+		Long:    fmt.Sprintf("import a vulnerability database archive from a local FILE.\nDB archives can be obtained from %q.", internal.DBUpdateURL),
+		Args:    cobra.ExactArgs(1),
+		PreRunE: disableUI(app),
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runDBImport(opts.DB, args[0])
 		},

--- a/cmd/grype/cli/commands/db_list.go
+++ b/cmd/grype/cli/commands/db_list.go
@@ -29,9 +29,10 @@ func DBList(app clio.Application) *cobra.Command {
 	}
 
 	return app.SetupCommand(&cobra.Command{
-		Use:   "list",
-		Short: "list all DBs available according to the listing URL",
-		Args:  cobra.ExactArgs(0),
+		Use:     "list",
+		Short:   "list all DBs available according to the listing URL",
+		PreRunE: disableUI(app),
+		Args:    cobra.ExactArgs(0),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDBList(opts)
 		},

--- a/cmd/grype/cli/commands/db_status.go
+++ b/cmd/grype/cli/commands/db_status.go
@@ -14,9 +14,10 @@ func DBStatus(app clio.Application) *cobra.Command {
 	opts := dbOptionsDefault(app.ID())
 
 	return app.SetupCommand(&cobra.Command{
-		Use:   "status",
-		Short: "display database status",
-		Args:  cobra.ExactArgs(0),
+		Use:      "status",
+		Short:    "display database status",
+		Args:     cobra.ExactArgs(0),
+		PostRunE: disableUI(app),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDBStatus(opts.DB)
 		},

--- a/cmd/grype/cli/commands/explain.go
+++ b/cmd/grype/cli/commands/explain.go
@@ -28,8 +28,9 @@ func Explain(app clio.Application) *cobra.Command {
 	opts := &explainOptions{}
 
 	return app.SetupCommand(&cobra.Command{
-		Use:   "explain --id [VULNERABILITY ID]",
-		Short: "Ask grype to explain a set of findings",
+		Use:     "explain --id [VULNERABILITY ID]",
+		Short:   "Ask grype to explain a set of findings",
+		PreRunE: disableUI(app),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			log.Warn("grype explain is a prototype feature and is subject to change")
 			isStdinPipeOrRedirect, err := internal.IsStdinPipeOrRedirect()

--- a/cmd/grype/cli/commands/util.go
+++ b/cmd/grype/cli/commands/util.go
@@ -7,8 +7,25 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
+
+	"github.com/anchore/clio"
+	"github.com/anchore/grype/cmd/grype/internal/ui"
 )
+
+func disableUI(app clio.Application) func(*cobra.Command, []string) error {
+	return func(_ *cobra.Command, _ []string) error {
+		type Stater interface {
+			State() *clio.State
+		}
+
+		state := app.(Stater).State()
+		state.UIs = []clio.UI{ui.None(state.Config.Log.Quiet)}
+
+		return nil
+	}
+}
 
 func stderrPrintLnf(message string, args ...interface{}) error {
 	if !strings.HasSuffix(message, "\n") {


### PR DESCRIPTION
We have a handful of commands that print out simple reports directly to stdout/stderr:
- `db status`
- `db check`
- `db import`
- `db list`
- `explain`
- `completion`

Without first disabling the TUI, which will put the terminal into raw mode, you may see artifacts in the terminal. This PR disables the TUI and allows for free-printing to the terminal on a per-command basis.