### PR TITLE
fix: only log matcher errors

### DIFF
--- a/grype/vulnerability_matcher.go
+++ b/grype/vulnerability_matcher.go
@@ -64,11 +64,7 @@ func (m *VulnerabilityMatcher) FindMatches(pkgs []pkg.Package, context pkg.Conte
 		}
 	}()
 
-	remainingMatches, ignoredMatches, err = m.findDBMatches(pkgs, context, progressMonitor)
-	if err != nil {
-		// errors returned from matchers during findDBMatches were being logged and not returned, so just log them here
-		log.WithFields("error", err).Debug("error(s) returned from findDBMatches")
-	}
+	remainingMatches, ignoredMatches = m.findDBMatches(pkgs, context, progressMonitor)
 
 	remainingMatches, ignoredMatches, err = m.findVEXMatches(context, remainingMatches, ignoredMatches, progressMonitor)
 	if err != nil {
@@ -88,13 +84,14 @@ func (m *VulnerabilityMatcher) FindMatches(pkgs []pkg.Package, context pkg.Conte
 	return remainingMatches, ignoredMatches, nil
 }
 
-func (m *VulnerabilityMatcher) findDBMatches(pkgs []pkg.Package, context pkg.Context, progressMonitor *monitorWriter) (*match.Matches, []match.IgnoredMatch, error) {
+func (m *VulnerabilityMatcher) findDBMatches(pkgs []pkg.Package, context pkg.Context, progressMonitor *monitorWriter) (*match.Matches, []match.IgnoredMatch) {
 	var ignoredMatches []match.IgnoredMatch
 
 	log.Trace("finding matches against DB")
 	matches, err := m.searchDBForMatches(context.Distro, pkgs, progressMonitor)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to find matches in DB: %w", err)
+		// errors returned from matchers during searchDBForMatches were being logged and not returned, so just log them here
+		log.WithFields("error", err).Debug("error(s) returned from searchDBForMatches")
 	}
 
 	matches, ignoredMatches = m.applyIgnoreRules(matches)
@@ -114,7 +111,7 @@ func (m *VulnerabilityMatcher) findDBMatches(pkgs []pkg.Package, context pkg.Con
 		ignoredMatches = m.mergeIgnoredMatches(originalIgnoredMatches, ignoredMatches)
 	}
 
-	return &matches, ignoredMatches, nil
+	return &matches, ignoredMatches
 }
 
 func (m *VulnerabilityMatcher) mergeIgnoredMatches(allIgnoredMatches ...[]match.IgnoredMatch) []match.IgnoredMatch {


### PR DESCRIPTION
During v6 refactoring, there was a small change made incorrectly to how errors were returned from matchers. This PR corrects this issue.