### PR TITLE
chore: remove quality gate Makefile db age check

### DIFF
--- a/test/quality/Makefile
+++ b/test/quality/Makefile
@@ -11,7 +11,6 @@ RESULT_SET = pr_vs_latest_via_sbom
 TEST_DB_URL_FILE = ./test-db-url
 TEST_DB_URL = $(shell cat $(TEST_DB_URL_FILE))
 TEST_DB = db.tar.gz
-LISTING_FILE = https://toolbox-data.anchore.io/grype/databases/listing.json
 
 # formatting variables
 BOLD := $(shell tput -T linux bold)
@@ -34,14 +33,8 @@ validate: venv $(VULNERABILITY_LABELS)/Makefile ## Run all quality checks agains
 capture: sboms vulns ## Collect and store all syft and grype results
 
 .PHONY: capture
-vulns: venv $(TEST_DB) check-db ## Collect and store all grype results
+vulns: venv $(TEST_DB) ## Collect and store all grype results
 	$(YARDSTICK) -v result capture -r $(RESULT_SET)
-
-.PHONY: check-db
-check-db:
-	@echo "Looking for test DB within the hosted listing file (which prunes DBs older that 90 days or the last 90 objects)"
-	@curl -sSL $(LISTING_FILE) | jq '.available[][] | select(.url == "$(TEST_DB_URL)") ' --exit-status || (echo "$(RED)DB is too stale to be used for testing. Please re-pin with a more up-to-date version.$(RESET)" && false)
-	@echo "DB is fresh enough to be used for testing!"
 
 $(TEST_DB):
 	@curl -o $(TEST_DB) -SsL $(TEST_DB_URL)


### PR DESCRIPTION
Since we lowered the number of days in the database listing file, it causes an issue in the quality tests here, since the Makefile validates the database exists in the listing file and would require updating the database URL quite frequently. This PR just removes the pseudo-age-check since we're already updating this every month with an automated workflow.