### PR TITLE
Fix DB v6 curator directory creation

### DIFF
--- a/grype/db/v6/distribution/client.go
+++ b/grype/db/v6/distribution/client.go
@@ -128,10 +128,14 @@ func (c client) isUpdateAvailable(current *v6.Description, candidate *LatestDocu
 func (c client) Download(archive Archive, dest string, downloadProgress *progress.Manual) (string, error) {
 	defer downloadProgress.SetCompleted()
 
+	if err := os.MkdirAll(dest, 0700); err != nil {
+		return "", fmt.Errorf("unable to create db download root dir: %w", err)
+	}
+
 	// note: as much as I'd like to use the afero FS abstraction here, the go-getter library does not support it
 	tempDir, err := os.MkdirTemp(dest, "grype-db-download")
 	if err != nil {
-		return "", fmt.Errorf("unable to create db temp dir: %w", err)
+		return "", fmt.Errorf("unable to create db client temp dir: %w", err)
 	}
 
 	// download the db to the temp dir

--- a/grype/db/v6/distribution/client_test.go
+++ b/grype/db/v6/distribution/client_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -169,6 +170,18 @@ func TestClient_Download(t *testing.T) {
 		require.Error(t, err)
 		require.Empty(t, tempDir)
 		require.Contains(t, err.Error(), "unable to download db")
+
+		mg.AssertExpectations(t)
+	})
+
+	t.Run("nested into dir that does not exist", func(t *testing.T) {
+		c, mg := setup()
+		mg.On("GetToDir", mock.Anything, "http://localhost:8080/path/to/archive.tar.gz?checksum=checksum123", mock.Anything).Return(nil)
+
+		nestedPath := filepath.Join(destDir, "nested")
+		tempDir, err := c.Download(*archive, nestedPath, &progress.Manual{})
+		require.NoError(t, err)
+		require.True(t, len(tempDir) > 0)
 
 		mg.AssertExpectations(t)
 	})


### PR DESCRIPTION
There are a few assumptions made by the v6 curator surrounding DB directory existence. This PR fixes activation-related issues with the DB not existing.