### PR TITLE
fix: Update gitmodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "test/quality/vulnerability-match-labels"]
 	path = test/quality/vulnerability-match-labels
-	url = git@github.com:anchore/vulnerability-match-labels.git
+	url = https://github.com/anchore/vulnerability-match-labels.git
 	branch = main


### PR DESCRIPTION
Fixes #2100  - we should not use git protocol URIs for modules as it can be problematic for consumers behind restrictive or poorly configured proxies.
