### PR TITLE
feat: multi-level configuration and profiles

### DIFF
--- a/cmd/grype/cli/cli.go
+++ b/cmd/grype/cli/cli.go
@@ -36,19 +36,19 @@ func create(id clio.Identification) (clio.Application, *cobra.Command) {
 		WithConfigInRootHelp().   // --help on the root command renders the full application config in the help text
 		WithUIConstructor(
 			// select a UI based on the logging configuration and state of stdin (if stdin is a tty)
-			func(cfg clio.Config) ([]clio.UI, error) {
+			func(cfg clio.Config) (*clio.UICollection, error) {
 				noUI := ui.None(cfg.Log.Quiet)
 				if !cfg.Log.AllowUI(os.Stdin) || cfg.Log.Quiet {
-					return []clio.UI{noUI}, nil
+					return clio.NewUICollection(noUI), nil
 				}
 
-				return []clio.UI{
+				return clio.NewUICollection(
 					ui.New(cfg.Log.Quiet,
 						grypeHandler.New(grypeHandler.DefaultHandlerConfig()),
 						syftHandler.New(syftHandler.DefaultHandlerConfig()),
 					),
 					noUI,
-				}, nil
+				), nil
 			},
 		).
 		WithInitializers(

--- a/cmd/grype/cli/commands/util.go
+++ b/cmd/grype/cli/commands/util.go
@@ -21,7 +21,7 @@ func disableUI(app clio.Application) func(*cobra.Command, []string) error {
 		}
 
 		state := app.(Stater).State()
-		state.UIs = []clio.UI{ui.None(state.Config.Log.Quiet)}
+		state.UI = clio.NewUICollection(ui.None(state.Config.Log.Quiet))
 
 		return nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/adrg/xdg v0.5.0
 	github.com/anchore/bubbly v0.0.0-20231115134915-def0aba654a9
-	github.com/anchore/clio v0.0.0-20240522144804-d81e109008aa
+	github.com/anchore/clio v0.0.0-20241015191535-f538a9016e10
 	github.com/anchore/go-collections v0.0.0-20240216171411-9321230ce537
 	github.com/anchore/go-logger v0.0.0-20230725134548-c21dafa1ec5a
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
@@ -62,6 +62,8 @@ require (
 	gorm.io/gorm v1.25.12
 )
 
+require gopkg.in/yaml.v3 v3.0.1
+
 require (
 	cloud.google.com/go v0.112.1 // indirect
 	cloud.google.com/go/compute v1.24.0 // indirect
@@ -80,7 +82,7 @@ require (
 	github.com/Microsoft/hcsshim v0.11.7 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
 	github.com/acobaugh/osrelease v0.1.0 // indirect
-	github.com/anchore/fangs v0.0.0-20240903175602-e716ef12c23d // indirect
+	github.com/anchore/fangs v0.0.0-20241014225144-4e1713cafd77 // indirect
 	github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb // indirect
 	github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
@@ -260,7 +262,6 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.55.3 // indirect
 	modernc.org/mathutil v1.6.0 // indirect
 	modernc.org/memory v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -238,10 +238,10 @@ github.com/anchore/archiver/v3 v3.5.2 h1:Bjemm2NzuRhmHy3m0lRe5tNoClB9A4zYyDV58Pa
 github.com/anchore/archiver/v3 v3.5.2/go.mod h1:e3dqJ7H78uzsRSEACH1joayhuSyhnonssnDhppzS1L4=
 github.com/anchore/bubbly v0.0.0-20231115134915-def0aba654a9 h1:p0ZIe0htYOX284Y4axJaGBvXHU0VCCzLN5Wf5XbKStU=
 github.com/anchore/bubbly v0.0.0-20231115134915-def0aba654a9/go.mod h1:3ZsFB9tzW3vl4gEiUeuSOMDnwroWxIxJelOOHUp8dSw=
-github.com/anchore/clio v0.0.0-20240522144804-d81e109008aa h1:pwlAn4O9SBUnlgfa69YcqIynbUyobLVFYu8HxSoCffA=
-github.com/anchore/clio v0.0.0-20240522144804-d81e109008aa/go.mod h1:nD3H5uIvjxlfmakOBgtyFQbk5Zjp3l538kxfpHPslzI=
-github.com/anchore/fangs v0.0.0-20240903175602-e716ef12c23d h1:ZD4wdCBgJJzJybjTUIEiiupLF7B9H3WLuBTjspBO2Mc=
-github.com/anchore/fangs v0.0.0-20240903175602-e716ef12c23d/go.mod h1:Xh4ObY3fmoMzOEVXwDtS1uK44JC7+nRD0n29/1KYFYg=
+github.com/anchore/clio v0.0.0-20241015191535-f538a9016e10 h1:3xmanFdoQEH0REvPA+gLm3Km0/981F4z2a/7ADTlv8k=
+github.com/anchore/clio v0.0.0-20241015191535-f538a9016e10/go.mod h1:h6Ly2hlKjQoPtI3rA8oB5afSmB/XimhcY55xbuW4Dwo=
+github.com/anchore/fangs v0.0.0-20241014225144-4e1713cafd77 h1:h7+GCqazHVS5GDJYYS6wjjglYi8xFnVWMdSUukoImTM=
+github.com/anchore/fangs v0.0.0-20241014225144-4e1713cafd77/go.mod h1:qbev5czQeyDO74fPNThiEKYkgt0mx1axb+5wQcxDPFY=
 github.com/anchore/go-collections v0.0.0-20240216171411-9321230ce537 h1:GjNGuwK5jWjJMyVppBjYS54eOiiSNv4Ba869k4wh72Q=
 github.com/anchore/go-collections v0.0.0-20240216171411-9321230ce537/go.mod h1:1aiktV46ATCkuVg0O573ZrH56BUawTECPETbZyBcqT8=
 github.com/anchore/go-logger v0.0.0-20230725134548-c21dafa1ec5a h1:nJ2G8zWKASyVClGVgG7sfM5mwoZlZ2zYpIzN2OhjWkw=

--- a/test/cli/config_test.go
+++ b/test/cli/config_test.go
@@ -1,0 +1,171 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func Test_configLoading(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.Chdir(cwd)) }()
+
+	configsDir := filepath.Join(cwd, "test-fixtures", "configs")
+	path := func(path string) string {
+		return filepath.Join(configsDir, filepath.Join(strings.Split(path, "/")...))
+	}
+
+	type ignore struct {
+		Vuln string `yaml:"vulnerability"`
+	}
+
+	type config struct {
+		Ignores []ignore `yaml:"ignore"`
+	}
+
+	tests := []struct {
+		name     string
+		home     string
+		cwd      string
+		args     []string
+		expected []ignore
+		err      string
+	}{
+		{
+			name: "single explicit config",
+			home: configsDir,
+			cwd:  cwd,
+			args: []string{
+				"-c",
+				path("dir1/.grype.yaml"),
+			},
+			expected: []ignore{
+				{
+					Vuln: "dir1-vuln1",
+				},
+				{
+					Vuln: "dir1-vuln2",
+				},
+			},
+		},
+		{
+			name: "multiple explicit config",
+			home: configsDir,
+			cwd:  cwd,
+			args: []string{
+				"-c",
+				path("dir1/.grype.yaml"),
+				"-c",
+				path("dir2/.grype.yaml"),
+			},
+			expected: []ignore{
+				{
+					Vuln: "dir1-vuln1",
+				},
+				{
+					Vuln: "dir1-vuln2",
+				},
+				{
+					Vuln: "dir2-vuln1",
+				},
+				{
+					Vuln: "dir2-vuln2",
+				},
+			},
+		},
+		{
+			name: "empty profile override",
+			home: configsDir,
+			cwd:  cwd,
+			args: []string{
+				"-c",
+				path("dir1/.grype.yaml"),
+				"-c",
+				path("dir2/.grype.yaml"),
+				"--profile",
+				"no-ignore",
+			},
+			expected: []ignore{},
+		},
+		{
+			name: "no profiles defined",
+			home: configsDir,
+			cwd:  configsDir,
+			args: []string{
+				"-c",
+				path("dir3/.grype.yaml"),
+				"--profile",
+				"invalid",
+			},
+			err: "not found in any configuration files",
+		},
+		{
+			name: "invalid profile name",
+			home: configsDir,
+			cwd:  cwd,
+			args: []string{
+				"-c",
+				path("dir1/.grype.yaml"),
+				"-c",
+				path("dir2/.grype.yaml"),
+				"--profile",
+				"alt",
+			},
+			err: "profile not found",
+		},
+		{
+			name: "explicit with profile override",
+			home: configsDir,
+			cwd:  cwd,
+			args: []string{
+				"-c",
+				path("dir1/.grype.yaml"),
+				"-c",
+				path("dir2/.grype.yaml"),
+				"--profile",
+				"alt-ignore",
+			},
+			expected: []ignore{
+				{
+					Vuln: "dir1-alt-vuln1", // dir1 is still first
+				},
+				{
+					Vuln: "dir1-alt-vuln2", // dir1 is still first
+				},
+				{
+					Vuln: "dir2-alt-vuln1",
+				},
+				{
+					Vuln: "dir2-alt-vuln2",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.NoError(t, os.Chdir(test.cwd))
+			defer func() { require.NoError(t, os.Chdir(cwd)) }()
+			env := map[string]string{
+				"HOME":            test.home,
+				"XDG_CONFIG_HOME": test.home,
+			}
+			_, stdout, stderr := runGrype(t, env, append([]string{"config", "--load"}, test.args...)...)
+			if test.err != "" {
+				require.Contains(t, stderr, test.err)
+				return
+			} else {
+				require.Empty(t, stderr)
+			}
+			got := config{}
+			err = yaml.NewDecoder(strings.NewReader(stdout)).Decode(&got)
+			require.NoError(t, err)
+			require.Equal(t, test.expected, got.Ignores)
+		})
+	}
+}

--- a/test/cli/test-fixtures/configs/dir1/.grype.yaml
+++ b/test/cli/test-fixtures/configs/dir1/.grype.yaml
@@ -1,0 +1,12 @@
+ignore:
+  - vulnerability: 'dir1-vuln1'
+  - vulnerability: 'dir1-vuln2'
+
+profiles:
+  no-ignore:
+    ignore: []
+
+  alt-ignore:
+    ignore:
+      - vulnerability: 'dir1-alt-vuln1'
+      - vulnerability: 'dir1-alt-vuln2'

--- a/test/cli/test-fixtures/configs/dir2/.grype.yaml
+++ b/test/cli/test-fixtures/configs/dir2/.grype.yaml
@@ -1,0 +1,9 @@
+ignore:
+  - vulnerability: 'dir2-vuln1'
+  - vulnerability: 'dir2-vuln2'
+
+profiles:
+  alt-ignore:
+    ignore:
+      - vulnerability: 'dir2-alt-vuln1'
+      - vulnerability: 'dir2-alt-vuln2'


### PR DESCRIPTION
# Description

This PR introduces changes to the configuration loading to support hierarchical configuration (loading local `.grype.yaml`, and a global `~/.grype.yaml`, for example), support for multiple configuration files (using multiple `-c` flags, etc.), and _configuration profiles_.

Fixes: #2009 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
