### PR TITLE
Add skopeo to managed utilities

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -2,7 +2,7 @@ tools:
   # we want to use a pinned version of binny to manage the toolchain (so binny manages itself!)
   - name: binny
     version:
-      want: v0.7.0
+      want: v0.8.0
     method: github-release
     with:
       repo: anchore/binny
@@ -102,3 +102,18 @@ tools:
     method: github-release
     with:
       repo: cli/cli
+
+  # used for integration tests
+  - name: skopeo
+    version:
+      want: v1.12.0
+    method: go-install
+    with:
+      module: github.com/containers/skopeo
+      entrypoint: cmd/skopeo
+      args:
+        - "-tags"
+        - containers_image_openpgp
+      env:
+        - CGO_ENABLED=0
+        - GO_DYN_FLAGS=""

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -49,7 +49,7 @@ func PullThroughImageCache(t testing.TB, imageName string) string {
 func saveImage(t testing.TB, imageName string, destPath string) {
 	sourceImage := fmt.Sprintf("docker://docker.io/%s", imageName)
 	destinationString := fmt.Sprintf("docker-archive:%s", destPath)
-	skopeoPath := filepath.Join(repoRoot(t), ".tmp", "skopeo")
+	skopeoPath := filepath.Join(repoRoot(t), ".tool", "skopeo")
 	policyPath := filepath.Join(repoRoot(t), "test", "integration", "test-fixtures", "skopeo-policy.json")
 
 	skopeoCommand := []string{


### PR DESCRIPTION
When trouble shooting an issue in another PR https://github.com/hibare/grype/actions/runs/9402939074/job/25898220305 I found that there were utilities being referenced in legacy locations. It seems that skopeo was missed when porting the tool management approach and the cache was busted, revealing the issue:

```
task: [integration] go test -v ./test/integration
=== RUN   TestCompareSBOMInputToLibResults
    utils_test.go:42: Cache miss for image anchore/test_images:vulnerabilities-alpine; copying to archive at /home/runner/work/grype/grype/test/integration/test-fixtures/cache/anchore-test_images-vulnerabilities-alpine.tar
    utils_test.go:68: fork/exec /home/runner/work/grype/grype/.tmp/skopeo: no such file or directory
```

This PR adds skopeo as a managed tool and updates the test util code to reference the new location.