### PR TITLE
fix: Optionally support regular expressions when applying ignore rules for package names/package upstream names

### DIFF
--- a/grype/match/ignore.go
+++ b/grype/match/ignore.go
@@ -206,22 +206,6 @@ func packageNameRegex(packageName string) (*regexp.Regexp, error) {
 	return regexp.Compile(pattern)
 }
 
-/*
-   func ifPackageNameApplies(name string) ignoreCondition {
-        return func(match Match) bool {
-                if strings.HasPrefix(name, "linux") && strings.Contains(name, "-headers-") {
-                        pattern, err := packageNameRegex(name)
-                        if err != nil {
-                                return false
-                        }
-                        return pattern.MatchString(match.Package.Name)
-                }
-
-                return name == match.Package.Name
-        }
-}
-*/
-
 func ifPackageNameApplies(name string) ignoreCondition {
 	var (
 		pattern *regexp.Regexp

--- a/grype/match/ignore_test.go
+++ b/grype/match/ignore_test.go
@@ -678,33 +678,6 @@ func TestApplyIgnoreRules(t *testing.T) {
 			},
 		},
 		{
-			name:       "ignore on name regex",
-			allMatches: kernelHeadersMatches,
-			ignoreRules: []IgnoreRule{
-				{
-					Package: IgnoreRulePackage{
-						Name: "kernel-headers.*",
-					},
-				},
-			},
-			expectedRemainingMatches: []Match{
-				kernelHeadersMatches[1],
-				kernelHeadersMatches[2],
-			},
-			expectedIgnoredMatches: []IgnoredMatch{
-				{
-					Match: kernelHeadersMatches[0],
-					AppliedIgnoreRules: []IgnoreRule{
-						{
-							Package: IgnoreRulePackage{
-								Name: "kernel-headers.*",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name:       "ignore on name regex, no matches",
 			allMatches: kernelHeadersMatches,
 			ignoreRules: []IgnoreRule{
@@ -729,33 +702,6 @@ func TestApplyIgnoreRules(t *testing.T) {
 			},
 			expectedRemainingMatches: kernelHeadersMatches,
 			expectedIgnoredMatches:   nil,
-		},
-		{
-			name:       "ignore on name regex, line termination test match",
-			allMatches: kernelHeadersMatches,
-			ignoreRules: []IgnoreRule{
-				{
-					Package: IgnoreRulePackage{
-						Name: "^kernel-headers$",
-					},
-				},
-			},
-			expectedRemainingMatches: []Match{
-				kernelHeadersMatches[1],
-				kernelHeadersMatches[2],
-			},
-			expectedIgnoredMatches: []IgnoredMatch{
-				{
-					Match: kernelHeadersMatches[0],
-					AppliedIgnoreRules: []IgnoreRule{
-						{
-							Package: IgnoreRulePackage{
-								Name: "^kernel-headers$",
-							},
-						},
-					},
-				},
-			},
 		},
 	}
 

--- a/grype/match/ignore_test.go
+++ b/grype/match/ignore_test.go
@@ -216,7 +216,7 @@ var (
 				Version: "5.2.1",
 				Type:    syftPkg.DebPkg,
 				Upstreams: []pkg.UpstreamPackage{
-					{Name: "linux"},
+					{Name: "notalinux"},
 				},
 			},
 			Details: []Detail{
@@ -568,7 +568,7 @@ func TestApplyIgnoreRules(t *testing.T) {
 				},
 				{
 					Package: IgnoreRulePackage{
-						UpstreamName: "linux-.*",
+						UpstreamName: "linux.*",
 					},
 				},
 			},
@@ -591,7 +591,7 @@ func TestApplyIgnoreRules(t *testing.T) {
 					AppliedIgnoreRules: []IgnoreRule{
 						{
 							Package: IgnoreRulePackage{
-								UpstreamName: "linux-.*",
+								UpstreamName: "linux.*",
 							},
 						},
 					},
@@ -638,7 +638,7 @@ func TestApplyIgnoreRules(t *testing.T) {
 				},
 				{
 					Package: IgnoreRulePackage{
-						Name:         "linux-.*-headers-.*",
+						Name:         "linux(-.*)?-headers-.*",
 						UpstreamName: "linux.*",
 						Type:         string(syftPkg.DebPkg),
 					},
@@ -667,7 +667,7 @@ func TestApplyIgnoreRules(t *testing.T) {
 					AppliedIgnoreRules: []IgnoreRule{
 						{
 							Package: IgnoreRulePackage{
-								Name:         "linux-.*-headers-.*",
+								Name:         "linux(-.*)?-headers-.*",
 								UpstreamName: "linux.*",
 								Type:         string(syftPkg.DebPkg),
 							},


### PR DESCRIPTION
### Description
Hello folks 👋 

In https://github.com/anchore/grype/pull/1809 both `ifPackageNameApplies` and `ifUpstreamPackageNameApplies` were updated to use regular expressions for all rule names/upstream names. This was recently updated in https://github.com/anchore/grype/pull/2320 too.

So far as I can see from the codebase only the linux kernel headers ignore rules require regular expression matching.

In my testing I've found that `FindMatches` is significantly slowed down by the amount of regular expression compilation being performed. 

For one of my test scans with about ~60k packages, using this branch results in a **2x speedup** of `FindMatches` with **~8GB less cumulative allocations** 

**Before**
---
<img width="208" alt="Screenshot 2025-02-13 at 11 16 29" src="https://github.com/user-attachments/assets/540ec579-f213-495a-bff1-08de02ef6e17" />

---

**After**
---
<img width="273" alt="Screenshot 2025-02-13 at 11 21 11" src="https://github.com/user-attachments/assets/bdabe985-974b-4d3a-9f8e-5ec7c07afdff" />

---

For now, I've modified `ifPackageNameApplies` and `ifUpstreamPackageNameApplies` to handle the linux-headers as special cases.

In future if we wish to support regular expressions more broadly perhaps there should be a nicer interface passed into the likes of `ifPackageNameApplies` and `ifUpstreamPackageNameApplies` rather than a string, and this interface could define whether or not to treat the match type as a regex etc...

I've had to make some changes to the unit tests.

I've removed two tests which seem to be testing behaviour that Grype doesn't have configuration for:
-  there are no existing ignore rules which define `kernel-headers.*` so I've removed the test `ignore on name regex`
-  there are no existing ignore rules which define regular expresions that start and end with anchor tags, so I've removed the test `ignore on name regex, line termination test match`

I've also modified some of the tests to match the actual patterns set out in Grype, namely:
-- `linux-.*-headers-.*` is now declared  `linux(-.*)?-headers-.*` 
-- `linux-.*` is now defined as `linux.*` .. as a result of fixing this I've also updated the upstream name from `linux` to `notalinux` for the test case. The ignore rules defined today would actually ignore `linux`, the only reason the test was passing before is because it defined the regex as `linux-.*`

In lieue of a larger refactor to have a nicer interface for `ifPackageNameApplies`/`ifUpstreamPackageNameApplies` which I've previously mentioned, it would at least perhaps be nice to declare the `linux(-.*)?-headers-.*` and `linux.*` as a const in some shared place. 

If the maintainers can suggest somewhere that would be a good fit, I'd be happy to create this.