### PR TITLE
Clean up config help text

### DIFF
--- a/cmd/grype/cli/commands/db_check.go
+++ b/cmd/grype/cli/commands/db_check.go
@@ -52,10 +52,11 @@ func DBCheck(app clio.Application) *cobra.Command {
 
 	// prevent from being shown in the grype config
 	type configWrapper struct {
-		Opts *dbCheckOptions `json:"-" yaml:"-" mapstructure:"-"`
+		Hidden     *dbCheckOptions `json:"-" yaml:"-" mapstructure:"-"`
+		*DBOptions `yaml:",inline" mapstructure:",squash"`
 	}
 
-	return app.SetupCommand(cmd, &configWrapper{opts})
+	return app.SetupCommand(cmd, &configWrapper{Hidden: opts, DBOptions: &opts.DBOptions})
 }
 
 func runDBCheck(opts dbCheckOptions) error {

--- a/cmd/grype/cli/commands/db_check.go
+++ b/cmd/grype/cli/commands/db_check.go
@@ -36,7 +36,7 @@ func DBCheck(app clio.Application) *cobra.Command {
 		DBOptions: *dbOptionsDefault(app.ID()),
 	}
 
-	return app.SetupCommand(&cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "check to see if there is a database update available",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -48,7 +48,14 @@ func DBCheck(app clio.Application) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDBCheck(*opts)
 		},
-	}, opts)
+	}
+
+	// prevent from being shown in the grype config
+	type configWrapper struct {
+		Opts *dbCheckOptions `json:"-" yaml:"-" mapstructure:"-"`
+	}
+
+	return app.SetupCommand(cmd, &configWrapper{opts})
 }
 
 func runDBCheck(opts dbCheckOptions) error {

--- a/cmd/grype/cli/commands/db_delete.go
+++ b/cmd/grype/cli/commands/db_delete.go
@@ -15,7 +15,7 @@ import (
 func DBDelete(app clio.Application) *cobra.Command {
 	opts := dbOptionsDefault(app.ID())
 
-	return app.SetupCommand(&cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "delete",
 		Short:   "delete the vulnerability database",
 		Args:    cobra.ExactArgs(0),
@@ -23,7 +23,14 @@ func DBDelete(app clio.Application) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDBDelete(*opts)
 		},
-	}, opts)
+	}
+
+	// prevent from being shown in the grype config
+	type configWrapper struct {
+		Opts *DBOptions `json:"-" yaml:"-" mapstructure:"-"`
+	}
+
+	return app.SetupCommand(cmd, &configWrapper{opts})
 }
 
 func runDBDelete(opts DBOptions) error {

--- a/cmd/grype/cli/commands/db_delete.go
+++ b/cmd/grype/cli/commands/db_delete.go
@@ -27,7 +27,7 @@ func DBDelete(app clio.Application) *cobra.Command {
 
 	// prevent from being shown in the grype config
 	type configWrapper struct {
-		Opts *DBOptions `json:"-" yaml:"-" mapstructure:"-"`
+		*DBOptions `yaml:",inline" mapstructure:",squash"`
 	}
 
 	return app.SetupCommand(cmd, &configWrapper{opts})

--- a/cmd/grype/cli/commands/db_diff.go
+++ b/cmd/grype/cli/commands/db_diff.go
@@ -65,10 +65,11 @@ func DBDiff(app clio.Application) *cobra.Command {
 
 	// prevent from being shown in the grype config
 	type configWrapper struct {
-		Opts *dbDiffOptions `json:"-" yaml:"-" mapstructure:"-"`
+		Hidden     *dbDiffOptions `json:"-" yaml:"-" mapstructure:"-"`
+		*DBOptions `yaml:",inline" mapstructure:",squash"`
 	}
 
-	return app.SetupCommand(cmd, &configWrapper{opts})
+	return app.SetupCommand(cmd, &configWrapper{Hidden: opts, DBOptions: &opts.DBOptions})
 }
 
 func runDBDiff(opts *dbDiffOptions, base string, target string) (errs error) {

--- a/cmd/grype/cli/commands/db_diff.go
+++ b/cmd/grype/cli/commands/db_diff.go
@@ -33,7 +33,7 @@ func DBDiff(app clio.Application) *cobra.Command {
 		DBOptions: *dbOptionsDefault(app.ID()),
 	}
 
-	return app.SetupCommand(&cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "diff [flags] base_db_url target_db_url",
 		Short: "diff two DBs and display the result",
 		Args:  cobra.MaximumNArgs(2),
@@ -61,7 +61,14 @@ func DBDiff(app clio.Application) *cobra.Command {
 
 			return runDBDiff(opts, base, target)
 		},
-	}, opts)
+	}
+
+	// prevent from being shown in the grype config
+	type configWrapper struct {
+		Opts *dbDiffOptions `json:"-" yaml:"-" mapstructure:"-"`
+	}
+
+	return app.SetupCommand(cmd, &configWrapper{opts})
 }
 
 func runDBDiff(opts *dbDiffOptions, base string, target string) (errs error) {

--- a/cmd/grype/cli/commands/db_import.go
+++ b/cmd/grype/cli/commands/db_import.go
@@ -17,7 +17,7 @@ import (
 func DBImport(app clio.Application) *cobra.Command {
 	opts := dbOptionsDefault(app.ID())
 
-	return app.SetupCommand(&cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "import FILE",
 		Short: "import a vulnerability database archive",
 		Long:  fmt.Sprintf("import a vulnerability database archive from a local FILE.\nDB archives can be obtained from %q.", internal.DBUpdateURL),
@@ -25,7 +25,14 @@ func DBImport(app clio.Application) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runDBImport(*opts, args[0])
 		},
-	}, opts)
+	}
+
+	// prevent from being shown in the grype config
+	type configWrapper struct {
+		Opts *DBOptions `json:"-" yaml:"-" mapstructure:"-"`
+	}
+
+	return app.SetupCommand(cmd, &configWrapper{opts})
 }
 
 func runDBImport(opts DBOptions, dbArchivePath string) error {

--- a/cmd/grype/cli/commands/db_import.go
+++ b/cmd/grype/cli/commands/db_import.go
@@ -29,7 +29,7 @@ func DBImport(app clio.Application) *cobra.Command {
 
 	// prevent from being shown in the grype config
 	type configWrapper struct {
-		Opts *DBOptions `json:"-" yaml:"-" mapstructure:"-"`
+		*DBOptions `yaml:",inline" mapstructure:",squash"`
 	}
 
 	return app.SetupCommand(cmd, &configWrapper{opts})

--- a/cmd/grype/cli/commands/db_list.go
+++ b/cmd/grype/cli/commands/db_list.go
@@ -44,10 +44,11 @@ func DBList(app clio.Application) *cobra.Command {
 
 	// prevent from being shown in the grype config
 	type configWrapper struct {
-		Opts *dbListOptions `json:"-" yaml:"-" mapstructure:"-"`
+		Hidden     *dbListOptions `json:"-" yaml:"-" mapstructure:"-"`
+		*DBOptions `yaml:",inline" mapstructure:",squash"`
 	}
 
-	return app.SetupCommand(cmd, &configWrapper{opts})
+	return app.SetupCommand(cmd, &configWrapper{Hidden: opts, DBOptions: &opts.DBOptions})
 }
 
 func runDBList(opts dbListOptions) error {

--- a/cmd/grype/cli/commands/db_list.go
+++ b/cmd/grype/cli/commands/db_list.go
@@ -32,7 +32,7 @@ func DBList(app clio.Application) *cobra.Command {
 		DBOptions: *dbOptionsDefault(app.ID()),
 	}
 
-	return app.SetupCommand(&cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "list all DBs available according to the listing URL",
 		PreRunE: disableUI(app),
@@ -40,7 +40,14 @@ func DBList(app clio.Application) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDBList(*opts)
 		},
-	}, opts)
+	}
+
+	// prevent from being shown in the grype config
+	type configWrapper struct {
+		Opts *dbListOptions `json:"-" yaml:"-" mapstructure:"-"`
+	}
+
+	return app.SetupCommand(cmd, &configWrapper{opts})
 }
 
 func runDBList(opts dbListOptions) error {

--- a/cmd/grype/cli/commands/db_providers.go
+++ b/cmd/grype/cli/commands/db_providers.go
@@ -37,14 +37,21 @@ func DBProviders(app clio.Application) *cobra.Command {
 		DBOptions: *dbOptionsDefault(app.ID()),
 	}
 
-	return app.SetupCommand(&cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "providers",
 		Short: "list vulnerability database providers",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDBProviders(opts, app)
 		},
-	}, opts)
+	}
+
+	// prevent from being shown in the grype config
+	type configWrapper struct {
+		Opts *dbProvidersOptions `json:"-" yaml:"-" mapstructure:"-"`
+	}
+
+	return app.SetupCommand(cmd, &configWrapper{opts})
 }
 
 func runDBProviders(opts *dbProvidersOptions, app clio.Application) error {

--- a/cmd/grype/cli/commands/db_providers.go
+++ b/cmd/grype/cli/commands/db_providers.go
@@ -48,10 +48,11 @@ func DBProviders(app clio.Application) *cobra.Command {
 
 	// prevent from being shown in the grype config
 	type configWrapper struct {
-		Opts *dbProvidersOptions `json:"-" yaml:"-" mapstructure:"-"`
+		Hidden     *dbProvidersOptions `json:"-" yaml:"-" mapstructure:"-"`
+		*DBOptions `yaml:",inline" mapstructure:",squash"`
 	}
 
-	return app.SetupCommand(cmd, &configWrapper{opts})
+	return app.SetupCommand(cmd, &configWrapper{Hidden: opts, DBOptions: &opts.DBOptions})
 }
 
 func runDBProviders(opts *dbProvidersOptions, app clio.Application) error {

--- a/cmd/grype/cli/commands/db_search.go
+++ b/cmd/grype/cli/commands/db_search.go
@@ -48,10 +48,11 @@ func DBSearch(app clio.Application) *cobra.Command {
 
 	// prevent from being shown in the grype config
 	type configWrapper struct {
-		Opts *dbQueryOptions `json:"-" yaml:"-" mapstructure:"-"`
+		Hidden     *dbQueryOptions `json:"-" yaml:"-" mapstructure:"-"`
+		*DBOptions `yaml:",inline" mapstructure:",squash"`
 	}
 
-	return app.SetupCommand(cmd, &configWrapper{opts})
+	return app.SetupCommand(cmd, &configWrapper{Hidden: opts, DBOptions: &opts.DBOptions})
 }
 
 func runDBSearch(opts dbQueryOptions, vulnerabilityID string) error {

--- a/cmd/grype/cli/commands/db_search.go
+++ b/cmd/grype/cli/commands/db_search.go
@@ -36,7 +36,7 @@ func DBSearch(app clio.Application) *cobra.Command {
 		DBOptions: *dbOptionsDefault(app.ID()),
 	}
 
-	return app.SetupCommand(&cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "search [vulnerability_id]",
 		Short: "get information on a vulnerability from the db",
 		Args:  cobra.ExactArgs(1),
@@ -44,7 +44,14 @@ func DBSearch(app clio.Application) *cobra.Command {
 			id := args[0]
 			return runDBSearch(*opts, id)
 		},
-	}, opts)
+	}
+
+	// prevent from being shown in the grype config
+	type configWrapper struct {
+		Opts *dbQueryOptions `json:"-" yaml:"-" mapstructure:"-"`
+	}
+
+	return app.SetupCommand(cmd, &configWrapper{opts})
 }
 
 func runDBSearch(opts dbQueryOptions, vulnerabilityID string) error {

--- a/cmd/grype/cli/commands/db_status.go
+++ b/cmd/grype/cli/commands/db_status.go
@@ -44,10 +44,11 @@ func DBStatus(app clio.Application) *cobra.Command {
 
 	// prevent from being shown in the grype config
 	type configWrapper struct {
-		Opts *dbStatusOptions `json:"-" yaml:"-" mapstructure:"-"`
+		Hidden     *dbStatusOptions `json:"-" yaml:"-" mapstructure:"-"`
+		*DBOptions `yaml:",inline" mapstructure:",squash"`
 	}
 
-	return app.SetupCommand(cmd, &configWrapper{opts})
+	return app.SetupCommand(cmd, &configWrapper{Hidden: opts, DBOptions: &opts.DBOptions})
 }
 
 func runDBStatus(opts dbStatusOptions) error {

--- a/cmd/grype/cli/commands/db_status.go
+++ b/cmd/grype/cli/commands/db_status.go
@@ -32,7 +32,7 @@ func DBStatus(app clio.Application) *cobra.Command {
 		DBOptions: *dbOptionsDefault(app.ID()),
 	}
 
-	return app.SetupCommand(&cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "status",
 		Short:   "display database status",
 		Args:    cobra.ExactArgs(0),
@@ -40,7 +40,14 @@ func DBStatus(app clio.Application) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDBStatus(*opts)
 		},
-	}, opts)
+	}
+
+	// prevent from being shown in the grype config
+	type configWrapper struct {
+		Opts *dbStatusOptions `json:"-" yaml:"-" mapstructure:"-"`
+	}
+
+	return app.SetupCommand(cmd, &configWrapper{opts})
 }
 
 func runDBStatus(opts dbStatusOptions) error {

--- a/cmd/grype/cli/commands/db_update.go
+++ b/cmd/grype/cli/commands/db_update.go
@@ -33,7 +33,7 @@ func DBUpdate(app clio.Application) *cobra.Command {
 
 	// prevent from being shown in the grype config
 	type configWrapper struct {
-		Opts *DBOptions `json:"-" yaml:"-" mapstructure:"-"`
+		*DBOptions `yaml:",inline" mapstructure:",squash"`
 	}
 
 	return app.SetupCommand(cmd, &configWrapper{opts})

--- a/cmd/grype/cli/commands/db_update.go
+++ b/cmd/grype/cli/commands/db_update.go
@@ -17,7 +17,7 @@ import (
 func DBUpdate(app clio.Application) *cobra.Command {
 	opts := dbOptionsDefault(app.ID())
 
-	return app.SetupCommand(&cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "download the latest vulnerability database",
 		Args:  cobra.ExactArgs(0),
@@ -29,7 +29,14 @@ func DBUpdate(app clio.Application) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDBUpdate(opts.DB, opts.Experimental.DBv6)
 		},
-	}, opts)
+	}
+
+	// prevent from being shown in the grype config
+	type configWrapper struct {
+		Opts *DBOptions `json:"-" yaml:"-" mapstructure:"-"`
+	}
+
+	return app.SetupCommand(cmd, &configWrapper{opts})
 }
 
 func runDBUpdate(opts options.Database, expUseV6 bool) error {

--- a/cmd/grype/cli/commands/explain.go
+++ b/cmd/grype/cli/commands/explain.go
@@ -27,7 +27,7 @@ func (d *explainOptions) AddFlags(flags clio.FlagSet) {
 func Explain(app clio.Application) *cobra.Command {
 	opts := &explainOptions{}
 
-	return app.SetupCommand(&cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "explain --id [VULNERABILITY ID]",
 		Short:   "Ask grype to explain a set of findings",
 		PreRunE: disableUI(app),
@@ -53,5 +53,12 @@ func Explain(app clio.Application) *cobra.Command {
 			// TODO: implement
 			return fmt.Errorf("requires grype json on stdin, please run 'grype -o json ... | grype explain ...'")
 		},
-	}, opts)
+	}
+
+	// prevent from being shown in the grype config
+	type configWrapper struct {
+		Opts *explainOptions `json:"-" yaml:"-" mapstructure:"-"`
+	}
+
+	return app.SetupCommand(cmd, &configWrapper{opts})
 }


### PR DESCRIPTION
Today we use the options structs from each command registered with clio to build the output of the `grype config` command. However, not all commands are meant to support options being configured via a config file -- but these are being shown in the `grype config` output anyway:
```
# og-config is `grype config` with the latest grype release
# new-config is `grype config` with grype built from this branch
diff /tmp/og-config /tmp/new-config
```
```diff
228,236d227
< 
< # delete downloaded databases after diff occurs (env: GRYPE_DELETE)
< delete: false
< 
< # format to display results (available=[table, json]) (env: GRYPE_OUTPUT)
< Output: 'table'
< 
< # CVE IDs to explain (env: GRYPE_CVE_IDS)
< cve-ids: []

```
Note that `Output` is for `grype db *` commands and there is still an `output` value documented in the `grype config` output.

This PR removes all subcommands from consideration when generating `grype config` output.