### PR TITLE
Add package spec alias + case insensitivity for v6 DBs

### DIFF
--- a/cmd/grype/cli/commands/internal/dbsearch/affected_packages.go
+++ b/cmd/grype/cli/commands/internal/dbsearch/affected_packages.go
@@ -120,7 +120,7 @@ func toPackage(pkg *v6.Package) *Package {
 	}
 	return &Package{
 		Name:      pkg.Name,
-		Ecosystem: pkg.Type,
+		Ecosystem: pkg.Ecosystem,
 	}
 }
 

--- a/cmd/grype/cli/commands/internal/dbsearch/affected_packages_test.go
+++ b/cmd/grype/cli/commands/internal/dbsearch/affected_packages_test.go
@@ -90,7 +90,7 @@ func TestAffectedPackageTableRowMarshalJSON(t *testing.T) {
 func TestNewAffectedPackageRows(t *testing.T) {
 	affectedPkgs := []v6.AffectedPackageHandle{
 		{
-			Package: &v6.Package{Name: "pkg1", Type: "ecosystem1"},
+			Package: &v6.Package{Name: "pkg1", Ecosystem: "ecosystem1"},
 			OperatingSystem: &v6.OperatingSystem{
 				Name:         "Linux",
 				MajorVersion: "5",
@@ -222,7 +222,7 @@ func TestAffectedPackages(t *testing.T) {
 
 	mockReader.On("GetAffectedPackages", mock.Anything, mock.Anything).Return([]v6.AffectedPackageHandle{
 		{
-			Package: &v6.Package{Name: "pkg1", Type: "ecosystem1"},
+			Package: &v6.Package{Name: "pkg1", Ecosystem: "ecosystem1"},
 			OperatingSystem: &v6.OperatingSystem{
 				Name:         "Linux",
 				MajorVersion: "5",

--- a/grype/db/v6/affected_package_store_test.go
+++ b/grype/db/v6/affected_package_store_test.go
@@ -850,6 +850,45 @@ func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 	}
 }
 
+func TestAffectedPackageStore_ApplyPackageAlias(t *testing.T) {
+	db := setupTestStore(t).db
+	bs := newBlobStore(db)
+	s := newAffectedPackageStore(db, bs)
+
+	tests := []struct {
+		name     string
+		input    *PackageSpecifier
+		expected string
+	}{
+		// positive cases
+		{name: "alias cocoapods", input: &PackageSpecifier{Ecosystem: "cocoapods"}, expected: "pod"},
+		{name: "alias pub", input: &PackageSpecifier{Ecosystem: "pub"}, expected: "dart-pub"},
+		{name: "alias otp", input: &PackageSpecifier{Ecosystem: "otp"}, expected: "erlang-otp"},
+		{name: "alias github", input: &PackageSpecifier{Ecosystem: "github"}, expected: "github-action"},
+		{name: "alias golang", input: &PackageSpecifier{Ecosystem: "golang"}, expected: "go-module"},
+		{name: "alias maven", input: &PackageSpecifier{Ecosystem: "maven"}, expected: "java-archive"},
+		{name: "alias composer", input: &PackageSpecifier{Ecosystem: "composer"}, expected: "php-composer"},
+		{name: "alias pecl", input: &PackageSpecifier{Ecosystem: "pecl"}, expected: "php-pecl"},
+		{name: "alias pypi", input: &PackageSpecifier{Ecosystem: "pypi"}, expected: "python"},
+		{name: "alias cran", input: &PackageSpecifier{Ecosystem: "cran"}, expected: "R-package"},
+		{name: "alias luarocks", input: &PackageSpecifier{Ecosystem: "luarocks"}, expected: "lua-rocks"},
+		{name: "alias cargo", input: &PackageSpecifier{Ecosystem: "cargo"}, expected: "rust-crate"},
+
+		// negative cases
+		{name: "generic type", input: &PackageSpecifier{Ecosystem: "generic/linux-kernel"}, expected: "generic/linux-kernel"},
+		{name: "empty ecosystem", input: &PackageSpecifier{Ecosystem: ""}, expected: ""},
+		{name: "matching type", input: &PackageSpecifier{Ecosystem: "python"}, expected: "python"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := s.applyPackageAlias(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, tt.input.Ecosystem)
+		})
+	}
+}
+
 func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 	// we always preload the OS aliases into the DB when staging for writing
 	db := setupTestStore(t).db

--- a/grype/db/v6/data.go
+++ b/grype/db/v6/data.go
@@ -1,6 +1,10 @@
 package v6
 
-import "github.com/anchore/syft/syft/pkg"
+import (
+	"strings"
+
+	"github.com/anchore/syft/syft/pkg"
+)
 
 // TODO: in a future iteration these should be raised up more explicitly by the vunnel providers
 func KnownOperatingSystemSpecifierOverrides() []OperatingSystemSpecifierOverride {
@@ -49,7 +53,7 @@ func KnownPackageSpecifierOverrides() []PackageSpecifierOverride {
 	var ret []PackageSpecifierOverride
 	for _, t := range pkg.AllPkgs {
 		purlType := t.PackageURLType()
-		if purlType == "" || purlType == string(t) {
+		if purlType == "" || purlType == string(t) || strings.HasPrefix(purlType, "generic") {
 			continue
 		}
 

--- a/grype/db/v6/data.go
+++ b/grype/db/v6/data.go
@@ -1,0 +1,66 @@
+package v6
+
+import "github.com/anchore/syft/syft/pkg"
+
+// TODO: in a future iteration these should be raised up more explicitly by the vunnel providers
+func KnownOperatingSystemSpecifierOverrides() []OperatingSystemSpecifierOverride {
+	strRef := func(s string) *string {
+		return &s
+	}
+	return []OperatingSystemSpecifierOverride{
+		{Alias: "centos", ReplacementName: strRef("rhel")},
+		{Alias: "rocky", ReplacementName: strRef("rhel")},
+		{Alias: "rockylinux", ReplacementName: strRef("rhel")}, // non-standard, but common (dockerhub uses "rockylinux")
+		{Alias: "alma", ReplacementName: strRef("rhel")},
+		{Alias: "almalinux", ReplacementName: strRef("rhel")}, // non-standard, but common (dockerhub uses "almalinux")
+		{Alias: "gentoo", ReplacementName: strRef("rhel")},
+		{Alias: "alpine", VersionPattern: ".*_alpha.*", ReplacementLabelVersion: strRef("edge"), Rolling: true},
+		{Alias: "wolfi", Rolling: true},
+		{Alias: "arch", Rolling: true},
+		{Alias: "archlinux", ReplacementName: strRef("arch"), Rolling: true}, // non-standard, but common (dockerhub uses "archlinux")
+		{Alias: "oracle", ReplacementName: strRef("ol")},                     // non-standard, but common
+		{Alias: "oraclelinux", ReplacementName: strRef("ol")},                // non-standard, but common (dockerhub uses "oraclelinux")
+		{Alias: "amazon", ReplacementName: strRef("amzn")},                   // non-standard, but common
+		{Alias: "amazonlinux", ReplacementName: strRef("amzn")},              // non-standard, but common (dockerhub uses "amazonlinux")
+		// TODO: trixie is a placeholder for now, but should be updated to sid when the time comes
+		// this needs to be automated, but isn't clear how to do so since you'll see things like this:
+		//
+		// ❯ docker run --rm debian:sid cat /etc/os-release | grep VERSION_CODENAME
+		//   VERSION_CODENAME=trixie
+		// ❯ docker run --rm debian:testing cat /etc/os-release | grep VERSION_CODENAME
+		//   VERSION_CODENAME=trixie
+		//
+		// ❯ curl -s http://deb.debian.org/debian/dists/testing/Release | grep '^Codename:'
+		//   Codename: trixie
+		// ❯ curl -s http://deb.debian.org/debian/dists/sid/Release | grep '^Codename:'
+		//   Codename: sid
+		//
+		// depending where the team is during the development cycle you will see different behavior, making automating
+		// this a little challenging.
+		{Alias: "debian", Codename: "trixie", Rolling: true}, // is currently sid, which is considered rolling
+	}
+}
+
+func KnownPackageSpecifierOverrides() []PackageSpecifierOverride {
+	// when matching packages, grype will always attempt to do so based off of the package type which means
+	// that any request must be in terms of the package type (relative to syft).
+
+	// remap package URL types to syft package types
+	var ret []PackageSpecifierOverride
+	for _, t := range pkg.AllPkgs {
+		purlType := t.PackageURLType()
+		if purlType == "" || purlType == string(t) {
+			continue
+		}
+
+		ret = append(ret, PackageSpecifierOverride{
+			Ecosystem:            purlType,
+			ReplacementEcosystem: ptr(string(t)),
+		})
+	}
+	return ret
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/grype/db/v6/store.go
+++ b/grype/db/v6/store.go
@@ -22,10 +22,15 @@ type store struct {
 }
 
 func InitialData() []any {
-	d := KnownOperatingSystemSpecifierOverrides()
 	var data []any
-	for _, v := range d {
-		data = append(data, &v)
+	os := KnownOperatingSystemSpecifierOverrides()
+	for i := range os {
+		data = append(data, &os[i])
+	}
+
+	p := KnownPackageSpecifierOverrides()
+	for i := range p {
+		data = append(data, &p[i])
 	}
 	return data
 }

--- a/grype/db/v6/vulnerability_store.go
+++ b/grype/db/v6/vulnerability_store.go
@@ -272,9 +272,9 @@ func handleVulnerabilityOptions(base, parentQuery *gorm.DB, configs ...Vulnerabi
 		if config.Name != "" {
 			if config.IncludeAliases {
 				includeAliasJoin = true
-				query = query.Where("vulnerability_handles.name = ? OR vulnerability_aliases.alias = ?", config.Name, config.Name)
+				query = query.Where("vulnerability_handles.name = ? collate nocase OR vulnerability_aliases.alias = ?  collate nocase", config.Name, config.Name)
 			} else {
-				query = query.Where("vulnerability_handles.name = ?", config.Name)
+				query = query.Where("vulnerability_handles.name = ?  collate nocase", config.Name)
 			}
 		}
 
@@ -302,7 +302,7 @@ func handleVulnerabilityOptions(base, parentQuery *gorm.DB, configs ...Vulnerabi
 	}
 
 	if includeAliasJoin {
-		parentQuery = parentQuery.Joins("LEFT JOIN vulnerability_aliases ON vulnerability_aliases.name = vulnerability_handles.name")
+		parentQuery = parentQuery.Joins("LEFT JOIN vulnerability_aliases ON vulnerability_aliases.name = vulnerability_handles.name collate nocase")
 	}
 
 	return parentQuery.Where(orConditions), nil


### PR DESCRIPTION
This adds the capability to search for package specifier ecosystem aliases, such as translating purl types to known syft package types, to ensure we're searching for the best ecosystem values relative to what's in the DB.

This PR also:
- renames the package.type field to package.ecosystem
- adds case insensitivity to commonly searched fields.