### PR TITLE
Add CPE provider

### DIFF
--- a/grype/internal/packagemetadata/discover_type_names.go
+++ b/grype/internal/packagemetadata/discover_type_names.go
@@ -18,6 +18,7 @@ var metadataExceptions = strset.New(
 	"FileMetadata",
 	"PURLFileMetadata",
 	"PURLLiteralMetadata",
+	"CPELiteralMetadata",
 )
 
 func DiscoverTypeNames() ([]string, error) {

--- a/grype/pkg/cpe_provider.go
+++ b/grype/pkg/cpe_provider.go
@@ -1,0 +1,100 @@
+package pkg
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/anchore/syft/syft/cpe"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/sbom"
+	"github.com/anchore/syft/syft/source"
+)
+
+const cpeInputPrefix = "cpe:"
+
+type CPELiteralMetadata struct {
+	CPE string
+}
+
+func cpeProvider(userInput string) ([]Package, Context, *sbom.SBOM, error) {
+	reader, ctx, err := getCPEReader(userInput)
+	if err != nil {
+		return nil, Context{}, nil, err
+	}
+
+	return decodeCPEFile(reader, ctx)
+}
+
+func getCPEReader(userInput string) (r io.Reader, ctx Context, err error) {
+	if strings.HasPrefix(userInput, cpeInputPrefix) {
+		ctx.Source = &source.Description{
+			Metadata: CPELiteralMetadata{
+				CPE: userInput,
+			},
+		}
+		return strings.NewReader(userInput), ctx, nil
+	}
+	return nil, ctx, errDoesNotProvide
+}
+
+func decodeCPEFile(reader io.Reader, ctx Context) ([]Package, Context, *sbom.SBOM, error) {
+	scanner := bufio.NewScanner(reader)
+	var packages []Package
+	var syftPkgs []pkg.Package
+
+	for scanner.Scan() {
+		rawLine := scanner.Text()
+		p, syftPkg, err := cpeToPackage(rawLine)
+		if err != nil {
+			return nil, Context{}, nil, err
+		}
+
+		if p != nil {
+			packages = append(packages, *p)
+		}
+		if syftPkg != nil {
+			syftPkgs = append(syftPkgs, *syftPkg)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, Context{}, nil, err
+	}
+
+	s := &sbom.SBOM{
+		Artifacts: sbom.Artifacts{
+			Packages: pkg.NewCollection(syftPkgs...),
+		},
+	}
+
+	return packages, ctx, s, nil
+}
+
+func cpeToPackage(rawLine string) (*Package, *pkg.Package, error) {
+	c, err := cpe.New(rawLine, "")
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to decode cpe %q: %w", rawLine, err)
+	}
+
+	syftPkg := pkg.Package{
+		Name:    c.Attributes.Product,
+		Version: c.Attributes.Version,
+		CPEs:    []cpe.CPE{c},
+		// TODO infer from cpe target sw, this is not as important since the only matcher for CPEs is the stock matcher
+		//Type:     pkgType,
+		// Language:...
+	}
+
+	syftPkg.SetID()
+
+	return &Package{
+		ID:       ID(c.Attributes.BindToFmtString()),
+		CPEs:     syftPkg.CPEs,
+		Name:     syftPkg.Name,
+		Version:  syftPkg.Version,
+		Type:     syftPkg.Type,
+		Language: syftPkg.Language,
+	}, &syftPkg, nil
+}

--- a/grype/pkg/cpe_provider.go
+++ b/grype/pkg/cpe_provider.go
@@ -24,7 +24,7 @@ func cpeProvider(userInput string) ([]Package, Context, *sbom.SBOM, error) {
 		return nil, Context{}, nil, err
 	}
 
-	return decodeCPEFile(reader, ctx)
+	return decodeCPEsFromReader(reader, ctx)
 }
 
 func getCPEReader(userInput string) (r io.Reader, ctx Context, err error) {
@@ -39,7 +39,7 @@ func getCPEReader(userInput string) (r io.Reader, ctx Context, err error) {
 	return nil, ctx, errDoesNotProvide
 }
 
-func decodeCPEFile(reader io.Reader, ctx Context) ([]Package, Context, *sbom.SBOM, error) {
+func decodeCPEsFromReader(reader io.Reader, ctx Context) ([]Package, Context, *sbom.SBOM, error) {
 	scanner := bufio.NewScanner(reader)
 	var packages []Package
 	var syftPkgs []pkg.Package

--- a/grype/pkg/cpe_provider_test.go
+++ b/grype/pkg/cpe_provider_test.go
@@ -38,7 +38,7 @@ func Test_CPEProvider(t *testing.T) {
 					Name:    "log4j",
 					Version: "2.14.1",
 					CPEs: []cpe.CPE{
-						must(cpe.New("cpe:/a:apache:log4j:2.14.1", "")),
+						cpe.Must("cpe:/a:apache:log4j:2.14.1", ""),
 					},
 				},
 			},
@@ -48,7 +48,7 @@ func Test_CPEProvider(t *testing.T) {
 						Name:    "log4j",
 						Version: "2.14.1",
 						CPEs: []cpe.CPE{
-							must(cpe.New("cpe:/a:apache:log4j:2.14.1", "")),
+							cpe.Must("cpe:/a:apache:log4j:2.14.1", ""),
 						},
 					}),
 				},
@@ -68,7 +68,7 @@ func Test_CPEProvider(t *testing.T) {
 				{
 					Name: "log4j",
 					CPEs: []cpe.CPE{
-						must(cpe.New("cpe:/a:apache:log4j", "")),
+						cpe.Must("cpe:/a:apache:log4j", ""),
 					},
 				},
 			},
@@ -77,7 +77,7 @@ func Test_CPEProvider(t *testing.T) {
 					Packages: pkg.NewCollection(pkg.Package{
 						Name: "log4j",
 						CPEs: []cpe.CPE{
-							must(cpe.New("cpe:/a:apache:log4j", "")),
+							cpe.Must("cpe:/a:apache:log4j", ""),
 						},
 					}),
 				},
@@ -98,7 +98,7 @@ func Test_CPEProvider(t *testing.T) {
 					Name:    "log4j",
 					Version: "2.14.1",
 					CPEs: []cpe.CPE{
-						must(cpe.New("cpe:2.3:a:apache:log4j:2.14.1:*:*:*:*:*:*:*", "")),
+						cpe.Must("cpe:2.3:a:apache:log4j:2.14.1:*:*:*:*:*:*:*", ""),
 					},
 				},
 			},
@@ -108,7 +108,7 @@ func Test_CPEProvider(t *testing.T) {
 						Name:    "log4j",
 						Version: "2.14.1",
 						CPEs: []cpe.CPE{
-							must(cpe.New("cpe:2.3:a:apache:log4j:2.14.1:*:*:*:*:*:*:*", "")),
+							cpe.Must("cpe:2.3:a:apache:log4j:2.14.1:*:*:*:*:*:*:*", ""),
 						},
 					}),
 				},
@@ -166,12 +166,4 @@ func Test_CPEProvider(t *testing.T) {
 			}
 		})
 	}
-}
-
-// Helper function to create CPE objects and panic on error (for use in test data only)
-func must(c cpe.CPE, err error) cpe.CPE {
-	if err != nil {
-		panic(err)
-	}
-	return c
 }

--- a/grype/pkg/cpe_provider_test.go
+++ b/grype/pkg/cpe_provider_test.go
@@ -1,0 +1,177 @@
+package pkg
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/cpe"
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/sbom"
+	"github.com/anchore/syft/syft/source"
+)
+
+func Test_CPEProvider(t *testing.T) {
+	tests := []struct {
+		name      string
+		userInput string
+		context   Context
+		pkgs      []Package
+		sbom      *sbom.SBOM
+		wantErr   require.ErrorAssertionFunc
+	}{
+		{
+			name:      "takes a single cpe",
+			userInput: "cpe:/a:apache:log4j:2.14.1",
+			context: Context{
+				Source: &source.Description{
+					Metadata: CPELiteralMetadata{
+						CPE: "cpe:/a:apache:log4j:2.14.1",
+					},
+				},
+			},
+			pkgs: []Package{
+				{
+					Name:    "log4j",
+					Version: "2.14.1",
+					CPEs: []cpe.CPE{
+						must(cpe.New("cpe:/a:apache:log4j:2.14.1", "")),
+					},
+				},
+			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name:    "log4j",
+						Version: "2.14.1",
+						CPEs: []cpe.CPE{
+							must(cpe.New("cpe:/a:apache:log4j:2.14.1", "")),
+						},
+					}),
+				},
+			},
+		},
+		{
+			name:      "takes cpe with no version",
+			userInput: "cpe:/a:apache:log4j",
+			context: Context{
+				Source: &source.Description{
+					Metadata: CPELiteralMetadata{
+						CPE: "cpe:/a:apache:log4j",
+					},
+				},
+			},
+			pkgs: []Package{
+				{
+					Name: "log4j",
+					CPEs: []cpe.CPE{
+						must(cpe.New("cpe:/a:apache:log4j", "")),
+					},
+				},
+			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name: "log4j",
+						CPEs: []cpe.CPE{
+							must(cpe.New("cpe:/a:apache:log4j", "")),
+						},
+					}),
+				},
+			},
+		},
+		{
+			name:      "takes CPE 2.3 format",
+			userInput: "cpe:2.3:a:apache:log4j:2.14.1:*:*:*:*:*:*:*",
+			context: Context{
+				Source: &source.Description{
+					Metadata: CPELiteralMetadata{
+						CPE: "cpe:2.3:a:apache:log4j:2.14.1:*:*:*:*:*:*:*",
+					},
+				},
+			},
+			pkgs: []Package{
+				{
+					Name:    "log4j",
+					Version: "2.14.1",
+					CPEs: []cpe.CPE{
+						must(cpe.New("cpe:2.3:a:apache:log4j:2.14.1:*:*:*:*:*:*:*", "")),
+					},
+				},
+			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name:    "log4j",
+						Version: "2.14.1",
+						CPEs: []cpe.CPE{
+							must(cpe.New("cpe:2.3:a:apache:log4j:2.14.1:*:*:*:*:*:*:*", "")),
+						},
+					}),
+				},
+			},
+		},
+
+		{
+			name:      "invalid prefix",
+			userInput: "dir:test-fixtures/cpe",
+			wantErr:   require.Error,
+		},
+	}
+
+	opts := []cmp.Option{
+		cmpopts.IgnoreFields(Package{}, "ID", "Locations", "Licenses", "Metadata", "Type", "Language"),
+	}
+
+	syftPkgOpts := []cmp.Option{
+		cmpopts.IgnoreFields(pkg.Package{}, "id", "Type", "Language"),
+		cmpopts.IgnoreUnexported(pkg.Package{}, file.LocationSet{}, pkg.LicenseSet{}),
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.wantErr == nil {
+				tc.wantErr = require.NoError
+			}
+
+			packages, ctx, gotSBOM, err := cpeProvider(tc.userInput)
+
+			tc.wantErr(t, err)
+			if err != nil {
+				require.Nil(t, packages)
+				return
+			}
+
+			if d := cmp.Diff(tc.context, ctx, opts...); d != "" {
+				t.Errorf("unexpected context (-want +got):\n%s", d)
+			}
+
+			require.Len(t, packages, len(tc.pkgs))
+			for idx, expected := range tc.pkgs {
+				if d := cmp.Diff(expected, packages[idx], opts...); d != "" {
+					t.Errorf("unexpected package (-want +got):\n%s", d)
+				}
+			}
+
+			gotSyftPkgs := gotSBOM.Artifacts.Packages.Sorted()
+			wantSyftPkgs := tc.sbom.Artifacts.Packages.Sorted()
+			require.Equal(t, len(gotSyftPkgs), len(wantSyftPkgs))
+			for idx, wantPkg := range wantSyftPkgs {
+				if d := cmp.Diff(wantPkg, gotSyftPkgs[idx], syftPkgOpts...); d != "" {
+					t.Errorf("unexpected Syft Package (-want +got):\n%s", d)
+				}
+			}
+		})
+	}
+}
+
+// Helper function to create CPE objects and panic on error (for use in test data only)
+func must(c cpe.CPE, err error) cpe.CPE {
+	if err != nil {
+		panic(err)
+	}
+	return c
+}

--- a/grype/pkg/provider.go
+++ b/grype/pkg/provider.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bmatcuk/doublestar/v2"
 
+	"github.com/anchore/grype/internal/log"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/sbom"
 )
@@ -23,14 +24,23 @@ func Provide(userInput string, config ProviderConfig) ([]Package, Context, *sbom
 				return nil, ctx, s, exclusionsErr
 			}
 		}
+		log.WithFields("input", userInput).Trace("interpreting input from the given SBOM")
 		return packages, ctx, s, err
 	}
 
 	packages, ctx, s, err = purlProvider(userInput)
 	if !errors.Is(err, errDoesNotProvide) {
+		log.WithFields("input", userInput).Trace("interpreting input from the given PURL(s)")
 		return packages, ctx, s, err
 	}
 
+	packages, ctx, s, err = cpeProvider(userInput)
+	if !errors.Is(err, errDoesNotProvide) {
+		log.WithFields("input", userInput).Trace("interpreting input from the given CPE")
+		return packages, ctx, s, err
+	}
+
+	log.WithFields("input", userInput).Trace("passing input to syft for interpretation")
 	return syftProvider(userInput, config)
 }
 

--- a/grype/presenter/models/source.go
+++ b/grype/presenter/models/source.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 
+	"github.com/anchore/grype/grype/pkg"
 	syftSource "github.com/anchore/syft/syft/source"
 )
 
@@ -14,6 +15,21 @@ type source struct {
 // newSource creates a new source object to be represented into JSON.
 func newSource(src syftSource.Description) (source, error) {
 	switch m := src.Metadata.(type) {
+	case pkg.PURLFileMetadata:
+		return source{
+			Type:   "purl-file",
+			Target: m.Path,
+		}, nil
+	case pkg.PURLLiteralMetadata:
+		return source{
+			Type:   "purl",
+			Target: m.PURL,
+		}, nil
+	case pkg.CPELiteralMetadata:
+		return source{
+			Type:   "cpe",
+			Target: m.CPE,
+		}, nil
 	case syftSource.ImageMetadata:
 		// ensure that empty collections are not shown as null
 		if m.RepoDigests == nil {

--- a/grype/presenter/models/source_test.go
+++ b/grype/presenter/models/source_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anchore/grype/grype/pkg"
 	syftSource "github.com/anchore/syft/syft/source"
 )
 
@@ -59,6 +60,52 @@ func TestNewSource(t *testing.T) {
 			expected: source{
 				Type:   "file",
 				Target: "/foo/bar/test.zip",
+			},
+		},
+		{
+			name: "purl-file",
+			metadata: syftSource.Description{
+				Metadata: pkg.PURLFileMetadata{
+					Path: "/path/to/purls.txt",
+				},
+			},
+			expected: source{
+				Type:   "purl-file",
+				Target: "/path/to/purls.txt",
+			},
+		},
+		{
+			name: "purl-literal",
+			metadata: syftSource.Description{
+				Metadata: pkg.PURLLiteralMetadata{
+					PURL: "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+				},
+			},
+			expected: source{
+				Type:   "purl",
+				Target: "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+			},
+		},
+		{
+			name: "cpe-literal",
+			metadata: syftSource.Description{
+				Metadata: pkg.CPELiteralMetadata{
+					CPE: "cpe:/a:apache:log4j:2.14.1",
+				},
+			},
+			expected: source{
+				Type:   "cpe",
+				Target: "cpe:/a:apache:log4j:2.14.1",
+			},
+		},
+		{
+			name: "nil metadata",
+			metadata: syftSource.Description{
+				Metadata: nil,
+			},
+			expected: source{
+				Type:   "unknown",
+				Target: "unknown",
 			},
 		},
 	}


### PR DESCRIPTION
This PR adjusts input processing for grype to allow for CPE literals from the CLI (in the same way PURLs are supported today):
```
grype 'cpe:2.3:a:zohocorp:manageengine_desktop_central:11'
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]  
   ├── by severity: 4 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   3 fixed, 1 not-fixed, 0 ignored 
NAME                          INSTALLED  FIXED-IN    TYPE  VULNERABILITY   SEVERITY 
manageengine_desktop_central  11         2020-03-07        CVE-2020-8540   Critical  
manageengine_desktop_central  11         100251            CVE-2018-11717  Critical  
manageengine_desktop_central  11         100230            CVE-2018-11716  Critical  
manageengine_desktop_central  11                           CVE-2017-7213   Critical
```

This allows for spot testing CPEs directly from CVE documentation much more easily instead of requiring a full syft package or container image artifact.

It was also found that PURL source formatting when using `-o json` was not functional -- this is also fixed in this PR since the same area was being addressed.