### PR TITLE
chore: only check for db update if local db is old enough

### DIFF
--- a/cmd/grype/cli/commands/db_check.go
+++ b/cmd/grype/cli/commands/db_check.go
@@ -30,6 +30,8 @@ func DBCheck(app clio.Application) *cobra.Command {
 }
 
 func runDBCheck(opts options.Database) error {
+	// `grype db check` should _always_ check for updates, regardless of config
+	opts.MinAgeToCheckForUpdate = 0
 	dbCurator, err := db.NewCurator(opts.ToCuratorConfig())
 	if err != nil {
 		return err

--- a/cmd/grype/cli/commands/db_check.go
+++ b/cmd/grype/cli/commands/db_check.go
@@ -19,10 +19,15 @@ func DBCheck(app clio.Application) *cobra.Command {
 	opts := dbOptionsDefault(app.ID())
 
 	return app.SetupCommand(&cobra.Command{
-		Use:     "check",
-		Short:   "check to see if there is a database update available",
-		PreRunE: disableUI(app),
-		Args:    cobra.ExactArgs(0),
+		Use:   "check",
+		Short: "check to see if there is a database update available",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// `grype db check` should _always_ check for updates, regardless of config
+			opts.DB.MinAgeToCheckForUpdate = 0
+
+			return disableUI(app)(cmd, args)
+		},
+		Args: cobra.ExactArgs(0),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDBCheck(opts.DB)
 		},
@@ -30,8 +35,6 @@ func DBCheck(app clio.Application) *cobra.Command {
 }
 
 func runDBCheck(opts options.Database) error {
-	// `grype db check` should _always_ check for updates, regardless of config
-	opts.MinAgeToCheckForUpdate = 0
 	dbCurator, err := db.NewCurator(opts.ToCuratorConfig())
 	if err != nil {
 		return err

--- a/cmd/grype/cli/commands/db_update.go
+++ b/cmd/grype/cli/commands/db_update.go
@@ -26,6 +26,8 @@ func DBUpdate(app clio.Application) *cobra.Command {
 }
 
 func runDBUpdate(opts options.Database) error {
+	// `grype db update` should _always_ check for updates, regardless of config
+	opts.MinAgeToCheckForUpdate = 0
 	dbCurator, err := db.NewCurator(opts.ToCuratorConfig())
 	if err != nil {
 		return err

--- a/cmd/grype/cli/commands/db_update.go
+++ b/cmd/grype/cli/commands/db_update.go
@@ -19,6 +19,11 @@ func DBUpdate(app clio.Application) *cobra.Command {
 		Use:   "update",
 		Short: "download the latest vulnerability database",
 		Args:  cobra.ExactArgs(0),
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			// `grype db update` should _always_ check for updates, regardless of config
+			opts.DB.MinAgeToCheckForUpdate = 0
+			return nil
+		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDBUpdate(opts.DB)
 		},
@@ -26,8 +31,6 @@ func DBUpdate(app clio.Application) *cobra.Command {
 }
 
 func runDBUpdate(opts options.Database) error {
-	// `grype db update` should _always_ check for updates, regardless of config
-	opts.MinAgeToCheckForUpdate = 0
 	dbCurator, err := db.NewCurator(opts.ToCuratorConfig())
 	if err != nil {
 		return err

--- a/cmd/grype/cli/options/database.go
+++ b/cmd/grype/cli/options/database.go
@@ -18,6 +18,7 @@ type Database struct {
 	AutoUpdate             bool          `yaml:"auto-update" json:"auto-update" mapstructure:"auto-update"`
 	ValidateByHashOnStart  bool          `yaml:"validate-by-hash-on-start" json:"validate-by-hash-on-start" mapstructure:"validate-by-hash-on-start"`
 	ValidateAge            bool          `yaml:"validate-age" json:"validate-age" mapstructure:"validate-age"`
+	MinAgeToCheckForUpdate time.Duration `yaml:"min-age-to-check-for-update" json:"min-age-to-check-for-update" mapstructure:"min-age-to-check-for-update"`
 	MaxAllowedBuiltAge     time.Duration `yaml:"max-allowed-built-age" json:"max-allowed-built-age" mapstructure:"max-allowed-built-age"`
 	UpdateAvailableTimeout time.Duration `yaml:"update-available-timeout" json:"update-available-timeout" mapstructure:"update-available-timeout"`
 	UpdateDownloadTimeout  time.Duration `yaml:"update-download-timeout" json:"update-download-timeout" mapstructure:"update-download-timeout"`
@@ -28,9 +29,10 @@ var _ interface {
 } = (*Database)(nil)
 
 const (
-	defaultMaxDBAge               time.Duration = time.Hour * 24 * 5
-	defaultUpdateAvailableTimeout               = time.Second * 30
-	defaultUpdateDownloadTimeout                = time.Second * 120
+	defaultMinBuiltAgeToCheckForUpdate               = time.Hour * 12
+	defaultMaxDBAge                    time.Duration = time.Hour * 24 * 5
+	defaultUpdateAvailableTimeout                    = time.Second * 30
+	defaultUpdateDownloadTimeout                     = time.Second * 120
 )
 
 func DefaultDatabase(id clio.Identification) Database {
@@ -40,6 +42,7 @@ func DefaultDatabase(id clio.Identification) Database {
 		AutoUpdate:  true,
 		ValidateAge: true,
 		// After this period (5 days) the db data is considered stale
+		MinAgeToCheckForUpdate: defaultMinBuiltAgeToCheckForUpdate,
 		MaxAllowedBuiltAge:     defaultMaxDBAge,
 		UpdateAvailableTimeout: defaultUpdateAvailableTimeout,
 		UpdateDownloadTimeout:  defaultUpdateDownloadTimeout,
@@ -53,6 +56,7 @@ func (cfg Database) ToCuratorConfig() db.Config {
 		CACert:              cfg.CACert,
 		ValidateByHashOnGet: cfg.ValidateByHashOnStart,
 		ValidateAge:         cfg.ValidateAge,
+		MinBuiltAgeToCheck:  cfg.MinAgeToCheckForUpdate,
 		MaxAllowedBuiltAge:  cfg.MaxAllowedBuiltAge,
 		ListingFileTimeout:  cfg.UpdateAvailableTimeout,
 		UpdateTimeout:       cfg.UpdateDownloadTimeout,

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,10 @@ require (
 	gorm.io/gorm v1.25.11
 )
 
-require github.com/anchore/go-collections v0.0.0-20240216171411-9321230ce537
+require (
+	github.com/anchore/go-collections v0.0.0-20240216171411-9321230ce537
+	github.com/magiconair/properties v1.8.7
+)
 
 require (
 	cloud.google.com/go v0.110.10 // indirect
@@ -164,7 +167,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
-	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/maruel/natural v1.1.1 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.mod
+++ b/go.mod
@@ -60,10 +60,7 @@ require (
 	gorm.io/gorm v1.25.11
 )
 
-require (
-	github.com/anchore/go-collections v0.0.0-20240216171411-9321230ce537
-	github.com/magiconair/properties v1.8.7
-)
+require github.com/anchore/go-collections v0.0.0-20240216171411-9321230ce537
 
 require (
 	cloud.google.com/go v0.110.10 // indirect
@@ -167,6 +164,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/maruel/natural v1.1.1 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/grype/match/matches_test.go
+++ b/grype/match/matches_test.go
@@ -3,13 +3,13 @@ package match
 import (
 	"testing"
 
-	"github.com/anchore/syft/syft/file"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/syft/syft/file"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 


### PR DESCRIPTION
Previously, grype would check for a database update on every invocation. However, this was causing slow downs in the CDN. Since new databases are typically made available every 24 hours, change grype to, by default, only check if a new database is available if the local database is more than 12 hours old.

See #1731 