### PR TITLE
fix(java): error out on maven search rate limiting

### DIFF
--- a/grype/matcher/java/matcher.go
+++ b/grype/matcher/java/matcher.go
@@ -59,7 +59,8 @@ func (m *Matcher) Match(store vulnerability.Provider, p pkg.Package) ([]match.Ma
 			if strings.Contains(err.Error(), "no artifact found") {
 				log.Debugf("no upstream maven artifact found for %s", p.Name)
 			} else {
-				log.WithFields("package", p.Name, "error", err).Warn("failed to resolve package details with maven")
+				log.WithFields("package", p.Name, "error", err).Error("failed to resolve package details with maven")
+				return nil, nil, fmt.Errorf("resolving package details with maven: %w", err)
 			}
 		} else {
 			matches = append(matches, upstreamMatches...)

--- a/grype/matcher/java/matcher_mocks_test.go
+++ b/grype/matcher/java/matcher_mocks_test.go
@@ -2,6 +2,7 @@ package java
 
 import (
 	"context"
+	"errors"
 
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/version"
@@ -32,15 +33,13 @@ func newMockProvider() vulnerability.Provider {
 }
 
 type mockMavenSearcher struct {
-	pkg pkg.Package
+	pkg                  pkg.Package
+	simulateRateLimiting bool
 }
 
 func (m mockMavenSearcher) GetMavenPackageBySha(context.Context, string) (*pkg.Package, error) {
-	return &m.pkg, nil
-}
-
-func newMockSearcher(pkg pkg.Package) MavenSearcher {
-	return mockMavenSearcher{
-		pkg,
+	if m.simulateRateLimiting {
+		return nil, errors.New("you been rate limited")
 	}
+	return &m.pkg, nil
 }

--- a/grype/matcher/java/matcher_test.go
+++ b/grype/matcher/java/matcher_test.go
@@ -14,6 +14,18 @@ import (
 )
 
 func TestMatcherJava_matchUpstreamMavenPackage(t *testing.T) {
+	newMatcher := func(searcher MavenSearcher) *Matcher {
+		return &Matcher{
+			cfg: MatcherConfig{
+				ExternalSearchConfig: ExternalSearchConfig{
+					SearchMavenUpstream: true,
+				},
+			},
+			MavenSearcher: searcher,
+		}
+	}
+	store := newMockProvider()
+
 	p := pkg.Package{
 		ID:       pkg.ID(uuid.NewString()),
 		Name:     "org.springframework.spring-webmvc",
@@ -29,38 +41,42 @@ func TestMatcherJava_matchUpstreamMavenPackage(t *testing.T) {
 			},
 		},
 	}
-	matcher := Matcher{
-		cfg: MatcherConfig{
-			ExternalSearchConfig: ExternalSearchConfig{
-				SearchMavenUpstream: true,
-			},
-			UseCPEs: false,
-		},
-		MavenSearcher: newMockSearcher(p),
-	}
-	store := newMockProvider()
-	actual, _ := matcher.matchUpstreamMavenPackages(store, p)
 
-	assert.Len(t, actual, 2, "unexpected matches count")
+	t.Run("matching from maven search results", func(t *testing.T) {
+		matcher := newMatcher(mockMavenSearcher{
+			pkg: p,
+		})
+		actual, _ := matcher.matchUpstreamMavenPackages(store, p)
 
-	foundCVEs := stringutil.NewStringSet()
-	for _, v := range actual {
-		foundCVEs.Add(v.Vulnerability.ID)
+		assert.Len(t, actual, 2, "unexpected matches count")
 
-		require.NotEmpty(t, v.Details)
-		for _, d := range v.Details {
-			assert.Equal(t, match.ExactIndirectMatch, d.Type, "indirect match not indicated")
-			assert.Equal(t, matcher.Type(), d.Matcher, "failed to capture matcher type")
+		foundCVEs := stringutil.NewStringSet()
+		for _, v := range actual {
+			foundCVEs.Add(v.Vulnerability.ID)
+
+			require.NotEmpty(t, v.Details)
+			for _, d := range v.Details {
+				assert.Equal(t, match.ExactIndirectMatch, d.Type, "indirect match not indicated")
+				assert.Equal(t, matcher.Type(), d.Matcher, "failed to capture matcher type")
+			}
+			assert.Equal(t, p.Name, v.Package.Name, "failed to capture original package name")
 		}
-		assert.Equal(t, p.Name, v.Package.Name, "failed to capture original package name")
-	}
 
-	for _, id := range []string{"CVE-2014-fake-2", "CVE-2013-fake-3"} {
-		if !foundCVEs.Contains(id) {
-			t.Errorf("missing discovered CVE: %s", id)
+		for _, id := range []string{"CVE-2014-fake-2", "CVE-2013-fake-3"} {
+			if !foundCVEs.Contains(id) {
+				t.Errorf("missing discovered CVE: %s", id)
+			}
 		}
-	}
-	if t.Failed() {
-		t.Logf("discovered CVES: %+v", foundCVEs)
-	}
+		if t.Failed() {
+			t.Logf("discovered CVES: %+v", foundCVEs)
+		}
+	})
+
+	t.Run("handles maven rate limiting", func(t *testing.T) {
+		matcher := newMatcher(mockMavenSearcher{simulateRateLimiting: true})
+
+		_, err := matcher.matchUpstreamMavenPackages(store, p)
+
+		assert.Errorf(t, err, "should have gotten an error from the rate limiting")
+	})
 }


### PR DESCRIPTION
Following on to #2384 — this makes the failure mode return an error, in addition to logging the issue.

The motivation for this is that otherwise, the unreliability of scan results caused by Maven's rate limiting can't be noticed in programmatic contexts — only by studying log messages.

This adjusts the logic such that if the user wants to use Maven searching to affect vuln matching results, and this is unable to happen successfully, an error is returned indicating as much, which can then prompt the user explicitly to change their approach, such as by turning off the search or adjusting the self rate limiting time.

cc: @rawlingsj @wagoodman 