### PR TITLE
Rename OperatingSystemAliases

### DIFF
--- a/grype/db/v6/affected_package_store.go
+++ b/grype/db/v6/affected_package_store.go
@@ -472,7 +472,7 @@ func (s *affectedPackageStore) applyAlias(d *OSSpecifier) error {
 		return nil
 	}
 
-	var aliases []OperatingSystemAlias
+	var aliases []OperatingSystemSpecifierOverride
 	err := s.db.Where("alias = ?", d.Name).Find(&aliases).Error
 	if err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -481,7 +481,7 @@ func (s *affectedPackageStore) applyAlias(d *OSSpecifier) error {
 		return nil
 	}
 
-	var alias *OperatingSystemAlias
+	var alias *OperatingSystemSpecifierOverride
 
 	for _, a := range aliases {
 		if a.Codename != "" && a.Codename != d.LabelVersion {

--- a/grype/db/v6/models.go
+++ b/grype/db/v6/models.go
@@ -30,7 +30,7 @@ func Models() []any {
 		// package related search tables
 		&AffectedPackageHandle{}, // join on package, operating system
 		&OperatingSystem{},
-		&OperatingSystemAlias{},
+		&OperatingSystemSpecifierOverride{},
 		&Package{},
 
 		// CPE related search tables
@@ -297,8 +297,9 @@ func (os *OperatingSystem) BeforeCreate(tx *gorm.DB) (err error) {
 	return nil
 }
 
-type OperatingSystemAlias struct {
-	// Name is alias name for the operating system.
+// OperatingSystemSpecifierOverride is a table that allows for overriding fields on v6.OSSpecifier instances when searching for specific OperatingSystems.
+type OperatingSystemSpecifierOverride struct {
+	// Alias is an alternative name/ID for the operating system.
 	Alias string `gorm:"column:alias;primaryKey;index:os_alias_idx"`
 
 	// Version is the matching version as found in the VERSION_ID field if the /etc/os-release file
@@ -320,11 +321,11 @@ type OperatingSystemAlias struct {
 }
 
 // TODO: in a future iteration these should be raised up more explicitly by the vunnel providers
-func KnownOperatingSystemAliases() []OperatingSystemAlias {
+func KnownOperatingSystemSpecifierOverrides() []OperatingSystemSpecifierOverride {
 	strRef := func(s string) *string {
 		return &s
 	}
-	return []OperatingSystemAlias{
+	return []OperatingSystemSpecifierOverride{
 		{Alias: "centos", ReplacementName: strRef("rhel")},
 		{Alias: "rocky", ReplacementName: strRef("rhel")},
 		{Alias: "rockylinux", ReplacementName: strRef("rhel")}, // non-standard, but common (dockerhub uses "rockylinux")
@@ -358,7 +359,7 @@ func KnownOperatingSystemAliases() []OperatingSystemAlias {
 	}
 }
 
-func (os *OperatingSystemAlias) BeforeCreate(_ *gorm.DB) (err error) {
+func (os *OperatingSystemSpecifierOverride) BeforeCreate(_ *gorm.DB) (err error) {
 	if os.Version != "" && os.VersionPattern != "" {
 		return fmt.Errorf("cannot have both version and version_pattern set")
 	}

--- a/grype/db/v6/models_test.go
+++ b/grype/db/v6/models_test.go
@@ -14,12 +14,12 @@ func TestOperatingSystemAlias_VersionMutualExclusivity(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		input  *OperatingSystemAlias
+		input  *OperatingSystemSpecifierOverride
 		errMsg string
 	}{
 		{
 			name: "version and version_pattern are mutually exclusive",
-			input: &OperatingSystemAlias{
+			input: &OperatingSystemSpecifierOverride{
 				Alias:          "ubuntu",
 				Version:        "20.04",
 				VersionPattern: "20.*",
@@ -28,7 +28,7 @@ func TestOperatingSystemAlias_VersionMutualExclusivity(t *testing.T) {
 		},
 		{
 			name: "only version is set",
-			input: &OperatingSystemAlias{
+			input: &OperatingSystemSpecifierOverride{
 				Alias:   "ubuntu",
 				Version: "20.04",
 			},
@@ -36,7 +36,7 @@ func TestOperatingSystemAlias_VersionMutualExclusivity(t *testing.T) {
 		},
 		{
 			name: "only version_pattern is set",
-			input: &OperatingSystemAlias{
+			input: &OperatingSystemSpecifierOverride{
 				Alias:          "ubuntu",
 				VersionPattern: "20.*",
 			},

--- a/grype/db/v6/store.go
+++ b/grype/db/v6/store.go
@@ -22,7 +22,7 @@ type store struct {
 }
 
 func InitialData() []any {
-	d := KnownOperatingSystemAliases()
+	d := KnownOperatingSystemSpecifierOverrides()
 	var data []any
 	for _, v := range d {
 		data = append(data, &v)


### PR DESCRIPTION
After chatting over the names with @kzantow it makes sense to orient the name for the OS aliases to what they are replacing -- not OS rows in the DB but instead fields on OSSpecifier structs.