### PR TITLE
Remove db debug statements for v6

### DIFF
--- a/grype/db/v6/db.go
+++ b/grype/db/v6/db.go
@@ -87,8 +87,6 @@ func NewLowLevelDB(dbFilePath string, empty, writable bool) (*gorm.DB, error) {
 	opts := []gormadapter.Option{
 		// 16 KB, useful for smaller DBs since ~85% of the DB is from the blobs table
 		gormadapter.WithStatements("PRAGMA page_size = 16384"),
-		// TODO: this should be removed after initial development (or wired to a config option)
-		gormadapter.WithDebug(true),
 	}
 
 	if empty && !writable {


### PR DESCRIPTION
This removes the sql debug statements when trace logging when using the v6 exp feature flag. This has no impact on debugging/logging for v1-5 DBs.