### PR TITLE
Add "Alpine Linux" to IDMapping; handle no CPEs error in findApkPackage.

### DIFF
--- a/grype/distro/type.go
+++ b/grype/distro/type.go
@@ -64,6 +64,7 @@ var IDMapping = map[string]Type{
 	"centos":        CentOS,
 	"fedora":        Fedora,
 	"alpine":        Alpine,
+	"Alpine Linux":  Alpine,
 	"busybox":       Busybox,
 	"amzn":          AmazonLinux,
 	"ol":            OracleLinux,

--- a/grype/matcher/apk/matcher.go
+++ b/grype/matcher/apk/matcher.go
@@ -14,8 +14,6 @@ import (
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
-var errNoCPEs = fmt.Errorf("attempted CPE match against package with no CPEs")
-
 type Matcher struct {
 }
 
@@ -149,7 +147,7 @@ func (m *Matcher) findApkPackage(store vulnerability.Provider, d *distro.Distro,
 	}
 
 	cpeMatches, err := m.cpeMatchesWithoutSecDBFixes(store, d, p)
-	if err != nil && err.Error() != errNoCPEs.Error() {
+	if err != nil && !errors.Is(err, search.ErrEmptyCPEMatch) {
 		return nil, err
 	}
 

--- a/grype/matcher/apk/matcher.go
+++ b/grype/matcher/apk/matcher.go
@@ -14,6 +14,8 @@ import (
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
+var errNoCPEs = fmt.Errorf("attempted CPE match against package with no CPEs")
+
 type Matcher struct {
 }
 
@@ -147,7 +149,7 @@ func (m *Matcher) findApkPackage(store vulnerability.Provider, d *distro.Distro,
 	}
 
 	cpeMatches, err := m.cpeMatchesWithoutSecDBFixes(store, d, p)
-	if err != nil {
+	if err != nil && err.Error() != errNoCPEs.Error() {
 		return nil, err
 	}
 

--- a/grype/matcher/apk/matcher.go
+++ b/grype/matcher/apk/matcher.go
@@ -147,7 +147,7 @@ func (m *Matcher) findApkPackage(store vulnerability.Provider, d *distro.Distro,
 	}
 
 	cpeMatches, err := m.cpeMatchesWithoutSecDBFixes(store, d, p)
-	if err != nil && !errors.Is(err, search.ErrEmptyCPEMatch) {
+	if err != nil {
 		return nil, err
 	}
 

--- a/grype/matcher/apk/matcher.go
+++ b/grype/matcher/apk/matcher.go
@@ -146,8 +146,9 @@ func (m *Matcher) findApkPackage(store vulnerability.Provider, d *distro.Distro,
 		return nil, err
 	}
 
+	// TODO: are there other errors that we should handle here that causes this to short circuit
 	cpeMatches, err := m.cpeMatchesWithoutSecDBFixes(store, d, p)
-	if err != nil {
+	if err != nil && !errors.Is(err, search.ErrEmptyCPEMatch) {
 		return nil, err
 	}
 

--- a/grype/matcher/apk/matcher_test.go
+++ b/grype/matcher/apk/matcher_test.go
@@ -640,7 +640,7 @@ func TestSecDBMatchesStillCountedWithCpeErrors(t *testing.T) {
 	// the test package will have no CPE causing an error,
 	// but the error should not cause the secDB matches to fail
 	secDbVuln := grypeDB.Vulnerability{
-		ID:                "CVE-2020-3",
+		ID:                "CVE-2020-2",
 		VersionConstraint: "<= 1.3.3-r0",
 		VersionFormat:     "apk",
 		Namespace:         "secdb:distro:alpine:3.12",

--- a/grype/matcher/apk/matcher_test.go
+++ b/grype/matcher/apk/matcher_test.go
@@ -635,6 +635,86 @@ func TestDistroMatchBySourceIndirection(t *testing.T) {
 	assertMatches(t, expected, actual)
 }
 
+func TestSecDBMatchesStillCountedWithCpeErrors(t *testing.T) {
+	// this should match the test package
+	// the test package will have no CPE causing an error,
+	// but the error should not cause the secDB matches to fail
+	secDbVuln := grypeDB.Vulnerability{
+		ID:                "CVE-2020-3",
+		VersionConstraint: "<= 1.3.3-r0",
+		VersionFormat:     "apk",
+		Namespace:         "secdb:distro:alpine:3.12",
+	}
+
+	store := mockStore{
+		backend: map[string]map[string][]grypeDB.Vulnerability{
+			"secdb:distro:alpine:3.12": {
+				"musl": []grypeDB.Vulnerability{secDbVuln},
+			},
+		},
+	}
+
+	provider, err := db.NewVulnerabilityProvider(&store)
+	require.NoError(t, err)
+
+	m := Matcher{}
+	d, err := distro.New(distro.Alpine, "3.12.0", "")
+	if err != nil {
+		t.Fatalf("failed to create a new distro: %+v", err)
+	}
+
+	p := pkg.Package{
+		ID:      pkg.ID(uuid.NewString()),
+		Name:    "musl-utils",
+		Version: "1.3.2-r0",
+		Type:    syftPkg.ApkPkg,
+		Upstreams: []pkg.UpstreamPackage{
+			{
+				Name: "musl",
+			},
+		},
+		CPEs: []cpe.CPE{},
+	}
+
+	vulnFound, err := vulnerability.NewVulnerability(secDbVuln)
+	assert.NoError(t, err)
+
+	expected := []match.Match{
+		{
+
+			Vulnerability: *vulnFound,
+			Package:       p,
+			Details: []match.Detail{
+				{
+					Type:       match.ExactIndirectMatch,
+					Confidence: 1.0,
+					SearchedBy: map[string]interface{}{
+						"distro": map[string]string{
+							"type":    d.Type.String(),
+							"version": d.RawVersion,
+						},
+						"package": map[string]string{
+							"name":    "musl",
+							"version": p.Version,
+						},
+						"namespace": "secdb:distro:alpine:3.12",
+					},
+					Found: map[string]interface{}{
+						"versionConstraint": vulnFound.Constraint.String(),
+						"vulnerabilityID":   "CVE-2020-2",
+					},
+					Matcher: match.ApkMatcher,
+				},
+			},
+		},
+	}
+
+	actual, err := m.Match(provider, d, p)
+	assert.NoError(t, err)
+
+	assertMatches(t, expected, actual)
+}
+
 func TestNVDMatchBySourceIndirection(t *testing.T) {
 	nvdVuln := grypeDB.Vulnerability{
 		ID:                "CVE-2020-1",


### PR DESCRIPTION
Even if there are vulnerability scan results for search.ByPackageDistro in apk matcher, if the SBOM does not have a CPE set, the results are ignored and the vulnerability search result becomes empty.

resolves #2039

And amazon Inspector sbom generator genereta this component.

```
    {
      "bom-ref": "comp-2",
      "type": "operating-system",
      "name": "Alpine Linux",
      "version": "3.17.1"
    }
```
To make grype recognize this file as Alpine, you need to add the following entry to grype/distro/type.go:
`
	"Alpine Linux":  Alpine,
`