### PR TITLE
fix: do not panic on cdx output from PURL file

### DIFF
--- a/grype/pkg/provider.go
+++ b/grype/pkg/provider.go
@@ -26,7 +26,7 @@ func Provide(userInput string, config ProviderConfig) ([]Package, Context, *sbom
 		return packages, ctx, s, err
 	}
 
-	packages, ctx, err = purlProvider(userInput)
+	packages, ctx, s, err = purlProvider(userInput)
 	if !errors.Is(err, errDoesNotProvide) {
 		return packages, ctx, s, err
 	}

--- a/grype/pkg/purl_provider_test.go
+++ b/grype/pkg/purl_provider_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/linux"
 	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/sbom"
 )
 
 func Test_PurlProvider(t *testing.T) {
@@ -17,6 +19,7 @@ func Test_PurlProvider(t *testing.T) {
 		userInput string
 		context   Context
 		pkgs      []Package
+		sbom      *sbom.SBOM
 		wantErr   require.ErrorAssertionFunc
 	}{
 		{
@@ -29,6 +32,16 @@ func Test_PurlProvider(t *testing.T) {
 					Version: "7.61.1",
 					Type:    pkg.ApkPkg,
 					PURL:    "pkg:apk/curl@7.61.1",
+				},
+			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name:    "curl",
+						Version: "7.61.1",
+						Type:    pkg.ApkPkg,
+						PURL:    "pkg:apk/curl@7.61.1",
+					}),
 				},
 			},
 		},
@@ -56,6 +69,22 @@ func Test_PurlProvider(t *testing.T) {
 					},
 				},
 			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name:    "sysv-rc",
+						Version: "2.88dsf-59",
+						Type:    pkg.DebPkg,
+						PURL:    "pkg:deb/debian/sysv-rc@2.88dsf-59?arch=all&distro=debian-jessie&upstream=sysvinit",
+					}),
+					LinuxDistribution: &linux.Release{
+						Name:            "debian",
+						ID:              "debian",
+						IDLike:          []string{"debian"},
+						VersionCodename: "jessie",
+					},
+				},
+			},
 		},
 		{
 			name:      "default upstream",
@@ -72,6 +101,16 @@ func Test_PurlProvider(t *testing.T) {
 							Name: "openssl",
 						},
 					},
+				},
+			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name:    "libcrypto3",
+						Version: "3.3.2",
+						Type:    pkg.ApkPkg,
+						PURL:    "pkg:apk/libcrypto3@3.3.2?upstream=openssl",
+					}),
 				},
 			},
 		},
@@ -91,6 +130,16 @@ func Test_PurlProvider(t *testing.T) {
 							Version: "3.2.1",
 						},
 					},
+				},
+			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name:    "libcrypto3",
+						Version: "3.3.2",
+						Type:    pkg.ApkPkg,
+						PURL:    "pkg:apk/libcrypto3@3.3.2?upstream=openssl%403.2.1",
+					}),
 				},
 			},
 		},
@@ -119,6 +168,22 @@ func Test_PurlProvider(t *testing.T) {
 					},
 				},
 			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name:    "systemd-x",
+						Version: "0:239-82.el8_10.2",
+						Type:    pkg.RpmPkg,
+						PURL:    "pkg:rpm/redhat/systemd-x@239-82.el8_10.2?arch=aarch64&distro=rhel-8.10&upstream=systemd-239-82.el8_10.2.src.rpm",
+					}),
+					LinuxDistribution: &linux.Release{
+						Name:    "rhel",
+						ID:      "rhel",
+						IDLike:  []string{"rhel"},
+						Version: "8.10",
+					},
+				},
+			},
 		},
 		{
 			name:      "RPM with epoch",
@@ -142,6 +207,22 @@ func Test_PurlProvider(t *testing.T) {
 							Name:    "dbus",
 							Version: "1.12.8-26.el8",
 						},
+					},
+				},
+			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name:    "dbus-common",
+						Version: "1:1.12.8-26.el8",
+						Type:    pkg.RpmPkg,
+						PURL:    "pkg:rpm/redhat/dbus-common@1.12.8-26.el8?arch=noarch&distro=rhel-8.10&epoch=1&upstream=dbus-1.12.8-26.el8.src.rpm",
+					}),
+					LinuxDistribution: &linux.Release{
+						Name:    "rhel",
+						ID:      "rhel",
+						IDLike:  []string{"rhel"},
+						Version: "8.10",
 					},
 				},
 			},
@@ -182,6 +263,37 @@ func Test_PurlProvider(t *testing.T) {
 					PURL:    "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
 				},
 			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(
+						pkg.Package{
+							Name:    "sysv-rc",
+							Version: "2.88dsf-59",
+							Type:    pkg.DebPkg,
+							PURL:    "pkg:deb/debian/sysv-rc@2.88dsf-59?arch=all&distro=debian-8&upstream=sysvinit",
+						},
+						pkg.Package{
+							Name:     "ant",
+							Version:  "1.10.8",
+							Type:     pkg.JavaPkg,
+							Language: pkg.Java,
+							PURL:     "pkg:maven/org.apache.ant/ant@1.10.8",
+						},
+						pkg.Package{
+							Name:     "log4j-core",
+							Version:  "2.14.1",
+							Type:     pkg.JavaPkg,
+							Language: pkg.Java,
+							PURL:     "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+						}),
+					LinuxDistribution: &linux.Release{
+						Name:    "debian",
+						ID:      "debian",
+						IDLike:  []string{"debian"},
+						Version: "8",
+					},
+				},
+			},
 		},
 		{
 			name:      "infer context when distro is present for single purl",
@@ -200,6 +312,22 @@ func Test_PurlProvider(t *testing.T) {
 					Version: "7.61.1",
 					Type:    pkg.ApkPkg,
 					PURL:    "pkg:apk/curl@7.61.1?arch=aarch64&distro=alpine-3.20.3",
+				},
+			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name:    "curl",
+						Version: "7.61.1",
+						Type:    pkg.ApkPkg,
+						PURL:    "pkg:apk/curl@7.61.1?arch=aarch64&distro=alpine-3.20.3",
+					}),
+					LinuxDistribution: &linux.Release{
+						Name:    "alpine",
+						ID:      "alpine",
+						IDLike:  []string{"alpine"},
+						Version: "3.20.3",
+					},
 				},
 			},
 		},
@@ -228,6 +356,28 @@ func Test_PurlProvider(t *testing.T) {
 					PURL:    "pkg:apk/curl@7.61.1?arch=aarch64&distro=alpine-3.20.3",
 				},
 			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name:    "openssl",
+						Version: "3.2.1",
+						Type:    pkg.ApkPkg,
+						PURL:    "pkg:apk/openssl@3.2.1?arch=aarch64&distro=alpine-3.20.3",
+					},
+						pkg.Package{
+							Name:    "curl",
+							Version: "7.61.1",
+							Type:    pkg.ApkPkg,
+							PURL:    "pkg:apk/curl@7.61.1?arch=aarch64&distro=alpine-3.20.3",
+						}),
+					LinuxDistribution: &linux.Release{
+						Name:    "alpine",
+						ID:      "alpine",
+						IDLike:  []string{"alpine"},
+						Version: "3.20.3",
+					},
+				},
+			},
 		},
 		{
 			name:      "different distro info in purls does not infer context",
@@ -249,6 +399,22 @@ func Test_PurlProvider(t *testing.T) {
 					PURL:    "pkg:apk/curl@7.61.1?arch=aarch64&distro=alpine-3.20.2",
 				},
 			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name:    "openssl",
+						Version: "3.2.1",
+						Type:    pkg.ApkPkg,
+						PURL:    "pkg:apk/openssl@3.2.1?arch=aarch64&distro=alpine-3.20.3",
+					},
+						pkg.Package{
+							Name:    "curl",
+							Version: "7.61.1",
+							Type:    pkg.ApkPkg,
+							PURL:    "pkg:apk/curl@7.61.1?arch=aarch64&distro=alpine-3.20.2",
+						}),
+				},
+			},
 		},
 		{
 			name:      "fails on path with nonexistant file",
@@ -263,6 +429,7 @@ func Test_PurlProvider(t *testing.T) {
 		{
 			name:      "allow empty purl file",
 			userInput: "purl:test-fixtures/purl/empty.json",
+			sbom:      &sbom.SBOM{},
 		},
 		{
 			name:      "fails on invalid purl in file",
@@ -285,13 +452,18 @@ func Test_PurlProvider(t *testing.T) {
 		cmpopts.IgnoreFields(Package{}, "ID", "Locations", "Licenses", "Metadata", "Language", "CPEs"),
 	}
 
+	syftPkgOpts := []cmp.Option{
+		cmpopts.IgnoreFields(pkg.Package{}, "id"),
+		cmpopts.IgnoreUnexported(pkg.Package{}, file.LocationSet{}, pkg.LicenseSet{}),
+	}
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.wantErr == nil {
 				tc.wantErr = require.NoError
 			}
 
-			packages, ctx, err := purlProvider(tc.userInput)
+			packages, ctx, gotSBOM, err := purlProvider(tc.userInput)
 
 			tc.wantErr(t, err)
 			if err != nil {
@@ -307,6 +479,26 @@ func Test_PurlProvider(t *testing.T) {
 				if d := cmp.Diff(expected, packages[idx], opts...); d != "" {
 					t.Errorf("unexpected context (-want +got):\n%s", d)
 				}
+			}
+
+			gotSyftPkgs := gotSBOM.Artifacts.Packages.Sorted()
+			wantSyftPkgs := tc.sbom.Artifacts.Packages.Sorted()
+			require.Equal(t, len(gotSyftPkgs), len(wantSyftPkgs))
+			for idx, wantPkg := range wantSyftPkgs {
+				if d := cmp.Diff(wantPkg, gotSyftPkgs[idx], syftPkgOpts...); d != "" {
+					t.Errorf("unexpected Syft Pkg (-want +got):\n%s", d)
+				}
+			}
+
+			wantSyftDistro := tc.sbom.Artifacts.LinuxDistribution
+			gotDistro := gotSBOM.Artifacts.LinuxDistribution
+			if wantSyftDistro == nil {
+				require.Nil(t, gotDistro)
+				return
+			}
+
+			if d := cmp.Diff(wantSyftDistro, gotDistro); d != "" {
+				t.Errorf("unexpected Syft Distro (-want +got):\n%s", d)
 			}
 		})
 	}


### PR DESCRIPTION
Previously, for formats that attempted to nest vulnerabilities within an SBOM, such as CycloneDX, scanning a PURL would panic because no SBOM was ever instantiated. Instantiate the SBOM.

Fixes #2324