### PR TITLE
Use v6 vulnerability status enum

### DIFF
--- a/grype/db/v6/affected_package_store_test.go
+++ b/grype/db/v6/affected_package_store_test.go
@@ -1112,7 +1112,7 @@ func testDistro1AffectedPackage2Handle() *AffectedPackageHandle {
 		},
 		Vulnerability: &VulnerabilityHandle{
 			Name:          "CVE-2023-1234",
-			Status:        string(VulnerabilityRejected),
+			Status:        VulnerabilityRejected,
 			PublishedDate: &now,
 			ModifiedDate:  &later,
 			Provider: &Provider{

--- a/grype/db/v6/models.go
+++ b/grype/db/v6/models.go
@@ -130,7 +130,7 @@ type VulnerabilityHandle struct {
 	Name string `gorm:"column:name;not null;index"`
 
 	// Status conveys the actionability of the current record
-	Status string `gorm:"column:status;not null;index"`
+	Status VulnerabilityStatus `gorm:"column:status;not null;index"`
 
 	// PublishedDate is the date the vulnerability record was first published
 	PublishedDate *time.Time `gorm:"column:published_date;index"`


### PR DESCRIPTION
This was an oversight in a previous PR -- enum types like this should be referenced in the table types if they are ultimately string types.