### PR TITLE
Add affected CPE store

### DIFF
--- a/grype/db/v6/affected_cpe_store.go
+++ b/grype/db/v6/affected_cpe_store.go
@@ -1,0 +1,106 @@
+package v6
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/anchore/grype/internal/log"
+)
+
+type AffectedCPEStoreWriter interface {
+	AddAffectedCPEs(packages ...*AffectedCPEHandle) error
+}
+
+type AffectedCPEStoreReader interface {
+	GetCPEsByProduct(packageName string, config *GetAffectedCPEOptions) ([]AffectedCPEHandle, error)
+}
+
+type GetAffectedCPEOptions struct {
+	PreloadCPE  bool
+	PreloadBlob bool
+}
+
+type affectedCPEStore struct {
+	db        *gorm.DB
+	blobStore *blobStore
+}
+
+func newAffectedCPEStore(db *gorm.DB, bs *blobStore) *affectedCPEStore {
+	return &affectedCPEStore{
+		db:        db,
+		blobStore: bs,
+	}
+}
+
+// AddAffectedCPEs adds one or more affected CPEs to the store
+func (s *affectedCPEStore) AddAffectedCPEs(packages ...*AffectedCPEHandle) error {
+	for _, pkg := range packages {
+		if err := s.blobStore.addBlobable(pkg); err != nil {
+			return fmt.Errorf("unable to add affected package blob: %w", err)
+		}
+
+		if err := s.db.Create(pkg).Error; err != nil {
+			return fmt.Errorf("unable to add affected CPE: %w", err)
+		}
+	}
+	return nil
+}
+
+// GetCPEsByProduct retrieves a single AffectedCPEHandle by product name
+func (s *affectedCPEStore) GetCPEsByProduct(packageName string, config *GetAffectedCPEOptions) ([]AffectedCPEHandle, error) {
+	if config == nil {
+		config = &GetAffectedCPEOptions{}
+	}
+
+	log.WithFields("product", packageName).Trace("fetching AffectedCPE record")
+
+	var pkgs []AffectedCPEHandle
+	query := s.db.
+		Joins("JOIN cpes ON cpes.id = affected_cpe_handles.cpe_id").
+		Where("cpes.product = ?", packageName)
+
+	query = s.handlePreload(query, *config)
+
+	err := query.Find(&pkgs).Error
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch affected package record: %w", err)
+	}
+
+	if config.PreloadBlob {
+		for i := range pkgs {
+			err := s.attachBlob(&pkgs[i])
+			if err != nil {
+				return nil, fmt.Errorf("unable to attach blob %#v: %w", pkgs[i], err)
+			}
+		}
+	}
+
+	return pkgs, nil
+}
+
+func (s *affectedCPEStore) handlePreload(query *gorm.DB, config GetAffectedCPEOptions) *gorm.DB {
+	if config.PreloadCPE {
+		query = query.Preload("CPE")
+	}
+
+	return query
+}
+
+// attachBlob attaches the BlobValue to the AffectedCPEHandle
+func (s *affectedCPEStore) attachBlob(cpe *AffectedCPEHandle) error {
+	var blobValue *AffectedPackageBlob
+
+	rawValue, err := s.blobStore.getBlobValue(cpe.BlobID)
+	if err != nil {
+		return fmt.Errorf("unable to fetch blob value for affected CPE: %w", err)
+	}
+
+	if err := json.Unmarshal([]byte(rawValue), &blobValue); err != nil {
+		return fmt.Errorf("unable to unmarshal blob value: %w", err)
+	}
+
+	cpe.BlobValue = blobValue
+	return nil
+}

--- a/grype/db/v6/affected_cpe_store_test.go
+++ b/grype/db/v6/affected_cpe_store_test.go
@@ -1,0 +1,100 @@
+package v6
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAffectedCPEStore_AddAffectedCPEs(t *testing.T) {
+	db := setupTestDB(t)
+	bw := newBlobStore(db)
+	s := newAffectedCPEStore(db, bw)
+
+	cpe1 := &AffectedCPEHandle{
+		VulnerabilityID: 1,
+		CpeID:           1,
+		CPE: &Cpe{
+			Type:    "a",
+			Vendor:  "vendor-1",
+			Product: "product-1",
+			Edition: "edition-1",
+		},
+		BlobValue: &AffectedPackageBlob{
+			CVEs: []string{"CVE-2023-5678"},
+		},
+	}
+
+	cpe2 := testAffectedCPEHandle()
+
+	err := s.AddAffectedCPEs(cpe1, cpe2)
+	require.NoError(t, err)
+
+	var result1 AffectedCPEHandle
+	err = db.Where("cpe_id = ?", 1).First(&result1).Error
+	require.NoError(t, err)
+	assert.Equal(t, cpe1.VulnerabilityID, result1.VulnerabilityID)
+	assert.Equal(t, cpe1.ID, result1.ID)
+	assert.Equal(t, cpe1.BlobID, result1.BlobID)
+	assert.Nil(t, result1.BlobValue) // since we're not preloading any fields on the fetch
+
+	var result2 AffectedCPEHandle
+	err = db.Where("cpe_id = ?", 2).First(&result2).Error
+	require.NoError(t, err)
+	assert.Equal(t, cpe2.VulnerabilityID, result2.VulnerabilityID)
+	assert.Equal(t, cpe2.ID, result2.ID)
+	assert.Equal(t, cpe2.BlobID, result2.BlobID)
+	assert.Nil(t, result2.BlobValue) // since we're not preloading any fields on the fetch
+}
+
+func TestAffectedCPEStore_GetCPEsByProduct(t *testing.T) {
+	db := setupTestDB(t)
+	bw := newBlobStore(db)
+	s := newAffectedCPEStore(db, bw)
+
+	cpe := testAffectedCPEHandle()
+	err := s.AddAffectedCPEs(cpe)
+	require.NoError(t, err)
+
+	results, err := s.GetCPEsByProduct(cpe.CPE.Product, nil)
+	require.NoError(t, err)
+
+	expected := []AffectedCPEHandle{*cpe}
+	require.Len(t, results, len(expected))
+	result := results[0]
+	assert.Equal(t, cpe.CpeID, result.CpeID)
+	assert.Equal(t, cpe.ID, result.ID)
+	assert.Equal(t, cpe.BlobID, result.BlobID)
+	require.Nil(t, result.BlobValue) // since we're not preloading any fields on the fetch
+
+	// fetch again with blob & cpe preloaded
+	results, err = s.GetCPEsByProduct(cpe.CPE.Product, &GetAffectedCPEOptions{PreloadCPE: true, PreloadBlob: true})
+	require.NoError(t, err)
+	require.Len(t, results, len(expected))
+	result = results[0]
+	assert.NotNil(t, result.BlobValue)
+	if d := cmp.Diff(*cpe, result); d != "" {
+		t.Errorf("unexpected result (-want +got):\n%s", d)
+	}
+}
+
+func testAffectedCPEHandle() *AffectedCPEHandle {
+	return &AffectedCPEHandle{
+		CPE: &Cpe{
+			Type:            "application",
+			Vendor:          "vendor",
+			Product:         "product",
+			Edition:         "edition",
+			Language:        "language",
+			SoftwareEdition: "software_edition",
+			TargetHardware:  "target_hardware",
+			TargetSoftware:  "target_software",
+			Other:           "other",
+		},
+		BlobValue: &AffectedPackageBlob{
+			CVEs: []string{"CVE-2024-4321"},
+		},
+	}
+}

--- a/grype/db/v6/affected_package_store_test.go
+++ b/grype/db/v6/affected_package_store_test.go
@@ -31,7 +31,7 @@ func TestAffectedPackageStore_AddAffectedPackages(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, pkg1.PackageID, result1.PackageID)
 	assert.Equal(t, pkg1.BlobID, result1.BlobID)
-	assert.Nil(t, result1.BlobValue) // no preloading on fetch
+	require.Nil(t, result1.BlobValue) // no preloading on fetch
 
 	var result2 AffectedPackageHandle
 	err = db.Where("package_id = ?", pkg2.PackageID).First(&result2).Error
@@ -55,13 +55,13 @@ func TestAffectedPackageStore_GetAffectedPackagesByName(t *testing.T) {
 	tests := []struct {
 		name        string
 		packageName string
-		options     *GetAffectedOptions
+		options     *GetAffectedPackageOptions
 		expected    []AffectedPackageHandle
 	}{
 		{
 			name:        "specific distro",
 			packageName: pkg2d1.Package.Name,
-			options: &GetAffectedOptions{
+			options: &GetAffectedPackageOptions{
 				Distro: &DistroSpecifier{
 					Name:         "ubuntu",
 					MajorVersion: "20",
@@ -73,7 +73,7 @@ func TestAffectedPackageStore_GetAffectedPackagesByName(t *testing.T) {
 		{
 			name:        "distro major version",
 			packageName: pkg2d1.Package.Name,
-			options: &GetAffectedOptions{
+			options: &GetAffectedPackageOptions{
 				Distro: &DistroSpecifier{
 					Name:         "ubuntu",
 					MajorVersion: "20",
@@ -84,7 +84,7 @@ func TestAffectedPackageStore_GetAffectedPackagesByName(t *testing.T) {
 		{
 			name:        "distro codename",
 			packageName: pkg2d1.Package.Name,
-			options: &GetAffectedOptions{
+			options: &GetAffectedPackageOptions{
 				Distro: &DistroSpecifier{
 					Name:     "ubuntu",
 					Codename: "groovy",
@@ -95,7 +95,7 @@ func TestAffectedPackageStore_GetAffectedPackagesByName(t *testing.T) {
 		{
 			name:        "no distro",
 			packageName: pkg2.Package.Name,
-			options: &GetAffectedOptions{
+			options: &GetAffectedPackageOptions{
 				Distro: NoDistroSpecified,
 			},
 			expected: []AffectedPackageHandle{*pkg2},
@@ -103,7 +103,7 @@ func TestAffectedPackageStore_GetAffectedPackagesByName(t *testing.T) {
 		{
 			name:        "any distro",
 			packageName: pkg2d1.Package.Name,
-			options: &GetAffectedOptions{
+			options: &GetAffectedPackageOptions{
 				Distro: AnyDistroSpecified,
 			},
 			expected: []AffectedPackageHandle{*pkg2d1, *pkg2, *pkg2d2},
@@ -111,7 +111,7 @@ func TestAffectedPackageStore_GetAffectedPackagesByName(t *testing.T) {
 		{
 			name:        "package type",
 			packageName: pkg2.Package.Name,
-			options: &GetAffectedOptions{
+			options: &GetAffectedPackageOptions{
 				PackageType: "type2",
 			},
 			expected: []AffectedPackageHandle{*pkg2},

--- a/grype/db/v6/store.go
+++ b/grype/db/v6/store.go
@@ -14,6 +14,7 @@ type store struct {
 	*providerStore
 	*vulnerabilityStore
 	*affectedPackageStore
+	*affectedCPEStore
 	blobStore *blobStore
 	db        *gorm.DB
 	config    Config
@@ -42,6 +43,7 @@ func newStore(cfg Config, write bool) (*store, error) {
 		providerStore:        newProviderStore(db),
 		vulnerabilityStore:   newVulnerabilityStore(db, bs),
 		affectedPackageStore: newAffectedPackageStore(db, bs),
+		affectedCPEStore:     newAffectedCPEStore(db, bs),
 		blobStore:            bs,
 		db:                   db,
 		config:               cfg,

--- a/grype/db/v6/vulnerability_store.go
+++ b/grype/db/v6/vulnerability_store.go
@@ -14,7 +14,7 @@ type VulnerabilityStoreWriter interface {
 }
 
 type VulnerabilityStoreReader interface {
-	GetVulnerability(id int64, config *GetVulnerabilityOptions) (*VulnerabilityHandle, error)
+	GetVulnerability(id ID, config *GetVulnerabilityOptions) (*VulnerabilityHandle, error)
 	GetVulnerabilitiesByName(vulnID string, config *GetVulnerabilityOptions) ([]VulnerabilityHandle, error)
 }
 
@@ -40,7 +40,7 @@ func newVulnerabilityStore(db *gorm.DB, bs *blobStore) *vulnerabilityStore {
 	}
 }
 
-func (s *vulnerabilityStore) GetVulnerability(id int64, config *GetVulnerabilityOptions) (*VulnerabilityHandle, error) {
+func (s *vulnerabilityStore) GetVulnerability(id ID, config *GetVulnerabilityOptions) (*VulnerabilityHandle, error) {
 	if config == nil {
 		config = DefaultGetVulnerabilityOptions()
 	}


### PR DESCRIPTION
Adds the following V6 schema models:
- `AffectedCPEHandle`
- `CPE`

The sotre has been updated to reflect the additional getters/setters for these objects (currently only supporting by product name, but this can be expanded in the future with additional config options).

Partially addresses #2132

Closes #2128