### PR TITLE
fix: Go main module pseudo version matching: turn off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,7 +855,8 @@ match:
     using-cpes: false
     # even if CPE matching is disabled, make an exception when scanning for "stdlib".
     always-use-cpe-for-stdlib: true
-    allow-main-module-pseudo-version-comparison: true
+    # allow main module pseudo versions, which may have only been "guessed at" by Syft, to be used in vulnerability matching
+    allow-main-module-pseudo-version-comparison: false
   stock:
     using-cpes: true
 ```

--- a/cmd/grype/cli/options/match.go
+++ b/cmd/grype/cli/options/match.go
@@ -34,7 +34,7 @@ func defaultGolangConfig() golangConfig {
 			UseCPEs: false,
 		},
 		AlwaysUseCPEForStdlib:                  true,
-		AllowMainModulePseudoVersionComparison: true,
+		AllowMainModulePseudoVersionComparison: false,
 	}
 }
 


### PR DESCRIPTION
About 6 weeks ago, I opened https://github.com/anchore/grype/pull/1797 in an effort to **reduce false negatives** for the main modules of Go binaries. Before that PR, Grype's previous behavior was to avoid vulnerability matching for the main module altogether if the detected module version was prefixed with `v0.0.0-`. Grype's reasoning for this had been that Syft will manufacture pseudo versions that start with `v0.0.0-` in the case where it's not able to find a real version in the Go binary itself.

By making the change in the PR linked above, we indeed saw some reduction in false negatives 🎉 , which was great. We weren't sure about the larger impact of false positives. I only [speculated](https://github.com/anchore/grype/pull/1797#issuecomment-2052672419) about the potential effects:

>My reason for expecting them is that I can dream up edge cases, like when the GHSA fixed version is `v3.0.1`, but the computed pseudoversion would be `v0.0.0-<some commit that's later than v3.0.1>`, and so Grype would show the main module as vulnerable when it's not.

**The bad news:** After seeing this change released and used on a broader set of images, it looks like this net effect is that Grype's F1 score is **worsened** considerably more than we anticipated. We've been able to recover some recall, but at a painful hit to precision.

**The good news:** I saw that after my original PR was merged, @spiffcs opened https://github.com/anchore/grype/pull/1816, which made this new behavior **configurable** and defaulted to on. IMHO, that was brilliant, and in hindsight I probably should've added that in my original PR, too. 😞 

At scale, this now-configurable behavior is working very much like CPE matching: it's great for scenarios where the user is willing to pay a high FP cost for the chance at not missing any matches, but on average it adds more noise than signal.

So with this PR, I suggest we adjust the noisy config option to work just like language package CPE matching: off by default but configurable to on, such that consumers can get more sane behavior by default, but they can crank up the sensitivity knob if they know what they're doing.

Curious for your thoughts!