### PR TITLE
Allow v6 store to support multiple qualifiers

### DIFF
--- a/grype/db/internal/gormadapter/logger.go
+++ b/grype/db/internal/gormadapter/logger.go
@@ -2,36 +2,71 @@ package gormadapter
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"gorm.io/gorm/logger"
 
+	anchoreLogger "github.com/anchore/go-logger"
 	"github.com/anchore/grype/internal/log"
 )
 
+// logAdapter is meant to adapt the gorm logger interface (see https://github.com/go-gorm/gorm/blob/v1.25.12/logger/logger.go)
+// to the anchore logger interface.
 type logAdapter struct {
+	debug         bool
+	slowThreshold time.Duration
+	level         logger.LogLevel
 }
 
-func newLogger() logger.Interface {
-	return logAdapter{}
+// LogMode sets the log level for the logger and returns a new instance
+func (l *logAdapter) LogMode(level logger.LogLevel) logger.Interface {
+	newlogger := *l
+	newlogger.level = level
+	return &newlogger
 }
 
-func (l logAdapter) LogMode(logger.LogLevel) logger.Interface {
-	return l
-}
-
-func (l logAdapter) Info(_ context.Context, _ string, _ ...interface{}) {
-	// unimplemented
+func (l logAdapter) Info(_ context.Context, fmt string, v ...interface{}) {
+	if l.level >= logger.Info {
+		if l.debug {
+			log.Infof("[sql] "+fmt, v...)
+		}
+	}
 }
 
 func (l logAdapter) Warn(_ context.Context, fmt string, v ...interface{}) {
-	log.Warnf("gorm: "+fmt, v...)
+	if l.level >= logger.Warn {
+		log.Warnf("[sql] "+fmt, v...)
+	}
 }
 
 func (l logAdapter) Error(_ context.Context, fmt string, v ...interface{}) {
-	log.Errorf("gorm: "+fmt, v...)
+	if l.level >= logger.Error {
+		log.Errorf("[sql] "+fmt, v...)
+	}
 }
 
-func (l logAdapter) Trace(_ context.Context, _ time.Time, _ func() (sql string, rowsAffected int64), _ error) {
-	// unimplemented
+// Trace logs the SQL statement and the duration it took to run the statement
+func (l logAdapter) Trace(_ context.Context, t time.Time, fn func() (sql string, rowsAffected int64), _ error) {
+	if l.level <= logger.Silent {
+		return
+	}
+
+	if l.debug {
+		sql, rowsAffected := fn()
+		elapsed := time.Since(t)
+		fields := anchoreLogger.Fields{
+			"rows":     rowsAffected,
+			"duration": elapsed,
+		}
+
+		isSlow := l.slowThreshold != 0 && elapsed > l.slowThreshold
+		if isSlow {
+			fields["is-slow"] = isSlow
+			fields["slow-threshold"] = fmt.Sprintf("> %s", l.slowThreshold)
+			log.WithFields(fields).Warnf("[sql] %s", sql)
+		} else {
+			log.WithFields(fields).Tracef("[sql] %s", sql)
+		}
+	}
 }

--- a/grype/db/v6/affected_package_store.go
+++ b/grype/db/v6/affected_package_store.go
@@ -242,7 +242,7 @@ func (s *affectedPackageStore) GetAffectedPackages(pkg *PackageSpecifier, config
 		log.WithFields("pkg", pkg.String(), "distro", config.OSs, "vulns", config.Vulnerabilities, "duration", time.Since(start)).Trace("fetched affected package record")
 	}()
 
-	query := s.handlePackage(s.db.Model(&AffectedPackageHandle{}), pkg)
+	query := s.handlePackage(s.db, pkg)
 
 	var err error
 	query, err = s.handleVulnerabilityOptions(query, config.Vulnerabilities)

--- a/grype/db/v6/affected_package_store.go
+++ b/grype/db/v6/affected_package_store.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -12,11 +14,22 @@ import (
 	"github.com/anchore/syft/syft/cpe"
 )
 
-var NoDistroSpecified = &DistroSpecifier{}
-var AnyDistroSpecified *DistroSpecifier
-var ErrMissingDistroIdentification = errors.New("missing distro name or codename")
+const (
+	// batchSize affects how many records are fetched at a time from the DB. Note: when using preload, row entries
+	// for related records may convey as parameters in a "WHERE x in (...)" which can lead to a large number of
+	// parameters in the query -- if above 999 then this will result in an error for sqlite. For this reason we
+	// try to keep this value well below 999.
+	batchSize = 300
+	anyPkg    = "any"
+	anyOS     = "any"
+)
+
+var NoOSSpecified = &OSSpecifier{}
+var AnyOSSpecified *OSSpecifier
+var ErrMissingDistroIdentification = errors.New("missing os name or codename")
 var ErrDistroNotPresent = errors.New("distro not present")
 var ErrMultipleOSMatches = errors.New("multiple OS matches found but not allowed")
+var ErrLimitReached = errors.New("query limit reached")
 
 type GetAffectedPackageOptions struct {
 	PreloadOS            bool
@@ -24,9 +37,12 @@ type GetAffectedPackageOptions struct {
 	PreloadPackageCPEs   bool
 	PreloadVulnerability bool
 	PreloadBlob          bool
-	Distro               *DistroSpecifier
-	Vulnerability        *VulnerabilitySpecifier
+	OSs                  OSSpecifiers
+	Vulnerabilities      VulnerabilitySpecifiers
+	Limit                int
 }
+
+type PackageSpecifiers []*PackageSpecifier
 
 type PackageSpecifier struct {
 	Name string
@@ -36,7 +52,7 @@ type PackageSpecifier struct {
 
 func (p *PackageSpecifier) String() string {
 	if p == nil {
-		return "no-package-specified"
+		return anyPkg
 	}
 
 	var args []string
@@ -53,14 +69,28 @@ func (p *PackageSpecifier) String() string {
 	}
 
 	if len(args) > 0 {
-		return fmt.Sprintf("pkg(%s)", strings.Join(args, ", "))
+		return fmt.Sprintf("package(%s)", strings.Join(args, ", "))
 	}
 
-	return "no-package-specified"
+	return anyPkg
 }
 
-// DistroSpecifier is a struct that represents a distro in a way that can be used to query the affected package store.
-type DistroSpecifier struct {
+func (p PackageSpecifiers) String() string {
+	if len(p) == 0 {
+		return anyPkg
+	}
+
+	var parts []string
+	for _, v := range p {
+		parts = append(parts, v.String())
+	}
+	return strings.Join(parts, ", ")
+}
+
+type OSSpecifiers []*OSSpecifier
+
+// OSSpecifier is a struct that represents a distro in a way that can be used to query the affected package store.
+type OSSpecifier struct {
 	// Name of the distro as identified by the ID field in /etc/os-release
 	Name string
 
@@ -81,7 +111,37 @@ type DistroSpecifier struct {
 	AllowMultiple bool
 }
 
-func (d DistroSpecifier) version() string {
+func (d *OSSpecifier) String() string {
+	if d == nil {
+		return anyOS
+	}
+
+	if *d == *NoOSSpecified {
+		return "none"
+	}
+
+	var version string
+	if d.MajorVersion != "" {
+		version = d.MajorVersion
+		if d.MinorVersion != "" {
+			version += "." + d.MinorVersion
+		}
+	} else {
+		version = d.Codename
+	}
+
+	distroDisplayName := d.Name
+	if version != "" {
+		distroDisplayName += "@" + version
+	}
+	if version == d.MajorVersion && d.Codename != "" {
+		distroDisplayName += " (" + d.Codename + ")"
+	}
+
+	return distroDisplayName
+}
+
+func (d OSSpecifier) version() string {
 	if d.MajorVersion != "" && d.MinorVersion != "" {
 		return d.MajorVersion + "." + d.MinorVersion
 	}
@@ -101,7 +161,28 @@ func (d DistroSpecifier) version() string {
 	return ""
 }
 
-func (d DistroSpecifier) matchesVersionPattern(pattern string) bool {
+func (d OSSpecifiers) String() string {
+	if d.IsAny() {
+		return anyOS
+	}
+	var parts []string
+	for _, v := range d {
+		parts = append(parts, v.String())
+	}
+	return strings.Join(parts, ", ")
+}
+
+func (d OSSpecifiers) IsAny() bool {
+	if len(d) == 0 {
+		return true
+	}
+	if len(d) == 1 && d[0] == AnyOSSpecified {
+		return true
+	}
+	return false
+}
+
+func (d OSSpecifier) matchesVersionPattern(pattern string) bool {
 	// check if version or version label matches the given regex
 	r, err := regexp.Compile(pattern)
 	if err != nil {
@@ -156,47 +237,66 @@ func (s *affectedPackageStore) GetAffectedPackages(pkg *PackageSpecifier, config
 		config = &GetAffectedPackageOptions{}
 	}
 
-	log.WithFields("pkg", pkg.String(), "distro", distroDisplay(config.Distro)).Trace("fetching AffectedPackage record")
+	start := time.Now()
+	defer func() {
+		log.WithFields("pkg", pkg.String(), "distro", config.OSs, "vulns", config.Vulnerabilities, "duration", time.Since(start)).Trace("fetched affected package record")
+	}()
 
-	query := s.handlePackage(s.db, pkg)
+	query := s.handlePackage(s.db.Model(&AffectedPackageHandle{}), pkg)
 
 	var err error
-	query, err = s.handleVulnerabilityOptions(query, config.Vulnerability)
+	query, err = s.handleVulnerabilityOptions(query, config.Vulnerabilities)
 	if err != nil {
 		return nil, err
 	}
 
-	query, err = s.handleDistroOptions(query, config.Distro)
+	query, err = s.handleOSOptions(query, config.OSs)
 	if err != nil {
 		return nil, err
 	}
 
 	query = s.handlePreload(query, *config)
 
-	var pkgs []AffectedPackageHandle
-	if err = query.Find(&pkgs).Error; err != nil {
-		return nil, fmt.Errorf("unable to fetch non-distro affected package record: %w", err)
-	}
+	var models []AffectedPackageHandle
 
-	if config.PreloadBlob {
-		for i := range pkgs {
-			err := s.blobStore.attachBlobValue(&pkgs[i])
-			if err != nil {
-				return nil, fmt.Errorf("unable to attach blob %#v: %w", pkgs[i], err)
+	var results []*AffectedPackageHandle
+	if err := query.FindInBatches(&results, batchSize, func(_ *gorm.DB, _ int) error { // nolint:dupl
+		if config.PreloadBlob {
+			var blobs []blobable
+			for _, r := range results {
+				blobs = append(blobs, r)
+			}
+			if err := s.blobStore.attachBlobValue(blobs...); err != nil {
+				return fmt.Errorf("unable to attach blobs: %w", err)
 			}
 		}
-	}
 
-	if config.PreloadVulnerability {
-		for i := range pkgs {
-			err := s.blobStore.attachBlobValue(pkgs[i].Vulnerability)
-			if err != nil {
-				return nil, fmt.Errorf("unable to attach vulnerability blob %#v: %w", pkgs[i], err)
+		if config.PreloadVulnerability {
+			var vulns []blobable
+			for _, r := range results {
+				if r.Vulnerability != nil {
+					vulns = append(vulns, r.Vulnerability)
+				}
+			}
+			if err := s.blobStore.attachBlobValue(vulns...); err != nil {
+				return fmt.Errorf("unable to attach vulnerability blob: %w", err)
 			}
 		}
+
+		for _, r := range results {
+			models = append(models, *r)
+		}
+
+		if config.Limit > 0 && len(models) >= config.Limit {
+			return ErrLimitReached
+		}
+
+		return nil
+	}).Error; err != nil {
+		return models, fmt.Errorf("unable to fetch affected package records: %w", err)
 	}
 
-	return pkgs, nil
+	return models, nil
 }
 
 func (s *affectedPackageStore) handlePackage(query *gorm.DB, config *PackageSpecifier) *gorm.DB {
@@ -221,57 +321,82 @@ func (s *affectedPackageStore) handlePackage(query *gorm.DB, config *PackageSpec
 	return query
 }
 
-func (s *affectedPackageStore) handleVulnerabilityOptions(query *gorm.DB, config *VulnerabilitySpecifier) (*gorm.DB, error) {
-	if config == nil {
+func (s *affectedPackageStore) handleVulnerabilityOptions(query *gorm.DB, configs []VulnerabilitySpecifier) (*gorm.DB, error) {
+	if len(configs) == 0 {
 		return query, nil
 	}
 	query = query.Joins("JOIN vulnerability_handles ON affected_package_handles.vulnerability_id = vulnerability_handles.id")
 
-	return handleVulnerabilityOptions(query, config)
+	return handleVulnerabilityOptions(s.db, query, configs...)
 }
 
-func (s *affectedPackageStore) handleDistroOptions(query *gorm.DB, config *DistroSpecifier) (*gorm.DB, error) {
-	var resolvedDistros []OperatingSystem
-	var err error
+func (s *affectedPackageStore) handleOSOptions(query *gorm.DB, configs []*OSSpecifier) (*gorm.DB, error) {
+	resolvedDistroMap := make(map[int64]OperatingSystem)
 
-	switch {
-	case hasDistroSpecified(config):
-		resolvedDistros, err = s.resolveDistro(*config)
-		if err != nil {
-			return nil, fmt.Errorf("unable to resolve distro: %w", err)
-		}
+	if len(configs) == 0 {
+		configs = append(configs, AnyOSSpecified)
+	}
 
+	var hasAny, hasNone, hasSpecific bool
+	for _, config := range configs {
 		switch {
-		case len(resolvedDistros) == 0:
-			return nil, ErrDistroNotPresent
-		case len(resolvedDistros) > 1 && !config.AllowMultiple:
-			return nil, ErrMultipleOSMatches
+		case hasDistroSpecified(config):
+			curResolvedDistros, err := s.resolveDistro(*config)
+			if err != nil {
+				return nil, fmt.Errorf("unable to resolve distro: %w", err)
+			}
+
+			switch {
+			case len(curResolvedDistros) == 0:
+				return nil, ErrDistroNotPresent
+			case len(curResolvedDistros) > 1 && !config.AllowMultiple:
+				return nil, ErrMultipleOSMatches
+			}
+			hasSpecific = true
+			for _, d := range curResolvedDistros {
+				resolvedDistroMap[int64(d.ID)] = d
+			}
+		case config == AnyOSSpecified:
+			// TODO: one enhancement we may want to do later is "has OS defined but is not specific" which this does NOT cover. This is "may or may not have an OS defined" which is different.
+			hasAny = true
+		case *config == *NoOSSpecified:
+			hasNone = true
 		}
-	case config == AnyDistroSpecified:
-		// TODO: one enhancement we may want to do later is "has OS defined but is not specific" which this does NOT cover. This is "may or may not have an OS defined" which is different.
+	}
+
+	if (hasAny || hasNone) && hasSpecific {
+		return nil, fmt.Errorf("cannot mix specific distro with any or none distro specifiers")
+	}
+
+	var resolvedDistros []OperatingSystem
+	switch {
+	case hasAny:
 		return query, nil
-	case *config == *NoDistroSpecified:
+	case hasNone:
 		return query.Where("operating_system_id IS NULL"), nil
+	case hasSpecific:
+		for _, d := range resolvedDistroMap {
+			resolvedDistros = append(resolvedDistros, d)
+		}
+		sort.Slice(resolvedDistros, func(i, j int) bool {
+			return resolvedDistros[i].ID < resolvedDistros[j].ID
+		})
 	}
 
 	query = query.Joins("JOIN operating_systems ON affected_package_handles.operating_system_id = operating_systems.id")
 
-	var count int
-	for _, o := range resolvedDistros {
-		if o.ID != 0 {
-			if count == 0 {
-				query = query.Where("operating_systems.id = ?", o.ID)
-			} else {
-				query = query.Or("operating_systems.id = ?", o.ID)
-			}
-			count++
+	if len(resolvedDistros) > 0 {
+		ids := make([]ID, len(resolvedDistros))
+		for i, d := range resolvedDistros {
+			ids[i] = d.ID
 		}
+		query = query.Where("operating_systems.id IN ?", ids)
 	}
 
 	return query, nil
 }
 
-func (s *affectedPackageStore) resolveDistro(d DistroSpecifier) ([]OperatingSystem, error) {
+func (s *affectedPackageStore) resolveDistro(d OSSpecifier) ([]OperatingSystem, error) {
 	if d.Name == "" && d.Codename == "" {
 		return nil, ErrMissingDistroIdentification
 	}
@@ -300,7 +425,7 @@ func (s *affectedPackageStore) resolveDistro(d DistroSpecifier) ([]OperatingSyst
 	return s.searchForDistroVersionVariants(query, d)
 }
 
-func (s *affectedPackageStore) searchForDistroVersionVariants(query *gorm.DB, d DistroSpecifier) ([]OperatingSystem, error) {
+func (s *affectedPackageStore) searchForDistroVersionVariants(query *gorm.DB, d OSSpecifier) ([]OperatingSystem, error) {
 	var allOs []OperatingSystem
 
 	handleQuery := func(q *gorm.DB, desc string) ([]OperatingSystem, error) {
@@ -354,7 +479,7 @@ func (s *affectedPackageStore) searchForDistroVersionVariants(query *gorm.DB, d 
 	return allOs, nil
 }
 
-func (s *affectedPackageStore) applyAlias(d *DistroSpecifier) error {
+func (s *affectedPackageStore) applyAlias(d *OSSpecifier) error {
 	if d.Name == "" {
 		return nil
 	}
@@ -416,21 +541,30 @@ func (s *affectedPackageStore) applyAlias(d *DistroSpecifier) error {
 }
 
 func (s *affectedPackageStore) handlePreload(query *gorm.DB, config GetAffectedPackageOptions) *gorm.DB {
+	var limitArgs []interface{}
+	if config.Limit > 0 {
+		query = query.Limit(config.Limit)
+		limitArgs = append(limitArgs, func(db *gorm.DB) *gorm.DB {
+			return db.Limit(config.Limit)
+		})
+	}
+
 	if config.PreloadPackage {
-		query = query.Preload("Package")
+		query = query.Preload("Package", limitArgs...)
 
 		if config.PreloadPackageCPEs {
-			query = query.Preload("Package.CPEs")
+			query = query.Preload("Package.CPEs", limitArgs...)
 		}
 	}
 
 	if config.PreloadVulnerability {
-		query = query.Preload("Vulnerability").Preload("Vulnerability.Provider")
+		query = query.Preload("Vulnerability", limitArgs...).Preload("Vulnerability.Provider", limitArgs...)
 	}
 
 	if config.PreloadOS {
-		query = query.Preload("OperatingSystem")
+		query = query.Preload("OperatingSystem", limitArgs...)
 	}
+
 	return query
 }
 
@@ -473,42 +607,12 @@ func handleCPEOptions(query *gorm.DB, c *cpe.Attributes) *gorm.DB {
 	return query
 }
 
-func distroDisplay(d *DistroSpecifier) string {
-	if d == nil {
-		return "any"
-	}
-
-	if *d == *NoDistroSpecified {
-		return "none"
-	}
-
-	var version string
-	if d.MajorVersion != "" {
-		version = d.MajorVersion
-		if d.MinorVersion != "" {
-			version += "." + d.MinorVersion
-		}
-	} else {
-		version = d.Codename
-	}
-
-	distroDisplayName := d.Name
-	if version != "" {
-		distroDisplayName += "@" + version
-	}
-	if version == d.MajorVersion && d.Codename != "" {
-		distroDisplayName += " (" + d.Codename + ")"
-	}
-
-	return distroDisplayName
-}
-
-func hasDistroSpecified(d *DistroSpecifier) bool {
-	if d == AnyDistroSpecified {
+func hasDistroSpecified(d *OSSpecifier) bool {
+	if d == AnyOSSpecified {
 		return false
 	}
 
-	if *d == *NoDistroSpecified {
+	if *d == *NoOSSpecified {
 		return false
 	}
 	return true

--- a/grype/db/v6/affected_package_store_test.go
+++ b/grype/db/v6/affected_package_store_test.go
@@ -540,11 +540,11 @@ func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 			name: "specific distro",
 			pkg:  pkgFromName(pkg2d1.Package.Name),
 			options: &GetAffectedPackageOptions{
-				Distro: &DistroSpecifier{
+				OSs: []*OSSpecifier{{
 					Name:         "ubuntu",
 					MajorVersion: "20",
 					MinorVersion: "04",
-				},
+				}},
 			},
 			expected: []AffectedPackageHandle{*pkg2d1},
 		},
@@ -552,11 +552,11 @@ func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 			name: "distro major version only (allow multiple)",
 			pkg:  pkgFromName(pkg2d1.Package.Name),
 			options: &GetAffectedPackageOptions{
-				Distro: &DistroSpecifier{
+				OSs: []*OSSpecifier{{
 					Name:          "ubuntu",
 					MajorVersion:  "20",
 					AllowMultiple: true,
-				},
+				}},
 			},
 			expected: []AffectedPackageHandle{*pkg2d1, *pkg2d2},
 		},
@@ -564,11 +564,11 @@ func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 			name: "distro major version only (default)",
 			pkg:  pkgFromName(pkg2d1.Package.Name),
 			options: &GetAffectedPackageOptions{
-				Distro: &DistroSpecifier{
+				OSs: []*OSSpecifier{{
 					Name:          "ubuntu",
 					MajorVersion:  "20",
 					AllowMultiple: false,
-				},
+				}},
 			},
 			wantErr: expectErrIs(t, ErrMultipleOSMatches),
 		},
@@ -576,10 +576,10 @@ func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 			name: "distro codename",
 			pkg:  pkgFromName(pkg2d1.Package.Name),
 			options: &GetAffectedPackageOptions{
-				Distro: &DistroSpecifier{
+				OSs: []*OSSpecifier{{
 					Name:     "ubuntu",
 					Codename: "groovy",
-				},
+				}},
 			},
 			expected: []AffectedPackageHandle{*pkg2d2},
 		},
@@ -587,7 +587,7 @@ func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 			name: "no distro",
 			pkg:  pkgFromName(pkg2.Package.Name),
 			options: &GetAffectedPackageOptions{
-				Distro: NoDistroSpecified,
+				OSs: []*OSSpecifier{NoOSSpecified},
 			},
 			expected: []AffectedPackageHandle{*pkg2},
 		},
@@ -595,7 +595,7 @@ func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 			name: "any distro",
 			pkg:  pkgFromName(pkg2d1.Package.Name),
 			options: &GetAffectedPackageOptions{
-				Distro: AnyDistroSpecified,
+				OSs: []*OSSpecifier{AnyOSSpecified},
 			},
 			expected: []AffectedPackageHandle{*pkg2d1, *pkg2, *pkg2d2},
 		},
@@ -608,9 +608,9 @@ func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 			name: "specific CVE",
 			pkg:  pkgFromName(pkg2d1.Package.Name),
 			options: &GetAffectedPackageOptions{
-				Vulnerability: &VulnerabilitySpecifier{
+				Vulnerabilities: []VulnerabilitySpecifier{{
 					Name: "CVE-2023-1234",
-				},
+				}},
 			},
 			expected: []AffectedPackageHandle{*pkg2d1},
 		},
@@ -618,12 +618,12 @@ func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 			name: "any CVE published after a date",
 			pkg:  pkgFromName(pkg2d1.Package.Name),
 			options: &GetAffectedPackageOptions{
-				Vulnerability: &VulnerabilitySpecifier{
+				Vulnerabilities: []VulnerabilitySpecifier{{
 					PublishedAfter: func() *time.Time {
 						now := time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC)
 						return &now
 					}(),
-				},
+				}},
 			},
 			expected: []AffectedPackageHandle{*pkg2d1, *pkg2d2},
 		},
@@ -631,12 +631,12 @@ func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 			name: "any CVE modified after a date",
 			pkg:  pkgFromName(pkg2d1.Package.Name),
 			options: &GetAffectedPackageOptions{
-				Vulnerability: &VulnerabilitySpecifier{
+				Vulnerabilities: []VulnerabilitySpecifier{{
 					ModifiedAfter: func() *time.Time {
 						now := time.Date(2023, 1, 1, 3, 4, 5, 0, time.UTC).Add(time.Hour * 2)
 						return &now
 					}(),
-				},
+				}},
 			},
 			expected: []AffectedPackageHandle{*pkg2d1},
 		},
@@ -644,9 +644,9 @@ func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 			name: "any rejected CVE",
 			pkg:  pkgFromName(pkg2d1.Package.Name),
 			options: &GetAffectedPackageOptions{
-				Vulnerability: &VulnerabilitySpecifier{
+				Vulnerabilities: []VulnerabilitySpecifier{{
 					Status: VulnerabilityRejected,
-				},
+				}},
 			},
 			expected: []AffectedPackageHandle{*pkg2d1},
 		},
@@ -720,13 +720,13 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		distro    DistroSpecifier
+		distro    OSSpecifier
 		expected  []OperatingSystem
 		expectErr require.ErrorAssertionFunc
 	}{
 		{
 			name: "specific distro with major and minor version",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				Name:         "ubuntu",
 				MajorVersion: "20",
 				MinorVersion: "04",
@@ -735,7 +735,7 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 		},
 		{
 			name: "alias resolution with major version",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				Name:         "centos",
 				MajorVersion: "8",
 			},
@@ -743,7 +743,7 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 		},
 		{
 			name: "alias resolution with major and minor version",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				Name:         "centos",
 				MajorVersion: "8",
 				MinorVersion: "1",
@@ -752,7 +752,7 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 		},
 		{
 			name: "distro with major version only",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				Name:         "debian",
 				MajorVersion: "10",
 			},
@@ -760,7 +760,7 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 		},
 		{
 			name: "codename resolution",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				Name:     "ubuntu",
 				Codename: "focal",
 			},
@@ -768,7 +768,7 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 		},
 		{
 			name: "codename and version info",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				Name:         "ubuntu",
 				MajorVersion: "20",
 				MinorVersion: "04",
@@ -778,7 +778,7 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 		},
 		{
 			name: "conflicting codename and version info",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				Name:         "ubuntu",
 				MajorVersion: "20",
 				MinorVersion: "04",
@@ -787,7 +787,7 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 		},
 		{
 			name: "alpine edge version",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				Name:         "alpine",
 				MajorVersion: "3",
 				MinorVersion: "21",
@@ -797,14 +797,14 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 		},
 		{
 			name: "arch rolling variant",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				Name: "arch",
 			},
 			expected: []OperatingSystem{*arch},
 		},
 		{
 			name: "wolfi rolling variant",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				Name:         "wolfi",
 				MajorVersion: "20221018",
 			},
@@ -812,7 +812,7 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 		},
 		{
 			name: "debian by codename for rolling alias",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				Name:         "debian",
 				MajorVersion: "13",
 				Codename:     "trixie", // TODO: what about sid status indication from pretty-name or /etc/debian_version?
@@ -821,7 +821,7 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 		},
 		{
 			name: "debian by codename",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				Name:     "debian",
 				Codename: "wheezy",
 			},
@@ -829,7 +829,7 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 		},
 		{
 			name: "debian by major version",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				Name:         "debian",
 				MajorVersion: "7",
 			},
@@ -837,7 +837,7 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 		},
 		{
 			name: "debian by major.minor version",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				Name:         "debian",
 				MajorVersion: "7",
 				MinorVersion: "2",
@@ -846,7 +846,7 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 		},
 		{
 			name: "alpine with major and minor version",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				Name:         "alpine",
 				MajorVersion: "3",
 				MinorVersion: "18",
@@ -855,14 +855,14 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 		},
 		{
 			name: "missing distro name",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				MajorVersion: "8",
 			},
 			expectErr: expectErrIs(t, ErrMissingDistroIdentification),
 		},
 		{
 			name: "nonexistent distro",
-			distro: DistroSpecifier{
+			distro: OSSpecifier{
 				Name:         "madeup",
 				MajorVersion: "99",
 			},
@@ -887,32 +887,32 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 	}
 }
 
-func TestDistroDisplay(t *testing.T) {
+func TestDistroSpecifier_String(t *testing.T) {
 	tests := []struct {
 		name     string
-		distro   *DistroSpecifier
+		distro   *OSSpecifier
 		expected string
 	}{
 		{
 			name:     "nil distro",
-			distro:   AnyDistroSpecified,
+			distro:   AnyOSSpecified,
 			expected: "any",
 		},
 		{
 			name:     "no distro specified",
-			distro:   NoDistroSpecified,
+			distro:   NoOSSpecified,
 			expected: "none",
 		},
 		{
 			name: "only name specified",
-			distro: &DistroSpecifier{
+			distro: &OSSpecifier{
 				Name: "ubuntu",
 			},
 			expected: "ubuntu",
 		},
 		{
 			name: "name and major version specified",
-			distro: &DistroSpecifier{
+			distro: &OSSpecifier{
 				Name:         "ubuntu",
 				MajorVersion: "20",
 			},
@@ -920,7 +920,7 @@ func TestDistroDisplay(t *testing.T) {
 		},
 		{
 			name: "name, major, and minor version specified",
-			distro: &DistroSpecifier{
+			distro: &OSSpecifier{
 				Name:         "ubuntu",
 				MajorVersion: "20",
 				MinorVersion: "04",
@@ -929,7 +929,7 @@ func TestDistroDisplay(t *testing.T) {
 		},
 		{
 			name: "name, major version, and codename specified",
-			distro: &DistroSpecifier{
+			distro: &OSSpecifier{
 				Name:         "ubuntu",
 				MajorVersion: "20",
 				Codename:     "focal",
@@ -938,7 +938,7 @@ func TestDistroDisplay(t *testing.T) {
 		},
 		{
 			name: "name and codename specified",
-			distro: &DistroSpecifier{
+			distro: &OSSpecifier{
 				Name:     "ubuntu",
 				Codename: "focal",
 			},
@@ -946,7 +946,7 @@ func TestDistroDisplay(t *testing.T) {
 		},
 		{
 			name: "name, major version, minor version, and codename specified",
-			distro: &DistroSpecifier{
+			distro: &OSSpecifier{
 				Name:         "ubuntu",
 				MajorVersion: "20",
 				MinorVersion: "04",
@@ -958,7 +958,7 @@ func TestDistroDisplay(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := distroDisplay(tt.distro)
+			result := tt.distro.String()
 			require.Equal(t, tt.expected, result)
 		})
 	}

--- a/grype/db/v6/blobs.go
+++ b/grype/db/v6/blobs.go
@@ -3,6 +3,7 @@ package v6
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -94,6 +95,14 @@ type CVSSSeverity struct {
 
 	// Score is the evaluated CVSS vector as a scalar between 0 and 10
 	Score float64 `json:"score"`
+}
+
+func (c CVSSSeverity) String() string {
+	vector := c.Vector
+	if !strings.HasPrefix(strings.ToLower(c.Vector), "cvss:") && c.Version != "" {
+		vector = fmt.Sprintf("CVSS:%s/%s", c.Version, c.Vector)
+	}
+	return fmt.Sprintf("%s (%1.1f)", vector, c.Score)
 }
 
 // AffectedPackageBlob represents a package affected by a vulnerability.

--- a/grype/db/v6/db.go
+++ b/grype/db/v6/db.go
@@ -87,6 +87,8 @@ func NewLowLevelDB(dbFilePath string, empty, writable bool) (*gorm.DB, error) {
 	opts := []gormadapter.Option{
 		// 16 KB, useful for smaller DBs since ~85% of the DB is from the blobs table
 		gormadapter.WithStatements("PRAGMA page_size = 16384"),
+		// TODO: this should be removed after initial development (or wired to a config option)
+		gormadapter.WithDebug(true),
 	}
 
 	if empty && !writable {
@@ -94,11 +96,11 @@ func NewLowLevelDB(dbFilePath string, empty, writable bool) (*gorm.DB, error) {
 	}
 
 	if empty {
-		opts = append(opts, gormadapter.WithTruncate(true, Models(), InitialData()))
-	}
-
-	if writable {
-		opts = append(opts, gormadapter.WithWritable(true))
+		opts = append(opts,
+			gormadapter.WithTruncate(true, Models(), InitialData()),
+		)
+	} else if writable {
+		opts = append(opts, gormadapter.WithWritable(true, Models()))
 	}
 
 	return gormadapter.Open(dbFilePath, opts...)

--- a/grype/db/v6/installation/curator.go
+++ b/grype/db/v6/installation/curator.go
@@ -27,9 +27,9 @@ const lastUpdateCheckFileName = "last_update_check"
 
 type monitor struct {
 	*progress.AtomicStage
-	downloadProgress dummyMonitor
-	importProgress   dummyMonitor
-	hydrateProgress  dummyMonitor
+	downloadProgress completionMonitor
+	importProgress   completionMonitor
+	hydrateProgress  completionMonitor
 }
 
 type Config struct {
@@ -483,9 +483,9 @@ func newMonitor() monitor {
 
 	return monitor{
 		AtomicStage:      stage,
-		downloadProgress: dummyMonitor{downloadProgress},
-		importProgress:   dummyMonitor{importProgress},
-		hydrateProgress:  dummyMonitor{hydrateProgress},
+		downloadProgress: completionMonitor{downloadProgress},
+		importProgress:   completionMonitor{importProgress},
+		hydrateProgress:  completionMonitor{hydrateProgress},
 	}
 }
 
@@ -495,11 +495,12 @@ func (m monitor) SetCompleted() {
 	m.hydrateProgress.SetCompleted()
 }
 
-type dummyMonitor struct {
+// completionMonitor is a progressable that, when SetComplete() is called, will set the progress to the total size
+type completionMonitor struct {
 	*progress.Manual
 }
 
-func (m dummyMonitor) SetCompleted() {
+func (m completionMonitor) SetCompleted() {
 	m.Set(m.Size())
 	m.Manual.SetCompleted()
 }

--- a/grype/db/v6/models.go
+++ b/grype/db/v6/models.go
@@ -187,13 +187,13 @@ type VulnerabilityAlias struct {
 // name (which might or might not be the product name in the CPE), in which case AffectedCPEHandle should be used.
 type AffectedPackageHandle struct {
 	ID              ID                   `gorm:"column:id;primaryKey"`
-	VulnerabilityID ID                   `gorm:"column:vulnerability_id;not null"`
+	VulnerabilityID ID                   `gorm:"column:vulnerability_id;index;not null"`
 	Vulnerability   *VulnerabilityHandle `gorm:"foreignKey:VulnerabilityID"`
 
-	OperatingSystemID *ID              `gorm:"column:operating_system_id"`
+	OperatingSystemID *ID              `gorm:"column:operating_system_id;index"`
 	OperatingSystem   *OperatingSystem `gorm:"foreignKey:OperatingSystemID"`
 
-	PackageID ID       `gorm:"column:package_id"`
+	PackageID ID       `gorm:"column:package_id;index"`
 	Package   *Package `gorm:"foreignKey:PackageID"`
 
 	BlobID    ID                   `gorm:"column:blob_id"`
@@ -225,7 +225,7 @@ func (v *AffectedPackageHandle) setBlob(rawBlobValue []byte) error {
 type Package struct {
 	ID   ID     `gorm:"column:id;primaryKey"`
 	Type string `gorm:"column:type;index:idx_package,unique"`
-	Name string `gorm:"column:name;index:idx_package,unique"`
+	Name string `gorm:"column:name;index:idx_package,unique;index:idx_package_name"`
 
 	CPEs []Cpe `gorm:"foreignKey:PackageID;constraint:OnDelete:CASCADE;"`
 }
@@ -282,7 +282,7 @@ type OperatingSystem struct {
 	MajorVersion string `gorm:"column:major_version;index:os_idx,unique"`
 	MinorVersion string `gorm:"column:minor_version;index:os_idx,unique"`
 	LabelVersion string `gorm:"column:label_version;index:os_idx,unique"`
-	Codename     string `gorm:"column:codename"`
+	Codename     string `gorm:"column:codename"` // TODO: should this be removed and use label-version instead?
 }
 
 func (os *OperatingSystem) BeforeCreate(tx *gorm.DB) (err error) {
@@ -399,8 +399,8 @@ type Cpe struct {
 	PackageID *ID `gorm:"column:package_id;index"`
 
 	Part            string `gorm:"column:part;not null;index:idx_cpe,unique"`
-	Vendor          string `gorm:"column:vendor;index:idx_cpe,unique"`
-	Product         string `gorm:"column:product;not null;index:idx_cpe,unique"`
+	Vendor          string `gorm:"column:vendor;index:idx_cpe,unique;index:idx_cpe_vendor"`
+	Product         string `gorm:"column:product;not null;index:idx_cpe,unique;index:idx_cpe_product"`
 	Edition         string `gorm:"column:edition;index:idx_cpe,unique"`
 	Language        string `gorm:"column:language;index:idx_cpe,unique"`
 	SoftwareEdition string `gorm:"column:software_edition;index:idx_cpe,unique"`

--- a/grype/db/v6/vulnerability_store.go
+++ b/grype/db/v6/vulnerability_store.go
@@ -1,7 +1,6 @@
 package v6
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -10,8 +9,11 @@ import (
 	"github.com/scylladb/go-set/strset"
 	"gorm.io/gorm"
 
+	"github.com/anchore/go-logger"
 	"github.com/anchore/grype/internal/log"
 )
+
+const anyVulnerability = "any"
 
 type VulnerabilityStoreWriter interface {
 	AddVulnerabilities(vulns ...*VulnerabilityHandle) error
@@ -23,7 +25,10 @@ type VulnerabilityStoreReader interface {
 
 type GetVulnerabilityOptions struct {
 	Preload bool
+	Limit   int
 }
+
+type VulnerabilitySpecifiers []VulnerabilitySpecifier
 
 type VulnerabilitySpecifier struct {
 	// Name of the vulnerability (e.g. CVE-2020-1234)
@@ -43,6 +48,9 @@ type VulnerabilitySpecifier struct {
 
 	// IncludeAliases for the given name or ID in results
 	IncludeAliases bool
+
+	// Providers
+	Providers []string
 }
 
 func (v *VulnerabilitySpecifier) String() string {
@@ -67,7 +75,30 @@ func (v *VulnerabilitySpecifier) String() string {
 		parts = append(parts, fmt.Sprintf("modifiedAfter=%s", v.ModifiedAfter.String()))
 	}
 
-	return fmt.Sprintf("VulnerabilitySpecifier(%s)", strings.Join(parts, ", "))
+	if v.IncludeAliases {
+		parts = append(parts, "includeAliases=true")
+	}
+
+	if len(v.Providers) > 0 {
+		parts = append(parts, fmt.Sprintf("providers=%s", strings.Join(v.Providers, ",")))
+	}
+
+	if len(parts) == 0 {
+		return anyVulnerability
+	}
+
+	return fmt.Sprintf("vulnerability(%s)", strings.Join(parts, ", "))
+}
+
+func (s VulnerabilitySpecifiers) String() string {
+	if len(s) == 0 {
+		return anyVulnerability
+	}
+	var parts []string
+	for _, v := range s {
+		parts = append(parts, v.String())
+	}
+	return strings.Join(parts, ", ")
 }
 
 func DefaultGetVulnerabilityOptions() *GetVulnerabilityOptions {
@@ -164,85 +195,121 @@ func (s *vulnerabilityStore) GetVulnerabilities(vuln *VulnerabilitySpecifier, co
 	if config == nil {
 		config = DefaultGetVulnerabilityOptions()
 	}
-	log.WithFields("vuln", vuln.String(), "preload", config.Preload).Trace("fetching Vulnerability records")
+	fields := logger.Fields{
+		"vuln":    vuln,
+		"preload": config.Preload,
+	}
+	start := time.Now()
+	defer func() {
+		fields["duration"] = time.Since(start)
+		log.WithFields(fields).Trace("fetched vulnerability records")
+	}()
 
-	var models []VulnerabilityHandle
-
-	query, err := handleVulnerabilityOptions(s.db, vuln)
-	if err != nil {
-		return nil, err
+	var err error
+	query := s.db
+	if vuln != nil {
+		query, err = handleVulnerabilityOptions(s.db.Model(&VulnerabilityHandle{}), query, *vuln)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	query = s.handlePreload(query, *config)
 
-	result := query.Find(&models)
+	var models []VulnerabilityHandle
 
-	if result.Error != nil {
-		return nil, fmt.Errorf("unable to fetch vulnerability records: %w", result.Error)
-	}
-
-	if config.Preload {
-		for i := range models {
-			err := s.attachBlob(&models[i])
-			if err != nil {
-				return nil, fmt.Errorf("unable to attach blob %#v: %w", models[i], err)
+	var results []*VulnerabilityHandle
+	if err := query.FindInBatches(&results, batchSize, func(_ *gorm.DB, _ int) error {
+		if config.Preload {
+			var blobs []blobable
+			for _, r := range results {
+				blobs = append(blobs, r)
+			}
+			if err := s.blobStore.attachBlobValue(blobs...); err != nil {
+				return fmt.Errorf("unable to attach blobs: %w", err)
 			}
 		}
+
+		for _, r := range results {
+			models = append(models, *r)
+		}
+
+		if config.Limit > 0 && len(models) >= config.Limit {
+			return ErrLimitReached
+		}
+
+		return nil
+	}).Error; err != nil {
+		return models, fmt.Errorf("unable to fetch vulnerability records: %w", err)
 	}
 
 	return models, err
 }
 
 func (s *vulnerabilityStore) handlePreload(query *gorm.DB, config GetVulnerabilityOptions) *gorm.DB {
+	var limitArgs []interface{}
+	if config.Limit > 0 {
+		query = query.Limit(config.Limit)
+		limitArgs = append(limitArgs, func(db *gorm.DB) *gorm.DB {
+			return db.Limit(config.Limit)
+		})
+	}
 	if config.Preload {
-		query = query.Preload("Provider")
+		query = query.Preload("Provider", limitArgs...)
 	}
 	return query
 }
 
-func (s *vulnerabilityStore) attachBlob(vh *VulnerabilityHandle) error {
-	var blobValue *VulnerabilityBlob
-
-	rawValue, err := s.blobStore.getBlobValue(vh.BlobID)
-	if err != nil {
-		return fmt.Errorf("unable to fetch vulnerability blob value: %w", err)
+func handleVulnerabilityOptions(base, parentQuery *gorm.DB, configs ...VulnerabilitySpecifier) (*gorm.DB, error) {
+	if len(configs) == 0 {
+		return parentQuery, nil
 	}
 
-	err = json.Unmarshal([]byte(rawValue), &blobValue)
-	if err != nil {
-		return fmt.Errorf("unable to unmarshal vulnerability blob value: %w", err)
-	}
+	orConditions := base.Model(&VulnerabilityHandle{})
+	var includeAliasJoin bool
+	for i, config := range configs {
+		query := base.Model(&VulnerabilityHandle{})
+		if config.Name != "" {
+			if config.IncludeAliases {
+				includeAliasJoin = true
+				query = query.Where("vulnerability_handles.name = ? OR vulnerability_aliases.alias = ?", config.Name, config.Name)
+			} else {
+				query = query.Where("vulnerability_handles.name = ?", config.Name)
+			}
+		}
 
-	vh.BlobValue = blobValue
+		if config.ID != 0 {
+			query = query.Where("vulnerability_handles.id = ?", config.ID)
+		}
 
-	return nil
-}
+		if config.PublishedAfter != nil {
+			query = query.Where("vulnerability_handles.published_date > ?", *config.PublishedAfter)
+		}
 
-func handleVulnerabilityOptions(query *gorm.DB, config *VulnerabilitySpecifier) (*gorm.DB, error) {
-	if config.Name != "" {
-		if config.IncludeAliases {
-			query = query.Joins("LEFT JOIN vulnerability_aliases ON vulnerability_aliases.name = vulnerability_handles.name")
-			query = query.Where("vulnerability_handles.name = ? OR vulnerability_aliases.alias = ?", config.Name, config.Name)
-		} else {
-			query = query.Where("vulnerability_handles.name = ?", config.Name)
+		if config.ModifiedAfter != nil {
+			query = query.Where("vulnerability_handles.modified_date > ?", *config.ModifiedAfter)
+		}
+
+		if config.Status != "" {
+			query = query.Where("vulnerability_handles.status = ?", config.Status)
+		}
+
+		if len(config.Providers) > 0 {
+			query = query.Where("vulnerability_handles.provider_id IN ?", config.Providers)
+		}
+
+		if i == 0 {
+			if len(configs) > 1 {
+				orConditions = orConditions.Or(query)
+			} else {
+				orConditions = query
+			}
 		}
 	}
 
-	if config.ID != 0 {
-		query = query.Where("vulnerability_handles.id = ?", config.ID)
+	if includeAliasJoin {
+		parentQuery = parentQuery.Joins("LEFT JOIN vulnerability_aliases ON vulnerability_aliases.name = vulnerability_handles.name")
 	}
 
-	if config.PublishedAfter != nil {
-		query = query.Where("vulnerability_handles.published_date > ?", *config.PublishedAfter)
-	}
-
-	if config.ModifiedAfter != nil {
-		query = query.Where("vulnerability_handles.modified_date > ?", *config.ModifiedAfter)
-	}
-
-	if config.Status != "" {
-		query = query.Where("vulnerability_handles.status = ?", config.Status)
-	}
-
-	return query, nil
+	return parentQuery.Where(orConditions), nil
 }

--- a/grype/db/v6/vulnerability_store.go
+++ b/grype/db/v6/vulnerability_store.go
@@ -267,7 +267,7 @@ func handleVulnerabilityOptions(base, parentQuery *gorm.DB, configs ...Vulnerabi
 
 	orConditions := base.Model(&VulnerabilityHandle{})
 	var includeAliasJoin bool
-	for i, config := range configs {
+	for _, config := range configs {
 		query := base.Model(&VulnerabilityHandle{})
 		if config.Name != "" {
 			if config.IncludeAliases {
@@ -298,13 +298,7 @@ func handleVulnerabilityOptions(base, parentQuery *gorm.DB, configs ...Vulnerabi
 			query = query.Where("vulnerability_handles.provider_id IN ?", config.Providers)
 		}
 
-		if i == 0 {
-			if len(configs) > 1 {
-				orConditions = orConditions.Or(query)
-			} else {
-				orConditions = query
-			}
-		}
+		orConditions = orConditions.Or(query)
 	}
 
 	if includeAliasJoin {

--- a/grype/db/v6/vulnerability_store.go
+++ b/grype/db/v6/vulnerability_store.go
@@ -208,7 +208,7 @@ func (s *vulnerabilityStore) GetVulnerabilities(vuln *VulnerabilitySpecifier, co
 	var err error
 	query := s.db
 	if vuln != nil {
-		query, err = handleVulnerabilityOptions(s.db.Model(&VulnerabilityHandle{}), query, *vuln)
+		query, err = handleVulnerabilityOptions(s.db, query, *vuln)
 		if err != nil {
 			return nil, err
 		}

--- a/grype/db/v6/vulnerability_store_test.go
+++ b/grype/db/v6/vulnerability_store_test.go
@@ -185,7 +185,9 @@ func TestVulnerabilityStore_GetVulnerabilities_ByName(t *testing.T) {
 
 	vuln1 := testVulnerabilityHandle()
 	name := vuln1.Name
-	vuln2 := VulnerabilityHandle{Name: name, BlobID: 2, Provider: vuln1.Provider} // note: no blob value
+	vuln2 := VulnerabilityHandle{Name: name, BlobID: 2, Provider: vuln1.Provider, BlobValue: &VulnerabilityBlob{
+		ID: name,
+	}}
 	err := s.AddVulnerabilities(&vuln1, &vuln2)
 	require.NoError(t, err)
 
@@ -320,4 +322,76 @@ func testVulnerabilityHandle() VulnerabilityHandle {
 			},
 		},
 	}
+}
+
+func TestVulnerabilityStore_GetVulnerabilities_ByProviders(t *testing.T) {
+	db := setupTestStore(t).db
+	bw := newBlobStore(db)
+	s := newVulnerabilityStore(db, bw)
+
+	provider1 := &Provider{ID: "provider1"}
+	provider2 := &Provider{ID: "provider2"}
+
+	vuln1 := VulnerabilityHandle{Name: "CVE-1234-5678", BlobID: 1, Provider: provider1}
+	vuln2 := VulnerabilityHandle{Name: "CVE-2345-6789", BlobID: 2, Provider: provider2}
+
+	err := s.AddVulnerabilities(&vuln1, &vuln2)
+	require.NoError(t, err)
+
+	results, err := s.GetVulnerabilities(&VulnerabilitySpecifier{Providers: []string{"provider1"}}, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, vuln1.Name, results[0].Name)
+	assert.Equal(t, vuln1.Provider.ID, results[0].ProviderID)
+
+	results, err = s.GetVulnerabilities(&VulnerabilitySpecifier{Providers: []string{"provider1", "provider2"}}, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.ElementsMatch(t, []string{vuln1.Name, vuln2.Name}, []string{results[0].Name, results[1].Name})
+}
+
+func TestVulnerabilityStore_GetVulnerabilities_FilterByMultipleFactors(t *testing.T) {
+	db := setupTestStore(t).db
+	bw := newBlobStore(db)
+	s := newVulnerabilityStore(db, bw)
+
+	now := time.Now()
+	oneDayAgo := now.Add(-24 * time.Hour)
+	halfDayAgo := now.Add(-12 * time.Hour)
+	tenDaysAgo := now.Add(-240 * time.Hour)
+
+	provider1 := &Provider{ID: "provider1"}
+	provider2 := &Provider{ID: "provider2"}
+
+	vuln1 := VulnerabilityHandle{
+		Name:          "CVE-1234-5678",
+		BlobID:        1,
+		Provider:      provider1,
+		PublishedDate: &halfDayAgo,
+	}
+
+	vuln2 := VulnerabilityHandle{
+		Name:          "CVE-2345-6789",
+		BlobID:        2,
+		Provider:      provider2, // filtered out due to provider
+		PublishedDate: &now,
+	}
+
+	vuln3 := VulnerabilityHandle{
+		Name:          "CVE-1234-5678",
+		BlobID:        3,
+		Provider:      provider1,
+		PublishedDate: &tenDaysAgo, // filtered out due to date
+	}
+
+	err := s.AddVulnerabilities(&vuln1, &vuln2, &vuln3)
+	require.NoError(t, err)
+
+	results, err := s.GetVulnerabilities(&VulnerabilitySpecifier{
+		Providers:      []string{"provider1"}, // filter by provider...
+		PublishedAfter: &oneDayAgo,            // filter by date published...
+	}, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, vuln1.Name, results[0].Name)
 }


### PR DESCRIPTION
Today the v6 store can search for singular things (a single vulnerability, filter by a single distro, search by a single package). This PR changes the store to support searching and filtering by multiple criteria (supporting https://github.com/anchore/grype/pull/2303).

All changes made:
- add slice of all `*Spec` objects in searching
- allow for configurable limit on queries (default is no limit)
- fetch and attach blobs in batches (not individually)
- fetch all queries in small batches (better support for queries with several results)
- adjust indexes:
  - hydrate them when opening a writable DB without truncate options
  - adds additional individual indexes for common search cases (search by name, product, or vendor)
- fix logging and monitor values when importing/downloading a DB
- better stringer support for `*Spec` classes (improved logging)
- upgrade the gorm logger:
  - enable debug option
  - support setting log level
  - warn on slow queries
  - trace logging support to show individual queries