### PR TITLE
fix: higher default timeout for database download

### DIFF
--- a/cmd/grype/cli/options/database.go
+++ b/cmd/grype/cli/options/database.go
@@ -30,7 +30,7 @@ var _ interface {
 const (
 	defaultMaxDBAge               time.Duration = time.Hour * 24 * 5
 	defaultUpdateAvailableTimeout               = time.Second * 30
-	defaultUpdateDownloadTimeout                = time.Second * 120
+	defaultUpdateDownloadTimeout                = time.Second * 300
 )
 
 func DefaultDatabase(id clio.Identification) Database {


### PR DESCRIPTION
Depending on region and network conditions, 120s was not enough time for many clients, leading to some complaints. Raise the default timeout to five minutes.

There's an open question whether we should wait for more data from the [latest attempt to resolve the CDN issues](https://anchorecommunity.discourse.group/t/grype-db-network-and-cdn-issues/48/4?u=willmurphy)

Fixes https://github.com/anchore/grype/issues/1885