### PR TITLE
docs: add mention of file scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ oci-archive:path/to/yourimage.tar      use a tarball from disk for OCI archives 
 oci-dir:path/to/yourimage              read directly from a path on disk for OCI layout directories (from Skopeo or otherwise)
 singularity:path/to/yourimage.sif      read directly from a Singularity Image Format (SIF) container on disk
 dir:path/to/yourproject                read directly from a path on disk (any directory)
+file:path/to/yourfile                  read directly from a file on disk
 sbom:path/to/syft.json                 read Syft JSON from path on disk
 registry:yourrepo/yourimage:tag        pull image directly from a registry (no container runtime required)
 ```


### PR DESCRIPTION
This PR adds a mention of the `file:` scheme to the docs.

Fixes: #2041