### PR TITLE
Add `grype db providers` command

### DIFF
--- a/cmd/grype/cli/commands/db_diff.go
+++ b/cmd/grype/cli/commands/db_diff.go
@@ -10,7 +10,6 @@ import (
 	"github.com/anchore/grype/cmd/grype/cli/options"
 	"github.com/anchore/grype/grype/db/legacy/distribution"
 	"github.com/anchore/grype/grype/differ"
-	"github.com/anchore/grype/internal"
 	"github.com/anchore/grype/internal/bus"
 	"github.com/anchore/grype/internal/log"
 )
@@ -30,7 +29,7 @@ func (d *dbDiffOptions) AddFlags(flags clio.FlagSet) {
 
 func DBDiff(app clio.Application) *cobra.Command {
 	opts := &dbDiffOptions{
-		Output:    internal.TableOutputFormat,
+		Output:    "table",
 		DBOptions: *dbOptionsDefault(app.ID()),
 	}
 

--- a/cmd/grype/cli/commands/db_list.go
+++ b/cmd/grype/cli/commands/db_list.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/anchore/clio"
 	"github.com/anchore/grype/grype/db/legacy/distribution"
-	"github.com/anchore/grype/internal"
 )
 
 type dbListOptions struct {
@@ -25,7 +24,7 @@ func (d *dbListOptions) AddFlags(flags clio.FlagSet) {
 
 func DBList(app clio.Application) *cobra.Command {
 	opts := &dbListOptions{
-		Output:    internal.TextOutputFormat,
+		Output:    "text",
 		DBOptions: *dbOptionsDefault(app.ID()),
 	}
 
@@ -59,7 +58,7 @@ func runDBList(opts *dbListOptions) error {
 	}
 
 	switch opts.Output {
-	case internal.TextOutputFormat:
+	case "text":
 		// summarize each listing entry for the current DB schema
 		for _, l := range available {
 			fmt.Printf("Built:    %s\n", l.Built)
@@ -68,7 +67,7 @@ func runDBList(opts *dbListOptions) error {
 		}
 
 		fmt.Printf("%d databases available for schema %d\n", len(available), supportedSchema)
-	case internal.JSONOutputFormat:
+	case "json":
 		// show entries for the current schema
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetEscapeHTML(false)
@@ -76,7 +75,7 @@ func runDBList(opts *dbListOptions) error {
 		if err := enc.Encode(&available); err != nil {
 			return fmt.Errorf("failed to db listing information: %+v", err)
 		}
-	case internal.RawOutputFormat:
+	case "raw":
 		// show the entire listing file
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetEscapeHTML(false)

--- a/cmd/grype/cli/commands/db_providers.go
+++ b/cmd/grype/cli/commands/db_providers.go
@@ -13,11 +13,12 @@ import (
 
 	"github.com/anchore/clio"
 	"github.com/anchore/grype/grype/db/legacy/distribution"
-	"github.com/anchore/grype/internal"
 	"github.com/anchore/grype/internal/bus"
 )
 
 const metadataFileName = "provider-metadata.json"
+const jsonOutputFormat = "json"
+const tableOutputFormat = "table"
 
 type dbProviderMetadata struct {
 	Name              string `json:"name"`
@@ -40,7 +41,7 @@ func (d *dbProvidersOptions) AddFlags(flags clio.FlagSet) {
 
 func DBProviders(app clio.Application) *cobra.Command {
 	opts := &dbProvidersOptions{
-		Output: internal.TableOutputFormat,
+		Output: tableOutputFormat,
 	}
 
 	return app.SetupCommand(&cobra.Command{
@@ -66,9 +67,9 @@ func runDBProviders(opts *dbProvidersOptions, app clio.Application) error {
 	sb := &strings.Builder{}
 
 	switch opts.Output {
-	case internal.TableOutputFormat:
+	case tableOutputFormat:
 		displayDBProvidersTable(providers.Providers, sb)
-	case internal.JSONOutputFormat:
+	case jsonOutputFormat:
 		err = displayDBProvidersJSON(providers, sb)
 		if err != nil {
 			return err

--- a/cmd/grype/cli/commands/db_providers.go
+++ b/cmd/grype/cli/commands/db_providers.go
@@ -54,7 +54,6 @@ func DBProviders(app clio.Application) *cobra.Command {
 }
 
 func runDBProviders(opts *dbProvidersOptions, app clio.Application) error {
-
 	metadataFileLocation, err := getMetadataFileLocation(app)
 	if err != nil {
 		return nil
@@ -83,7 +82,6 @@ func runDBProviders(opts *dbProvidersOptions, app clio.Application) error {
 }
 
 func getMetadataFileLocation(app clio.Application) (*string, error) {
-
 	dbCurator, err := distribution.NewCurator(dbOptionsDefault(app.ID()).DB.ToCuratorConfig())
 	if err != nil {
 		return nil, err

--- a/cmd/grype/cli/commands/db_providers_test.go
+++ b/cmd/grype/cli/commands/db_providers_test.go
@@ -22,11 +22,11 @@ func TestGetDBProviders(t *testing.T) {
 			fileLocation: "./test-fixtures",
 			expectedProviders: dbProviders{
 				Providers: []dbProviderMetadata{
-					dbProviderMetadata{
+					{
 						Name:              "provider1",
 						LastSuccessfulRun: "2024-10-16T01:33:16.844201Z",
 					},
-					dbProviderMetadata{
+					{
 						Name:              "provider2",
 						LastSuccessfulRun: "2024-10-16T01:32:43.516596Z",
 					},
@@ -70,11 +70,11 @@ func TestDisplayDBProvidersTable(t *testing.T) {
 			name: "display providers table",
 			providers: dbProviders{
 				Providers: []dbProviderMetadata{
-					dbProviderMetadata{
+					{
 						Name:              "provider1",
 						LastSuccessfulRun: "2024-10-16T01:33:16.844201Z",
 					},
-					dbProviderMetadata{
+					{
 						Name:              "provider2",
 						LastSuccessfulRun: "2024-10-16T01:32:43.516596Z",
 					},
@@ -114,11 +114,11 @@ func TestDisplayDBProvidersJSON(t *testing.T) {
 			name: "display providers table",
 			providers: dbProviders{
 				Providers: []dbProviderMetadata{
-					dbProviderMetadata{
+					{
 						Name:              "provider1",
 						LastSuccessfulRun: "2024-10-16T01:33:16.844201Z",
 					},
-					dbProviderMetadata{
+					{
 						Name:              "provider2",
 						LastSuccessfulRun: "2024-10-16T01:32:43.516596Z",
 					},

--- a/cmd/grype/cli/commands/db_search.go
+++ b/cmd/grype/cli/commands/db_search.go
@@ -12,7 +12,6 @@ import (
 	"github.com/anchore/clio"
 	"github.com/anchore/grype/grype"
 	"github.com/anchore/grype/grype/vulnerability"
-	"github.com/anchore/grype/internal"
 	"github.com/anchore/grype/internal/bus"
 	"github.com/anchore/grype/internal/log"
 )
@@ -30,7 +29,7 @@ func (c *dbQueryOptions) AddFlags(flags clio.FlagSet) {
 
 func DBSearch(app clio.Application) *cobra.Command {
 	opts := &dbQueryOptions{
-		Output:    internal.TableOutputFormat,
+		Output:    "table",
 		DBOptions: *dbOptionsDefault(app.ID()),
 	}
 
@@ -78,7 +77,7 @@ func present(outputFormat string, vulnerabilities []vulnerability.Vulnerability,
 	}
 
 	switch outputFormat {
-	case internal.TableOutputFormat:
+	case "table":
 		rows := [][]string{}
 		for _, v := range vulnerabilities {
 			rows = append(rows, []string{v.ID, v.PackageName, v.Namespace, v.Constraint.String()})
@@ -103,7 +102,7 @@ func present(outputFormat string, vulnerabilities []vulnerability.Vulnerability,
 
 		table.AppendBulk(rows)
 		table.Render()
-	case internal.JSONOutputFormat:
+	case "json":
 		enc := json.NewEncoder(output)
 		enc.SetEscapeHTML(false)
 		enc.SetIndent("", " ")

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -2,6 +2,3 @@ package internal
 
 // note: do not change this
 const DBUpdateURL = "https://toolbox-data.anchore.io/grype/databases/listing.json"
-
-const JSONOutputFormat = "json"
-const TableOutputFormat = "table"

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -5,5 +5,3 @@ const DBUpdateURL = "https://toolbox-data.anchore.io/grype/databases/listing.jso
 
 const JSONOutputFormat = "json"
 const TableOutputFormat = "table"
-const TextOutputFormat = "text"
-const RawOutputFormat = "raw"


### PR DESCRIPTION
# Issue

resolves #2131 

# Changes

- Provider data is read from `provider-metadata.json` file.
- Added flag `-o`/`--output` flags which accept `json` and `table`.
- Display logic is separate from the provider data collection. 
- Can be easily updated for db schema `v6`.
- Fails gracefully, with relevant error message, for absence of `provider-metadata.json` file.
- Updated `Readme.md` for the new command.