### PR TITLE
Use tool for DCO checks

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -1,0 +1,23 @@
+name: DCO
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python 3.x
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Check DCO
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pip3 install -U dco-check
+          dco-check --verbose --exclude-pattern 'dependabot\[bot\]@users\.noreply\.github\.com'


### PR DESCRIPTION
There is an outage noted for the github app we use for checking DCO compliance on each PR and commits on main. In the meantime we'll use a similar python tool to ensure compliance on PRs and consider switching back to the other app once the functionality has been restored.

Similar to https://github.com/anchore/syft/pull/2926