### PR TITLE
fix: hash vuln db only once on load

### DIFF
--- a/grype/db/curator.go
+++ b/grype/db/curator.go
@@ -120,7 +120,7 @@ func (c *Curator) Status() Status {
 		SchemaVersion: metadata.Version,
 		Location:      c.dbDir,
 		Checksum:      metadata.Checksum,
-		Err:           c.Validate(),
+		Err:           nil,
 	}
 }
 

--- a/grype/load_vulnerability_db_bench_test.go
+++ b/grype/load_vulnerability_db_bench_test.go
@@ -1,0 +1,26 @@
+package grype
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/anchore/grype/grype/db"
+	"github.com/anchore/grype/internal"
+)
+
+// this benchmark was added to measure the performance
+// of LoadVulnerabilityDB, specifically in regards to hash validation.
+// https://github.com/anchore/grype/issues/1502
+func BenchmarkLoadVulnerabilityDB(b *testing.B) {
+	cfg := db.Config{
+		DBRootDir:           filepath.Join(".tmp", "grype-db"),
+		ListingURL:          internal.DBUpdateURL,
+		ValidateByHashOnGet: true,
+	}
+	for range b.N {
+		_, _, _, err := LoadVulnerabilityDB(cfg, true)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1502

This PR aims to improve the performance of `LoadVulnerabilityDB` when `ValidateByHashOnGet` is set to `true`

As described in the linked issue, `GetStore` and `Status` both hash the db. This PR changes `Status` to not hash the db by removing the call to `c.Validate`

As far as I can tell, `Status` is only used in a few places:

1. `LoadVulnerabilityDB`

    This should not be an issue since `GetStore` already hashes the db
    
    https://github.com/anchore/grype/blob/e7ceffadc856ce70b2854eefa3fc78f8770365e7/grype/load_vulnerability_db.go#L28

1. `runDBStatus`

    I am unsure whether hashing the db is desired behavior for `grype db status`. If so, perhaps a new field could be added to `db.Config` to allow CLI and library users to configure this behavior?
    
    https://github.com/anchore/grype/blob/e7ceffadc856ce70b2854eefa3fc78f8770365e7/cmd/grype/cli/commands/db_status.go#L33

1. `Test_DifferDirectory`

    This test doesn't appear to rely on the hashing behavior in `Status`

    https://github.com/anchore/grype/blob/e7ceffadc856ce70b2854eefa3fc78f8770365e7/grype/differ/differ_test.go#L41
    https://github.com/anchore/grype/blob/e7ceffadc856ce70b2854eefa3fc78f8770365e7/grype/differ/differ_test.go#L47