### PR TITLE
Migrate searchable vulnerability data out of v6 blob

### DIFF
--- a/cmd/grype/cli/commands/db_search.go
+++ b/cmd/grype/cli/commands/db_search.go
@@ -70,7 +70,7 @@ func newDBSearch(opts dbQueryOptions, vulnerabilityID string) error {
 		return fmt.Errorf("unable to get providers: %w", err)
 	}
 
-	vh, err := reader.GetVulnerabilitiesByName(vulnerabilityID, &v6.GetVulnerabilityOptions{
+	vh, err := reader.GetVulnerabilities(&v6.VulnerabilitySpecifier{Name: vulnerabilityID}, &v6.GetVulnerabilityOptions{
 		Preload: true,
 	})
 	if err != nil {

--- a/grype/db/v6/affected_cpe_store.go
+++ b/grype/db/v6/affected_cpe_store.go
@@ -117,7 +117,7 @@ func (s *affectedCPEStore) handleVulnerabilityOptions(query *gorm.DB, config *Vu
 
 	query = query.Joins("JOIN vulnerability_handles ON affected_cpe_handles.vulnerability_id = vulnerability_handles.id")
 
-	return handleVulnerabilityOptions(s.db, query, config)
+	return handleVulnerabilityOptions(query, config)
 }
 
 func (s *affectedCPEStore) handlePreload(query *gorm.DB, config GetAffectedCPEOptions) *gorm.DB {

--- a/grype/db/v6/affected_cpe_store.go
+++ b/grype/db/v6/affected_cpe_store.go
@@ -67,13 +67,16 @@ func (s *affectedCPEStore) GetAffectedCPEs(cpe *cpe.Attributes, config *GetAffec
 
 	query := s.handleCPE(s.db, cpe)
 
-	query = s.handleVulnerabilityOptions(query, config.Vulnerability)
+	var err error
+	query, err = s.handleVulnerabilityOptions(query, config.Vulnerability)
+	if err != nil {
+		return nil, err
+	}
 
 	query = s.handlePreload(query, *config)
 
 	var pkgs []AffectedCPEHandle
-	err := query.Find(&pkgs).Error
-	if err != nil {
+	if err = query.Find(&pkgs).Error; err != nil {
 		return nil, fmt.Errorf("unable to fetch affected package record: %w", err)
 	}
 
@@ -104,53 +107,17 @@ func (s *affectedCPEStore) handleCPE(query *gorm.DB, c *cpe.Attributes) *gorm.DB
 	}
 	query = query.Joins("JOIN cpes ON cpes.id = affected_cpe_handles.cpe_id")
 
-	if c.Part != cpe.Any {
-		query = query.Where("cpes.part = ?", c.Part)
-	}
-
-	if c.Vendor != cpe.Any {
-		query = query.Where("cpes.vendor = ?", c.Vendor)
-	}
-
-	if c.Product != cpe.Any {
-		query = query.Where("cpes.product = ?", c.Product)
-	}
-
-	if c.Edition != cpe.Any {
-		query = query.Where("cpes.edition = ?", c.Edition)
-	}
-
-	if c.Language != cpe.Any {
-		query = query.Where("cpes.language = ?", c.Language)
-	}
-
-	if c.SWEdition != cpe.Any {
-		query = query.Where("cpes.sw_edition = ?", c.SWEdition)
-	}
-
-	if c.TargetSW != cpe.Any {
-		query = query.Where("cpes.target_sw = ?", c.TargetSW)
-	}
-
-	if c.TargetHW != cpe.Any {
-		query = query.Where("cpes.target_hw = ?", c.TargetHW)
-	}
-
-	if c.Other != cpe.Any {
-		query = query.Where("cpes.other = ?", c.Other)
-	}
-
-	return query
+	return handleCPEOptions(query, c)
 }
 
-func (s *affectedCPEStore) handleVulnerabilityOptions(query *gorm.DB, config *VulnerabilitySpecifier) *gorm.DB {
+func (s *affectedCPEStore) handleVulnerabilityOptions(query *gorm.DB, config *VulnerabilitySpecifier) (*gorm.DB, error) {
 	if config == nil {
-		return query
+		return query, nil
 	}
-	if config.Name != "" {
-		query = query.Joins("JOIN vulnerability_handles ON affected_cpe_handles.vulnerability_id = vulnerability_handles.id").Where("vulnerability_handles.name = ?", config.Name)
-	}
-	return query
+
+	query = query.Joins("JOIN vulnerability_handles ON affected_cpe_handles.vulnerability_id = vulnerability_handles.id")
+
+	return handleVulnerabilityOptions(s.db, query, config)
 }
 
 func (s *affectedCPEStore) handlePreload(query *gorm.DB, config GetAffectedCPEOptions) *gorm.DB {
@@ -159,7 +126,7 @@ func (s *affectedCPEStore) handlePreload(query *gorm.DB, config GetAffectedCPEOp
 	}
 
 	if config.PreloadVulnerability {
-		query = query.Preload("Vulnerability")
+		query = query.Preload("Vulnerability").Preload("Vulnerability.Provider")
 	}
 
 	return query

--- a/grype/db/v6/affected_cpe_store_test.go
+++ b/grype/db/v6/affected_cpe_store_test.go
@@ -17,6 +17,9 @@ func TestAffectedCPEStore_AddAffectedCPEs(t *testing.T) {
 
 	cpe1 := &AffectedCPEHandle{
 		Vulnerability: &VulnerabilityHandle{ // vuln id = 1
+			Provider: &Provider{
+				ID: "nvd",
+			},
 			Name: "CVE-2023-5678",
 		},
 		CpeID: 1,
@@ -92,6 +95,9 @@ func TestAffectedCPEStore_PreventDuplicateCPEs(t *testing.T) {
 	cpe1 := &AffectedCPEHandle{
 		Vulnerability: &VulnerabilityHandle{ // vuln id = 1
 			Name: "CVE-2023-5678",
+			Provider: &Provider{
+				ID: "nvd",
+			},
 		},
 		CpeID: 1,
 		CPE: &Cpe{
@@ -112,6 +118,9 @@ func TestAffectedCPEStore_PreventDuplicateCPEs(t *testing.T) {
 	duplicateCPE := &AffectedCPEHandle{
 		Vulnerability: &VulnerabilityHandle{ // vuln id = 2, different VulnerabilityID for testing...
 			Name: "CVE-2024-1234",
+			Provider: &Provider{
+				ID: "nvd",
+			},
 		},
 		CpeID: 2,
 		CPE: &Cpe{
@@ -158,6 +167,9 @@ func testAffectedCPEHandle() *AffectedCPEHandle {
 	return &AffectedCPEHandle{
 		Vulnerability: &VulnerabilityHandle{
 			Name: "CVE-2024-4321",
+			Provider: &Provider{
+				ID: "nvd",
+			},
 		},
 		CPE: &Cpe{
 			Part:            "application",

--- a/grype/db/v6/affected_package_store.go
+++ b/grype/db/v6/affected_package_store.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -104,6 +105,9 @@ func (d DistroSpecifier) version() string {
 type VulnerabilitySpecifier struct {
 	// Name of the vulnerability (e.g. CVE-2020-1234)
 	Name string
+
+	PublishedAfter *time.Time
+	ModifiedAfter  *time.Time
 }
 
 func (d DistroSpecifier) matchesVersionPattern(pattern string) bool {
@@ -165,9 +169,12 @@ func (s *affectedPackageStore) GetAffectedPackages(pkg *PackageSpecifier, config
 
 	query := s.handlePackage(s.db, pkg)
 
-	query = s.handleVulnerabilityOptions(query, config.Vulnerability)
-
 	var err error
+	query, err = s.handleVulnerabilityOptions(query, config.Vulnerability)
+	if err != nil {
+		return nil, err
+	}
+
 	query, err = s.handleDistroOptions(query, config.Distro)
 	if err != nil {
 		return nil, err
@@ -176,8 +183,7 @@ func (s *affectedPackageStore) GetAffectedPackages(pkg *PackageSpecifier, config
 	query = s.handlePreload(query, *config)
 
 	var pkgs []AffectedPackageHandle
-	err = query.Find(&pkgs).Error
-	if err != nil {
+	if err = query.Find(&pkgs).Error; err != nil {
 		return nil, fmt.Errorf("unable to fetch non-distro affected package record: %w", err)
 	}
 
@@ -218,55 +224,19 @@ func (s *affectedPackageStore) handlePackage(query *gorm.DB, config *PackageSpec
 
 	if config.CPE != nil {
 		query = query.Joins("JOIN cpes ON packages.id = cpes.package_id")
-		c := config.CPE
-		if c.Part != cpe.Any {
-			query = query.Where("cpes.part = ?", c.Part)
-		}
-
-		if c.Vendor != cpe.Any {
-			query = query.Where("cpes.vendor = ?", c.Vendor)
-		}
-
-		if c.Product != cpe.Any {
-			query = query.Where("cpes.product = ?", c.Product)
-		}
-
-		if c.Edition != cpe.Any {
-			query = query.Where("cpes.edition = ?", c.Edition)
-		}
-
-		if c.Language != cpe.Any {
-			query = query.Where("cpes.language = ?", c.Language)
-		}
-
-		if c.SWEdition != cpe.Any {
-			query = query.Where("cpes.sw_edition = ?", c.SWEdition)
-		}
-
-		if c.TargetSW != cpe.Any {
-			query = query.Where("cpes.target_sw = ?", c.TargetSW)
-		}
-
-		if c.TargetHW != cpe.Any {
-			query = query.Where("cpes.target_hw = ?", c.TargetHW)
-		}
-
-		if c.Other != cpe.Any {
-			query = query.Where("cpes.other = ?", c.Other)
-		}
+		query = handleCPEOptions(query, config.CPE)
 	}
 
 	return query
 }
 
-func (s *affectedPackageStore) handleVulnerabilityOptions(query *gorm.DB, config *VulnerabilitySpecifier) *gorm.DB {
+func (s *affectedPackageStore) handleVulnerabilityOptions(query *gorm.DB, config *VulnerabilitySpecifier) (*gorm.DB, error) {
 	if config == nil {
-		return query
+		return query, nil
 	}
-	if config.Name != "" {
-		query = query.Joins("JOIN vulnerability_handles ON affected_package_handles.vulnerability_id = vulnerability_handles.id").Where("vulnerability_handles.name = ?", config.Name)
-	}
-	return query
+	query = query.Joins("JOIN vulnerability_handles ON affected_package_handles.vulnerability_id = vulnerability_handles.id")
+
+	return handleVulnerabilityOptions(s.db, query, config)
 }
 
 func (s *affectedPackageStore) handleDistroOptions(query *gorm.DB, config *DistroSpecifier) (*gorm.DB, error) {
@@ -464,13 +434,70 @@ func (s *affectedPackageStore) handlePreload(query *gorm.DB, config GetAffectedP
 	}
 
 	if config.PreloadVulnerability {
-		query = query.Preload("Vulnerability")
+		query = query.Preload("Vulnerability").Preload("Vulnerability.Provider")
 	}
 
 	if config.PreloadOS {
 		query = query.Preload("OperatingSystem")
 	}
 	return query
+}
+
+func handleCPEOptions(query *gorm.DB, c *cpe.Attributes) *gorm.DB {
+	if c.Part != cpe.Any {
+		query = query.Where("cpes.part = ?", c.Part)
+	}
+
+	if c.Vendor != cpe.Any {
+		query = query.Where("cpes.vendor = ?", c.Vendor)
+	}
+
+	if c.Product != cpe.Any {
+		query = query.Where("cpes.product = ?", c.Product)
+	}
+
+	if c.Edition != cpe.Any {
+		query = query.Where("cpes.edition = ?", c.Edition)
+	}
+
+	if c.Language != cpe.Any {
+		query = query.Where("cpes.language = ?", c.Language)
+	}
+
+	if c.SWEdition != cpe.Any {
+		query = query.Where("cpes.sw_edition = ?", c.SWEdition)
+	}
+
+	if c.TargetSW != cpe.Any {
+		query = query.Where("cpes.target_sw = ?", c.TargetSW)
+	}
+
+	if c.TargetHW != cpe.Any {
+		query = query.Where("cpes.target_hw = ?", c.TargetHW)
+	}
+
+	if c.Other != cpe.Any {
+		query = query.Where("cpes.other = ?", c.Other)
+	}
+	return query
+}
+
+func handleVulnerabilityOptions(basis, query *gorm.DB, config *VulnerabilitySpecifier) (*gorm.DB, error) {
+	if config.ModifiedAfter != nil && config.PublishedAfter != nil {
+		return nil, fmt.Errorf("only one of ModifiedAfter or PublishedAfter can be specified for a vulnerability")
+	}
+
+	if config.Name != "" {
+		query.Where("vulnerability_handles.name = ?", config.Name)
+	}
+
+	if config.PublishedAfter != nil {
+		query = query.Where("vulnerability_handles.published_date > ?", *config.PublishedAfter)
+	} else if config.ModifiedAfter != nil {
+		query = query.Where(basis.Where("vulnerability_handles.published_date > ?", *config.ModifiedAfter).Or("vulnerability_handles.modified_date > ?", *config.ModifiedAfter))
+	}
+
+	return query, nil
 }
 
 func distroDisplay(d *DistroSpecifier) string {

--- a/grype/db/v6/affected_package_store_test.go
+++ b/grype/db/v6/affected_package_store_test.go
@@ -141,6 +141,12 @@ func TestAffectedPackageStore_AddAffectedPackages(t *testing.T) {
 
 	setupTestStoreWithPackages := func(t *testing.T) (*AffectedPackageHandle, *AffectedPackageHandle, *affectedPackageStore) {
 		pkg1 := &AffectedPackageHandle{
+			Vulnerability: &VulnerabilityHandle{
+				Name: "CVE-2023-1234",
+				Provider: &Provider{
+					ID: "provider1",
+				},
+			},
 			Package: &Package{Name: "pkg1", Type: "type1"},
 			BlobValue: &AffectedPackageBlob{
 				CVEs: []string{"CVE-2023-1234"},
@@ -198,12 +204,12 @@ func TestAffectedPackageStore_AddAffectedPackages(t *testing.T) {
 	t.Run("preload CPEs", func(t *testing.T) {
 		pkg1, _, s := setupTestStoreWithPackages(t)
 
-		cpe := Cpe{
+		c := Cpe{
 			Part:    "a",
 			Vendor:  "vendor1",
 			Product: "product1",
 		}
-		pkg1.Package.CPEs = []Cpe{cpe}
+		pkg1.Package.CPEs = []Cpe{c}
 
 		err := s.AddAffectedPackages(pkg1)
 		require.NoError(t, err)
@@ -221,16 +227,22 @@ func TestAffectedPackageStore_AddAffectedPackages(t *testing.T) {
 		require.NotNil(t, result.Package)
 
 		// the IDs should have been set, and there is only one, so we know the correct values
-		cpe.ID = 1
-		cpe.PackageID = idRef(1)
+		c.ID = 1
+		c.PackageID = idRef(1)
 
-		if d := cmp.Diff([]Cpe{cpe}, result.Package.CPEs); d != "" {
+		if d := cmp.Diff([]Cpe{c}, result.Package.CPEs); d != "" {
 			t.Errorf("unexpected result (-want +got):\n%s", d)
 		}
 	})
 
 	t.Run("Package deduplication", func(t *testing.T) {
 		pkg1 := &AffectedPackageHandle{
+			Vulnerability: &VulnerabilityHandle{
+				Name: "CVE-2023-1234",
+				Provider: &Provider{
+					ID: "provider1",
+				},
+			},
 			Package: &Package{Name: "pkg1", Type: "type1"},
 			BlobValue: &AffectedPackageBlob{
 				CVEs: []string{"CVE-2023-1234"},
@@ -238,6 +250,12 @@ func TestAffectedPackageStore_AddAffectedPackages(t *testing.T) {
 		}
 
 		pkg2 := &AffectedPackageHandle{
+			Vulnerability: &VulnerabilityHandle{
+				Name: "CVE-2023-1234",
+				Provider: &Provider{
+					ID: "provider1",
+				},
+			},
 			Package: &Package{Name: "pkg1", Type: "type1"}, // same!
 			BlobValue: &AffectedPackageBlob{
 				CVEs: []string{"CVE-2023-56789"},
@@ -275,6 +293,12 @@ func TestAffectedPackageStore_AddAffectedPackages(t *testing.T) {
 		}
 
 		pkg1 := &AffectedPackageHandle{
+			Vulnerability: &VulnerabilityHandle{
+				Name: "CVE-2023-1234",
+				Provider: &Provider{
+					ID: "provider1",
+				},
+			},
 			Package: &Package{Name: "pkg1", Type: "type1", CPEs: []Cpe{cpe1}},
 			BlobValue: &AffectedPackageBlob{
 				CVEs: []string{"CVE-2023-1234"},
@@ -282,6 +306,12 @@ func TestAffectedPackageStore_AddAffectedPackages(t *testing.T) {
 		}
 
 		pkg2 := &AffectedPackageHandle{
+			Vulnerability: &VulnerabilityHandle{
+				Name: "CVE-2023-56789",
+				Provider: &Provider{
+					ID: "provider1",
+				},
+			},
 			Package: &Package{Name: "pkg1", Type: "type1", CPEs: []Cpe{cpe1, cpe2}}, // duplicate CPE + additional CPE
 			BlobValue: &AffectedPackageBlob{
 				CVEs: []string{"CVE-2023-56789"},
@@ -336,6 +366,12 @@ func TestAffectedPackageStore_AddAffectedPackages(t *testing.T) {
 		}
 
 		pkg1 := &AffectedPackageHandle{
+			Vulnerability: &VulnerabilityHandle{
+				Name: "CVE-2023-1234",
+				Provider: &Provider{
+					ID: "provider1",
+				},
+			},
 			Package: &Package{Name: "pkg1", Type: "type1", CPEs: []Cpe{cpe1}},
 			BlobValue: &AffectedPackageBlob{
 				CVEs: []string{"CVE-2023-1234"},
@@ -343,6 +379,12 @@ func TestAffectedPackageStore_AddAffectedPackages(t *testing.T) {
 		}
 
 		pkg2 := &AffectedPackageHandle{
+			Vulnerability: &VulnerabilityHandle{
+				Name: "CVE-2023-56789",
+				Provider: &Provider{
+					ID: "provider1",
+				},
+			},
 			Package: &Package{Name: "pkg2", Type: "type1", CPEs: []Cpe{cpe1, cpe2}}, // overlapping CPEs for different packages
 			BlobValue: &AffectedPackageBlob{
 				CVEs: []string{"CVE-2023-56789"},
@@ -363,12 +405,24 @@ func TestAffectedPackageStore_GetAffectedPackages_ByCPE(t *testing.T) {
 	cpe1 := Cpe{Part: "a", Vendor: "vendor1", Product: "product1"}
 	cpe2 := Cpe{Part: "a", Vendor: "vendor2", Product: "product2"}
 	pkg1 := &AffectedPackageHandle{
+		Vulnerability: &VulnerabilityHandle{
+			Name: "CVE-2023-1234",
+			Provider: &Provider{
+				ID: "provider1",
+			},
+		},
 		Package: &Package{Name: "pkg1", Type: "type1", CPEs: []Cpe{cpe1}},
 		BlobValue: &AffectedPackageBlob{
 			CVEs: []string{"CVE-2023-1234"},
 		},
 	}
 	pkg2 := &AffectedPackageHandle{
+		Vulnerability: &VulnerabilityHandle{
+			Name: "CVE-2023-5678",
+			Provider: &Provider{
+				ID: "provider1",
+			},
+		},
 		Package: &Package{Name: "pkg2", Type: "type2", CPEs: []Cpe{cpe2}},
 		BlobValue: &AffectedPackageBlob{
 			CVEs: []string{"CVE-2023-5678"},
@@ -393,9 +447,10 @@ func TestAffectedPackageStore_GetAffectedPackages_ByCPE(t *testing.T) {
 				Product: "product1",
 			},
 			options: &GetAffectedPackageOptions{
-				PreloadPackageCPEs: true,
-				PreloadPackage:     true,
-				PreloadBlob:        true,
+				PreloadPackageCPEs:   true,
+				PreloadPackage:       true,
+				PreloadBlob:          true,
+				PreloadVulnerability: true,
 			},
 			expected: []AffectedPackageHandle{*pkg1},
 		},
@@ -406,9 +461,10 @@ func TestAffectedPackageStore_GetAffectedPackages_ByCPE(t *testing.T) {
 				Vendor: "vendor2",
 			},
 			options: &GetAffectedPackageOptions{
-				PreloadPackageCPEs: true,
-				PreloadPackage:     true,
-				PreloadBlob:        true,
+				PreloadPackageCPEs:   true,
+				PreloadPackage:       true,
+				PreloadBlob:          true,
+				PreloadVulnerability: true,
 			},
 			expected: []AffectedPackageHandle{*pkg2},
 		},
@@ -418,9 +474,10 @@ func TestAffectedPackageStore_GetAffectedPackages_ByCPE(t *testing.T) {
 				Part: "a",
 			},
 			options: &GetAffectedPackageOptions{
-				PreloadPackageCPEs: true,
-				PreloadPackage:     true,
-				PreloadBlob:        true,
+				PreloadPackageCPEs:   true,
+				PreloadPackage:       true,
+				PreloadBlob:          true,
+				PreloadVulnerability: true,
 			},
 			expected: []AffectedPackageHandle{*pkg1, *pkg2},
 		},
@@ -432,9 +489,10 @@ func TestAffectedPackageStore_GetAffectedPackages_ByCPE(t *testing.T) {
 				Product: "unknown_product",
 			},
 			options: &GetAffectedPackageOptions{
-				PreloadPackageCPEs: true,
-				PreloadPackage:     true,
-				PreloadBlob:        true,
+				PreloadPackageCPEs:   true,
+				PreloadPackage:       true,
+				PreloadBlob:          true,
+				PreloadVulnerability: true,
 			},
 			expected: nil,
 		},
@@ -876,6 +934,9 @@ func testDistro1AffectedPackage2Handle() *AffectedPackageHandle {
 		},
 		Vulnerability: &VulnerabilityHandle{
 			Name: "CVE-2023-4567",
+			Provider: &Provider{
+				ID: "ubuntu",
+			},
 		},
 		OperatingSystem: &OperatingSystem{
 			Name:         "ubuntu",
@@ -897,6 +958,9 @@ func testDistro2AffectedPackage2Handle() *AffectedPackageHandle {
 		},
 		Vulnerability: &VulnerabilityHandle{
 			Name: "CVE-2023-4567",
+			Provider: &Provider{
+				ID: "ubuntu",
+			},
 		},
 		OperatingSystem: &OperatingSystem{
 			Name:         "ubuntu",
@@ -918,6 +982,9 @@ func testNonDistroAffectedPackage2Handle() *AffectedPackageHandle {
 		},
 		Vulnerability: &VulnerabilityHandle{
 			Name: "CVE-2023-4567",
+			Provider: &Provider{
+				ID: "wolfi",
+			},
 		},
 		BlobValue: &AffectedPackageBlob{
 			CVEs: []string{"CVE-2023-4567"},

--- a/grype/db/v6/blobs.go
+++ b/grype/db/v6/blobs.go
@@ -11,26 +11,11 @@ type VulnerabilityBlob struct {
 	// ID is the lowercase unique string identifier for the vulnerability relative to the provider
 	ID string `json:"id"`
 
-	// ProviderName of the Vunnel provider (or sub processor responsible for data records from a single specific source, e.g. "ubuntu")
-	ProviderName string `json:"provider"`
-
 	// Assigners is a list of names, email, or organizations who submitted the vulnerability
 	Assigners []string `json:"assigner,omitempty"`
 
-	// Status conveys the actionability of the current record
-	Status VulnerabilityStatus `json:"status"`
-
 	// Description of the vulnerability as provided by the source
-	Description string `json:"description"`
-
-	// PublishedDate is the date the vulnerability record was first published
-	PublishedDate *time.Time `json:"published,omitempty"`
-
-	// ModifiedDate is the date the vulnerability record was last modified
-	ModifiedDate *time.Time `json:"modified,omitempty"`
-
-	// WithdrawnDate is the date the vulnerability record was withdrawn
-	WithdrawnDate *time.Time `json:"withdrawn,omitempty"`
+	Description string `json:"description,omitempty"`
 
 	// References are URLs to external resources that provide more information about the vulnerability
 	References []Reference `json:"refs,omitempty"`

--- a/grype/db/v6/db.go
+++ b/grype/db/v6/db.go
@@ -36,7 +36,6 @@ type Reader interface {
 
 type Writer interface {
 	DBMetadataStoreWriter
-	ProviderStoreWriter
 	VulnerabilityStoreWriter
 	AffectedPackageStoreWriter
 	AffectedCPEStoreWriter

--- a/grype/db/v6/models.go
+++ b/grype/db/v6/models.go
@@ -25,6 +25,7 @@ func Models() []any {
 
 		// vulnerability related search tables
 		&VulnerabilityHandle{},
+		&VulnerabilityAlias{},
 
 		// package related search tables
 		&AffectedPackageHandle{}, // join on package, operating system
@@ -167,6 +168,14 @@ func (v *VulnerabilityHandle) setBlob(rawBlobValue []byte) error {
 
 	v.BlobValue = &blobValue
 	return nil
+}
+
+type VulnerabilityAlias struct {
+	// Name is the unique name for the vulnerability
+	Name string `gorm:"column:name;primaryKey;index"`
+
+	// Alias is an alternative name for the vulnerability that must be upstream from the Name (e.g if name is "RHSA-1234" then the upstream could be "CVE-1234-5678", but not the other way around)
+	Alias string `gorm:"column:alias;primaryKey;index;not null"`
 }
 
 // package related search tables //////////////////////////////////////////////////////

--- a/grype/db/v6/models.go
+++ b/grype/db/v6/models.go
@@ -93,6 +93,32 @@ type Provider struct {
 	InputDigest string `gorm:"column:input_digest"`
 }
 
+func (p *Provider) BeforeCreate(tx *gorm.DB) (err error) {
+	// if the name and version already exist in the table then we should not insert a new record
+	var existing Provider
+	result := tx.Where("id = ?", p.ID).First(&existing)
+	if result.Error == nil {
+		if existing.Processor == p.Processor && existing.DateCaptured == p.DateCaptured && existing.InputDigest == p.InputDigest && p.Version == existing.Version {
+			// record already exists
+			p.ID = existing.ID
+			return nil
+		}
+
+		// overwrite the existing provider if found
+		existing.Processor = p.Processor
+		existing.DateCaptured = p.DateCaptured
+		existing.InputDigest = p.InputDigest
+		existing.Version = p.Version
+		if err := tx.Save(&existing).Error; err != nil {
+			return fmt.Errorf("failed to update existing %q provider record: %w", p.ID, err)
+		}
+		return nil
+	}
+
+	// create a new provider record if not found
+	return nil
+}
+
 // vulnerability related search tables //////////////////////////////////////////////////////
 
 // VulnerabilityHandle represents the pointer to the core advisory record for a single known vulnerability from a specific provider.
@@ -101,6 +127,21 @@ type VulnerabilityHandle struct {
 
 	// Name is the unique name for the vulnerability (same as the decoded VulnerabilityBlob.ID)
 	Name string `gorm:"column:name;not null;index"`
+
+	// Status conveys the actionability of the current record
+	Status string `gorm:"column:status;not null;index"`
+
+	// PublishedDate is the date the vulnerability record was first published
+	PublishedDate *time.Time `gorm:"column:published_date;index"`
+
+	// ModifiedDate is the date the vulnerability record was last modified
+	ModifiedDate *time.Time `gorm:"column:modified_date;index"`
+
+	// WithdrawnDate is the date the vulnerability record was withdrawn
+	WithdrawnDate *time.Time `gorm:"column:withdrawn_date;index"`
+
+	ProviderID string    `gorm:"column:provider_id;not null;index"`
+	Provider   *Provider `gorm:"foreignKey:ProviderID"`
 
 	BlobID    ID                 `gorm:"column:blob_id;index,unique"`
 	BlobValue *VulnerabilityBlob `gorm:"-"`
@@ -137,7 +178,7 @@ func (v *VulnerabilityHandle) setBlob(rawBlobValue []byte) error {
 // name (which might or might not be the product name in the CPE), in which case AffectedCPEHandle should be used.
 type AffectedPackageHandle struct {
 	ID              ID                   `gorm:"column:id;primaryKey"`
-	VulnerabilityID *ID                  `gorm:"column:vulnerability_id"`
+	VulnerabilityID ID                   `gorm:"column:vulnerability_id;not null"`
 	Vulnerability   *VulnerabilityHandle `gorm:"foreignKey:VulnerabilityID"`
 
 	OperatingSystemID *ID              `gorm:"column:operating_system_id"`
@@ -280,7 +321,7 @@ func (os *OperatingSystemAlias) BeforeCreate(_ *gorm.DB) (err error) {
 // find vulnerabilities by these identifiers but not assert they are related to an entry in the Packages table.
 type AffectedCPEHandle struct {
 	ID              ID                   `gorm:"column:id;primaryKey"`
-	VulnerabilityID *ID                  `gorm:"column:vulnerability_id"`
+	VulnerabilityID ID                   `gorm:"column:vulnerability_id;not null"`
 	Vulnerability   *VulnerabilityHandle `gorm:"foreignKey:VulnerabilityID"`
 
 	CpeID ID   `gorm:"column:cpe_id"`

--- a/grype/db/v6/provider_store_test.go
+++ b/grype/db/v6/provider_store_test.go
@@ -52,13 +52,20 @@ func TestProviderStore(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := newProviderStore(setupTestStore(t).db)
+			db := setupTestStore(t).db
+			s := newProviderStore(db)
 			if tt.wantErr == nil {
 				tt.wantErr = require.NoError
 			}
-			for i, p := range tt.providers {
+			for i := range tt.providers {
+				p := tt.providers[i]
+				// note: we always write providers via the vulnerability handle (there is no store adder)
+				vuln := VulnerabilityHandle{
+					Name:     "CVE-1234-5678",
+					Provider: &p,
+				}
 				isLast := i == len(tt.providers)-1
-				err := s.AddProvider(&p)
+				err := db.Create(&vuln).Error
 				if !isLast {
 					require.NoError(t, err)
 					continue

--- a/grype/db/v6/vulnerability_store.go
+++ b/grype/db/v6/vulnerability_store.go
@@ -39,6 +39,9 @@ type VulnerabilitySpecifier struct {
 
 	// ModifiedAfter is a filter to only return vulnerabilities modified after the given time
 	ModifiedAfter *time.Time
+
+	// IncludeAliases for the given name or ID in results
+	IncludeAliases bool
 }
 
 func (v *VulnerabilitySpecifier) String() string {
@@ -183,11 +186,16 @@ func (s *vulnerabilityStore) attachBlob(vh *VulnerabilityHandle) error {
 
 func handleVulnerabilityOptions(query *gorm.DB, config *VulnerabilitySpecifier) (*gorm.DB, error) {
 	if config.Name != "" {
-		query.Where("vulnerability_handles.name = ?", config.Name)
+		if config.IncludeAliases {
+			query = query.Joins("LEFT JOIN vulnerability_aliases ON vulnerability_aliases.name = vulnerability_handles.name")
+			query = query.Where("vulnerability_handles.name = ? OR vulnerability_aliases.alias = ?", config.Name, config.Name)
+		} else {
+			query = query.Where("vulnerability_handles.name = ?", config.Name)
+		}
 	}
 
 	if config.ID != 0 {
-		query.Where("vulnerability_handles.id = ?", config.ID)
+		query = query.Where("vulnerability_handles.id = ?", config.ID)
 	}
 
 	if config.PublishedAfter != nil {

--- a/grype/db/v6/vulnerability_store.go
+++ b/grype/db/v6/vulnerability_store.go
@@ -52,7 +52,11 @@ func (s *vulnerabilityStore) GetVulnerability(id ID, config *GetVulnerabilityOpt
 
 	var model VulnerabilityHandle
 
-	result := s.db.Where("id = ?", id).First(&model)
+	query := s.db.Where("id = ?", id)
+
+	query = s.handlePreload(query, *config)
+
+	result := query.First(&model)
 
 	if result.Error != nil {
 		return nil, fmt.Errorf("unable to fetch vulnerability record: %w", result.Error)
@@ -74,7 +78,11 @@ func (s *vulnerabilityStore) GetVulnerabilitiesByName(name string, config *GetVu
 
 	var allModels []VulnerabilityHandle
 
-	err := s.db.Where("name = ?", name).Find(&allModels).Error
+	query := s.db.Where("name = ?", name)
+
+	query = s.handlePreload(query, *config)
+
+	err := query.Find(&allModels).Error
 
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch vulnerability record: %w", err)
@@ -90,6 +98,13 @@ func (s *vulnerabilityStore) GetVulnerabilitiesByName(name string, config *GetVu
 	}
 
 	return allModels, nil
+}
+
+func (s *vulnerabilityStore) handlePreload(query *gorm.DB, config GetVulnerabilityOptions) *gorm.DB {
+	if config.Preload {
+		query = query.Preload("Provider")
+	}
+	return query
 }
 
 func (s *vulnerabilityStore) attachBlob(vh *VulnerabilityHandle) error {
@@ -115,6 +130,13 @@ func (s *vulnerabilityStore) AddVulnerabilities(vulnerabilities ...*Vulnerabilit
 		// this adds the blob value to the DB and sets the ID on the vulnerability handle
 		if err := s.blobStore.addBlobable(v); err != nil {
 			return fmt.Errorf("unable to add affected blob: %w", err)
+		}
+
+		if v.PublishedDate != nil && v.ModifiedDate == nil {
+			// the data here should be consistent, and we are norming around initial publication counts as a modification date.
+			// this allows for easily refining queries based on both publication date and modification date without needing
+			// to worry about this edge case.
+			v.ModifiedDate = v.PublishedDate
 		}
 
 		// write the vulnerability handle to the DB

--- a/grype/db/v6/vulnerability_store.go
+++ b/grype/db/v6/vulnerability_store.go
@@ -3,7 +3,10 @@ package v6
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
+	"github.com/scylladb/go-set/strset"
 	"gorm.io/gorm"
 
 	"github.com/anchore/grype/internal/log"
@@ -14,12 +17,53 @@ type VulnerabilityStoreWriter interface {
 }
 
 type VulnerabilityStoreReader interface {
-	GetVulnerability(id ID, config *GetVulnerabilityOptions) (*VulnerabilityHandle, error)
-	GetVulnerabilitiesByName(vulnID string, config *GetVulnerabilityOptions) ([]VulnerabilityHandle, error)
+	GetVulnerabilities(vuln *VulnerabilitySpecifier, config *GetVulnerabilityOptions) ([]VulnerabilityHandle, error)
 }
 
 type GetVulnerabilityOptions struct {
 	Preload bool
+}
+
+type VulnerabilitySpecifier struct {
+	// Name of the vulnerability (e.g. CVE-2020-1234)
+	Name string
+
+	// ID is the DB ID of the vulnerability
+	ID ID
+
+	// Status is the status of the vulnerability (e.g. "active", "rejected", etc.)
+	Status VulnerabilityStatus
+
+	// PublishedAfter is a filter to only return vulnerabilities published after the given time
+	PublishedAfter *time.Time
+
+	// ModifiedAfter is a filter to only return vulnerabilities modified after the given time
+	ModifiedAfter *time.Time
+}
+
+func (v *VulnerabilitySpecifier) String() string {
+	var parts []string
+	if v.Name != "" {
+		parts = append(parts, fmt.Sprintf("name=%s", v.Name))
+	}
+
+	if v.ID != 0 {
+		parts = append(parts, fmt.Sprintf("id=%d", v.ID))
+	}
+
+	if v.Status != "" {
+		parts = append(parts, fmt.Sprintf("status=%s", v.Status))
+	}
+
+	if v.PublishedAfter != nil {
+		parts = append(parts, fmt.Sprintf("publishedAfter=%s", v.PublishedAfter.String()))
+	}
+
+	if v.ModifiedAfter != nil {
+		parts = append(parts, fmt.Sprintf("modifiedAfter=%s", v.ModifiedAfter.String()))
+	}
+
+	return fmt.Sprintf("VulnerabilitySpecifier(%s)", strings.Join(parts, ", "))
 }
 
 func DefaultGetVulnerabilityOptions() *GetVulnerabilityOptions {
@@ -40,64 +84,76 @@ func newVulnerabilityStore(db *gorm.DB, bs *blobStore) *vulnerabilityStore {
 	}
 }
 
-func (s *vulnerabilityStore) GetVulnerability(id ID, config *GetVulnerabilityOptions) (*VulnerabilityHandle, error) {
-	if config == nil {
-		config = DefaultGetVulnerabilityOptions()
+func (s *vulnerabilityStore) AddVulnerabilities(vulnerabilities ...*VulnerabilityHandle) error {
+	for _, v := range vulnerabilities {
+		// this adds the blob value to the DB and sets the ID on the vulnerability handle
+		if err := s.blobStore.addBlobable(v); err != nil {
+			return fmt.Errorf("unable to add affected blob: %w", err)
+		}
+
+		if v.PublishedDate != nil && v.ModifiedDate == nil {
+			// the data here should be consistent, and we are norming around initial publication counts as a modification date.
+			// this allows for easily refining queries based on both publication date and modification date without needing
+			// to worry about this edge case.
+			v.ModifiedDate = v.PublishedDate
+		}
+
+		if v.BlobValue != nil {
+			aliases := strset.New(v.BlobValue.Aliases...)
+			aliases.Remove(v.Name)
+			var aliasModels []VulnerabilityAlias
+			for _, alias := range aliases.List() {
+				aliasModels = append(aliasModels, VulnerabilityAlias{
+					Name:  v.Name,
+					Alias: alias,
+				})
+			}
+			for _, aliasModel := range aliasModels {
+				if err := s.db.FirstOrCreate(&aliasModel).Error; err != nil {
+					return err
+				}
+			}
+		}
+
+		// write the vulnerability handle to the DB
+		if err := s.db.Create(v).Error; err != nil {
+			return err
+		}
 	}
-	log.WithFields("id", id, "preload", config.Preload).Trace("fetching Vulnerability record")
-
-	if id == 0 {
-		return nil, fmt.Errorf("id must be > 0")
-	}
-
-	var model VulnerabilityHandle
-
-	query := s.db.Where("id = ?", id)
-
-	query = s.handlePreload(query, *config)
-
-	result := query.First(&model)
-
-	if result.Error != nil {
-		return nil, fmt.Errorf("unable to fetch vulnerability record: %w", result.Error)
-	}
-
-	var err error
-	if config.Preload {
-		err = s.attachBlob(&model)
-	}
-
-	return &model, err
+	return nil
 }
 
-func (s *vulnerabilityStore) GetVulnerabilitiesByName(name string, config *GetVulnerabilityOptions) ([]VulnerabilityHandle, error) {
+func (s *vulnerabilityStore) GetVulnerabilities(vuln *VulnerabilitySpecifier, config *GetVulnerabilityOptions) ([]VulnerabilityHandle, error) {
 	if config == nil {
 		config = DefaultGetVulnerabilityOptions()
 	}
-	log.WithFields("name", name, "preload", config.Preload).Trace("fetching Vulnerability record")
+	log.WithFields("vuln", vuln.String(), "preload", config.Preload).Trace("fetching Vulnerability records")
 
-	var allModels []VulnerabilityHandle
+	var models []VulnerabilityHandle
 
-	query := s.db.Where("name = ?", name)
+	query, err := handleVulnerabilityOptions(s.db, vuln)
+	if err != nil {
+		return nil, err
+	}
 
 	query = s.handlePreload(query, *config)
 
-	err := query.Find(&allModels).Error
+	result := query.Find(&models)
 
-	if err != nil {
-		return nil, fmt.Errorf("unable to fetch vulnerability record: %w", err)
+	if result.Error != nil {
+		return nil, fmt.Errorf("unable to fetch vulnerability records: %w", result.Error)
 	}
 
 	if config.Preload {
-		for i := range allModels {
-			err := s.attachBlob(&allModels[i])
+		for i := range models {
+			err := s.attachBlob(&models[i])
 			if err != nil {
-				return nil, fmt.Errorf("unable to attach blob %#v: %w", allModels[i], err)
+				return nil, fmt.Errorf("unable to attach blob %#v: %w", models[i], err)
 			}
 		}
 	}
 
-	return allModels, nil
+	return models, err
 }
 
 func (s *vulnerabilityStore) handlePreload(query *gorm.DB, config GetVulnerabilityOptions) *gorm.DB {
@@ -125,24 +181,26 @@ func (s *vulnerabilityStore) attachBlob(vh *VulnerabilityHandle) error {
 	return nil
 }
 
-func (s *vulnerabilityStore) AddVulnerabilities(vulnerabilities ...*VulnerabilityHandle) error {
-	for _, v := range vulnerabilities {
-		// this adds the blob value to the DB and sets the ID on the vulnerability handle
-		if err := s.blobStore.addBlobable(v); err != nil {
-			return fmt.Errorf("unable to add affected blob: %w", err)
-		}
-
-		if v.PublishedDate != nil && v.ModifiedDate == nil {
-			// the data here should be consistent, and we are norming around initial publication counts as a modification date.
-			// this allows for easily refining queries based on both publication date and modification date without needing
-			// to worry about this edge case.
-			v.ModifiedDate = v.PublishedDate
-		}
-
-		// write the vulnerability handle to the DB
-		if err := s.db.Create(v).Error; err != nil {
-			return err
-		}
+func handleVulnerabilityOptions(query *gorm.DB, config *VulnerabilitySpecifier) (*gorm.DB, error) {
+	if config.Name != "" {
+		query.Where("vulnerability_handles.name = ?", config.Name)
 	}
-	return nil
+
+	if config.ID != 0 {
+		query.Where("vulnerability_handles.id = ?", config.ID)
+	}
+
+	if config.PublishedAfter != nil {
+		query = query.Where("vulnerability_handles.published_date > ?", *config.PublishedAfter)
+	}
+
+	if config.ModifiedAfter != nil {
+		query = query.Where("vulnerability_handles.modified_date > ?", *config.ModifiedAfter)
+	}
+
+	if config.Status != "" {
+		query = query.Where("vulnerability_handles.status = ?", config.Status)
+	}
+
+	return query, nil
 }

--- a/grype/db/v6/vulnerability_store_test.go
+++ b/grype/db/v6/vulnerability_store_test.go
@@ -15,7 +15,7 @@ func TestVulnerabilityStore_AddVulnerabilities(t *testing.T) {
 	bw := newBlobStore(db)
 	s := newVulnerabilityStore(db, bw)
 
-	vuln1 := &VulnerabilityHandle{
+	vuln1 := VulnerabilityHandle{
 		Name: "CVE-1234-5678",
 		BlobValue: &VulnerabilityBlob{
 			ID: "CVE-1234-5678",
@@ -27,7 +27,7 @@ func TestVulnerabilityStore_AddVulnerabilities(t *testing.T) {
 
 	vuln2 := testVulnerabilityHandle()
 
-	err := s.AddVulnerabilities(vuln1, vuln2)
+	err := s.AddVulnerabilities(&vuln1, &vuln2)
 	require.NoError(t, err)
 
 	var result1 VulnerabilityHandle
@@ -70,26 +70,31 @@ func TestVulnerabilityStore_AddVulnerabilities_missingModifiedDate(t *testing.T)
 	assert.NotNil(t, vuln.ModifiedDate)
 }
 
-func TestVulnerabilityStore_GetVulnerability(t *testing.T) {
+func TestVulnerabilityStore_GetVulnerability_ByID(t *testing.T) {
 	db := setupTestStore(t).db
 	bw := newBlobStore(db)
 	s := newVulnerabilityStore(db, bw)
 
 	vuln := testVulnerabilityHandle()
-	err := s.AddVulnerabilities(vuln)
+	err := s.AddVulnerabilities(&vuln)
 	require.NoError(t, err)
 
-	result, err := s.GetVulnerability(vuln.ID, nil) // don't preload by default
+	results, err := s.GetVulnerabilities(&VulnerabilitySpecifier{ID: vuln.ID}, nil) // don't preload by default
 	require.NoError(t, err)
+	require.Len(t, results, 1)
+	result := results[0]
+
 	if d := cmp.Diff(vuln, result, cmpopts.IgnoreFields(VulnerabilityHandle{}, "Provider", "BlobValue")); d != "" {
 		t.Errorf("unexpected result (-want +got):\n%s", d)
 	}
 	assert.Nil(t, result.BlobValue) // since we're not preloading any fields on the fetch
 	assert.Nil(t, result.Provider)  // since we're not preloading any fields on the fetch
 
-	result, err = s.GetVulnerability(vuln.ID, &GetVulnerabilityOptions{Preload: true})
-
+	results, err = s.GetVulnerabilities(&VulnerabilitySpecifier{ID: vuln.ID}, &GetVulnerabilityOptions{Preload: true})
 	require.NoError(t, err)
+	require.Len(t, results, 1)
+	result = results[0]
+
 	assert.NotNil(t, result.BlobValue)
 	assert.NotNil(t, result.Provider)
 	if d := cmp.Diff(vuln, result); d != "" {
@@ -97,20 +102,20 @@ func TestVulnerabilityStore_GetVulnerability(t *testing.T) {
 	}
 }
 
-func TestVulnerabilityStore_GetVulnerabilitiesByName(t *testing.T) {
+func TestVulnerabilityStore_GetVulnerabilities_ByName(t *testing.T) {
 	db := setupTestStore(t).db
 	bw := newBlobStore(db)
 	s := newVulnerabilityStore(db, bw)
 
 	vuln1 := testVulnerabilityHandle()
 	name := vuln1.Name
-	vuln2 := &VulnerabilityHandle{Name: name, BlobID: 2, Provider: vuln1.Provider} // note: no blob value
-	err := s.AddVulnerabilities(vuln1, vuln2)
+	vuln2 := VulnerabilityHandle{Name: name, BlobID: 2, Provider: vuln1.Provider} // note: no blob value
+	err := s.AddVulnerabilities(&vuln1, &vuln2)
 	require.NoError(t, err)
 
-	expected := []VulnerabilityHandle{*vuln1, *vuln2}
+	expected := []VulnerabilityHandle{vuln1, vuln2}
 
-	results, err := s.GetVulnerabilitiesByName(name, nil) // don't preload by default
+	results, err := s.GetVulnerabilities(&VulnerabilitySpecifier{Name: name}, nil) // don't preload by default
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 	for i, result := range results {
@@ -121,7 +126,7 @@ func TestVulnerabilityStore_GetVulnerabilitiesByName(t *testing.T) {
 		assert.Nil(t, result.Provider)  // since we're not preloading any fields on the fetch
 	}
 
-	results, err = s.GetVulnerabilitiesByName(name, &GetVulnerabilityOptions{Preload: true})
+	results, err = s.GetVulnerabilities(&VulnerabilitySpecifier{Name: name}, &GetVulnerabilityOptions{Preload: true})
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
@@ -132,10 +137,10 @@ func TestVulnerabilityStore_GetVulnerabilitiesByName(t *testing.T) {
 	}
 }
 
-func testVulnerabilityHandle() *VulnerabilityHandle {
+func testVulnerabilityHandle() VulnerabilityHandle {
 	now := time.Now()
 
-	return &VulnerabilityHandle{
+	return VulnerabilityHandle{
 		Name:          "CVE-8765-4321",
 		Status:        "status!",
 		PublishedDate: &now,

--- a/grype/db/v6/vulnerability_store_test.go
+++ b/grype/db/v6/vulnerability_store_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,6 +19,9 @@ func TestVulnerabilityStore_AddVulnerabilities(t *testing.T) {
 		Name: "CVE-1234-5678",
 		BlobValue: &VulnerabilityBlob{
 			ID: "CVE-1234-5678",
+		},
+		Provider: &Provider{
+			ID: "provider!",
 		},
 	}
 
@@ -33,6 +37,7 @@ func TestVulnerabilityStore_AddVulnerabilities(t *testing.T) {
 	assert.Equal(t, vuln1.ID, result1.ID)
 	assert.Equal(t, vuln1.BlobID, result1.BlobID)
 	assert.Nil(t, result1.BlobValue) // since we're not preloading any fields on the fetch
+	assert.Nil(t, result1.Provider)  // since we're not preloading any fields on the fetch
 
 	var result2 VulnerabilityHandle
 	err = db.Where("name = ?", "CVE-8765-4321").First(&result2).Error
@@ -41,6 +46,28 @@ func TestVulnerabilityStore_AddVulnerabilities(t *testing.T) {
 	assert.Equal(t, vuln2.ID, result2.ID)
 	assert.Equal(t, vuln2.BlobID, result2.BlobID)
 	assert.Nil(t, result2.BlobValue) // since we're not preloading any fields on the fetch
+	assert.Nil(t, result1.Provider)  // since we're not preloading any fields on the fetch
+}
+
+func TestVulnerabilityStore_AddVulnerabilities_missingModifiedDate(t *testing.T) {
+	db := setupTestStore(t).db
+	bw := newBlobStore(db)
+	s := newVulnerabilityStore(db, bw)
+
+	now := time.Now()
+	vuln := &VulnerabilityHandle{
+		Name:          "CVE-1234-5678",
+		PublishedDate: &now, // have publication date without modification date
+		Provider: &Provider{
+			ID: "provider!",
+		},
+	}
+
+	err := s.AddVulnerabilities(vuln)
+	require.NoError(t, err)
+
+	// patched!
+	assert.NotNil(t, vuln.ModifiedDate)
 }
 
 func TestVulnerabilityStore_GetVulnerability(t *testing.T) {
@@ -54,15 +81,17 @@ func TestVulnerabilityStore_GetVulnerability(t *testing.T) {
 
 	result, err := s.GetVulnerability(vuln.ID, nil) // don't preload by default
 	require.NoError(t, err)
-	assert.Equal(t, vuln.Name, result.Name)
-	assert.Equal(t, vuln.ID, result.ID)
-	assert.Equal(t, vuln.BlobID, result.BlobID)
+	if d := cmp.Diff(vuln, result, cmpopts.IgnoreFields(VulnerabilityHandle{}, "Provider", "BlobValue")); d != "" {
+		t.Errorf("unexpected result (-want +got):\n%s", d)
+	}
 	assert.Nil(t, result.BlobValue) // since we're not preloading any fields on the fetch
+	assert.Nil(t, result.Provider)  // since we're not preloading any fields on the fetch
 
 	result, err = s.GetVulnerability(vuln.ID, &GetVulnerabilityOptions{Preload: true})
 
 	require.NoError(t, err)
-	require.NotNil(t, result.BlobValue)
+	assert.NotNil(t, result.BlobValue)
+	assert.NotNil(t, result.Provider)
 	if d := cmp.Diff(vuln, result); d != "" {
 		t.Errorf("unexpected result (-want +got):\n%s", d)
 	}
@@ -75,7 +104,7 @@ func TestVulnerabilityStore_GetVulnerabilitiesByName(t *testing.T) {
 
 	vuln1 := testVulnerabilityHandle()
 	name := vuln1.Name
-	vuln2 := &VulnerabilityHandle{Name: name, BlobID: 2} // note: no blob value
+	vuln2 := &VulnerabilityHandle{Name: name, BlobID: 2, Provider: vuln1.Provider} // note: no blob value
 	err := s.AddVulnerabilities(vuln1, vuln2)
 	require.NoError(t, err)
 
@@ -89,6 +118,7 @@ func TestVulnerabilityStore_GetVulnerabilitiesByName(t *testing.T) {
 		assert.Equal(t, expected[i].ID, result.ID)
 		assert.Equal(t, expected[i].BlobID, result.BlobID)
 		assert.Nil(t, result.BlobValue) // since we're not preloading any fields on the fetch
+		assert.Nil(t, result.Provider)  // since we're not preloading any fields on the fetch
 	}
 
 	results, err = s.GetVulnerabilitiesByName(name, &GetVulnerabilityOptions{Preload: true})
@@ -106,16 +136,18 @@ func testVulnerabilityHandle() *VulnerabilityHandle {
 	now := time.Now()
 
 	return &VulnerabilityHandle{
-		Name: "CVE-8765-4321",
+		Name:          "CVE-8765-4321",
+		Status:        "status!",
+		PublishedDate: &now,
+		ModifiedDate:  &now,
+		WithdrawnDate: &now,
+		Provider: &Provider{
+			ID: "provider!",
+		},
 		BlobValue: &VulnerabilityBlob{
-			ID:            "CVE-8765-4321",
-			ProviderName:  "provider!",
-			Assigners:     []string{"assigner!"},
-			Status:        "status!",
-			Description:   "description!",
-			PublishedDate: &now,
-			ModifiedDate:  &now,
-			WithdrawnDate: &now,
+			ID:          "CVE-8765-4321",
+			Assigners:   []string{"assigner!"},
+			Description: "description!",
 			References: []Reference{
 				{
 					URL:  "url!",

--- a/grype/db/v6/vulnerability_store_test.go
+++ b/grype/db/v6/vulnerability_store_test.go
@@ -70,6 +70,48 @@ func TestVulnerabilityStore_AddVulnerabilities_missingModifiedDate(t *testing.T)
 	assert.NotNil(t, vuln.ModifiedDate)
 }
 
+func TestVulnerabilityStore_AddVulnerabilities_Aliases(t *testing.T) {
+	db := setupTestStore(t).db
+	bw := newBlobStore(db)
+	s := newVulnerabilityStore(db, bw)
+
+	vuln := &VulnerabilityHandle{
+		Name: "CVE-1234-5678",
+		BlobValue: &VulnerabilityBlob{
+			ID:      "CVE-1234-5678",
+			Aliases: []string{"ALIAS-1", "ALIAS-2", "CVE-1234-5678"},
+		},
+		Provider: &Provider{
+			ID: "provider!",
+		},
+	}
+
+	err := s.AddVulnerabilities(vuln)
+	require.NoError(t, err)
+
+	var aliases []VulnerabilityAlias
+	err = db.Where("name = ?", "CVE-1234-5678").Find(&aliases).Error
+	require.NoError(t, err)
+
+	expectedAliases := []VulnerabilityAlias{
+		{Name: "CVE-1234-5678", Alias: "ALIAS-1"},
+		{Name: "CVE-1234-5678", Alias: "ALIAS-2"},
+	}
+	assert.Len(t, aliases, len(expectedAliases))
+
+	for _, expected := range expectedAliases {
+		assert.Contains(t, aliases, expected)
+	}
+
+	uniqueAliases := make(map[string]struct{})
+	for _, alias := range aliases {
+		key := alias.Name + ":" + alias.Alias
+		_, exists := uniqueAliases[key]
+		assert.False(t, exists, "duplicate alias found")
+		uniqueAliases[key] = struct{}{}
+	}
+}
+
 func TestVulnerabilityStore_GetVulnerability_ByID(t *testing.T) {
 	db := setupTestStore(t).db
 	bw := newBlobStore(db)
@@ -135,6 +177,72 @@ func TestVulnerabilityStore_GetVulnerabilities_ByName(t *testing.T) {
 			t.Errorf("unexpected result (-want +got):\n%s", d)
 		}
 	}
+}
+
+func TestVulnerabilityStore_GetVulnerabilities_Aliases(t *testing.T) {
+	db := setupTestStore(t).db
+	bw := newBlobStore(db)
+	s := newVulnerabilityStore(db, bw)
+
+	vuln1 := &VulnerabilityHandle{
+		Name: "CVE-1234-5678",
+		BlobValue: &VulnerabilityBlob{
+			ID:      "CVE-1234-5678",
+			Aliases: []string{"ALIAS-1", "ALIAS-2"},
+		},
+		Provider: &Provider{
+			ID: "provider!",
+		},
+	}
+
+	vuln2 := &VulnerabilityHandle{
+		Name: "ALIAS-1",
+		BlobValue: &VulnerabilityBlob{
+			ID: "ALIAS-1",
+		},
+		Provider: &Provider{
+			ID: "provider2!",
+		},
+	}
+
+	err := s.AddVulnerabilities(vuln1, vuln2)
+	require.NoError(t, err)
+
+	t.Run("include aliases", func(t *testing.T) {
+		specifierWithAliases := &VulnerabilitySpecifier{
+			Name:           "ALIAS-1",
+			IncludeAliases: true,
+		}
+
+		results, err := s.GetVulnerabilities(specifierWithAliases, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+		assert.ElementsMatch(t, []string{"CVE-1234-5678", "ALIAS-1"}, []string{results[0].Name, results[1].Name})
+	})
+
+	t.Run("dont include aliases", func(t *testing.T) {
+		specifierWithoutAliases := &VulnerabilitySpecifier{
+			Name:           "ALIAS-1",
+			IncludeAliases: false,
+		}
+
+		results, err := s.GetVulnerabilities(specifierWithoutAliases, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "ALIAS-1", results[0].Name)
+	})
+
+	t.Run("direct match without aliases", func(t *testing.T) {
+		specifierDirectMatch := &VulnerabilitySpecifier{
+			Name:           "CVE-1234-5678",
+			IncludeAliases: false,
+		}
+
+		results, err := s.GetVulnerabilities(specifierDirectMatch, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "CVE-1234-5678", results[0].Name)
+	})
 }
 
 func testVulnerabilityHandle() VulnerabilityHandle {


### PR DESCRIPTION
Updating the v6 vulnerability handle model to be able to search by:
- published date
- modified date
- withdrawn date
- status

One impact of this change is that distribution archives are now ~5 MB larger than before this PR.

In the same vein as #2297 , this makes the vulnerability store have only a single getter and parameterizes all search possibilities.


This PR also adjusts the following behavior:
- when adding vulnerabilities via the store we ensure that all records with publication dates have a modification date as well.
- provider information to only be written with vulnerability records. This makes it more difficult to write a vuln entry without a provider or vice versa. For this reason all adder methods on the provider store were removed.
- migrates code for affected* store input specifiers (cpe and vulnerability) such that they are shared.

