### PR TITLE
Performance enhancements for DB v6 writes

### DIFF
--- a/cmd/grype/cli/commands/internal/dbsearch/affected_packages.go
+++ b/cmd/grype/cli/commands/internal/dbsearch/affected_packages.go
@@ -55,6 +55,7 @@ func (c *CPE) String() string {
 	if c == nil {
 		return ""
 	}
+
 	return v6.Cpe(*c).String()
 }
 

--- a/grype/db/internal/gormadapter/open.go
+++ b/grype/db/internal/gormadapter/open.go
@@ -26,6 +26,7 @@ var writerStatements = []string{
 var heavyWriteStatements = []string{
 	`PRAGMA cache_size = -1073741824`, // ~1 GB (negative means treat as bytes not page count); one caveat is to not pick a value that risks swapping behavior, negating performance gains
 	`PRAGMA mmap_size = 1073741824`,   // ~1 GB; the maximum size of the memory-mapped I/O buffer (to access the database file as if it were a part of the process’s virtual memory)
+	`PRAGMA defer_foreign_keys = ON`,  // defer enforcement of foreign key constraints until the end of the transaction (to avoid the overhead of checking constraints for each row)
 }
 
 var readConnectionOptions = []string{
@@ -146,67 +147,119 @@ func Open(path string, options ...Option) (*gorm.DB, error) {
 		return nil, fmt.Errorf("unable to connect to DB: %w", err)
 	}
 
-	return prepareDB(dbObj, cfg)
+	return cfg.prepareDB(dbObj)
 }
 
-func prepareDB(dbObj *gorm.DB, cfg config) (*gorm.DB, error) {
-	if cfg.writable {
-		log.Trace("using writable DB statements")
-		if err := applyStatements(dbObj, writerStatements); err != nil {
+func (c config) prepareDB(dbObj *gorm.DB) (*gorm.DB, error) {
+	if c.writable {
+		log.Debug("using writable DB statements")
+		if err := c.applyStatements(dbObj, writerStatements); err != nil {
 			return nil, fmt.Errorf("unable to apply DB writer statements: %w", err)
 		}
 	}
 
-	if cfg.truncate && cfg.allowLargeMemoryFootprint {
-		log.Trace("using large memory footprint DB statements")
-		if err := applyStatements(dbObj, heavyWriteStatements); err != nil {
+	if c.truncate && c.allowLargeMemoryFootprint {
+		log.Debug("using large memory footprint DB statements")
+		if err := c.applyStatements(dbObj, heavyWriteStatements); err != nil {
 			return nil, fmt.Errorf("unable to apply DB heavy writer statements: %w", err)
 		}
 	}
 
 	if len(commonStatements) > 0 {
-		if err := applyStatements(dbObj, commonStatements); err != nil {
+		if err := c.applyStatements(dbObj, commonStatements); err != nil {
 			return nil, fmt.Errorf("unable to apply DB common statements: %w", err)
 		}
 	}
 
-	if len(cfg.statements) > 0 {
-		if err := applyStatements(dbObj, cfg.statements); err != nil {
+	if len(c.statements) > 0 {
+		if err := c.applyStatements(dbObj, c.statements); err != nil {
 			return nil, fmt.Errorf("unable to apply DB custom statements: %w", err)
 		}
 	}
 
-	if len(cfg.models) > 0 && cfg.writable {
-		log.Trace("applying DB migrations")
-		if err := dbObj.AutoMigrate(cfg.models...); err != nil {
+	if len(c.models) > 0 && c.writable {
+		log.Debug("applying DB migrations")
+		if err := dbObj.AutoMigrate(c.models...); err != nil {
 			return nil, fmt.Errorf("unable to migrate: %w", err)
 		}
 	}
 
-	if len(cfg.initialData) > 0 && cfg.truncate {
-		log.Trace("writing initial data")
-		for _, d := range cfg.initialData {
+	if len(c.initialData) > 0 && c.truncate {
+		log.Debug("writing initial data")
+		for _, d := range c.initialData {
 			if err := dbObj.Create(d).Error; err != nil {
 				return nil, fmt.Errorf("unable to create initial data: %w", err)
 			}
 		}
 	}
 
-	if cfg.debug {
+	if c.debug {
 		dbObj = dbObj.Debug()
 	}
 
 	return dbObj, nil
 }
 
-func applyStatements(db *gorm.DB, statements []string) error {
+func (c config) applyStatements(db *gorm.DB, statements []string) error {
 	for _, sqlStmt := range statements {
-		db.Exec(sqlStmt)
-		if db.Error != nil {
-			return fmt.Errorf("unable to execute (%s): %w", sqlStmt, db.Error)
+		if err := db.Exec(sqlStmt).Error; err != nil {
+			return fmt.Errorf("unable to execute (%s): %w", sqlStmt, err)
+		}
+		if strings.HasPrefix(sqlStmt, "PRAGMA") {
+			name, value, err := c.pragmaNameValue(sqlStmt)
+			if err != nil {
+				return fmt.Errorf("unable to parse PRAGMA statement: %w", err)
+			}
+
+			var result string
+			if err := db.Raw("PRAGMA " + name + ";").Scan(&result).Error; err != nil {
+				return fmt.Errorf("unable to verify PRAGMA %q: %w", name, err)
+			}
+
+			if !strings.EqualFold(result, value) {
+				if value == "ON" && result == "1" {
+					continue
+				}
+				if value == "OFF" && result == "0" {
+					continue
+				}
+				return fmt.Errorf("PRAGMA %q was not set to %q (%q)", name, value, result)
+			}
 		}
 	}
 	return nil
+}
+
+func (c config) pragmaNameValue(sqlStmt string) (string, string, error) {
+	sqlStmt = strings.TrimSuffix(strings.TrimSpace(sqlStmt), ";") // remove the trailing semicolon
+	if strings.Count(sqlStmt, ";") > 0 {
+		return "", "", fmt.Errorf("PRAGMA statements should not contain semicolons: %q", sqlStmt)
+	}
+
+	// check if the pragma was set, parse the pragma name and value from the statement. This is because
+	// sqlite will not return errors when there are issues with the pragma key or value, but it will
+	// be inconsistent with the expected value if you explicitly check
+	var name, value string
+
+	clean := strings.TrimPrefix(sqlStmt, "PRAGMA")
+	fields := strings.SplitN(clean, "=", 2)
+	if len(fields) == 2 {
+		name = strings.ToLower(strings.TrimSpace(fields[0]))
+		value = strings.TrimSpace(fields[1])
+	} else {
+		return "", "", fmt.Errorf("unable to parse PRAGMA statement: %q", sqlStmt)
+	}
+
+	if c.memory && name == "mmap_size" {
+		// memory only DBs do not have mmap capability
+		value = ""
+	}
+
+	if name == "" {
+		return "", "", fmt.Errorf("unable to parse name from PRAGMA statement: %q", sqlStmt)
+	}
+
+	return name, value, nil
 }
 
 func deleteDB(path string) error {

--- a/grype/db/internal/gormadapter/open.go
+++ b/grype/db/internal/gormadapter/open.go
@@ -182,6 +182,10 @@ func (c config) prepareDB(dbObj *gorm.DB) (*gorm.DB, error) {
 		if err := dbObj.AutoMigrate(c.models...); err != nil {
 			return nil, fmt.Errorf("unable to migrate: %w", err)
 		}
+		// now that there are potentially new models and indexes, analyze the DB to ensure the query planner is up-to-date
+		if err := dbObj.Exec("ANALYZE").Error; err != nil {
+			return nil, fmt.Errorf("unable to analyze DB: %w", err)
+		}
 	}
 
 	if len(c.initialData) > 0 && c.truncate {

--- a/grype/db/internal/gormadapter/open_test.go
+++ b/grype/db/internal/gormadapter/open_test.go
@@ -127,3 +127,98 @@ func TestPrepareWritableDB(t *testing.T) {
 		require.Contains(t, err.Error(), "unable to create parent directory")
 	})
 }
+
+func TestPragmaNameValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       config
+		input     string
+		wantName  string
+		wantValue string
+		wantErr   require.ErrorAssertionFunc
+	}{
+		{
+			name:      "basic pragma",
+			cfg:       config{memory: false},
+			input:     "PRAGMA journal_mode=WAL",
+			wantName:  "journal_mode",
+			wantValue: "WAL",
+		},
+		{
+			name:      "pragma with spaces",
+			cfg:       config{memory: false},
+			input:     "PRAGMA   cache_size  =   2000  ",
+			wantName:  "cache_size",
+			wantValue: "2000",
+		},
+		{
+			name:      "pragma with trailing semicolon",
+			cfg:       config{memory: false},
+			input:     "PRAGMA synchronous=NORMAL;",
+			wantName:  "synchronous",
+			wantValue: "NORMAL",
+		},
+		{
+			name:    "pragma with multiple semicolons",
+			cfg:     config{memory: false},
+			input:   "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;",
+			wantErr: require.Error,
+		},
+		{
+			name:    "invalid pragma format",
+			cfg:     config{memory: false},
+			input:   "PRAGMA invalid_format",
+			wantErr: require.Error,
+		},
+		{
+			name:      "mmap_size pragma with memory DB",
+			cfg:       config{memory: true},
+			input:     "PRAGMA mmap_size=1000",
+			wantName:  "mmap_size",
+			wantValue: "", // should be empty for memory DB
+		},
+		{
+			name:      "mmap_size pragma with regular DB",
+			cfg:       config{memory: false},
+			input:     "PRAGMA mmap_size=1000",
+			wantName:  "mmap_size",
+			wantValue: "1000",
+		},
+		{
+			name:      "pragma with numeric value",
+			cfg:       config{memory: false},
+			input:     "PRAGMA page_size=4096",
+			wantName:  "page_size",
+			wantValue: "4096",
+		},
+		{
+			name:      "pragma with mixed case",
+			cfg:       config{memory: false},
+			input:     "PRAGMA Journal_Mode=WAL",
+			wantName:  "journal_mode",
+			wantValue: "WAL",
+		},
+		{
+			name:    "empty pragma",
+			cfg:     config{memory: false},
+			input:   "PRAGMA =value",
+			wantErr: require.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantErr == nil {
+				tt.wantErr = require.NoError
+			}
+
+			gotName, gotValue, err := tt.cfg.pragmaNameValue(tt.input)
+			tt.wantErr(t, err)
+
+			if err == nil {
+				require.Equal(t, tt.wantName, gotName)
+				require.Equal(t, tt.wantValue, gotValue)
+			}
+		})
+	}
+}

--- a/grype/db/v6/affected_cpe_store_test.go
+++ b/grype/db/v6/affected_cpe_store_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAffectedCPEStore_AddAffectedCPEs(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore()
+	bw := newBlobStore(db)
 	s := newAffectedCPEStore(db, bw)
 
 	cpe1 := &AffectedCPEHandle{
@@ -57,7 +57,7 @@ func TestAffectedCPEStore_AddAffectedCPEs(t *testing.T) {
 
 func TestAffectedCPEStore_GetCPEs(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore()
+	bw := newBlobStore(db)
 	s := newAffectedCPEStore(db, bw)
 
 	c := testAffectedCPEHandle()
@@ -88,7 +88,7 @@ func TestAffectedCPEStore_GetCPEs(t *testing.T) {
 
 func TestAffectedCPEStore_GetExact(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore()
+	bw := newBlobStore(db)
 	s := newAffectedCPEStore(db, bw)
 
 	c := testAffectedCPEHandle()
@@ -108,7 +108,7 @@ func TestAffectedCPEStore_GetExact(t *testing.T) {
 
 func TestAffectedCPEStore_Get_CaseInsensitive(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore()
+	bw := newBlobStore(db)
 	s := newAffectedCPEStore(db, bw)
 
 	c := testAffectedCPEHandle()
@@ -137,7 +137,7 @@ func TestAffectedCPEStore_Get_CaseInsensitive(t *testing.T) {
 
 func TestAffectedCPEStore_PreventDuplicateCPEs(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore()
+	bw := newBlobStore(db)
 	s := newAffectedCPEStore(db, bw)
 
 	cpe1 := &AffectedCPEHandle{

--- a/grype/db/v6/affected_package_store.go
+++ b/grype/db/v6/affected_package_store.go
@@ -316,6 +316,7 @@ func (s *affectedPackageStore) addOs(packages ...*AffectedPackageHandle) error {
 	byCacheKey := make(map[string][]*OperatingSystem)
 	for _, p := range packages {
 		if p.OperatingSystem != nil {
+			p.OperatingSystem.clean()
 			key := p.OperatingSystem.cacheKey()
 			if existingID, ok := cacheInst.getID(p.OperatingSystem); ok {
 				// seen in a previous transaction...
@@ -670,6 +671,8 @@ func (s *affectedPackageStore) searchForDistroVersionVariants(query *gorm.DB, d 
 	}
 
 	// search by the most specific criteria first, then fallback
+	d.MajorVersion = strings.TrimPrefix(d.MajorVersion, "0")
+	d.MinorVersion = strings.TrimPrefix(d.MinorVersion, "0")
 
 	var result []OperatingSystem
 	var err error

--- a/grype/db/v6/affected_package_store_test.go
+++ b/grype/db/v6/affected_package_store_test.go
@@ -138,7 +138,7 @@ func defaultAffectedPackageHandlePreloadCases() []affectedPackageHandlePreloadCo
 func TestAffectedPackageStore_AddAffectedPackages(t *testing.T) {
 	setupAffectedPackageStore := func(t *testing.T) *affectedPackageStore {
 		db := setupTestStore(t).db
-		return newAffectedPackageStore(db, newBlobStore())
+		return newAffectedPackageStore(db, newBlobStore(db))
 	}
 
 	setupTestStoreWithPackages := func(t *testing.T) (*AffectedPackageHandle, *AffectedPackageHandle, *affectedPackageStore) {
@@ -401,7 +401,7 @@ func TestAffectedPackageStore_AddAffectedPackages(t *testing.T) {
 
 func TestAffectedPackageStore_GetAffectedPackages_ByCPE(t *testing.T) {
 	db := setupTestStore(t).db
-	bs := newBlobStore()
+	bs := newBlobStore(db)
 	s := newAffectedPackageStore(db, bs)
 
 	cpe1 := Cpe{Part: "a", Vendor: "vendor1", Product: "product1"}
@@ -521,7 +521,7 @@ func TestAffectedPackageStore_GetAffectedPackages_ByCPE(t *testing.T) {
 
 func TestAffectedPackageStore_GetAffectedPackages_CaseInsensitive(t *testing.T) {
 	db := setupTestStore(t).db
-	bs := newBlobStore()
+	bs := newBlobStore(db)
 	s := newAffectedPackageStore(db, bs)
 
 	cpe1 := Cpe{Part: "a", Vendor: "Vendor1", Product: "Product1"} // capitalized
@@ -630,7 +630,7 @@ func TestAffectedPackageStore_GetAffectedPackages_CaseInsensitive(t *testing.T) 
 
 func TestAffectedPackageStore_GetAffectedPackages_MultipleVulnerabilitySpecs(t *testing.T) {
 	db := setupTestStore(t).db
-	bs := newBlobStore()
+	bs := newBlobStore(db)
 	s := newAffectedPackageStore(db, bs)
 
 	cpe1 := Cpe{Part: "a", Vendor: "vendor1", Product: "product1"}
@@ -685,7 +685,7 @@ func TestAffectedPackageStore_GetAffectedPackages_MultipleVulnerabilitySpecs(t *
 
 func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 	db := setupTestStore(t).db
-	bs := newBlobStore()
+	bs := newBlobStore(db)
 	s := newAffectedPackageStore(db, bs)
 
 	pkg2d1 := testDistro1AffectedPackage2Handle()
@@ -852,7 +852,7 @@ func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 
 func TestAffectedPackageStore_ApplyPackageAlias(t *testing.T) {
 	db := setupTestStore(t).db
-	bs := newBlobStore()
+	bs := newBlobStore(db)
 	s := newAffectedPackageStore(db, bs)
 
 	tests := []struct {
@@ -892,7 +892,7 @@ func TestAffectedPackageStore_ApplyPackageAlias(t *testing.T) {
 func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 	// we always preload the OS aliases into the DB when staging for writing
 	db := setupTestStore(t).db
-	bs := newBlobStore()
+	bs := newBlobStore(db)
 	s := newAffectedPackageStore(db, bs)
 
 	ubuntu2004 := &OperatingSystem{Name: "ubuntu", ReleaseID: "ubuntu", MajorVersion: "20", MinorVersion: "04", LabelVersion: "focal"}

--- a/grype/db/v6/affected_package_store_test.go
+++ b/grype/db/v6/affected_package_store_test.go
@@ -536,7 +536,7 @@ func TestAffectedPackageStore_GetAffectedPackages_CaseInsensitive(t *testing.T) 
 			Name:         "Ubuntu", // capitalized
 			ReleaseID:    "zubuntu",
 			MajorVersion: "20",
-			MinorVersion: "04",
+			MinorVersion: "04", // leading 0
 			Codename:     "focal",
 		},
 		Package: &Package{Name: "Pkg1", Ecosystem: "Type1", CPEs: []Cpe{cpe1}}, // capitalized
@@ -545,7 +545,26 @@ func TestAffectedPackageStore_GetAffectedPackages_CaseInsensitive(t *testing.T) 
 		},
 	}
 
-	err := s.AddAffectedPackages(pkg1)
+	pkg2 := &AffectedPackageHandle{ // this should never register as a match
+		Vulnerability: &VulnerabilityHandle{
+			Name: "CVE-2222-2222",
+			Provider: &Provider{
+				ID: "provider2",
+			},
+		},
+		OperatingSystem: &OperatingSystem{
+			Name:         "ubuntu",
+			ReleaseID:    "ubuntu",
+			MajorVersion: "20",
+			MinorVersion: "10",
+		},
+		Package: &Package{Name: "pkg2", Ecosystem: "type2"},
+		BlobValue: &AffectedPackageBlob{
+			CVEs: []string{"CVE-2222-2222"},
+		},
+	}
+
+	err := s.AddAffectedPackages(pkg1, pkg2)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -579,12 +598,23 @@ func TestAffectedPackageStore_GetAffectedPackages_CaseInsensitive(t *testing.T) 
 			expected: 1,
 		},
 		{
-			name: "get by OS name",
+			name: "get by OS name and version (leading 0)",
 			options: &GetAffectedPackageOptions{
 				OSs: []*OSSpecifier{{
 					Name:         "uBUNtu",
 					MajorVersion: "20",
 					MinorVersion: "04",
+				}},
+			},
+			expected: 1,
+		},
+		{
+			name: "get by OS name and version",
+			options: &GetAffectedPackageOptions{
+				OSs: []*OSSpecifier{{
+					Name:         "uBUNtu",
+					MajorVersion: "20",
+					MinorVersion: "4",
 				}},
 			},
 			expected: 1,
@@ -944,6 +974,15 @@ func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 				Name:         "ubuntu",
 				MajorVersion: "20",
 				MinorVersion: "04",
+			},
+			expected: []OperatingSystem{*ubuntu2004},
+		},
+		{
+			name: "specific distro with major and minor version (missing left padding)",
+			distro: OSSpecifier{
+				Name:         "ubuntu",
+				MajorVersion: "20",
+				MinorVersion: "4",
 			},
 			expected: []OperatingSystem{*ubuntu2004},
 		},

--- a/grype/db/v6/affected_package_store_test.go
+++ b/grype/db/v6/affected_package_store_test.go
@@ -138,7 +138,7 @@ func defaultAffectedPackageHandlePreloadCases() []affectedPackageHandlePreloadCo
 func TestAffectedPackageStore_AddAffectedPackages(t *testing.T) {
 	setupAffectedPackageStore := func(t *testing.T) *affectedPackageStore {
 		db := setupTestStore(t).db
-		return newAffectedPackageStore(db, newBlobStore(db))
+		return newAffectedPackageStore(db, newBlobStore())
 	}
 
 	setupTestStoreWithPackages := func(t *testing.T) (*AffectedPackageHandle, *AffectedPackageHandle, *affectedPackageStore) {
@@ -401,7 +401,7 @@ func TestAffectedPackageStore_AddAffectedPackages(t *testing.T) {
 
 func TestAffectedPackageStore_GetAffectedPackages_ByCPE(t *testing.T) {
 	db := setupTestStore(t).db
-	bs := newBlobStore(db)
+	bs := newBlobStore()
 	s := newAffectedPackageStore(db, bs)
 
 	cpe1 := Cpe{Part: "a", Vendor: "vendor1", Product: "product1"}
@@ -521,7 +521,7 @@ func TestAffectedPackageStore_GetAffectedPackages_ByCPE(t *testing.T) {
 
 func TestAffectedPackageStore_GetAffectedPackages_CaseInsensitive(t *testing.T) {
 	db := setupTestStore(t).db
-	bs := newBlobStore(db)
+	bs := newBlobStore()
 	s := newAffectedPackageStore(db, bs)
 
 	cpe1 := Cpe{Part: "a", Vendor: "Vendor1", Product: "Product1"} // capitalized
@@ -630,7 +630,7 @@ func TestAffectedPackageStore_GetAffectedPackages_CaseInsensitive(t *testing.T) 
 
 func TestAffectedPackageStore_GetAffectedPackages_MultipleVulnerabilitySpecs(t *testing.T) {
 	db := setupTestStore(t).db
-	bs := newBlobStore(db)
+	bs := newBlobStore()
 	s := newAffectedPackageStore(db, bs)
 
 	cpe1 := Cpe{Part: "a", Vendor: "vendor1", Product: "product1"}
@@ -685,12 +685,12 @@ func TestAffectedPackageStore_GetAffectedPackages_MultipleVulnerabilitySpecs(t *
 
 func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 	db := setupTestStore(t).db
-	bs := newBlobStore(db)
+	bs := newBlobStore()
 	s := newAffectedPackageStore(db, bs)
 
 	pkg2d1 := testDistro1AffectedPackage2Handle()
-	pkg2d2 := testDistro2AffectedPackage2Handle()
 	pkg2 := testNonDistroAffectedPackage2Handle()
+	pkg2d2 := testDistro2AffectedPackage2Handle()
 	err := s.AddAffectedPackages(pkg2d1, pkg2, pkg2d2)
 	require.NoError(t, err)
 
@@ -852,7 +852,7 @@ func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 
 func TestAffectedPackageStore_ApplyPackageAlias(t *testing.T) {
 	db := setupTestStore(t).db
-	bs := newBlobStore(db)
+	bs := newBlobStore()
 	s := newAffectedPackageStore(db, bs)
 
 	tests := []struct {
@@ -892,7 +892,7 @@ func TestAffectedPackageStore_ApplyPackageAlias(t *testing.T) {
 func TestAffectedPackageStore_ResolveDistro(t *testing.T) {
 	// we always preload the OS aliases into the DB when staging for writing
 	db := setupTestStore(t).db
-	bs := newBlobStore(db)
+	bs := newBlobStore()
 	s := newAffectedPackageStore(db, bs)
 
 	ubuntu2004 := &OperatingSystem{Name: "ubuntu", ReleaseID: "ubuntu", MajorVersion: "20", MinorVersion: "04", LabelVersion: "focal"}

--- a/grype/db/v6/blob_store.go
+++ b/grype/db/v6/blob_store.go
@@ -2,7 +2,6 @@ package v6
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -20,16 +19,16 @@ type blobable interface {
 }
 
 type blobStore struct {
-	db *gorm.DB
+	idsByDigest map[string]ID
 }
 
-func newBlobStore(db *gorm.DB) *blobStore {
+func newBlobStore() *blobStore {
 	return &blobStore{
-		db: db,
+		idsByDigest: make(map[string]ID),
 	}
 }
 
-func (s *blobStore) addBlobable(bs ...blobable) error {
+func (s *blobStore) addBlobable(tx *gorm.DB, bs ...blobable) error {
 	for i := range bs {
 		b := bs[i]
 		v := b.getBlobValue()
@@ -38,7 +37,7 @@ func (s *blobStore) addBlobable(bs ...blobable) error {
 		}
 		bl := newBlob(v)
 
-		if err := s.addBlobs(bl); err != nil {
+		if err := s.addBlobs(tx, bl); err != nil {
 			return err
 		}
 
@@ -47,49 +46,39 @@ func (s *blobStore) addBlobable(bs ...blobable) error {
 	return nil
 }
 
-func (s *blobStore) addBlobs(blobs ...*Blob) error {
+func (s *blobStore) addBlobs(tx *gorm.DB, blobs ...*Blob) error {
 	for i := range blobs {
 		v := blobs[i]
 		digest := v.computeDigest()
 
-		var blobDigest BlobDigest
-		err := s.db.Where("id = ?", digest).First(&blobDigest).Error
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			return fmt.Errorf("failed to get blob digest: %w", err)
-		}
-
-		if blobDigest.BlobID != 0 {
-			v.ID = blobDigest.BlobID
+		if id, ok := s.idsByDigest[digest]; ok && id != 0 {
+			v.ID = id
 			continue
 		}
 
-		if err := s.db.Create(v).Error; err != nil {
+		if err := tx.Create(v).Error; err != nil {
 			return fmt.Errorf("failed to create blob: %w", err)
 		}
 
-		blobDigest = BlobDigest{
-			ID:     digest,
-			BlobID: v.ID,
-		}
-		if err := s.db.Create(blobDigest).Error; err != nil {
-			return fmt.Errorf("failed to create blob digest: %w", err)
+		if v.ID != 0 {
+			s.idsByDigest[digest] = v.ID
 		}
 	}
 	return nil
 }
 
-func (s *blobStore) getBlobValues(ids ...ID) ([]Blob, error) {
+func (s *blobStore) getBlobValues(tx *gorm.DB, ids ...ID) ([]Blob, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
 	var blobs []Blob
-	if err := s.db.Where("id IN ?", ids).Find(&blobs).Error; err != nil {
+	if err := tx.Where("id IN ?", ids).Find(&blobs).Error; err != nil {
 		return nil, fmt.Errorf("failed to get blob values: %w", err)
 	}
 	return blobs, nil
 }
 
-func (s *blobStore) attachBlobValue(bs ...blobable) error {
+func (s *blobStore) attachBlobValue(tx *gorm.DB, bs ...blobable) error {
 	start := time.Now()
 	defer func() {
 		log.WithFields("duration", time.Since(start), "count", len(bs)).Trace("attached blob values")
@@ -108,7 +97,7 @@ func (s *blobStore) attachBlobValue(bs ...blobable) error {
 		setterByID[id] = append(setterByID[id], b)
 	}
 
-	vs, err := s.getBlobValues(ids...)
+	vs, err := s.getBlobValues(tx, ids...)
 	if err != nil {
 		return fmt.Errorf("failed to get blob value: %w", err)
 	}
@@ -124,23 +113,6 @@ func (s *blobStore) attachBlobValue(bs ...blobable) error {
 		}
 	}
 
-	return nil
-}
-
-func (s *blobStore) Close() error {
-	var count int64
-	if err := s.db.Model(&Blob{}).Count(&count).Error; err != nil {
-		return fmt.Errorf("failed to count blobs: %w", err)
-	}
-
-	log.WithFields("records", count).Trace("finalizing blobs")
-
-	// we use the blob_digests table when writing entries to ensure we have unique blobs, but for distribution this
-	// is no longer needed and saves on space considerably. For this reason, we drop the table after we are
-	// done writing blobs so that the DB is always in a distributable state.
-	if err := s.db.Exec("DROP TABLE blob_digests").Error; err != nil {
-		return fmt.Errorf("failed to drop blob digests: %w", err)
-	}
 	return nil
 }
 

--- a/grype/db/v6/blob_store_test.go
+++ b/grype/db/v6/blob_store_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestBlobWriter_AddBlobs(t *testing.T) {
 	db := setupTestStore(t).db
-	writer := newBlobStore()
+	writer := newBlobStore(db)
 
 	obj1 := map[string]string{"key": "value1"}
 	obj2 := map[string]string{"key": "value2"}
@@ -18,7 +18,7 @@ func TestBlobWriter_AddBlobs(t *testing.T) {
 	blob2 := newBlob(obj2)
 	blob3 := newBlob(obj1) // same as blob1
 
-	err := writer.addBlobs(db, blob1, blob2, blob3)
+	err := writer.addBlobs(blob1, blob2, blob3)
 	require.NoError(t, err)
 
 	require.NotZero(t, blob1.ID)

--- a/grype/db/v6/blob_store_test.go
+++ b/grype/db/v6/blob_store_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestBlobWriter_AddBlobs(t *testing.T) {
 	db := setupTestStore(t).db
-	writer := newBlobStore(db)
+	writer := newBlobStore()
 
 	obj1 := map[string]string{"key": "value1"}
 	obj2 := map[string]string{"key": "value2"}
@@ -18,7 +18,7 @@ func TestBlobWriter_AddBlobs(t *testing.T) {
 	blob2 := newBlob(obj2)
 	blob3 := newBlob(obj1) // same as blob1
 
-	err := writer.addBlobs(blob1, blob2, blob3)
+	err := writer.addBlobs(db, blob1, blob2, blob3)
 	require.NoError(t, err)
 
 	require.NotZero(t, blob1.ID)
@@ -31,27 +31,6 @@ func TestBlobWriter_AddBlobs(t *testing.T) {
 	var result2 Blob
 	require.NoError(t, db.Where("id = ?", blob2.ID).First(&result2).Error)
 	assert.Equal(t, blob2.Value, result2.Value)
-}
-
-func TestBlobWriter_Close(t *testing.T) {
-	db := setupTestStore(t).db
-	writer := newBlobStore(db)
-
-	obj := map[string]string{"key": "value"}
-	blob := newBlob(obj)
-	require.NoError(t, writer.addBlobs(blob))
-
-	// ensure the blob digest table is created
-	var blobDigest BlobDigest
-	require.NoError(t, db.First(&blobDigest).Error)
-	require.NotZero(t, blobDigest.ID)
-
-	err := writer.Close()
-	require.NoError(t, err)
-
-	// ensure the blob digest table is deleted
-	err = db.First(&blobDigest).Error
-	require.ErrorContains(t, err, "no such table: blob_digests")
 }
 
 func TestBlob_computeDigest(t *testing.T) {

--- a/grype/db/v6/blobs.go
+++ b/grype/db/v6/blobs.go
@@ -129,7 +129,7 @@ type AffectedPackageQualifiers struct {
 // AffectedRange defines a specific range of versions affected by a vulnerability.
 type AffectedRange struct {
 	// Version defines the version constraints for affected software.
-	Version AffectedVersion `json:"version"`
+	Version AffectedVersion `json:"version,omitempty"`
 
 	// Fix provides details on the fix version and its state if available.
 	Fix *Fix `json:"fix,omitempty"`
@@ -141,7 +141,7 @@ type Fix struct {
 	Version string `json:"version,omitempty"`
 
 	// State represents the status of the fix (e.g., "fixed", "unaffected").
-	State FixStatus `json:"state"`
+	State FixStatus `json:"state,omitempty"`
 
 	// Detail provides additional fix information, such as commit details.
 	Detail *FixDetail `json:"detail,omitempty"`
@@ -165,5 +165,5 @@ type AffectedVersion struct {
 	Type string `json:"type,omitempty"`
 
 	// Constraint defines the version range constraint for affected versions.
-	Constraint string `json:"constraint"`
+	Constraint string `json:"constraint,omitempty"`
 }

--- a/grype/db/v6/cache.go
+++ b/grype/db/v6/cache.go
@@ -1,0 +1,112 @@
+package v6
+
+import (
+	"context"
+	"sync"
+)
+
+const (
+	cpesTableCacheKey             = "cpes"
+	operatingSystemsTableCacheKey = "operating_systems"
+	vulnerabilitiesTableCacheKey  = "vulnerabilities"
+)
+
+const cacheKey = contextKey("multiModelCache")
+
+type contextKey string
+
+type cachable interface {
+	cacheKey() string
+	tableName() string
+}
+
+type cacheIDManager interface {
+	rowID() ID
+	setRowID(ID)
+}
+
+type cacheStringIDManager interface {
+	rowID() string
+	setRowID(string)
+}
+
+func withCacheContext(ctx context.Context, c *cache) context.Context {
+	return context.WithValue(ctx, cacheKey, c)
+}
+
+func cacheFromContext(ctx context.Context) (*cache, bool) {
+	c, ok := ctx.Value(cacheKey).(*cache)
+	return c, ok
+}
+
+type cache struct {
+	mu      sync.RWMutex
+	idKeys  map[string]map[string]ID
+	strKeys map[string]map[string]string
+}
+
+func newCache() *cache {
+	return &cache{
+		idKeys:  make(map[string]map[string]ID),
+		strKeys: make(map[string]map[string]string),
+	}
+}
+
+func (c *cache) getID(ca cachable) (ID, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if tableCache, exists := c.idKeys[ca.tableName()]; exists {
+		id, found := tableCache[ca.cacheKey()]
+		return id, found
+	}
+	return 0, false
+}
+
+func (c *cache) getString(ca cachable) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if tableCache, exists := c.strKeys[ca.tableName()]; exists {
+		id, found := tableCache[ca.cacheKey()]
+		return id, found
+	}
+	return "", false
+}
+
+func (c *cache) set(ca cachable) {
+	switch cam := ca.(type) {
+	case cacheIDManager:
+		c.setIDEntry(cam.rowID(), ca)
+	case cacheStringIDManager:
+		c.setStringEntry(cam.rowID(), ca)
+	default:
+		panic("unsupported cacheable type")
+	}
+}
+
+func (c *cache) setStringEntry(id string, ca cachable) {
+	table := ca.tableName()
+	key := ca.cacheKey()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, exists := c.strKeys[table]; !exists {
+		c.strKeys[table] = make(map[string]string)
+	}
+
+	c.strKeys[table][key] = id
+}
+
+func (c *cache) setIDEntry(id ID, ca cachable) {
+	table := ca.tableName()
+	key := ca.cacheKey()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, exists := c.idKeys[table]; !exists {
+		c.idKeys[table] = make(map[string]ID)
+	}
+
+	c.idKeys[table][key] = id
+}

--- a/grype/db/v6/cache.go
+++ b/grype/db/v6/cache.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	cpesTableCacheKey             = "cpes"
+	packagesTableCacheKey         = "packages"
 	operatingSystemsTableCacheKey = "operating_systems"
 	vulnerabilitiesTableCacheKey  = "vulnerabilities"
 )

--- a/grype/db/v6/cache_test.go
+++ b/grype/db/v6/cache_test.go
@@ -1,0 +1,150 @@
+package v6
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockCachableID struct {
+	key   string
+	table string
+	id    ID
+}
+
+func (m *mockCachableID) cacheKey() string  { return m.key }
+func (m *mockCachableID) tableName() string { return m.table }
+func (m *mockCachableID) rowID() ID         { return m.id }
+func (m *mockCachableID) setRowID(id ID)    { m.id = id }
+
+type mockCachableString struct {
+	key   string
+	table string
+	id    string
+}
+
+func (m *mockCachableString) cacheKey() string   { return m.key }
+func (m *mockCachableString) tableName() string  { return m.table }
+func (m *mockCachableString) rowID() string      { return m.id }
+func (m *mockCachableString) setRowID(id string) { m.id = id }
+
+func newTestCachableString(key, table, id string) *mockCachableString {
+	return &mockCachableString{key: key, table: table, id: id}
+}
+
+func newTestCachableID(key, table string, id ID) *mockCachableID {
+	return &mockCachableID{key: key, table: table, id: id}
+}
+
+func TestCache_GetString_Found(t *testing.T) {
+	c := newCache()
+	item := newTestCachableString("test-key", "test-table", "test-id")
+
+	c.setStringEntry("test-id", item)
+
+	str, found := c.getString(item)
+	require.True(t, found)
+	require.Equal(t, "test-id", str)
+}
+
+func TestCache_GetString_NotFound(t *testing.T) {
+	c := newCache()
+	item := newTestCachableString("missing-key", "test-table", "")
+
+	str, found := c.getString(item)
+	require.False(t, found)
+	require.Empty(t, str)
+}
+
+func TestCache_Set_ID(t *testing.T) {
+	c := newCache()
+	item := newTestCachableID("test-key", "test-table", 123)
+
+	c.set(item)
+
+	id, found := c.getID(item)
+	require.True(t, found)
+	require.Equal(t, ID(123), id)
+}
+
+func TestCache_Set_String(t *testing.T) {
+	c := newCache()
+	item := newTestCachableString("test-key", "test-table", "test-id")
+
+	c.set(item)
+
+	str, found := c.getString(item)
+	require.True(t, found)
+	require.Equal(t, "test-id", str)
+}
+
+func TestCache_Set_Panic(t *testing.T) {
+	c := newCache()
+	invalidItem := struct{ cachable }{}
+
+	require.PanicsWithValue(t, "unsupported cacheable type", func() {
+		c.set(invalidItem)
+	})
+}
+
+func TestCache_SetStringEntry_New(t *testing.T) {
+	c := newCache()
+	item := newTestCachableString("test-key", "test-table", "")
+
+	c.setStringEntry("new-id", item)
+
+	str, found := c.getString(item)
+	require.True(t, found)
+	require.Equal(t, "new-id", str)
+}
+
+func TestCache_SetStringEntry_Update(t *testing.T) {
+	c := newCache()
+	item := newTestCachableString("test-key", "test-table", "old-id")
+
+	c.setStringEntry("old-id", item)
+	c.setStringEntry("new-id", item)
+
+	str, found := c.getString(item)
+	require.True(t, found)
+	require.Equal(t, "new-id", str)
+}
+
+func TestCache_SetIDEntry_New(t *testing.T) {
+	c := newCache()
+	item := newTestCachableID("test-key", "test-table", 0)
+
+	c.setIDEntry(123, item)
+
+	id, found := c.getID(item)
+	require.True(t, found)
+	require.Equal(t, ID(123), id)
+}
+
+func TestCache_SetIDEntry_Update(t *testing.T) {
+	c := newCache()
+	item := newTestCachableID("test-key", "test-table", 123)
+
+	c.setIDEntry(123, item)
+	c.setIDEntry(456, item)
+
+	id, found := c.getID(item)
+	require.True(t, found)
+	require.Equal(t, ID(456), id)
+}
+
+func TestWithCacheContext(t *testing.T) {
+	c := newCache()
+	ctx := withCacheContext(context.Background(), c)
+
+	cache, ok := cacheFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, c, cache)
+}
+
+func TestCacheFromContext_NotFound(t *testing.T) {
+	cache, ok := cacheFromContext(context.Background())
+	require.False(t, ok)
+	require.Nil(t, cache)
+}

--- a/grype/db/v6/db.go
+++ b/grype/db/v6/db.go
@@ -1,6 +1,7 @@
 package v6
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -84,10 +85,7 @@ func Hydrater() func(string) error {
 // NewLowLevelDB creates a new empty DB for writing or opens an existing one for reading from the given path. This is
 // not recommended for typical interactions with the vulnerability DB, use NewReader and NewWriter instead.
 func NewLowLevelDB(dbFilePath string, empty, writable bool) (*gorm.DB, error) {
-	opts := []gormadapter.Option{
-		// 16 KB, useful for smaller DBs since ~85% of the DB is from the blobs table
-		gormadapter.WithStatements("PRAGMA page_size = 16384"),
-	}
+	var opts []gormadapter.Option
 
 	if empty && !writable {
 		return nil, fmt.Errorf("cannot open an empty database for reading only")
@@ -101,5 +99,15 @@ func NewLowLevelDB(dbFilePath string, empty, writable bool) (*gorm.DB, error) {
 		opts = append(opts, gormadapter.WithWritable(true, Models()))
 	}
 
-	return gormadapter.Open(dbFilePath, opts...)
+	dbObj, err := gormadapter.Open(dbFilePath, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	if empty {
+		// speed up writes by persisting key-to-ID lookups when writing to the DB
+		dbObj = dbObj.WithContext(withCacheContext(context.Background(), newCache()))
+	}
+
+	return dbObj, err
 }

--- a/grype/db/v6/models.go
+++ b/grype/db/v6/models.go
@@ -283,7 +283,7 @@ type Package struct {
 	Ecosystem string `gorm:"column:ecosystem;index:idx_package,unique,collate:NOCASE"`
 
 	// Name is the name of the package within the ecosystem
-	Name string `gorm:"column:name;index:idx_package,unique;index:idx_package_name,collate:NOCASE"`
+	Name string `gorm:"column:name;index:idx_package,unique,collate:NOCASE;index:idx_package_name,collate:NOCASE"`
 
 	// CPEs is the list of Common Platform Enumeration (CPE) identifiers that represent this package
 	CPEs []Cpe `gorm:"foreignKey:PackageID;constraint:OnDelete:CASCADE;"`
@@ -473,7 +473,14 @@ func (o *OperatingSystem) setRowID(i ID) {
 	o.ID = i
 }
 
+func (o *OperatingSystem) clean() {
+	o.MajorVersion = strings.TrimLeft(o.MajorVersion, "0")
+	o.MinorVersion = strings.TrimLeft(o.MinorVersion, "0")
+}
+
 func (o *OperatingSystem) BeforeCreate(tx *gorm.DB) (err error) {
+	o.clean()
+
 	if cacheInst, ok := cacheFromContext(tx.Statement.Context); ok {
 		if existing, ok := cacheInst.getID(o); ok {
 			o.setRowID(existing)

--- a/grype/db/v6/provider_store_test.go
+++ b/grype/db/v6/provider_store_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestProviderStore(t *testing.T) {
 	now := time.Date(2021, 1, 1, 2, 3, 4, 5, time.UTC)
-	other := time.Date(2022, 2, 3, 4, 5, 6, 7, time.UTC)
 	tests := []struct {
 		name      string
 		providers []Provider
@@ -26,25 +25,6 @@ func TestProviderStore(t *testing.T) {
 					Processor:    "vunnel",
 					DateCaptured: &now,
 					InputDigest:  "sha256:abcd1234",
-				},
-			},
-		},
-		{
-			name: "add existing provider",
-			providers: []Provider{
-				{ // original
-					ID:           "ubuntu",
-					Version:      "1.0",
-					Processor:    "vunnel",
-					DateCaptured: &now,
-					InputDigest:  "sha256:abcd1234",
-				},
-				{ //  overwrite...
-					ID:           "ubuntu",
-					Version:      "2.0",
-					Processor:    "something-else",
-					DateCaptured: &other,
-					InputDigest:  "sha256:cdef5678",
 				},
 			},
 		},

--- a/grype/db/v6/store.go
+++ b/grype/db/v6/store.go
@@ -46,7 +46,7 @@ func newStore(cfg Config, empty, writable bool) (*store, error) {
 		return nil, fmt.Errorf("failed to open db: %w", err)
 	}
 
-	bs := newBlobStore(db)
+	bs := newBlobStore()
 	return &store{
 		dbMetadataStore:      newDBMetadataStore(db),
 		providerStore:        newProviderStore(db),
@@ -65,11 +65,6 @@ func (s *store) Close() error {
 	log.Debug("closing store")
 	if s.readOnly {
 		return nil
-	}
-
-	// this will drop the digest blob table entirely
-	if err := s.blobStore.Close(); err != nil {
-		return fmt.Errorf("failed to finalize blobs: %w", err)
 	}
 
 	// drop all indexes, which saves a lot of space distribution-wise (these get re-created on running gorm auto-migrate)

--- a/grype/db/v6/store.go
+++ b/grype/db/v6/store.go
@@ -46,7 +46,7 @@ func newStore(cfg Config, empty, writable bool) (*store, error) {
 		return nil, fmt.Errorf("failed to open db: %w", err)
 	}
 
-	bs := newBlobStore()
+	bs := newBlobStore(db)
 	return &store{
 		dbMetadataStore:      newDBMetadataStore(db),
 		providerStore:        newProviderStore(db),

--- a/grype/db/v6/store_test.go
+++ b/grype/db/v6/store_test.go
@@ -8,17 +8,13 @@ import (
 )
 
 func TestStoreClose(t *testing.T) {
+
 	t.Run("readonly mode does nothing", func(t *testing.T) {
 		s := setupTestStore(t)
 		s.readOnly = true
 
 		err := s.Close()
 		require.NoError(t, err)
-
-		// the blob_digests table should still exist
-		var exists int
-		s.db.Raw("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'blob_digests'").Scan(&exists)
-		assert.Equal(t, 1, exists)
 
 		// ensure we have our indexes
 		var indexes []string
@@ -37,11 +33,6 @@ func TestStoreClose(t *testing.T) {
 
 		err := s.Close()
 		require.NoError(t, err)
-
-		// ensure the digests table was dropped
-		var exists int
-		s.db.Raw("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'blob_digests'").Scan(&exists)
-		assert.Equal(t, 0, exists)
 
 		// ensure all of our indexes were dropped
 		indexes = nil

--- a/grype/db/v6/vulnerability_store.go
+++ b/grype/db/v6/vulnerability_store.go
@@ -1,7 +1,6 @@
 package v6
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -120,9 +119,19 @@ func newVulnerabilityStore(db *gorm.DB, bs *blobStore) *vulnerabilityStore {
 }
 
 func (s *vulnerabilityStore) AddVulnerabilities(vulnerabilities ...*VulnerabilityHandle) error {
-	for _, v := range vulnerabilities {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		return s.addVulnerabilities(tx, vulnerabilities...)
+	})
+}
+
+func (s *vulnerabilityStore) addVulnerabilities(tx *gorm.DB, vulnerabilities ...*VulnerabilityHandle) error {
+	if err := s.addProviders(tx, vulnerabilities...); err != nil {
+		return fmt.Errorf("unable to add providers: %w", err)
+	}
+	for i := range vulnerabilities {
+		v := vulnerabilities[i]
 		// this adds the blob value to the DB and sets the ID on the vulnerability handle
-		if err := s.blobStore.addBlobable(v); err != nil {
+		if err := s.blobStore.addBlobable(tx, v); err != nil {
 			return fmt.Errorf("unable to add affected blob: %w", err)
 		}
 
@@ -144,50 +153,117 @@ func (s *vulnerabilityStore) AddVulnerabilities(vulnerabilities ...*Vulnerabilit
 				})
 			}
 			for _, aliasModel := range aliasModels {
-				if err := s.db.FirstOrCreate(&aliasModel).Error; err != nil {
+				if err := tx.FirstOrCreate(&aliasModel).Error; err != nil {
 					return err
 				}
 			}
 		}
-
-		if err := s.addUniqueVulnerability(v); err != nil {
+		if err := createRecordsWithCache(tx, v); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *vulnerabilityStore) addProviders(tx *gorm.DB, vulnerabilities ...*VulnerabilityHandle) error { // nolint:dupl
+	cacheInst, ok := cacheFromContext(tx.Statement.Context)
+	if !ok {
+		return fmt.Errorf("unable to fetch provider cache from context")
+	}
+
+	var final []*Provider
+	byCacheKey := make(map[string][]*Provider)
+	for _, v := range vulnerabilities {
+		if v.Provider != nil {
+			key := v.Provider.cacheKey()
+			if existingID, ok := cacheInst.getString(v.Provider); ok {
+				// seen in a previous transaction...
+				v.ProviderID = existingID
+			} else if _, ok := byCacheKey[key]; !ok {
+				// not seen within this transaction
+				final = append(final, v.Provider)
+			}
+			byCacheKey[key] = append(byCacheKey[key], v.Provider)
+		}
+	}
+
+	if len(final) == 0 {
+		return nil
+	}
+
+	if err := tx.Create(final).Error; err != nil {
+		return fmt.Errorf("unable to create provider records: %w", err)
+	}
+
+	for _, refs := range byCacheKey {
+		for _, ref := range refs {
+			cacheInst.set(ref)
+		}
+	}
+
+	for _, v := range vulnerabilities {
+		if v.Provider != nil {
+			v.ProviderID = v.Provider.ID
 		}
 	}
 	return nil
 }
 
-func (s *vulnerabilityStore) addUniqueVulnerability(v *VulnerabilityHandle) error {
-	// if this is a unique (name, status, published, modified, withdrawn, provider_id, blob_id) then it will be created
-	// otherwise do not create the new entry (this is to prevent duplicates)
-	query := s.db.Where("name = ? AND status = ? AND provider_id = ? AND blob_id = ?", v.Name, v.Status, v.ProviderID, v.BlobID)
-
-	if v.PublishedDate != nil {
-		query = query.Where("published_date = ?", *v.PublishedDate)
-	} else {
-		query = query.Where("published_date IS NULL")
+func createRecordsWithCache(tx *gorm.DB, items ...*VulnerabilityHandle) error {
+	// look for existing records from the cache, and only create new records
+	cacheInst, ok := cacheFromContext(tx.Statement.Context)
+	if !ok {
+		return fmt.Errorf("cache not found in context")
 	}
 
-	if v.ModifiedDate != nil {
-		query = query.Where("modified_date = ?", *v.ModifiedDate)
-	} else {
-		query = query.Where("modified_date IS NULL")
-	}
+	// store all entries by their cache key (throw away duplicates)
+	skippedRecordsByCacheKey := map[string][]*VulnerabilityHandle{}
+	usedKeys := strset.New()
+	var finalWrites []*VulnerabilityHandle
+	for i := range items {
+		p := items[i]
+		key := p.cacheKey()
 
-	if v.WithdrawnDate != nil {
-		query = query.Where("withdrawn_date = ?", *v.WithdrawnDate)
-	} else {
-		query = query.Where("withdrawn_date IS NULL")
-	}
-
-	if err := query.First(v).Error; err != nil {
-		if !errors.Is(err, gorm.ErrRecordNotFound) {
-			return err
+		if usedKeys.Has(key) {
+			skippedRecordsByCacheKey[key] = append(skippedRecordsByCacheKey[key], p)
+			continue
 		}
-		if err := s.db.Create(v).Error; err != nil {
-			return err
+
+		if _, ok := skippedRecordsByCacheKey[key]; ok {
+			skippedRecordsByCacheKey[key] = append(skippedRecordsByCacheKey[key], p)
+			continue
+		}
+		if _, ok := cacheInst.getID(p); ok {
+			skippedRecordsByCacheKey[key] = append(skippedRecordsByCacheKey[key], p)
+			continue
+		}
+
+		finalWrites = append(finalWrites, p)
+		usedKeys.Add(key)
+	}
+
+	for i := range finalWrites {
+		if err := tx.Omit("Provider").Create(finalWrites[i]).Error; err != nil {
+			return fmt.Errorf("unable to create record %#v: %w", finalWrites[i], err)
 		}
 	}
+
+	// ensure we're always updating the cache with the latest data + the records with any new IDs
+	for i := range finalWrites {
+		cacheInst.set(finalWrites[i])
+	}
+
+	for _, batch := range skippedRecordsByCacheKey {
+		for i := range batch {
+			id, ok := cacheInst.getID(batch[i])
+			if !ok {
+				return fmt.Errorf("unable to find ID: %#v", batch[i])
+			}
+			batch[i].setRowID(id)
+		}
+	}
+
 	return nil
 }
 
@@ -225,7 +301,7 @@ func (s *vulnerabilityStore) GetVulnerabilities(vuln *VulnerabilitySpecifier, co
 			for _, r := range results {
 				blobs = append(blobs, r)
 			}
-			if err := s.blobStore.attachBlobValue(blobs...); err != nil {
+			if err := s.blobStore.attachBlobValue(s.db, blobs...); err != nil {
 				return fmt.Errorf("unable to attach blobs: %w", err)
 			}
 		}

--- a/grype/db/v6/vulnerability_store.go
+++ b/grype/db/v6/vulnerability_store.go
@@ -119,19 +119,13 @@ func newVulnerabilityStore(db *gorm.DB, bs *blobStore) *vulnerabilityStore {
 }
 
 func (s *vulnerabilityStore) AddVulnerabilities(vulnerabilities ...*VulnerabilityHandle) error {
-	return s.db.Transaction(func(tx *gorm.DB) error {
-		return s.addVulnerabilities(tx, vulnerabilities...)
-	})
-}
-
-func (s *vulnerabilityStore) addVulnerabilities(tx *gorm.DB, vulnerabilities ...*VulnerabilityHandle) error {
-	if err := s.addProviders(tx, vulnerabilities...); err != nil {
+	if err := s.addProviders(s.db, vulnerabilities...); err != nil {
 		return fmt.Errorf("unable to add providers: %w", err)
 	}
 	for i := range vulnerabilities {
 		v := vulnerabilities[i]
 		// this adds the blob value to the DB and sets the ID on the vulnerability handle
-		if err := s.blobStore.addBlobable(tx, v); err != nil {
+		if err := s.blobStore.addBlobable(v); err != nil {
 			return fmt.Errorf("unable to add affected blob: %w", err)
 		}
 
@@ -153,12 +147,12 @@ func (s *vulnerabilityStore) addVulnerabilities(tx *gorm.DB, vulnerabilities ...
 				})
 			}
 			for _, aliasModel := range aliasModels {
-				if err := tx.FirstOrCreate(&aliasModel).Error; err != nil {
+				if err := s.db.FirstOrCreate(&aliasModel).Error; err != nil {
 					return err
 				}
 			}
 		}
-		if err := createRecordsWithCache(tx, v); err != nil {
+		if err := createRecordsWithCache(s.db, v); err != nil {
 			return err
 		}
 	}
@@ -196,15 +190,25 @@ func (s *vulnerabilityStore) addProviders(tx *gorm.DB, vulnerabilities ...*Vulne
 		return fmt.Errorf("unable to create provider records: %w", err)
 	}
 
+	// update the cache with the new records
+	for _, ref := range final {
+		cacheInst.set(ref)
+	}
+
+	// update all references with the IDs from the cache
 	for _, refs := range byCacheKey {
 		for _, ref := range refs {
-			cacheInst.set(ref)
+			id, ok := cacheInst.getString(ref)
+			if ok {
+				ref.setRowID(id)
+			}
 		}
 	}
 
-	for _, v := range vulnerabilities {
-		if v.Provider != nil {
-			v.ProviderID = v.Provider.ID
+	// update the parent objects with the FK ID
+	for _, p := range vulnerabilities {
+		if p.Provider != nil {
+			p.ProviderID = p.Provider.ID
 		}
 	}
 	return nil
@@ -301,7 +305,7 @@ func (s *vulnerabilityStore) GetVulnerabilities(vuln *VulnerabilitySpecifier, co
 			for _, r := range results {
 				blobs = append(blobs, r)
 			}
-			if err := s.blobStore.attachBlobValue(s.db, blobs...); err != nil {
+			if err := s.blobStore.attachBlobValue(blobs...); err != nil {
 				return fmt.Errorf("unable to attach blobs: %w", err)
 			}
 		}

--- a/grype/db/v6/vulnerability_store_test.go
+++ b/grype/db/v6/vulnerability_store_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestVulnerabilityStore_AddVulnerabilities(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore()
+	bw := newBlobStore(db)
 	s := newVulnerabilityStore(db, bw)
 
 	vuln1 := VulnerabilityHandle{
@@ -51,7 +51,7 @@ func TestVulnerabilityStore_AddVulnerabilities(t *testing.T) {
 
 func TestVulnerabilityStore_NoDuplicateVulnerabilities(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore()
+	bw := newBlobStore(db)
 	s := newVulnerabilityStore(db, bw)
 
 	vuln := VulnerabilityHandle{
@@ -85,7 +85,7 @@ func TestVulnerabilityStore_NoDuplicateVulnerabilities(t *testing.T) {
 
 func TestVulnerabilityStore_AddVulnerabilities_missingModifiedDate(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore()
+	bw := newBlobStore(db)
 	s := newVulnerabilityStore(db, bw)
 
 	now := time.Now()
@@ -106,7 +106,7 @@ func TestVulnerabilityStore_AddVulnerabilities_missingModifiedDate(t *testing.T)
 
 func TestVulnerabilityStore_AddVulnerabilities_Aliases(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore()
+	bw := newBlobStore(db)
 	s := newVulnerabilityStore(db, bw)
 
 	vuln := &VulnerabilityHandle{
@@ -148,7 +148,7 @@ func TestVulnerabilityStore_AddVulnerabilities_Aliases(t *testing.T) {
 
 func TestVulnerabilityStore_GetVulnerability_ByID(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore()
+	bw := newBlobStore(db)
 	s := newVulnerabilityStore(db, bw)
 
 	vuln := testVulnerabilityHandle()
@@ -180,7 +180,7 @@ func TestVulnerabilityStore_GetVulnerability_ByID(t *testing.T) {
 
 func TestVulnerabilityStore_GetVulnerabilities_ByName(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore()
+	bw := newBlobStore(db)
 	s := newVulnerabilityStore(db, bw)
 
 	vuln1 := testVulnerabilityHandle()
@@ -217,7 +217,7 @@ func TestVulnerabilityStore_GetVulnerabilities_ByName(t *testing.T) {
 
 func TestVulnerabilityStore_GetVulnerabilities_Aliases(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore()
+	bw := newBlobStore(db)
 	s := newVulnerabilityStore(db, bw)
 
 	vuln1 := &VulnerabilityHandle{
@@ -326,7 +326,7 @@ func testVulnerabilityHandle() VulnerabilityHandle {
 
 func TestVulnerabilityStore_GetVulnerabilities_ByProviders(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore()
+	bw := newBlobStore(db)
 	s := newVulnerabilityStore(db, bw)
 
 	provider1 := &Provider{ID: "provider1"}
@@ -352,7 +352,7 @@ func TestVulnerabilityStore_GetVulnerabilities_ByProviders(t *testing.T) {
 
 func TestVulnerabilityStore_GetVulnerabilities_FilterByMultipleFactors(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore()
+	bw := newBlobStore(db)
 	s := newVulnerabilityStore(db, bw)
 
 	now := time.Now()

--- a/grype/db/v6/vulnerability_store_test.go
+++ b/grype/db/v6/vulnerability_store_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestVulnerabilityStore_AddVulnerabilities(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore(db)
+	bw := newBlobStore()
 	s := newVulnerabilityStore(db, bw)
 
 	vuln1 := VulnerabilityHandle{
@@ -51,7 +51,7 @@ func TestVulnerabilityStore_AddVulnerabilities(t *testing.T) {
 
 func TestVulnerabilityStore_NoDuplicateVulnerabilities(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore(db)
+	bw := newBlobStore()
 	s := newVulnerabilityStore(db, bw)
 
 	vuln := VulnerabilityHandle{
@@ -85,7 +85,7 @@ func TestVulnerabilityStore_NoDuplicateVulnerabilities(t *testing.T) {
 
 func TestVulnerabilityStore_AddVulnerabilities_missingModifiedDate(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore(db)
+	bw := newBlobStore()
 	s := newVulnerabilityStore(db, bw)
 
 	now := time.Now()
@@ -106,7 +106,7 @@ func TestVulnerabilityStore_AddVulnerabilities_missingModifiedDate(t *testing.T)
 
 func TestVulnerabilityStore_AddVulnerabilities_Aliases(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore(db)
+	bw := newBlobStore()
 	s := newVulnerabilityStore(db, bw)
 
 	vuln := &VulnerabilityHandle{
@@ -148,7 +148,7 @@ func TestVulnerabilityStore_AddVulnerabilities_Aliases(t *testing.T) {
 
 func TestVulnerabilityStore_GetVulnerability_ByID(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore(db)
+	bw := newBlobStore()
 	s := newVulnerabilityStore(db, bw)
 
 	vuln := testVulnerabilityHandle()
@@ -180,7 +180,7 @@ func TestVulnerabilityStore_GetVulnerability_ByID(t *testing.T) {
 
 func TestVulnerabilityStore_GetVulnerabilities_ByName(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore(db)
+	bw := newBlobStore()
 	s := newVulnerabilityStore(db, bw)
 
 	vuln1 := testVulnerabilityHandle()
@@ -217,7 +217,7 @@ func TestVulnerabilityStore_GetVulnerabilities_ByName(t *testing.T) {
 
 func TestVulnerabilityStore_GetVulnerabilities_Aliases(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore(db)
+	bw := newBlobStore()
 	s := newVulnerabilityStore(db, bw)
 
 	vuln1 := &VulnerabilityHandle{
@@ -326,7 +326,7 @@ func testVulnerabilityHandle() VulnerabilityHandle {
 
 func TestVulnerabilityStore_GetVulnerabilities_ByProviders(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore(db)
+	bw := newBlobStore()
 	s := newVulnerabilityStore(db, bw)
 
 	provider1 := &Provider{ID: "provider1"}
@@ -352,7 +352,7 @@ func TestVulnerabilityStore_GetVulnerabilities_ByProviders(t *testing.T) {
 
 func TestVulnerabilityStore_GetVulnerabilities_FilterByMultipleFactors(t *testing.T) {
 	db := setupTestStore(t).db
-	bw := newBlobStore(db)
+	bw := newBlobStore()
 	s := newVulnerabilityStore(db, bw)
 
 	now := time.Now()

--- a/schema/grype/db-search/json/schema-1.0.0.json
+++ b/schema/grype/db-search/json/schema-1.0.0.json
@@ -107,10 +107,7 @@
           "$ref": "#/$defs/Fix"
         }
       },
-      "type": "object",
-      "required": [
-        "version"
-      ]
+      "type": "object"
     },
     "AffectedVersion": {
       "$defs": {
@@ -129,10 +126,7 @@
           "type": "string"
         }
       },
-      "type": "object",
-      "required": [
-        "constraint"
-      ]
+      "type": "object"
     },
     "CPE": {
       "properties": {
@@ -208,10 +202,7 @@
           "$ref": "#/$defs/FixDetail"
         }
       },
-      "type": "object",
-      "required": [
-        "state"
-      ]
+      "type": "object"
     },
     "FixDetail": {
       "$defs": {

--- a/schema/grype/db-search/json/schema-latest.json
+++ b/schema/grype/db-search/json/schema-latest.json
@@ -107,10 +107,7 @@
           "$ref": "#/$defs/Fix"
         }
       },
-      "type": "object",
-      "required": [
-        "version"
-      ]
+      "type": "object"
     },
     "AffectedVersion": {
       "$defs": {
@@ -129,10 +126,7 @@
           "type": "string"
         }
       },
-      "type": "object",
-      "required": [
-        "constraint"
-      ]
+      "type": "object"
     },
     "CPE": {
       "properties": {
@@ -208,10 +202,7 @@
           "$ref": "#/$defs/FixDetail"
         }
       },
-      "type": "object",
-      "required": [
-        "state"
-      ]
+      "type": "object"
     },
     "FixDetail": {
       "$defs": {


### PR DESCRIPTION
All changes on this PR are purely to decrease the time it takes to build a v6 DB, which when incorporated the build time in CI drops from ~2.5 hours to ~25 minutes 🎉

Changes:
- add in-memory ID lookup for common or expensive models (e.g. CPEs originally had a large where clause to fetch similar rows, now this is an O(1) map lookup based on a string). This has been applied to CPEs, OperatingSystems, VulnerabilityHandles, Packages, and Providers. These are relatively flat records and based on debug logs appear to have a high cache hit rate. This also required ensuring we are correctly using this cache across transactions as well as within a transaction (deduplicating in memory).
- Minimizing use of any queries to the DB within `BeforeCreate` hooks
- keep blob digests in memory, not to a separate digests table (theme: maximize the items not written to the DB).
- removed the pragma for 16KB page sizes (this had little effect on DB size and a small performance boost for write times).

While working on this, I did make some unrelated changes:
- I noticed that pragma statements are not strongly verified by sqlite, so explicit checks were added (when adding a new pragma).