### PR TITLE
`latest.json` from reader should allow for empty values

### DIFF
--- a/grype/db/v6/distribution/client.go
+++ b/grype/db/v6/distribution/client.go
@@ -233,12 +233,12 @@ func isSupersededBy(current *v6.Description, candidate v6.Description) bool {
 	otherModelPart, otherOk := candidate.SchemaVersion.ModelPart()
 	currentModelPart, currentOk := current.SchemaVersion.ModelPart()
 
-	if !otherOk {
+	if !currentOk {
 		log.Error("existing database has no schema version, doing nothing...")
 		return false
 	}
 
-	if !currentOk {
+	if !otherOk {
 		log.Error("update has no schema version, doing nothing...")
 		return false
 	}

--- a/grype/db/v6/distribution/latest.go
+++ b/grype/db/v6/distribution/latest.go
@@ -59,14 +59,12 @@ func NewLatestDocument(entries ...Archive) *LatestDocument {
 
 func NewLatestFromReader(reader io.Reader) (*LatestDocument, error) {
 	var l LatestDocument
-
 	if err := json.NewDecoder(reader).Decode(&l); err != nil {
 		return nil, fmt.Errorf("unable to parse DB latest.json: %w", err)
 	}
 
-	// inflate entry data from parent
-	if l.Archive.Description.SchemaVersion != "" {
-		l.Archive.Description.SchemaVersion = l.SchemaVersion
+	if l == (LatestDocument{}) {
+		return nil, nil
 	}
 
 	return &l, nil

--- a/grype/db/v6/distribution/latest_test.go
+++ b/grype/db/v6/distribution/latest_test.go
@@ -68,6 +68,7 @@ func TestNewLatestDocument(t *testing.T) {
 }
 
 func TestNewLatestFromReader(t *testing.T) {
+
 	t.Run("valid JSON", func(t *testing.T) {
 		latestDoc := LatestDocument{
 			Archive: Archive{
@@ -87,11 +88,19 @@ func TestNewLatestFromReader(t *testing.T) {
 		require.Equal(t, latestDoc.Archive.Description.Built.Time, result.Archive.Description.Built.Time)
 	})
 
+	t.Run("empty", func(t *testing.T) {
+		emptyJSON := []byte("{}")
+		val, err := NewLatestFromReader(bytes.NewReader(emptyJSON))
+		require.NoError(t, err)
+		assert.Nil(t, val)
+	})
+
 	t.Run("invalid JSON", func(t *testing.T) {
 		invalidJSON := []byte("invalid json")
-		_, err := NewLatestFromReader(bytes.NewReader(invalidJSON))
+		val, err := NewLatestFromReader(bytes.NewReader(invalidJSON))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unable to parse DB latest.json")
+		assert.Nil(t, val)
 	})
 }
 


### PR DESCRIPTION
Noticed odd output with v6 experiment enabled when running `db check`:
<img width="509" alt="Screenshot 2024-12-02 at 5 18 36 PM" src="https://github.com/user-attachments/assets/acc82ec5-48b8-4add-afba-4bf814710f40">

From a testing perspective there is good coverage for functionality, however, the logging lines were flipped (in the wrong conditions).

It was also found that getting a latest doc from a reader wasn't allowing for there to be no update (indicated as nil in testing currently).

This PR fixes this behavior:
<img width="434" alt="Screenshot 2024-12-02 at 5 15 07 PM" src="https://github.com/user-attachments/assets/1415cebe-f036-483f-9729-488309f6d126">
