### PR TITLE
Skip matching on packages with missing version info

### DIFF
--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -36,6 +36,7 @@ import (
 	"github.com/anchore/grype/internal/log"
 	"github.com/anchore/grype/internal/stringutil"
 	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/cataloging"
 	"github.com/anchore/syft/syft/linux"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/sbom"
@@ -305,6 +306,11 @@ func getProviderConfig(opts *options.Grype) pkg.ProviderConfig {
 	cfg := syft.DefaultCreateSBOMConfig()
 	cfg.Packages.JavaArchive.IncludeIndexedArchives = opts.Search.IncludeIndexedArchives
 	cfg.Packages.JavaArchive.IncludeUnindexedArchives = opts.Search.IncludeUnindexedArchives
+
+	// when we run into a package with missing information like version, then this is not useful in the context
+	// of vulnerability matching. Though there will be downstream processing to handle this case, we can still
+	// save us the effort of ever attempting to match with these packages as early as possible.
+	cfg.Compliance.MissingVersion = cataloging.ComplianceActionDrop
 
 	return pkg.ProviderConfig{
 		SyftProviderConfig: pkg.SyftProviderConfig{

--- a/cmd/grype/cli/commands/root_test.go
+++ b/cmd/grype/cli/commands/root_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/cataloging"
 	"github.com/anchore/syft/syft/pkg/cataloger/binary"
 )
 
@@ -54,14 +55,18 @@ func Test_getProviderConfig(t *testing.T) {
 		want pkg.ProviderConfig
 	}{
 		{
-			name: "default-options-are-set",
+			name: "syft default api options are used",
 			opts: options.DefaultGrype(clio.Identification{
 				Name:    "test",
 				Version: "1.0",
 			}),
 			want: pkg.ProviderConfig{
 				SyftProviderConfig: pkg.SyftProviderConfig{
-					SBOMOptions: syft.DefaultCreateSBOMConfig(),
+					SBOMOptions: func() *syft.CreateSBOMConfig {
+						cfg := syft.DefaultCreateSBOMConfig()
+						cfg.Compliance.MissingVersion = cataloging.ComplianceActionDrop
+						return cfg
+					}(),
 					RegistryOptions: &image.RegistryOptions{
 						Credentials: []image.RegistryCredentials{},
 					},

--- a/grype/matcher/apk/matcher_test.go
+++ b/grype/matcher/apk/matcher_test.go
@@ -1003,7 +1003,7 @@ func TestNVDMatchBySourceIndirection(t *testing.T) {
 					Type:       match.CPEMatch,
 					Confidence: 0.9,
 					SearchedBy: search.CPEParameters{
-						CPEs:      []string{"cpe:2.3:a:musl:musl:*:*:*:*:*:*:*:*"},
+						CPEs:      []string{"cpe:2.3:a:musl:musl:1.3.2-r0:*:*:*:*:*:*:*"},
 						Namespace: "nvd:cpe",
 						Package: search.CPEPackageParameter{
 							Name:    "musl",

--- a/grype/search/cpe.go
+++ b/grype/search/cpe.go
@@ -14,6 +14,7 @@ import (
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/version"
 	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/grype/internal/log"
 	"github.com/anchore/syft/syft/cpe"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
@@ -102,9 +103,18 @@ func ByPackageCPE(store vulnerability.ProviderByCPE, d *distro.Distro, p pkg.Pac
 			searchVersion = alpineCPEComparableVersion(searchVersion)
 		}
 
-		if searchVersion == wfn.NA || searchVersion == wfn.Any {
+		if searchVersion == wfn.NA || searchVersion == wfn.Any || isUnknownVersion(searchVersion) {
 			searchVersion = p.Version
 		}
+
+		if isUnknownVersion(searchVersion) {
+			log.WithFields("package", p).Warn("skipping package with unknown version")
+			continue
+		}
+
+		// we should always show the exact CPE we searched by, not just what's in the component analysis (since we
+		// may alter the version based on above processing)
+		c.Attributes.Version = searchVersion
 
 		format := version.FormatFromPkg(p)
 

--- a/grype/search/cpe.go
+++ b/grype/search/cpe.go
@@ -108,7 +108,7 @@ func ByPackageCPE(store vulnerability.ProviderByCPE, d *distro.Distro, p pkg.Pac
 		}
 
 		if isUnknownVersion(searchVersion) {
-			log.WithFields("package", p).Warn("skipping package with unknown version")
+			log.WithFields("package", p.Name).Trace("skipping package with unknown version")
 			continue
 		}
 

--- a/grype/search/cpe_test.go
+++ b/grype/search/cpe_test.go
@@ -216,6 +216,71 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 			},
 		},
 		{
+			name: "fallback to package version",
+			p: pkg.Package{
+				CPEs: []cpe.CPE{
+					cpe.Must("cpe:2.3:*:activerecord:activerecord:unknown:rando1:*:ra:*:ruby:*:*", ""),
+					cpe.Must("cpe:2.3:*:activerecord:activerecord:unknown:rando4:*:re:*:rails:*:*", ""),
+				},
+				Name:     "activerecord",
+				Version:  "3.7.5",
+				Language: syftPkg.Ruby,
+				Type:     syftPkg.GemPkg,
+			},
+			expected: []match.Match{
+				{
+
+					Vulnerability: vulnerability.Vulnerability{
+						ID: "CVE-2017-fake-1",
+					},
+					Package: pkg.Package{
+						CPEs: []cpe.CPE{
+							cpe.Must("cpe:2.3:*:activerecord:activerecord:unknown:rando1:*:ra:*:ruby:*:*", ""),
+							cpe.Must("cpe:2.3:*:activerecord:activerecord:unknown:rando4:*:re:*:rails:*:*", ""),
+						},
+						Name:     "activerecord",
+						Version:  "3.7.5",
+						Language: syftPkg.Ruby,
+						Type:     syftPkg.GemPkg,
+					},
+					Details: []match.Detail{
+						{
+							Type:       match.CPEMatch,
+							Confidence: 0.9,
+							SearchedBy: CPEParameters{
+								Namespace: "nvd:cpe",
+								CPEs:      []string{"cpe:2.3:*:activerecord:activerecord:3.7.5:rando4:*:re:*:rails:*:*"},
+								Package: CPEPackageParameter{
+									Name:    "activerecord",
+									Version: "3.7.5",
+								},
+							},
+							Found: CPEResult{
+								CPEs:              []string{"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*"},
+								VersionConstraint: "< 3.7.6 (semver)",
+								VulnerabilityID:   "CVE-2017-fake-1",
+							},
+							Matcher: matcher,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "suppress matching when missing version",
+			p: pkg.Package{
+				CPEs: []cpe.CPE{
+					cpe.Must("cpe:2.3:*:activerecord:activerecord:unknown:rando1:*:ra:*:ruby:*:*", ""),
+					cpe.Must("cpe:2.3:*:activerecord:activerecord:unknown:rando4:*:re:*:rails:*:*", ""),
+				},
+				Name:     "activerecord",
+				Version:  "",
+				Language: syftPkg.Ruby,
+				Type:     syftPkg.GemPkg,
+			},
+			expected: []match.Match{},
+		},
+		{
 			name: "multiple matches",
 			p: pkg.Package{
 				CPEs: []cpe.CPE{
@@ -511,7 +576,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							Type:       match.CPEMatch,
 							Confidence: 0.9,
 							SearchedBy: CPEParameters{
-								CPEs:      []string{"cpe:2.3:*:sw:sw:*:*:*:*:*:*:*:*"},
+								CPEs:      []string{"cpe:2.3:*:sw:sw:0.1:*:*:*:*:*:*:*"},
 								Namespace: "nvd:cpe",
 								Package: CPEPackageParameter{
 									Name:    "sw",
@@ -567,7 +632,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							Type:       match.CPEMatch,
 							Confidence: 0.9,
 							SearchedBy: CPEParameters{
-								CPEs:      []string{"cpe:2.3:*:funfun:funfun:*:*:*:*:*:python:*:*"},
+								CPEs:      []string{"cpe:2.3:*:funfun:funfun:5.2.1:*:*:*:*:python:*:*"},
 								Namespace: "nvd:cpe",
 								Package: CPEPackageParameter{
 									Name:    "funfun",
@@ -618,7 +683,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							Type:       match.CPEMatch,
 							Confidence: 0.9,
 							SearchedBy: CPEParameters{
-								CPEs:      []string{"cpe:2.3:a:handlebarsjs:handlebars:*:*:*:*:*:*:*:*"},
+								CPEs:      []string{"cpe:2.3:a:handlebarsjs:handlebars:0.1:*:*:*:*:*:*:*"},
 								Namespace: "nvd:cpe",
 								Package: CPEPackageParameter{
 									Name:    "handlebars",
@@ -668,7 +733,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							Type:       match.CPEMatch,
 							Confidence: 0.9,
 							SearchedBy: CPEParameters{
-								CPEs:      []string{"cpe:2.3:a:handlebarsjs:handlebars:*:*:*:*:*:*:*:*"},
+								CPEs:      []string{"cpe:2.3:a:handlebarsjs:handlebars:0.1:*:*:*:*:*:*:*"},
 								Namespace: "nvd:cpe",
 								Package: CPEPackageParameter{
 									Name:    "handlebars",
@@ -718,7 +783,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							Type:       match.CPEMatch,
 							Confidence: 0.9,
 							SearchedBy: CPEParameters{
-								CPEs:      []string{"cpe:2.3:a:handlebarsjs:handlebars:*:*:*:*:*:*:*:*"},
+								CPEs:      []string{"cpe:2.3:a:handlebarsjs:handlebars:0.1:*:*:*:*:*:*:*"},
 								Namespace: "nvd:cpe",
 								Package: CPEPackageParameter{
 									Name:    "handlebars",
@@ -781,7 +846,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							Type:       match.CPEMatch,
 							Confidence: 0.9,
 							SearchedBy: CPEParameters{
-								CPEs:      []string{"cpe:2.3:a:handlebarsjs:handlebars:*:*:*:*:*:*:*:*"},
+								CPEs:      []string{"cpe:2.3:a:handlebarsjs:handlebars:0.1:*:*:*:*:*:*:*"},
 								Namespace: "nvd:cpe",
 								Package: CPEPackageParameter{
 									Name:    "handlebars",

--- a/grype/search/distro.go
+++ b/grype/search/distro.go
@@ -3,6 +3,7 @@ package search
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/match"
@@ -14,6 +15,11 @@ import (
 
 func ByPackageDistro(store vulnerability.ProviderByDistro, d *distro.Distro, p pkg.Package, upstreamMatcher match.MatcherType) ([]match.Match, error) {
 	if d == nil {
+		return nil, nil
+	}
+
+	if isUnknownVersion(p.Version) {
+		log.WithFields("package", p).Warn("skipping package with unknown version")
 		return nil, nil
 	}
 
@@ -76,4 +82,8 @@ func ByPackageDistro(store vulnerability.ProviderByDistro, d *distro.Distro, p p
 	}
 
 	return matches, err
+}
+
+func isUnknownVersion(v string) bool {
+	return v == "" || strings.ToLower(v) == "unknown"
 }

--- a/grype/search/distro.go
+++ b/grype/search/distro.go
@@ -19,7 +19,7 @@ func ByPackageDistro(store vulnerability.ProviderByDistro, d *distro.Distro, p p
 	}
 
 	if isUnknownVersion(p.Version) {
-		log.WithFields("package", p).Warn("skipping package with unknown version")
+		log.WithFields("package", p.Name).Trace("skipping package with unknown version")
 		return nil, nil
 	}
 

--- a/grype/search/distro_test.go
+++ b/grype/search/distro_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/match"
@@ -106,8 +107,15 @@ func TestFindMatchesByPackageDistro(t *testing.T) {
 
 	store := newMockProviderByDistro()
 	actual, err := ByPackageDistro(store, d, p, match.PythonMatcher)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assertMatchesUsingIDsForVulnerabilities(t, expected, actual)
+
+	// prove we do not search for unknown versions
+	p.Version = "unknown"
+	actual, err = ByPackageDistro(store, d, p, match.PythonMatcher)
+	require.NoError(t, err)
+	assert.Empty(t, actual)
+
 }
 
 func TestFindMatchesByPackageDistroSles(t *testing.T) {

--- a/grype/search/language.go
+++ b/grype/search/language.go
@@ -13,6 +13,12 @@ import (
 )
 
 func ByPackageLanguage(store vulnerability.ProviderByLanguage, d *distro.Distro, p pkg.Package, upstreamMatcher match.MatcherType) ([]match.Match, error) {
+	if isUnknownVersion(p.Version) {
+		log.WithFields("package", p).Warn("skipping package with unknown version")
+
+		return nil, nil
+	}
+
 	verObj, err := version.NewVersionFromPkg(p)
 	if err != nil {
 		if errors.Is(err, version.ErrUnsupportedVersion) {

--- a/grype/search/language.go
+++ b/grype/search/language.go
@@ -14,7 +14,7 @@ import (
 
 func ByPackageLanguage(store vulnerability.ProviderByLanguage, d *distro.Distro, p pkg.Package, upstreamMatcher match.MatcherType) ([]match.Match, error) {
 	if isUnknownVersion(p.Version) {
-		log.WithFields("package", p).Warn("skipping package with unknown version")
+		log.WithFields("package", p.Name).Trace("skipping package with unknown version")
 
 		return nil, nil
 	}

--- a/grype/vulnerability_matcher_test.go
+++ b/grype/vulnerability_matcher_test.go
@@ -592,7 +592,7 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 							SearchedBy: search.CPEParameters{
 								Namespace: "nvd:cpe",
 								CPEs: []string{
-									"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*",
+									"cpe:2.3:*:activerecord:activerecord:3.7.5:*:*:*:*:rails:*:*",
 								},
 								Package: search.CPEPackageParameter{
 									Name:    "activerecord",
@@ -690,25 +690,11 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 					Package: activerecordPkg,
 					Details: match.Details{
 						{
-							Type: match.ExactDirectMatch,
-							SearchedBy: map[string]any{
-								"language":  "ruby",
-								"namespace": "github:language:ruby",
-								"package":   map[string]string{"name": "activerecord", "version": "3.7.5"},
-							},
-							Found: map[string]any{
-								"versionConstraint": "< 3.7.6 (unknown)",
-								"vulnerabilityID":   "GHSA-2014-fake-3",
-							},
-							Matcher:    "ruby-gem-matcher",
-							Confidence: 1,
-						},
-						{
 							Type: match.CPEMatch,
 							SearchedBy: search.CPEParameters{
 								Namespace: "nvd:cpe",
 								CPEs: []string{
-									"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*",
+									"cpe:2.3:*:activerecord:activerecord:3.7.5:*:*:*:*:rails:*:*",
 								},
 								Package: search.CPEPackageParameter{
 									Name:    "activerecord",
@@ -724,6 +710,20 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 							},
 							Matcher:    "ruby-gem-matcher",
 							Confidence: 0.9,
+						},
+						{
+							Type: match.ExactDirectMatch,
+							SearchedBy: map[string]any{
+								"language":  "ruby",
+								"namespace": "github:language:ruby",
+								"package":   map[string]string{"name": "activerecord", "version": "3.7.5"},
+							},
+							Found: map[string]any{
+								"versionConstraint": "< 3.7.6 (unknown)",
+								"vulnerabilityID":   "GHSA-2014-fake-3",
+							},
+							Matcher:    "ruby-gem-matcher",
+							Confidence: 1,
 						},
 					},
 				},
@@ -775,7 +775,7 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 							SearchedBy: search.CPEParameters{
 								Namespace: "nvd:cpe",
 								CPEs: []string{
-									"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*",
+									"cpe:2.3:*:activerecord:activerecord:3.7.5:*:*:*:*:rails:*:*",
 								},
 								Package: search.CPEPackageParameter{
 									Name:    "activerecord",
@@ -887,7 +887,7 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 								SearchedBy: search.CPEParameters{
 									Namespace: "nvd:cpe",
 									CPEs: []string{
-										"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*",
+										"cpe:2.3:*:activerecord:activerecord:3.7.5:*:*:*:*:rails:*:*",
 									},
 									Package: search.CPEPackageParameter{
 										Name:    "activerecord",
@@ -1038,7 +1038,7 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 								SearchedBy: search.CPEParameters{
 									Namespace: "nvd:cpe",
 									CPEs: []string{
-										"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*",
+										"cpe:2.3:*:activerecord:activerecord:3.7.5:*:*:*:*:rails:*:*",
 									},
 									Package: search.CPEPackageParameter{
 										Name:    "activerecord",


### PR DESCRIPTION
As discussed on [discourse](https://anchorecommunity.discourse.group/t/grype-reporting-vulns-for-unknown-versions/174/5), grype should not be searching for packages that are missing version information as these will always yield incorrect results.

Additionally while working on this it was found that searched CPE versions were not always being raised accurately (when being overridden) -- this PR additionally fixes this behavior.