### PR TITLE
Add advisory tag constant

### DIFF
--- a/grype/db/v6/enumerations.go
+++ b/grype/db/v6/enumerations.go
@@ -60,6 +60,11 @@ const (
 	NotAffectedFixStatus FixStatus = "not-affected"
 )
 
+const (
+	// AdvisoryReferenceTag is a tag that can be used to identify vulnerability advisory URL references
+	AdvisoryReferenceTag = "advisory"
+)
+
 func ParseVulnerabilityStatus(s string) VulnerabilityStatus {
 	switch strings.TrimSpace(strings.ToLower(s)) {
 	case string(VulnerabilityActive), "":


### PR DESCRIPTION
This will be used in grype-db when transforming OS related records with advisories (so they are explicitly tagged)