### PR TITLE
external-sources: make maven rate limit configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,10 +284,13 @@ external-sources:
   enable: true
   maven:
     search-upstream-by-sha1: true
-    base-url: https://repo1.maven.org/maven2
+    base-url: https://search.maven.org/solrsearch/select
+    rate-limit: 300ms # Time between Maven API requests
 ```
 
 You can also configure the base-url if you're using another registry as your maven endpoint.
+
+The rate at which Maven API requests are made can be configured to match your environment's requirements. The default is 300ms between requests.
 
 ### Output formats
 
@@ -738,7 +741,8 @@ external-sources:
   enable: false
   maven:
     search-upstream-by-sha1: true
-    base-url: https://repo1.maven.org/maven2
+    base-url: https://search.maven.org/solrsearch/select
+    rate-limit: 300ms
 
 db:
   # check for database updates on execution

--- a/cmd/grype/cli/options/datasources.go
+++ b/cmd/grype/cli/options/datasources.go
@@ -1,6 +1,8 @@
 package options
 
 import (
+	"time"
+
 	"github.com/anchore/clio"
 	"github.com/anchore/grype/grype/db/v5/matcher/java"
 )
@@ -19,8 +21,9 @@ var _ interface {
 } = (*externalSources)(nil)
 
 type maven struct {
-	SearchUpstreamBySha1 bool   `yaml:"search-upstream" json:"searchUpstreamBySha1" mapstructure:"search-maven-upstream"`
-	BaseURL              string `yaml:"base-url" json:"baseUrl" mapstructure:"base-url"`
+	SearchUpstreamBySha1 bool          `yaml:"search-upstream" json:"searchUpstreamBySha1" mapstructure:"search-maven-upstream"`
+	BaseURL              string        `yaml:"base-url" json:"baseUrl" mapstructure:"base-url"`
+	RateLimit            time.Duration `yaml:"rate-limit" json:"rateLimit" mapstructure:"rate-limit"`
 }
 
 func defaultExternalSources() externalSources {
@@ -28,6 +31,7 @@ func defaultExternalSources() externalSources {
 		Maven: maven{
 			SearchUpstreamBySha1: true,
 			BaseURL:              defaultMavenBaseURL,
+			RateLimit:            300 * time.Millisecond,
 		},
 	}
 }
@@ -41,6 +45,7 @@ func (cfg externalSources) ToJavaMatcherConfig() java.ExternalSearchConfig {
 	return java.ExternalSearchConfig{
 		SearchMavenUpstream: smu,
 		MavenBaseURL:        cfg.Maven.BaseURL,
+		MavenRateLimit:      cfg.Maven.RateLimit,
 	}
 }
 

--- a/grype/db/v5/matcher/java/maven_search.go
+++ b/grype/db/v5/matcher/java/maven_search.go
@@ -30,11 +30,11 @@ type mavenSearch struct {
 
 // newMavenSearch creates a new mavenSearch instance with rate limiting
 // rate is specified as 1 request per 300ms
-func newMavenSearch(client *http.Client, baseURL string) *mavenSearch {
+func newMavenSearch(client *http.Client, baseURL string, rateLimit time.Duration) *mavenSearch {
 	return &mavenSearch{
 		client:      client,
 		baseURL:     baseURL,
-		rateLimiter: rate.NewLimiter(rate.Every(300*time.Millisecond), 1), // 1 request per 300ms, using the integration test to determine the best rate.
+		rateLimiter: rate.NewLimiter(rate.Every(rateLimit), 1),
 	}
 }
 


### PR DESCRIPTION
Allow overriding the default 300ms rate limit for maven API requests via config. This helps users tune request rates based on their specific environment and maven server capacity/restrictions.

Example config:

```yaml
external-sources:
 maven:
   rate-limit: 400ms # or lower than the default if users prefer
```

This PR also includes:
- addition of unit test for the new configurable rate limits
- removal of single unit test case, testing default config as unnecessary given the `defaultExternalSources`
- doc updates for new config, also updated the base maven URL in the docs to match what is being used
- small fix to warn logging, if `no artifact is found`, we don't want to log a warning