### PR TITLE
chore: add grype version to application update check headers

### DIFF
--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -259,13 +259,12 @@ func checkForAppUpdate(id clio.Identification, opts *options.Grype) {
 		return
 	}
 
-	version := id.Version
-	isAvailable, newVersion, err := isUpdateAvailable(version)
+	isAvailable, newVersion, err := isUpdateAvailable(id)
 	if err != nil {
 		log.Errorf(err.Error())
 	}
 	if isAvailable {
-		log.Infof("new version of %s is available: %s (currently running: %s)", id.Name, newVersion, version)
+		log.Infof("new version of %s is available: %s (currently running: %s)", id.Name, newVersion, id.Version)
 
 		bus.Publish(partybus.Event{
 			Type: event.CLIAppUpdateAvailable,


### PR DESCRIPTION
In order to better understand which versions of grype are in use, this PR just adds a `User-Agent` header that is set when grype checks for updates, which only includes the application name and version. This behavior matches [what Syft is doing](https://github.com/anchore/syft/blob/a4b5dcd0df80f6a58c8610e25104647710c1da5d/cmd/syft/internal/commands/update.go#L97).