### PR TITLE
Updating maven URLs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ external-sources:
   enable: true
   maven:
     search-upstream-by-sha1: true
-    base-url: https://search.maven.org/solrsearch/select
+    base-url: https://repo1.maven.org/maven2
 ```
 
 You can also configure the base-url if you're using another registry as your maven endpoint.
@@ -728,7 +728,7 @@ external-sources:
   enable: false
   maven:
     search-upstream-by-sha1: true
-    base-url: https://search.maven.org/solrsearch/select
+    base-url: https://repo1.maven.org/maven2
 
 db:
   # check for database updates on execution


### PR DESCRIPTION
Docs  with new end points:
https://central.sonatype.org/consume/
URL - 
https://repo1.maven.org/maven2


Current url and response:
https://search.maven.org/solrsearch/select
Solr returned 400, msg: 