### PR TITLE
fix: use location `RealPath` not `String()` for match sorting

### DIFF
--- a/grype/match/sort.go
+++ b/grype/match/sort.go
@@ -34,11 +34,11 @@ func (m ByElements) Less(i, j int) bool {
 						loc2 := m[j].Package.Locations.ToSlice()
 						var locStr1 string
 						for _, location := range loc1 {
-							locStr1 += location.String()
+							locStr1 += location.RealPath
 						}
 						var locStr2 string
 						for _, location := range loc2 {
-							locStr2 += location.String()
+							locStr2 += location.RealPath
 						}
 
 						return locStr1 < locStr2


### PR DESCRIPTION
This is a follow-up to #1944. Using `String()` works _mostly_ for sorting, but I expected `String()` to return a simple filepath, and instead it returns a funky string like: `Location<id=72 RealPath="usr/lib/go/pkg/tool/linux_amd64/buildid">`. 

This causes issues because the `id=<...>` value will be sorted lexically, and more than that, it looks like for most paths in Syft, this `id` value is controlled by an auto-incrementing global variable, so its value will vary quite widely across different execution contexts.

(I'm not sure if anything is depending on this kind of `Location< .... >` string value... If not, it could potentially be worth considering changing `String()` to return the RealPath or AccessPath to be friendlier to library consumers.)

This PR updates the sorting logic to use the `RealPath` for now, which should be stable. Holler if this assumption is incorrect for any reason!
