### PR TITLE
Disable ui before run function on db status

### DIFF
--- a/cmd/grype/cli/commands/db_status.go
+++ b/cmd/grype/cli/commands/db_status.go
@@ -14,10 +14,10 @@ func DBStatus(app clio.Application) *cobra.Command {
 	opts := dbOptionsDefault(app.ID())
 
 	return app.SetupCommand(&cobra.Command{
-		Use:      "status",
-		Short:    "display database status",
-		Args:     cobra.ExactArgs(0),
-		PostRunE: disableUI(app),
+		Use:     "status",
+		Short:   "display database status",
+		Args:    cobra.ExactArgs(0),
+		PreRunE: disableUI(app),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDBStatus(opts.DB)
 		},


### PR DESCRIPTION
The UI is being disabled after the run instead of before the run, leading to garbled output:
```
❯ grype db status
Location:  /Users/wagoodman/Library/Caches/grype/db/5
                                                     Built:     2024-07-24 01:31:07 +0000 UTC
                                                                                             Schema:    5
                                                                                                         Checksum:  sha256:e56b36edcd25dcff0566eecb2b83fad05e5451d881b81662d9b16f903185b235
                                                                                                                                                                                           Status:    valid

```

This PR fixes this behavior