### PR TITLE
Add low pass filter to DB update checks

### DIFF
--- a/cmd/grype/cli/commands/db_check.go
+++ b/cmd/grype/cli/commands/db_check.go
@@ -19,10 +19,14 @@ func DBCheck(app clio.Application) *cobra.Command {
 	opts := dbOptionsDefault(app.ID())
 
 	return app.SetupCommand(&cobra.Command{
-		Use:     "check",
-		Short:   "check to see if there is a database update available",
-		PreRunE: disableUI(app),
-		Args:    cobra.ExactArgs(0),
+		Use:   "check",
+		Short: "check to see if there is a database update available",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// DB commands should not opt into the low-pass check filter
+			opts.DB.MaxUpdateCheckFrequency = 0
+			return disableUI(app)(cmd, args)
+		},
+		Args: cobra.ExactArgs(0),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDBCheck(opts.DB)
 		},

--- a/cmd/grype/cli/commands/db_update.go
+++ b/cmd/grype/cli/commands/db_update.go
@@ -19,6 +19,11 @@ func DBUpdate(app clio.Application) *cobra.Command {
 		Use:   "update",
 		Short: "download the latest vulnerability database",
 		Args:  cobra.ExactArgs(0),
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			// DB commands should not opt into the low-pass check filter
+			opts.DB.MaxUpdateCheckFrequency = 0
+			return nil
+		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDBUpdate(opts.DB)
 		},

--- a/cmd/grype/cli/options/database.go
+++ b/cmd/grype/cli/options/database.go
@@ -12,17 +12,18 @@ import (
 )
 
 type Database struct {
-	ID                     clio.Identification `yaml:"-" json:"-" mapstructure:"-"`
-	Dir                    string              `yaml:"cache-dir" json:"cache-dir" mapstructure:"cache-dir"`
-	UpdateURL              string              `yaml:"update-url" json:"update-url" mapstructure:"update-url"`
-	CACert                 string              `yaml:"ca-cert" json:"ca-cert" mapstructure:"ca-cert"`
-	AutoUpdate             bool                `yaml:"auto-update" json:"auto-update" mapstructure:"auto-update"`
-	ValidateByHashOnStart  bool                `yaml:"validate-by-hash-on-start" json:"validate-by-hash-on-start" mapstructure:"validate-by-hash-on-start"`
-	ValidateAge            bool                `yaml:"validate-age" json:"validate-age" mapstructure:"validate-age"`
-	MaxAllowedBuiltAge     time.Duration       `yaml:"max-allowed-built-age" json:"max-allowed-built-age" mapstructure:"max-allowed-built-age"`
-	RequireUpdateCheck     bool                `yaml:"require-update-check" json:"require-update-check" mapstructure:"require-update-check"`
-	UpdateAvailableTimeout time.Duration       `yaml:"update-available-timeout" json:"update-available-timeout" mapstructure:"update-available-timeout"`
-	UpdateDownloadTimeout  time.Duration       `yaml:"update-download-timeout" json:"update-download-timeout" mapstructure:"update-download-timeout"`
+	ID                      clio.Identification `yaml:"-" json:"-" mapstructure:"-"`
+	Dir                     string              `yaml:"cache-dir" json:"cache-dir" mapstructure:"cache-dir"`
+	UpdateURL               string              `yaml:"update-url" json:"update-url" mapstructure:"update-url"`
+	CACert                  string              `yaml:"ca-cert" json:"ca-cert" mapstructure:"ca-cert"`
+	AutoUpdate              bool                `yaml:"auto-update" json:"auto-update" mapstructure:"auto-update"`
+	ValidateByHashOnStart   bool                `yaml:"validate-by-hash-on-start" json:"validate-by-hash-on-start" mapstructure:"validate-by-hash-on-start"`
+	ValidateAge             bool                `yaml:"validate-age" json:"validate-age" mapstructure:"validate-age"`
+	MaxAllowedBuiltAge      time.Duration       `yaml:"max-allowed-built-age" json:"max-allowed-built-age" mapstructure:"max-allowed-built-age"`
+	RequireUpdateCheck      bool                `yaml:"require-update-check" json:"require-update-check" mapstructure:"require-update-check"`
+	UpdateAvailableTimeout  time.Duration       `yaml:"update-available-timeout" json:"update-available-timeout" mapstructure:"update-available-timeout"`
+	UpdateDownloadTimeout   time.Duration       `yaml:"update-download-timeout" json:"update-download-timeout" mapstructure:"update-download-timeout"`
+	MaxUpdateCheckFrequency time.Duration       `yaml:"max-update-check-frequency" json:"max-update-check-frequency" mapstructure:"max-update-check-frequency"`
 }
 
 var _ interface {
@@ -30,9 +31,10 @@ var _ interface {
 } = (*Database)(nil)
 
 const (
-	defaultMaxDBAge               time.Duration = time.Hour * 24 * 5
-	defaultUpdateAvailableTimeout               = time.Second * 30
-	defaultUpdateDownloadTimeout                = time.Second * 300
+	defaultMaxDBAge                time.Duration = time.Hour * 24 * 5
+	defaultUpdateAvailableTimeout                = time.Second * 30
+	defaultUpdateDownloadTimeout                 = time.Second * 300
+	defaultMaxUpdateCheckFrequency               = time.Hour * 2
 )
 
 func DefaultDatabase(id clio.Identification) Database {
@@ -43,25 +45,27 @@ func DefaultDatabase(id clio.Identification) Database {
 		AutoUpdate:  true,
 		ValidateAge: true,
 		// After this period (5 days) the db data is considered stale
-		MaxAllowedBuiltAge:     defaultMaxDBAge,
-		RequireUpdateCheck:     false,
-		UpdateAvailableTimeout: defaultUpdateAvailableTimeout,
-		UpdateDownloadTimeout:  defaultUpdateDownloadTimeout,
+		MaxAllowedBuiltAge:      defaultMaxDBAge,
+		RequireUpdateCheck:      false,
+		UpdateAvailableTimeout:  defaultUpdateAvailableTimeout,
+		UpdateDownloadTimeout:   defaultUpdateDownloadTimeout,
+		MaxUpdateCheckFrequency: defaultMaxUpdateCheckFrequency,
 	}
 }
 
 func (cfg Database) ToCuratorConfig() distribution.Config {
 	return distribution.Config{
-		ID:                  cfg.ID,
-		DBRootDir:           cfg.Dir,
-		ListingURL:          cfg.UpdateURL,
-		CACert:              cfg.CACert,
-		ValidateByHashOnGet: cfg.ValidateByHashOnStart,
-		ValidateAge:         cfg.ValidateAge,
-		MaxAllowedBuiltAge:  cfg.MaxAllowedBuiltAge,
-		RequireUpdateCheck:  cfg.RequireUpdateCheck,
-		ListingFileTimeout:  cfg.UpdateAvailableTimeout,
-		UpdateTimeout:       cfg.UpdateDownloadTimeout,
+		ID:                      cfg.ID,
+		DBRootDir:               cfg.Dir,
+		ListingURL:              cfg.UpdateURL,
+		CACert:                  cfg.CACert,
+		ValidateByHashOnGet:     cfg.ValidateByHashOnStart,
+		ValidateAge:             cfg.ValidateAge,
+		MaxAllowedBuiltAge:      cfg.MaxAllowedBuiltAge,
+		RequireUpdateCheck:      cfg.RequireUpdateCheck,
+		ListingFileTimeout:      cfg.UpdateAvailableTimeout,
+		UpdateTimeout:           cfg.UpdateDownloadTimeout,
+		UpdateCheckMaxFrequency: cfg.MaxUpdateCheckFrequency,
 	}
 }
 
@@ -80,4 +84,5 @@ Default max age is 120h (or five days)`)
 This file is ~156KiB as of 2024-04-17 so the download should be quick; adjust as needed`)
 	descriptions.Add(&cfg.UpdateDownloadTimeout, `Timeout for downloading actual vulnerability DB
 The DB is ~156MB as of 2024-04-17 so slower connections may exceed the default timeout; adjust as needed`)
+	descriptions.Add(&cfg.MaxUpdateCheckFrequency, `Maximum frequency to check for vulnerability database updates`)
 }

--- a/go.mod
+++ b/go.mod
@@ -212,6 +212,7 @@ require (
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.19.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/sylabs/sif/v2 v2.17.1 // indirect
 	github.com/sylabs/squashfs v1.0.0 // indirect

--- a/grype/load_vulnerability_db.go
+++ b/grype/load_vulnerability_db.go
@@ -14,7 +14,7 @@ func LoadVulnerabilityDB(cfg distribution.Config, update bool) (*store.Store, *d
 	}
 
 	if update {
-		log.Debug("looking for updates on vulnerability database")
+		log.Debug("looking for vulnerability database updates")
 		_, err := dbCurator.Update()
 		if err != nil {
 			return nil, nil, nil, err

--- a/test/cli/db_validations_test.go
+++ b/test/cli/db_validations_test.go
@@ -17,11 +17,48 @@ func TestDBValidations(t *testing.T) {
 			name: "fail on bad DB load",
 			args: []string{"-vv", "dir:."},
 			env: map[string]string{
-				"GRYPE_DB_CACHE_DIR": t.TempDir(),
-				"GRYPE_DB_CA_CERT":   "./does-not-exist.crt",
+				"GRYPE_DB_CA_CERT": "./does-not-exist.crt",
 			},
 			assertions: []traitAssertion{
 				assertInOutput("failed to load vulnerability db"),
+				assertFailingReturnCode,
+			},
+		},
+		{
+			// check for a DB update always works when running "grype db check"
+			name: "always check for updates",
+			args: []string{"-vvv", "db", "check"},
+			env: map[string]string{
+				"GRYPE_DB_MAX_UPDATE_CHECK_FREQUENCY": "10h",
+			},
+			assertions: []traitAssertion{
+				assertInOutput("checking for available database updates"),
+				assertFailingReturnCode,
+			},
+		},
+		{
+			// check for a DB update always works when running "grype db update"
+			name: "always update",
+			args: []string{"-vvv", "db", "update"},
+			env: map[string]string{
+				"GRYPE_DB_MAX_UPDATE_CHECK_FREQUENCY": "10h",
+			},
+			assertions: []traitAssertion{
+				assertInOutput("no max-frequency set for update check"),
+				assertInOutput("checking for available database updates"),
+				assertFailingReturnCode,
+			},
+		},
+		{
+			name: "ensure db update frequency config is wired and responsive",
+			args: []string{"-vvv", t.TempDir()},
+			env: map[string]string{
+				"GRYPE_DB_MAX_UPDATE_CHECK_FREQUENCY": "10h",
+			},
+			assertions: []traitAssertion{
+				assertInOutput("first-run of DB update"),
+				assertInOutput("checking for available database updates"),
+				assertInOutput("max-update-check-frequency: 10h"),
 				assertFailingReturnCode,
 			},
 		},
@@ -29,6 +66,8 @@ func TestDBValidations(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			test.env["GRYPE_DB_CACHE_DIR"] = t.TempDir()
+			test.env["GRYPE_DB_UPDATE_URL"] = "https://localhost:8080"
 			cmd, stdout, stderr := runGrype(t, test.env, test.args...)
 			for _, traitAssertionFn := range test.assertions {
 				traitAssertionFn(t, stdout, stderr, cmd.ProcessState.ExitCode())


### PR DESCRIPTION
Currently grype will always reach out to check if there is a DB update, even if grype is run several times with in a short period of time. In reality we're only updating the DB once a day at this time, so checking for an update this frequently is fairly wasteful both client-wise and on the CDN.

This change adds a new `update-check-max-frequency` with a default of 2 hours. This only affects the scan path and not `db check` and `db update` paths.

This will also have the added value of reducing traffic spikes when we publish new databases, assuming most clients are not explicitly running `db update`.