### PR TITLE
Add EPSS models to the v6 DB

### DIFF
--- a/grype/db/v6/db.go
+++ b/grype/db/v6/db.go
@@ -22,11 +22,12 @@ const (
 	Revision = 0
 
 	// Addition indicates how many changes have been introduced that are compatible with all historical data
-	Addition = 1
+	Addition = 2
 
 	// v6 model changelog:
 	// 6.0.0: Initial version 🎉
-	// 6.0.1: Add CISA KEV store
+	// 6.0.1: Add CISA KEV to VulnerabilityDecorator store
+	// 6.0.2: Add EPSS to VulnerabilityDecorator store
 )
 
 const (

--- a/grype/db/v6/db_metadata_store.go
+++ b/grype/db/v6/db_metadata_store.go
@@ -39,7 +39,7 @@ func (s *dbMetadataStore) GetDBMetadata() (*DBMetadata, error) {
 func (s *dbMetadataStore) SetDBMetadata() error {
 	log.Trace("writing DB metadata")
 
-	if err := s.db.Unscoped().Where("true").Delete(&DBMetadata{}).Error; err != nil {
+	if err := s.db.Where("true").Delete(&DBMetadata{}).Error; err != nil {
 		return fmt.Errorf("failed to delete existing DB metadata record: %w", err)
 	}
 

--- a/grype/db/v6/db_metadata_store_test.go
+++ b/grype/db/v6/db_metadata_store_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestDbMetadataStore_empty(t *testing.T) {
 	db := setupTestStore(t).db
-	require.NoError(t, db.Unscoped().Where("1 = 1").Delete(&DBMetadata{}).Error) // delete all existing records
+	require.NoError(t, db.Where("true").Delete(&DBMetadata{}).Error) // delete all existing records
 	s := newDBMetadataStore(db)
 
 	// attempt to fetch a non-existent record

--- a/grype/db/v6/installation/curator_test.go
+++ b/grype/db/v6/installation/curator_test.go
@@ -114,7 +114,7 @@ func writeTestDescriptionToDB(t *testing.T, dir string, desc db.Description) str
 	d, err := db.NewLowLevelDB(c.DBFilePath(), false, true, true)
 	require.NoError(t, err)
 
-	if err := d.Unscoped().Where("true").Delete(&db.DBMetadata{}).Error; err != nil {
+	if err := d.Where("true").Delete(&db.DBMetadata{}).Error; err != nil {
 		t.Fatalf("failed to delete existing DB metadata record: %v", err)
 	}
 

--- a/grype/db/v6/models.go
+++ b/grype/db/v6/models.go
@@ -42,6 +42,8 @@ func Models() []any {
 
 		// decorations to vulnerability records
 		&KnownExploitedVulnerabilityHandle{},
+		&EpssHandle{},
+		&EpssMetadata{},
 	}
 }
 
@@ -772,4 +774,17 @@ func (v *KnownExploitedVulnerabilityHandle) setBlob(rawBlobValue []byte) error {
 
 	v.BlobValue = &blobValue
 	return nil
+}
+
+type EpssMetadata struct {
+	Date time.Time `gorm:"column:date;not null"`
+}
+
+type EpssHandle struct {
+	ID int64 `gorm:"primaryKey"`
+
+	Cve        string    `gorm:"column:cve;not null;index,collate:NOCASE"`
+	Epss       float64   `gorm:"column:epss;not null"`
+	Percentile float64   `gorm:"column:percentile;not null"`
+	Date       time.Time `gorm:"-"` // note we do not store the date in this table since it is expected to be the same for all records, that is what EpssMetadata is for
 }

--- a/grype/db/v6/vulnerability_decorator_store.go
+++ b/grype/db/v6/vulnerability_decorator_store.go
@@ -42,7 +42,7 @@ func newVulnerabilityDecoratorStore(db *gorm.DB, bs *blobStore, dbVersion schema
 
 func (s *vulnerabilityDecoratorStore) AddEpss(epss ...*EpssHandle) error {
 	if !s.epssEnabled {
-		// when populating a new DB we should never run into capability issues
+		// when populating a new DB any capability issues found should result in halting
 		return ErrDBCapabilityNotSupported
 	}
 
@@ -62,7 +62,7 @@ func (s *vulnerabilityDecoratorStore) AddEpss(epss ...*EpssHandle) error {
 
 func (s *vulnerabilityDecoratorStore) setEPSSMetadata(date time.Time) error {
 	if !s.epssEnabled {
-		// when populating a new DB we should never run into capability issues
+		// when populating a new DB any capability issues found should result in halting
 		return ErrDBCapabilityNotSupported
 	}
 
@@ -70,12 +70,12 @@ func (s *vulnerabilityDecoratorStore) setEPSSMetadata(date time.Time) error {
 		if s.epssDate.Equal(date) {
 			return nil
 		}
-		log.WithFields("current", s.epssDate.String(), "new", date.String()).Warn("observed multiple EPSS dates")
+		return fmt.Errorf("observed multiple EPSS dates: current=%q new=%q", s.epssDate.String(), date.String())
 	}
 
 	log.Trace("writing EPSS metadata")
 
-	if err := s.db.Unscoped().Where("true").Delete(&EpssMetadata{}).Error; err != nil {
+	if err := s.db.Where("true").Delete(&EpssMetadata{}).Error; err != nil {
 		return fmt.Errorf("failed to delete existing EPSS metadata record: %w", err)
 	}
 
@@ -147,7 +147,7 @@ func (s *vulnerabilityDecoratorStore) GetEpss(cve string) ([]EpssHandle, error) 
 
 func (s *vulnerabilityDecoratorStore) AddKnownExploitedVulnerabilities(kevs ...*KnownExploitedVulnerabilityHandle) error {
 	if !s.kevEnabled {
-		// when populating a new DB we should never run into capability issues
+		// when populating a new DB any capability issues found should result in halting
 		return ErrDBCapabilityNotSupported
 	}
 

--- a/grype/db/v6/vulnerability_decorator_store.go
+++ b/grype/db/v6/vulnerability_decorator_store.go
@@ -12,26 +12,137 @@ import (
 )
 
 type VulnerabilityDecoratorStoreWriter interface {
-	AddKnownExploitedVulnerabilities(kevs ...*KnownExploitedVulnerabilityHandle) error
+	AddKnownExploitedVulnerabilities(...*KnownExploitedVulnerabilityHandle) error
+	AddEpss(...*EpssHandle) error
 }
 
 type VulnerabilityDecoratorStoreReader interface {
 	GetKnownExploitedVulnerabilities(cve string) ([]KnownExploitedVulnerabilityHandle, error)
+	GetEpss(cve string) ([]EpssHandle, error)
 }
 
 type vulnerabilityDecoratorStore struct {
-	db         *gorm.DB
-	blobStore  *blobStore
-	kevEnabled bool
+	db          *gorm.DB
+	blobStore   *blobStore
+	kevEnabled  bool
+	epssEnabled bool
+	epssDate    *time.Time
 }
 
 func newVulnerabilityDecoratorStore(db *gorm.DB, bs *blobStore, dbVersion schemaver.SchemaVer) *vulnerabilityDecoratorStore {
 	minSupportedKEVClientVersion := schemaver.New(6, 0, 1)
+	minSupportedEPSSClientVersion := schemaver.New(6, 0, 2)
 	return &vulnerabilityDecoratorStore{
-		db:         db,
-		blobStore:  bs,
-		kevEnabled: dbVersion.GreaterOrEqualTo(minSupportedKEVClientVersion),
+		db:          db,
+		blobStore:   bs,
+		kevEnabled:  dbVersion.GreaterOrEqualTo(minSupportedKEVClientVersion),
+		epssEnabled: dbVersion.GreaterOrEqualTo(minSupportedEPSSClientVersion),
 	}
+}
+
+func (s *vulnerabilityDecoratorStore) AddEpss(epss ...*EpssHandle) error {
+	if !s.epssEnabled {
+		// when populating a new DB we should never run into capability issues
+		return ErrDBCapabilityNotSupported
+	}
+
+	for i := range epss {
+		e := epss[i]
+
+		if err := s.db.Create(e).Error; err != nil {
+			return fmt.Errorf("unable to create EPSS: %w", err)
+		}
+
+		if err := s.setEPSSMetadata(e.Date); err != nil {
+			return fmt.Errorf("unable to set EPSS metadata: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *vulnerabilityDecoratorStore) setEPSSMetadata(date time.Time) error {
+	if !s.epssEnabled {
+		// when populating a new DB we should never run into capability issues
+		return ErrDBCapabilityNotSupported
+	}
+
+	if s.epssDate != nil {
+		if s.epssDate.Equal(date) {
+			return nil
+		}
+		log.WithFields("current", s.epssDate.String(), "new", date.String()).Warn("observed multiple EPSS dates")
+	}
+
+	log.Trace("writing EPSS metadata")
+
+	if err := s.db.Unscoped().Where("true").Delete(&EpssMetadata{}).Error; err != nil {
+		return fmt.Errorf("failed to delete existing EPSS metadata record: %w", err)
+	}
+
+	instance := &EpssMetadata{
+		Date: date,
+	}
+
+	if err := s.db.Create(instance).Error; err != nil {
+		return fmt.Errorf("failed to create EPSS metadata record: %w", err)
+	}
+
+	s.epssDate = &date
+	return nil
+}
+
+func (s *vulnerabilityDecoratorStore) getEPSSMetadata() (*EpssMetadata, error) {
+	log.Trace("fetching EPSS metadata")
+
+	var model EpssMetadata
+
+	result := s.db.First(&model)
+	return &model, result.Error
+}
+
+func (s *vulnerabilityDecoratorStore) GetEpss(cve string) ([]EpssHandle, error) {
+	if !s.epssEnabled {
+		// capability incompatibilities should gracefully degrade, returning no data or errors
+		return nil, nil
+	}
+
+	fields := logger.Fields{
+		"cve": cve,
+	}
+	start := time.Now()
+	var count int
+	defer func() {
+		fields["duration"] = time.Since(start)
+		fields["records"] = count
+		log.WithFields(fields).Trace("fetched EPSS records")
+	}()
+
+	var models []EpssHandle
+	var results []*EpssHandle
+
+	if s.epssDate == nil {
+		// fetch and cache the EPSS metadata
+		metadata, err := s.getEPSSMetadata()
+		if err != nil {
+			return nil, fmt.Errorf("unable to fetch EPSS metadata: %w", err)
+		}
+		s.epssDate = &metadata.Date
+	}
+
+	if err := s.db.Where("cve = ?", cve).FindInBatches(&results, batchSize, func(_ *gorm.DB, _ int) error {
+		for _, r := range results {
+			r.Date = *s.epssDate
+			models = append(models, *r)
+		}
+
+		count += len(results)
+
+		return nil
+	}).Error; err != nil {
+		return models, fmt.Errorf("unable to fetch EPSS records: %w", err)
+	}
+
+	return models, nil
 }
 
 func (s *vulnerabilityDecoratorStore) AddKnownExploitedVulnerabilities(kevs ...*KnownExploitedVulnerabilityHandle) error {

--- a/grype/db/v6/vulnerability_provider.go
+++ b/grype/db/v6/vulnerability_provider.go
@@ -66,9 +66,16 @@ func (s vulnerabilityProvider) VulnerabilityMetadata(ref vulnerability.Reference
 		}, nil
 	}
 
-	kevs, err := s.fetchKnownExploited(getCVEs(vuln))
+	cves := getCVEs(vuln)
+
+	kevs, err := s.fetchKnownExploited(cves)
 	if err != nil {
-		log.WithFields("id", ref.ID, "vulnerability", vuln.String(), "error", err).Debug("unable to extract known exploited from vulnerability")
+		log.WithFields("id", ref.ID, "vulnerability", vuln.String(), "error", err).Debug("unable to fetch known exploited from vulnerability")
+	}
+
+	epss, err := s.fetchEpss(cves)
+	if err != nil {
+		log.WithFields("id", ref.ID, "vulnerability", vuln.String(), "error", err).Debug("unable to fetch epss from vulnerability")
 	}
 
 	return &vulnerability.Metadata{
@@ -80,6 +87,7 @@ func (s vulnerabilityProvider) VulnerabilityMetadata(ref vulnerability.Reference
 		Description:    vuln.BlobValue.Description,
 		Cvss:           cvss,
 		KnownExploited: kevs,
+		EPSS:           epss,
 	}, nil
 }
 
@@ -116,6 +124,27 @@ func (s vulnerabilityProvider) fetchKnownExploited(cves []string) ([]vulnerabili
 				Notes:                      kev.BlobValue.Notes,
 				URLs:                       kev.BlobValue.URLs,
 				CWEs:                       kev.BlobValue.CWEs,
+			})
+		}
+	}
+	return out, errs
+}
+
+func (s vulnerabilityProvider) fetchEpss(cves []string) ([]vulnerability.EPSS, error) {
+	var out []vulnerability.EPSS
+	var errs error
+	for _, cve := range cves {
+		entries, err := s.reader.GetEpss(cve)
+		if err != nil {
+			errs = multierror.Append(errs, err)
+			continue
+		}
+		for _, entry := range entries {
+			out = append(out, vulnerability.EPSS{
+				CVE:        entry.Cve,
+				EPSS:       entry.Epss,
+				Percentile: entry.Percentile,
+				Date:       entry.Date,
 			})
 		}
 	}

--- a/grype/presenter/models/vulnerability_metadata.go
+++ b/grype/presenter/models/vulnerability_metadata.go
@@ -15,6 +15,7 @@ type VulnerabilityMetadata struct {
 	Description    string           `json:"description,omitempty"`
 	Cvss           []Cvss           `json:"cvss"`
 	KnownExploited []KnownExploited `json:"knownExploited,omitempty"`
+	EPSS           []EPSS           `json:"epss,omitempty"`
 }
 
 type KnownExploited struct {
@@ -28,6 +29,13 @@ type KnownExploited struct {
 	Notes                      string   `json:"notes,omitempty"`
 	URLs                       []string `json:"urls,omitempty"`
 	CWEs                       []string `json:"cwes,omitempty"`
+}
+
+type EPSS struct {
+	CVE        string  `json:"cve"`
+	EPSS       float64 `json:"epss"`
+	Percentile float64 `json:"percentile"`
+	Date       string  `json:"date"`
 }
 
 func NewVulnerabilityMetadata(id, namespace string, metadata *vulnerability.Metadata) VulnerabilityMetadata {
@@ -52,6 +60,7 @@ func NewVulnerabilityMetadata(id, namespace string, metadata *vulnerability.Meta
 		Description:    metadata.Description,
 		Cvss:           NewCVSS(metadata),
 		KnownExploited: toKnownExploited(metadata.KnownExploited),
+		EPSS:           toEPSS(metadata.EPSS),
 	}
 }
 
@@ -69,6 +78,19 @@ func toKnownExploited(knownExploited []vulnerability.KnownExploited) []KnownExpl
 			Notes:                      ke.Notes,
 			URLs:                       ke.URLs,
 			CWEs:                       ke.CWEs,
+		}
+	}
+	return result
+}
+
+func toEPSS(epss []vulnerability.EPSS) []EPSS {
+	result := make([]EPSS, len(epss))
+	for idx, e := range epss {
+		result[idx] = EPSS{
+			CVE:        e.CVE,
+			EPSS:       e.EPSS,
+			Percentile: e.Percentile,
+			Date:       e.Date.Format(time.DateOnly),
 		}
 	}
 	return result

--- a/grype/vulnerability/metadata.go
+++ b/grype/vulnerability/metadata.go
@@ -11,6 +11,7 @@ type Metadata struct {
 	Description    string
 	Cvss           []Cvss
 	KnownExploited []KnownExploited
+	EPSS           []EPSS
 }
 
 type Cvss struct {
@@ -47,4 +48,11 @@ type KnownExploited struct {
 	Notes                      string
 	URLs                       []string
 	CWEs                       []string
+}
+
+type EPSS struct {
+	CVE        string
+	EPSS       float64
+	Percentile float64
+	Date       time.Time
 }


### PR DESCRIPTION
Adds EPSS scores to the JSON output on each vulnerability record. Note: this does not affect the sorting of the table yet, which will be done when KEV and EPSS are incorporated.

Partially addresses https://github.com/anchore/grype/issues/1973