### PR TITLE
chore: update release script to use gh from binny

### DIFF
--- a/.github/scripts/trigger-release.sh
+++ b/.github/scripts/trigger-release.sh
@@ -4,15 +4,22 @@ set -eu
 bold=$(tput bold)
 normal=$(tput sgr0)
 
-if ! [ -x "$(command -v gh)" ]; then
-    echo "The GitHub CLI could not be found. To continue follow the instructions at https://github.com/cli/cli#installation"
+GH_CLI=.tool/gh
+
+if ! [ -x "$(command -v $GH_CLI)" ]; then
+    echo "The GitHub CLI could not be found. run: make bootstrap"
     exit 1
 fi
 
 # we want to stop the release as early as possible if the version is not a release version
 ./.github/scripts/check-syft-version-is-release.sh
 
-gh auth status
+$GH_CLI auth status
+
+# set the default repo in cases where multiple remotes are defined
+$GH_CLI repo set-default anchore/grype
+
+export GITHUB_TOKEN="${GITHUB_TOKEN-"$($GH_CLI auth token)"}"
 
 # we need all of the git state to determine the next version. Since tagging is done by
 # the release pipeline it is possible to not have all of the tags from previous releases.
@@ -40,7 +47,7 @@ done
 
 echo "${bold}Kicking off release for ${NEXT_VERSION}${normal}..."
 echo
-gh workflow run release.yaml -f version=${NEXT_VERSION}
+$GH_CLI workflow run release.yaml -f version=${NEXT_VERSION}
 
 echo
 echo "${bold}Waiting for release to start...${normal}"
@@ -48,6 +55,6 @@ sleep 10
 
 set +e
 
-echo "${bold}Head to the release workflow to monitor the release:${normal} $(gh run list --workflow=release.yaml --limit=1 --json url --jq '.[].url')"
-id=$(gh run list --workflow=release.yaml --limit=1 --json databaseId --jq '.[].databaseId')
-gh run watch $id --exit-status || (echo ; echo "${bold}Logs of failed step:${normal}" && GH_PAGER="" gh run view $id --log-failed)
+echo "${bold}Head to the release workflow to monitor the release:${normal} $($GH_CLI run list --workflow=release.yaml --limit=1 --json url --jq '.[].url')"
+id=$($GH_CLI run list --workflow=release.yaml --limit=1 --json databaseId --jq '.[].databaseId')
+$GH_CLI run watch $id --exit-status || (echo ; echo "${bold}Logs of failed step:${normal}" && GH_PAGER="" $GH_CLI run view $id --log-failed)


### PR DESCRIPTION
This PR adjusts the release workflow to use the `.tool/gh` instead of relying on a `gh` in the path as well as defaulting the GITHUB_TOKEN based on a `gh auth login`.

Note: I used this version of the script to successfully release: https://github.com/anchore/grype/releases/tag/v0.79.4