### PR TITLE
feat: update to go 1.24.x

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -26,7 +26,7 @@ tools:
   # used for linting
   - name: golangci-lint
     version:
-      want: v1.63.4
+      want: v1.64.2
     method: github-release
     with:
       repo: golangci/golangci-lint

--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -4,7 +4,7 @@ inputs:
   go-version:
     description: "Go version to install"
     required: true
-    default: "1.23.x"
+    default: "1.24.x"
   python-version:
     description: "Python version to install"
     required: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/grype
 
-go 1.23.2
+go 1.24.0
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.9.2


### PR DESCRIPTION
# Description

Update to building with go [1.24.x](https://tip.golang.org/doc/go1.24) so that the main module version gets set during `go build`