### PR TITLE
fix: uppercased package in json

### DIFF
--- a/grype/search/cpe.go
+++ b/grype/search/cpe.go
@@ -24,9 +24,9 @@ type CPEPackageParameter struct {
 }
 
 type CPEParameters struct {
-	Namespace string   `json:"namespace"`
-	CPEs      []string `json:"cpes"`
-	Package   CPEPackageParameter
+	Namespace string              `json:"namespace"`
+	CPEs      []string            `json:"cpes"`
+	Package   CPEPackageParameter `json:"package"`
 }
 
 func (i *CPEParameters) Merge(other CPEParameters) error {


### PR DESCRIPTION
A missing JSON tag resulted in an uppercased `Package` key being output incorectly; this PR corrects the issue.

Fixes #1877 