### PR TITLE
Add ability to map CPEs directly to packages (v6 schema)

### DIFF
--- a/grype/db/v6/affected_package_store.go
+++ b/grype/db/v6/affected_package_store.go
@@ -197,14 +197,6 @@ func (s *affectedPackageStore) handlePackageCPE(query *gorm.DB, c cpe.Attributes
 		query = query.Where("cpes.product = ?", c.Product)
 	}
 
-	if c.Version != cpe.Any {
-		query = query.Where("cpes.version = ?", c.Version)
-	}
-
-	if c.Update != cpe.Any {
-		query = query.Where("cpes.update = ?", c.Update)
-	}
-
 	if c.Edition != cpe.Any {
 		query = query.Where("cpes.edition = ?", c.Edition)
 	}


### PR DESCRIPTION
This PR allows for direct associations of `Packages` to `CPEs` so that raising up more accurate `AffectedPackageHandles` over `AffectedCPEHandles` is possible. The data enrichment process we apply to the NVD data today will be leveraging this functionality (which lands when a new vunnel provider is written). This also makes the nomenclature correction of renaming `cpe.Type` to `cpe.Part`.