### PR TITLE
Fix broken link to cosign documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Checksums are applied to all artifacts, and the resulting checksum file is signe
 
 You need the following tool to verify signature:
 
-- [Cosign](https://docs.sigstore.dev/cosign/installation/)
+- [Cosign](https://docs.sigstore.dev/cosign/system_config/installation/)
 
 Verification steps are as follow:
 


### PR DESCRIPTION
Just noticed the link was broken -- upstream changed the URL :sweat_smile: 

Hope it helps!