### PR TITLE
feat: --enrich flag to enable data enrichment

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,10 +12,10 @@ linters:
   enable:
     - asciicheck
     - bodyclose
+    - copyloopvar
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
     - funlen
     - gocognit
     - goconst

--- a/cmd/grype/cli/options/datasources.go
+++ b/cmd/grype/cli/options/datasources.go
@@ -2,7 +2,6 @@ package options
 
 import (
 	"github.com/anchore/clio"
-	"github.com/anchore/grype/grype/matcher/java"
 )
 
 const (
@@ -10,7 +9,7 @@ const (
 )
 
 type externalSources struct {
-	Enable bool  `yaml:"enable" json:"enable" mapstructure:"enable"`
+	Enable *bool `yaml:"enable" json:"enable" mapstructure:"enable"`
 	Maven  maven `yaml:"maven" json:"maven" mapstructure:"maven"`
 }
 
@@ -19,28 +18,16 @@ var _ interface {
 } = (*externalSources)(nil)
 
 type maven struct {
-	SearchUpstreamBySha1 bool   `yaml:"search-upstream" json:"searchUpstreamBySha1" mapstructure:"search-maven-upstream"`
+	SearchUpstreamBySha1 *bool  `yaml:"search-upstream" json:"searchUpstreamBySha1" mapstructure:"search-maven-upstream"`
 	BaseURL              string `yaml:"base-url" json:"baseUrl" mapstructure:"base-url"`
 }
 
 func defaultExternalSources() externalSources {
 	return externalSources{
 		Maven: maven{
-			SearchUpstreamBySha1: true,
+			SearchUpstreamBySha1: nil,
 			BaseURL:              defaultMavenBaseURL,
 		},
-	}
-}
-
-func (cfg externalSources) ToJavaMatcherConfig() java.ExternalSearchConfig {
-	// always respect if global config is disabled
-	smu := cfg.Maven.SearchUpstreamBySha1
-	if !cfg.Enable {
-		smu = cfg.Enable
-	}
-	return java.ExternalSearchConfig{
-		SearchMavenUpstream: smu,
-		MavenBaseURL:        cfg.Maven.BaseURL,
 	}
 }
 


### PR DESCRIPTION
This PR adds the same `--enrich` flag that Syft supports to enable data enrichment operations, such as searching Maven Central to resolve variables as necessary.

Fixes: #1012