### PR TITLE
chore: update test_db_url

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,4 +1,3 @@
-
 version: "3"
 vars:
   OWNER: anchore

--- a/test/quality/Makefile
+++ b/test/quality/Makefile
@@ -8,7 +8,7 @@ VULNERABILITY_LABELS = ./vulnerability-labels
 RESULT_SET = pr_vs_latest_via_sbom
 
 # update periodically with values from "grype db list"
-TEST_DB_URL = https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v5_2024-02-23T01:23:09Z_d8fbe227a9343b20a702.tar.gz
+TEST_DB_URL = https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v5_2024-06-24T01:29:58Z_1719202889.tar.gz
 TEST_DB = db.tar.gz
 LISTING_FILE = https://toolbox-data.anchore.io/grype/databases/listing.json
 


### PR DESCRIPTION
## Summary
Our `TEST_DB` for the quality gate was very far behind our most recent build.

This patch unblocks our CI for other current pull requests.

I think keeping the target pinned here still makes sense, but maybe 5/6 months is too large a window? Happy to hear others thoughts on the way it should be.