### PR TITLE
chore: enable dependabot to keep boostrap action updated

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -29,7 +29,7 @@ runs:
   using: "composite"
   steps:
     # note: go mod and build is automatically cached on default with v4+
-    - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
+    - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       if: inputs.go-version != ''
       with:
         go-version: ${{ inputs.go-version }}
@@ -40,7 +40,7 @@ runs:
 
     - name: Restore tool cache
       id: tool-cache
-      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
+      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
       with:
         path: ${{ github.workspace }}/.tool
         key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-tool-${{ hashFiles('.binny.yaml') }}

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/boostrap"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION
Allows dependabot to also keep the boostrap action updated