### PR TITLE
(DBv6) Do not warn if DB missing when updating

### DIFF
--- a/grype/db/v6/description.go
+++ b/grype/db/v6/description.go
@@ -18,6 +18,8 @@ import (
 	"github.com/anchore/grype/internal/schemaver"
 )
 
+var ErrDBDoesNotExist = errors.New("database does not exist")
+
 const ChecksumFileName = VulnerabilityDBFileName + ".checksum"
 
 type Description struct {
@@ -70,7 +72,7 @@ func ReadDescription(dbFilePath string) (*Description, error) {
 	// check if exists
 	if _, err := os.Stat(dbFilePath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("database does not exist")
+			return nil, ErrDBDoesNotExist
 		}
 		return nil, fmt.Errorf("failed to access database file: %w", err)
 	}

--- a/grype/db/v6/installation/curator.go
+++ b/grype/db/v6/installation/curator.go
@@ -1,6 +1,7 @@
 package installation
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -130,7 +131,11 @@ func (c curator) Delete() error {
 func (c curator) Update() (bool, error) {
 	current, err := db.ReadDescription(c.config.DBFilePath())
 	if err != nil {
-		log.WithFields("error", err).Warn("unable to read current database metadata (continuing with update)")
+		// we should not warn if the DB does not exist, as this is a common first-run case... but other cases we
+		// may care about, so warn in those cases.
+		if !errors.Is(err, db.ErrDBDoesNotExist) {
+			log.WithFields("error", err).Warn("unable to read current database metadata (continuing with update)")
+		}
 		// downstream any non-existent DB should always be replaced with any best-candidate found
 		current = nil
 	} else {


### PR DESCRIPTION
Note when starting with no state and updating the DB there is a warning:
<img width="773" alt="Screenshot 2024-12-18 at 2 29 29 PM" src="https://github.com/user-attachments/assets/2b6ff990-7da8-49f7-b153-bcf2fde95294" />

This PR adjusts the behavior such that this common case does not warn:
<img width="624" alt="Screenshot 2024-12-18 at 2 29 53 PM" src="https://github.com/user-attachments/assets/fc51319f-5164-4a19-aba9-2149ba8d7b11" />
