### PR TITLE
Do not fail when inflating DB records

### DIFF
--- a/grype/db/vulnerability_provider.go
+++ b/grype/db/vulnerability_provider.go
@@ -52,7 +52,8 @@ func (pr *VulnerabilityProvider) Get(id, namespace string) ([]vulnerability.Vuln
 	for _, vuln := range vulns {
 		vulnObj, err := vulnerability.NewVulnerability(vuln)
 		if err != nil {
-			return nil, fmt.Errorf("provider failed to inflate vulnerability record (namespace=%q id=%q): %w", vuln.Namespace, vuln.ID, err)
+			log.WithFields("namespace", vuln.Namespace, "id", vuln.ID).Errorf("failed to inflate vulnerability record: %v", err)
+			continue
 		}
 
 		results = append(results, *vulnObj)
@@ -87,7 +88,8 @@ func (pr *VulnerabilityProvider) GetByDistro(d *distro.Distro, p pkg.Package) ([
 			for _, vuln := range allPkgVulns {
 				vulnObj, err := vulnerability.NewVulnerability(vuln)
 				if err != nil {
-					return nil, fmt.Errorf("provider failed to inflate vulnerability record (namespace=%q id=%q distro=%q): %w", vuln.Namespace, vuln.ID, d, err)
+					log.WithFields("namespace", vuln.Namespace, "id", vuln.ID).Errorf("failed to inflate vulnerability record (by distro): %v", err)
+					continue
 				}
 
 				vulnerabilities = append(vulnerabilities, *vulnObj)
@@ -121,7 +123,8 @@ func (pr *VulnerabilityProvider) GetByLanguage(l syftPkg.Language, p pkg.Package
 			for _, vuln := range allPkgVulns {
 				vulnObj, err := vulnerability.NewVulnerability(vuln)
 				if err != nil {
-					return nil, fmt.Errorf("provider failed to inflate vulnerability record (namespace=%q id=%q language=%q): %w", vuln.Namespace, vuln.ID, l, err)
+					log.WithFields("namespace", vuln.Namespace, "id", vuln.ID).Errorf("failed to inflate vulnerability record (by language): %v", err)
+					continue
 				}
 
 				vulnerabilities = append(vulnerabilities, *vulnObj)
@@ -169,7 +172,8 @@ func (pr *VulnerabilityProvider) GetByCPE(requestCPE cpe.CPE) ([]vulnerability.V
 			if len(candidateMatchCpes) > 0 {
 				vulnObj, err := vulnerability.NewVulnerability(vuln)
 				if err != nil {
-					return nil, fmt.Errorf("provider failed to inflate vulnerability record (namespace=%q id=%q cpe=%q): %w", vuln.Namespace, vuln.ID, requestCPE.Attributes.BindToFmtString(), err)
+					log.WithFields("namespace", vuln.Namespace, "id", vuln.ID, "cpe", requestCPE.Attributes.BindToFmtString()).Errorf("failed to inflate vulnerability record (by CPE): %v", err)
+					continue
 				}
 
 				vulnObj.CPEs = candidateMatchCpes

--- a/grype/db/vulnerability_provider_mocks_test.go
+++ b/grype/db/vulnerability_provider_mocks_test.go
@@ -31,6 +31,14 @@ func (d *mockStore) stub() {
 				ID:                "CVE-2013-fake-2",
 				VersionFormat:     "deb",
 			},
+			// poison the well! this is not a valid entry, but we want the matching process to survive and find other good results...
+			{
+				PackageName:       "neutron",
+				Namespace:         "debian:distro:debian:8",
+				VersionConstraint: "< 70.3.0-rc0", // intentionally bad value
+				ID:                "CVE-2014-fake-3",
+				VersionFormat:     "apk",
+			},
 		},
 	}
 	d.data["nvd:cpe"] = map[string][]grypeDB.Vulnerability{
@@ -62,7 +70,7 @@ func (d *mockStore) stub() {
 				ID:                "CVE-2014-fake-5",
 				VersionFormat:     "unknown",
 				CPEs: []string{
-					"cpe:2.3:*:couldntgetthisrightcouldyou:activerecord:4.0.1:*:*:*:*:*:*:*",
+					"cpe:2.3:*:couldntgetthisrightcouldyou:activerecord:4.0.1:*:*:*:*:*:*:*", // shouldn't match on this
 				},
 			},
 			{
@@ -72,7 +80,18 @@ func (d *mockStore) stub() {
 				ID:                "CVE-2014-fake-6",
 				VersionFormat:     "unknown",
 				CPEs: []string{
-					"cpe:2.3:*:awesome:awesome:*:*:*:*:*:*:*:*",
+					"cpe:2.3:*:awesome:awesome:*:*:*:*:*:*:*:*", // shouldn't match on this
+				},
+			},
+			// poison the well! this is not a valid entry, but we want the matching process to survive and find other good results...
+			{
+				PackageName:       "activerecord",
+				Namespace:         "nvd:cpe",
+				VersionConstraint: "< 70.3.0-rc0", // intentionally bad value
+				ID:                "CVE-2014-fake-7",
+				VersionFormat:     "apk",
+				CPEs: []string{
+					"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*",
 				},
 			},
 		},

--- a/grype/db/vulnerability_provider_test.go
+++ b/grype/db/vulnerability_provider_test.go
@@ -198,4 +198,9 @@ func Test_Get(t *testing.T) {
 			t.Errorf("diff: %+v", d)
 		}
 	}
+
+	// prove we survive a bad request
+	actual, err = provider.Get("CVE-2014-fake-3", "debian:distro:debian:8")
+	require.NoError(t, err)
+	assert.Empty(t, actual)
 }


### PR DESCRIPTION
Fixes #2048

Today when we are fetching a entry from the DB we will raise up failures when attempting to craft vulnerability objects all the way back up through the matcher. This is not correct behavior since there may have been matched we could have raised up but did not. Instead we should be logging warnings when this occurs (since it affects the results of the report, even if it's not actionable) and still allow for other matches to be made.