### PR TITLE
fix: exclude binary packages from CPE target software component filter logic

### DIFF
--- a/grype/search/cpe_test.go
+++ b/grype/search/cpe_test.go
@@ -689,6 +689,56 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 			},
 		},
 		{
+			name: "Ensure target_sw mismatch does not apply to binary packages",
+			p: pkg.Package{
+				CPEs: []cpe.CPE{
+					cpe.Must("cpe:2.3:a:handlebarsjs:handlebars:*:*:*:*:*:*:*:*", ""),
+				},
+				Name:     "handlebars",
+				Version:  "0.1",
+				Language: syftPkg.UnknownLanguage,
+				Type:     syftPkg.BinaryPkg,
+			},
+			expected: []match.Match{
+				{
+					Vulnerability: vulnerability.Vulnerability{
+						ID: "CVE-2021-23369",
+					},
+					Package: pkg.Package{
+						CPEs: []cpe.CPE{
+							cpe.Must("cpe:2.3:a:handlebarsjs:handlebars:*:*:*:*:*:*:*:*", ""),
+						},
+						Name:     "handlebars",
+						Version:  "0.1",
+						Language: syftPkg.UnknownLanguage,
+						Type:     syftPkg.BinaryPkg,
+					},
+					Details: []match.Detail{
+						{
+							Type:       match.CPEMatch,
+							Confidence: 0.9,
+							SearchedBy: CPEParameters{
+								CPEs:      []string{"cpe:2.3:a:handlebarsjs:handlebars:*:*:*:*:*:*:*:*"},
+								Namespace: "nvd:cpe",
+								Package: CPEPackageParameter{
+									Name:    "handlebars",
+									Version: "0.1",
+								},
+							},
+							Found: CPEResult{
+								CPEs: []string{
+									"cpe:2.3:a:handlebarsjs:handlebars:*:*:*:*:*:node.js:*:*",
+								},
+								VersionConstraint: "< 4.7.7 (unknown)",
+								VulnerabilityID:   "CVE-2021-23369",
+							},
+							Matcher: matcher,
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "package without CPEs returns error",
 			p: pkg.Package{
 				Name: "some-package",

--- a/grype/search/only_vulnerable_targets.go
+++ b/grype/search/only_vulnerable_targets.go
@@ -42,6 +42,11 @@ func onlyVulnerableTargets(p pkg.Package, allVulns []vulnerability.Vulnerability
 		return allVulns
 	}
 
+	// Do not filter by target software for any binary type packages since the composition is unknown
+	if p.Type == syftPkg.BinaryPkg {
+		return allVulns
+	}
+
 	// There are quite a few cases within java where other ecosystem components (particularly javascript packages)
 	// are embedded directly within jar files, so we can't yet make this assumption with java as it will cause dropping
 	// of valid vulnerabilities that syft has specific logic https://github.com/anchore/syft/blob/main/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go#L48-L75


### PR DESCRIPTION
Fixes #2178 