### PR TITLE
fix match sort ordering for different locations

### DIFF
--- a/grype/match/matches_test.go
+++ b/grype/match/matches_test.go
@@ -3,6 +3,7 @@ package match
 import (
 	"testing"
 
+	"github.com/anchore/syft/syft/file"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -104,20 +105,36 @@ func TestMatchesSortMixedDimensions(t *testing.T) {
 			},
 		},
 		Package: pkg.Package{
-			ID:      pkg.ID(uuid.NewString()),
-			Name:    "package-d",
-			Version: "2.0.0",
-			Type:    syftPkg.RpmPkg,
+			ID:        pkg.ID(uuid.NewString()),
+			Name:      "package-d",
+			Version:   "2.0.0",
+			Type:      syftPkg.RpmPkg,
+			Locations: file.NewLocationSet(file.NewLocation("/some/first-path")),
+		},
+	}
+	ninth := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "CVE-2020-0020",
+			Fix: vulnerability.Fix{
+				Versions: []string{"3.0.0"},
+			},
+		},
+		Package: pkg.Package{
+			ID:        pkg.ID(uuid.NewString()),
+			Name:      "package-d",
+			Version:   "2.0.0",
+			Type:      syftPkg.RpmPkg,
+			Locations: file.NewLocationSet(file.NewLocation("/some/other-path")),
 		},
 	}
 
 	input := []Match{
 		// shuffle vulnerability id, package name, package version, and package type
-		fifth, eighth, third, seventh, first, sixth, second, fourth,
+		ninth, fifth, eighth, third, seventh, first, sixth, second, fourth,
 	}
 	matches := NewMatches(input...)
 
-	assertMatchOrder(t, []Match{first, second, third, fourth, fifth, sixth, seventh, eighth}, matches.Sorted())
+	assertMatchOrder(t, []Match{first, second, third, fourth, fifth, sixth, seventh, eighth, ninth}, matches.Sorted())
 
 }
 

--- a/grype/match/sort.go
+++ b/grype/match/sort.go
@@ -28,6 +28,21 @@ func (m ByElements) Less(i, j int) bool {
 					sort.Strings(fixVersions2)
 					fixStr1 := strings.Join(fixVersions1, ",")
 					fixStr2 := strings.Join(fixVersions2, ",")
+
+					if fixStr1 == fixStr2 {
+						loc1 := m[i].Package.Locations.ToSlice()
+						loc2 := m[j].Package.Locations.ToSlice()
+						var locStr1 string
+						for _, location := range loc1 {
+							locStr1 += location.String()
+						}
+						var locStr2 string
+						for _, location := range loc2 {
+							locStr2 += location.String()
+						}
+
+						return locStr1 < locStr2
+					}
 					return fixStr1 < fixStr2
 				}
 				return m[i].Package.Type < m[j].Package.Type


### PR DESCRIPTION
A common case in vulnerability matching is when two vulnerability matches are the same except for their location. I noticed this case was causing Grype to produce inconsistent output when using its match sorting, e.g. `sort.Sort(match.ByElements(matches))`.

This PR adds consideration for locations into the match sort ordering logic.