### PR TITLE
doc: Add official Grype logo license information

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,3 +874,10 @@ match:
 The following areas of potential development are currently being investigated:
 
 - Support for allowlist, package mapping
+
+
+## Grype Logo
+
+<p xmlns:cc="http://creativecommons.org/ns#" xmlns:dct="http://purl.org/dc/terms/"><a property="dct:title" rel="cc:attributionURL" href="https://anchore.com/wp-content/uploads/2024/11/grype-logo.svg">Grype Logo</a> by <a rel="cc:attributionURL dct:creator" property="cc:attributionName" href="https://anchore.com/">Anchore</a> is licensed under <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">CC BY 4.0<img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt=""><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt=""></a></p>
+
+


### PR DESCRIPTION
This clarifies the license under which the Grype "alien" logo is released. This is necessary to enable us to share the logo in certain online communities.