### PR TITLE
doc: Updates for the Slack to Discourse migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 contact_links:
 
-  - name: Join the Slack community 💬
-    # link to our community Slack registration page
-    url: https://anchore.com/slack
+  - name: Join our Discourse community 💬
+    # link to our community Discourse site
+    url: https://anchore.com/discourse
     about: 'Come chat with us! Ask for help, join our software development efforts, or just give us feedback!'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![GitHub release](https://img.shields.io/github/release/anchore/grype.svg)](https://github.com/anchore/grype/releases/latest)
 [![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/anchore/grype.svg)](https://github.com/anchore/grype)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/anchore/grype/blob/main/LICENSE)
-[![Slack Invite](https://img.shields.io/badge/Slack-Join-blue?logo=slack)](https://anchore.com/slack)
+[![Join our Discourse](https://img.shields.io/badge/Discourse-Join-blue?logo=discourse)](https://anchore.com/discourse)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/anchore/grype/badge)](https://scorecard.dev/viewer/?uri=github.com/anchore/grype)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/6708/badge)](https://www.bestpractices.dev/projects/6708)
 


### PR DESCRIPTION
This updates the links to the community Slack to Discourse links.