### PR TITLE
Add explore CVE

### DIFF
--- a/cmd/grype/cli/cli.go
+++ b/cmd/grype/cli/cli.go
@@ -81,6 +81,7 @@ func create(id clio.Identification) (clio.Application, *cobra.Command) {
 		commands.DB(app),
 		commands.Completion(app),
 		commands.Explain(app),
+		commands.Explore(app),
 		clio.VersionCommand(id, syftVersion, dbVersion),
 		clio.ConfigCommand(app, nil),
 	)

--- a/cmd/grype/cli/commands/explore.go
+++ b/cmd/grype/cli/commands/explore.go
@@ -1,0 +1,1 @@
+package commands

--- a/cmd/grype/cli/commands/explore.go
+++ b/cmd/grype/cli/commands/explore.go
@@ -1,1 +1,19 @@
 package commands
+
+import (
+	"github.com/anchore/clio"
+	"github.com/spf13/cobra"
+)
+
+func Explore(app clio.Application) *cobra.Command {
+	explore := &cobra.Command{
+		Use:   "explore",
+		Short: "vulnerability explore operations",
+	}
+
+	explore.AddCommand(
+		ExploreCVE(app),
+	)
+
+	return explore
+}

--- a/cmd/grype/cli/commands/explore_cve.go
+++ b/cmd/grype/cli/commands/explore_cve.go
@@ -1,0 +1,1 @@
+package commands

--- a/cmd/grype/cli/commands/explore_cve.go
+++ b/cmd/grype/cli/commands/explore_cve.go
@@ -38,7 +38,7 @@ func ExploreCVE(app clio.Application) *cobra.Command {
 	}
 
 	return app.SetupCommand(&cobra.Command{
-		Use:   "cve [flags] cve_id",
+		Use:   "cve [flags] vulnerability_id",
 		Short: "explore a vulnerability and display information",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) (err error) {

--- a/cmd/grype/cli/commands/explore_cve.go
+++ b/cmd/grype/cli/commands/explore_cve.go
@@ -1,1 +1,135 @@
 package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/anchore/clio"
+	"github.com/anchore/grype/cmd/grype/cli/options"
+	"github.com/anchore/grype/grype"
+	"github.com/anchore/grype/grype/db"
+	"github.com/anchore/grype/grype/store"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/grype/internal/bus"
+	"github.com/anchore/grype/internal/log"
+	"github.com/hashicorp/go-multierror"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+type cveExploreOptions struct {
+	Output string           `yaml:"output" json:"output" mapstructure:"output"`
+	cveID  string           `yaml:"cveID" json:"cveID" mapstructure:"cveID"`
+	DB     options.Database `yaml:"db" json:"db" mapstructure:"db"`
+}
+
+var _ clio.FlagAdder = (*cveExploreOptions)(nil)
+
+func (c *cveExploreOptions) AddFlags(flags clio.FlagSet) {
+	flags.StringVarP(&c.Output, "output", "o", "format to display results (available=[table, json])")
+}
+
+func ExploreCVE(app clio.Application) *cobra.Command {
+	opts := &cveExploreOptions{
+		Output: "table",
+		DB:     options.DefaultDatabase(app.ID()),
+	}
+
+	return app.SetupCommand(&cobra.Command{
+		Use:   "cve [flags] cve_id",
+		Short: "explore a vulnerability and display information",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) (err error) {
+			var cveID string
+			cveID = args[0]
+			return runExploreCVE(opts, cveID)
+		},
+	}, opts)
+}
+
+func runExploreCVE(opts *cveExploreOptions, cveID string) (errs error) {
+	var str *store.Store
+	var status *db.Status
+	var dbCloser *db.Closer
+
+	err := parallel(
+		func() (err error) {
+			log.Debug("loading DB")
+			str, status, dbCloser, err = grype.LoadVulnerabilityDB(opts.DB.ToCuratorConfig(), opts.DB.AutoUpdate)
+			return validateDBLoad(err, status)
+		},
+	)
+
+	if err != nil {
+		return err
+	}
+
+	if dbCloser != nil {
+		defer dbCloser.Close()
+	}
+
+	vulnerabilities, err := str.Get(cveID, "")
+	if err != nil {
+		return err
+	}
+
+	sb := &strings.Builder{}
+	if len(vulnerabilities) == 0 {
+		sb.WriteString("CVE doesn't exist in the DB\n")
+	} else {
+		err := present(opts.Output, vulnerabilities, sb)
+		if err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+
+	bus.Report(sb.String())
+
+	return errs
+}
+
+func present(outputFormat string, vulnerabilities []vulnerability.Vulnerability, output io.Writer) error {
+	if vulnerabilities == nil {
+		return nil
+	}
+
+	switch outputFormat {
+	case "table":
+		rows := [][]string{}
+		for _, v := range vulnerabilities {
+			rows = append(rows, []string{v.ID, v.PackageName, v.Namespace, v.Constraint.String()})
+		}
+
+		table := tablewriter.NewWriter(output)
+		columns := []string{"ID", "Package Name", "Namespace", "Version Constraint"}
+
+		table.SetHeader(columns)
+		table.SetAutoWrapText(false)
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
+
+		table.SetHeaderLine(false)
+		table.SetBorder(false)
+		table.SetAutoFormatHeaders(true)
+		table.SetCenterSeparator("")
+		table.SetColumnSeparator("")
+		table.SetRowSeparator("")
+		table.SetTablePadding("  ")
+		table.SetNoWhiteSpace(true)
+
+		table.AppendBulk(rows)
+		table.Render()
+	case "json":
+		enc := json.NewEncoder(output)
+		enc.SetEscapeHTML(false)
+		enc.SetIndent("", " ")
+		if err := enc.Encode(vulnerabilities); err != nil {
+			return fmt.Errorf("failed to encode diff information: %+v", err)
+		}
+	default:
+		return fmt.Errorf("unsupported output format: %s", outputFormat)
+	}
+	return nil
+}

--- a/cmd/grype/cli/commands/explore_cve.go
+++ b/cmd/grype/cli/commands/explore_cve.go
@@ -38,7 +38,7 @@ func ExploreCVE(app clio.Application) *cobra.Command {
 	}
 
 	return app.SetupCommand(&cobra.Command{
-		Use:   "cve [flags] vulnerability_id",
+		Use:   "cve [flags] cve_id",
 		Short: "explore a vulnerability and display information",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) (err error) {

--- a/cmd/grype/cli/commands/explore_cve.go
+++ b/cmd/grype/cli/commands/explore_cve.go
@@ -39,7 +39,7 @@ func ExploreCVE(app clio.Application) *cobra.Command {
 
 	return app.SetupCommand(&cobra.Command{
 		Use:   "cve [flags] cve_id",
-		Short: "explore a cve and display information",
+		Short: "explore a vulnerability and display information",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) (err error) {
 			var cveID string

--- a/cmd/grype/cli/commands/explore_cve.go
+++ b/cmd/grype/cli/commands/explore_cve.go
@@ -39,7 +39,7 @@ func ExploreCVE(app clio.Application) *cobra.Command {
 
 	return app.SetupCommand(&cobra.Command{
 		Use:   "cve [flags] cve_id",
-		Short: "explore a vulnerability and display information",
+		Short: "explore a cve and display information",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) (err error) {
 			var cveID string

--- a/grype/db/v5/store/store.go
+++ b/grype/db/v5/store/store.go
@@ -99,7 +99,12 @@ func (s *store) GetVulnerabilityNamespaces() ([]string, error) {
 func (s *store) GetVulnerability(namespace, id string) ([]v5.Vulnerability, error) {
 	var models []model.VulnerabilityModel
 
-	result := s.db.Where("namespace = ? AND id = ?", namespace, id).Find(&models)
+	var query = s.db
+	if namespace != "" {
+		query = query.Where("namespace = ?", namespace)
+	}
+
+	result := query.Where("id = ?", id).Find(&models)
 
 	var vulnerabilities = make([]v5.Vulnerability, len(models))
 	for idx, m := range models {

--- a/grype/db/vulnerability_provider.go
+++ b/grype/db/vulnerability_provider.go
@@ -51,6 +51,9 @@ func (pr *VulnerabilityProvider) Get(id, namespace string) ([]vulnerability.Vuln
 	var results []vulnerability.Vulnerability
 	for _, vuln := range vulns {
 		vulnObj, err := vulnerability.NewVulnerability(vuln)
+		if len(namespace) == 0 {
+			vulnObj.PackageName = vuln.PackageName
+		}
 		if err != nil {
 			return nil, fmt.Errorf("provider failed to inflate vulnerability record (namespace=%q id=%q): %w", vuln.Namespace, vuln.ID, err)
 		}

--- a/grype/vulnerability/vulnerability.go
+++ b/grype/vulnerability/vulnerability.go
@@ -15,6 +15,7 @@ type Reference struct {
 }
 
 type Vulnerability struct {
+	PackageName            string
 	Constraint             version.Constraint
 	PackageQualifiers      []qualifier.Qualifier
 	CPEs                   []cpe.CPE


### PR DESCRIPTION
Sometimes I want to understand if the DB has the vulnerability I am looking for.
Today in order to do that I need to go to listing.json -> get the latest URL -> Download it -> open DBeaver -> use a simple SQL query.

This PR creates a new endpoint which can accomplish it in a simple command grype explore cve <cve_id>

solves - https://github.com/anchore/grype/issues/1629