### PR TITLE
Add initial os aliases to the DB after DB v6 migration

### DIFF
--- a/grype/db/v6/affected_package_store_test.go
+++ b/grype/db/v6/affected_package_store_test.go
@@ -686,19 +686,10 @@ func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 }
 
 func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
+	// we always preload the OS aliases into the DB when staging for writing
 	db := setupTestStore(t).db
 	bs := newBlobStore(db)
 	s := newAffectedPackageStore(db, bs)
-
-	aliases := []OperatingSystemAlias{
-		{Name: "centos", ReplacementName: strRef("rhel")},
-		{Name: "rocky", ReplacementName: strRef("rhel")},
-		{Name: "alpine", VersionPattern: ".*_alpha.*", ReplacementLabelVersion: strRef("edge"), Rolling: true},
-		{Name: "wolfi", Rolling: true},
-		{Name: "arch", Rolling: true},
-		{Name: "debian", Codename: "trixie", Rolling: true}, // is currently sid, which is considered rolling
-	}
-	require.NoError(t, db.Create(&aliases).Error)
 
 	ubuntu2004 := &OperatingSystem{Name: "ubuntu", MajorVersion: "20", MinorVersion: "04", Codename: "focal"}
 	ubuntu2010 := &OperatingSystem{Name: "ubuntu", MajorVersion: "20", MinorVersion: "10", Codename: "groovy"}

--- a/grype/db/v6/store.go
+++ b/grype/db/v6/store.go
@@ -31,6 +31,13 @@ func newStore(cfg Config, write bool) (*store, error) {
 		return nil, fmt.Errorf("failed to open db: %w", err)
 	}
 
+	if write {
+		// add hard-coded os aliases
+		if err := db.Create(KnownOperatingSystemAliases()).Error; err != nil {
+			return nil, fmt.Errorf("failed to add os aliases: %w", err)
+		}
+	}
+
 	bs := newBlobStore(db)
 	return &store{
 		dbMetadataStore:      newDBMetadataStore(db),


### PR DESCRIPTION
This ports the [logic that controls which namespace](https://github.com/anchore/grype/blob/v0.85.0/grype/db/v5/namespace/index.go) to use when searching for matches in v5 to v6. Specifically, v6 is a data-driven approach, however, only the schema and [store has been updated](https://github.com/anchore/grype/blob/0699f8434242998a79578651b39ca15e6a3f721c/grype/db/v6/affected_package_store.go#L279-L284), no data has been hydrated so that it can be used in matching --this PR hydrates the lookup table. 

Q: Why not plumb this in through vunnel? 
A: We may do that one day, but it's not necessary to do that today. 

Q: Wait -- you said data-driven, but this code change is in grype... wouldn't this require a code change to add/modify these aliases, thus entirely defeating the point of making it data driven?
A: This code change affects how the DB is written, which we publish nightly. The key point is to not have this mapping in the matching-side of grype, where users would need to install a new version of grype in order to get updated mappings. This is much more ideal since a code change here doesn't require a grype release, but only that the nightly publisher job gets the update in grype-db (which is running off of main).