### PR TITLE
version: add golang 1.24 version fixup

### DIFF
--- a/grype/version/golang_version.go
+++ b/grype/version/golang_version.go
@@ -48,9 +48,21 @@ func newGolangVersion(v string) (*golangVersion, error) {
 	if v == "(devel)" {
 		return nil, ErrUnsupportedVersion
 	}
+
+	// Invalid Semver fix ups
+
 	// go stdlib is reported by syft as a go package with version like "go1.24.1"
 	// other versions have "v" as a prefix, which the semver lib handles automatically
-	semver, err := hashiVer.NewSemver(strings.TrimPrefix(v, "go"))
+	fixedUp := strings.TrimPrefix(v, "go")
+
+	// go1.24 creates non-dot separated build metadata fields, e.g. +incompatible+dirty
+	// Fix up as per semver spec
+	before, after, found := strings.Cut(fixedUp, "+")
+	if found {
+		fixedUp = before + "+" + strings.ReplaceAll(after, "+", ".")
+	}
+
+	semver, err := hashiVer.NewSemver(fixedUp)
 	if err != nil {
 		return nil, err
 	}

--- a/grype/version/golang_version_test.go
+++ b/grype/version/golang_version_test.go
@@ -41,6 +41,14 @@ func TestNewGolangVersion(t *testing.T) {
 			},
 		},
 		{
+			name:  "semver with +incompatible+dirty",
+			input: "v24.0.7+incompatible+dirty",
+			expected: golangVersion{
+				raw:    "v24.0.7+incompatible+dirty",
+				semVer: hashiVer.Must(hashiVer.NewSemver("v24.0.7+incompatible.dirty")),
+			},
+		},
+		{
 			name:  "standard library",
 			input: "go1.21.4",
 			expected: golangVersion{
@@ -71,6 +79,7 @@ func TestNewGolangVersion(t *testing.T) {
 				require.Error(t, err)
 				return
 			}
+			assert.Nil(t, err)
 			assert.Equal(t, tc.expected, *v)
 		})
 	}


### PR DESCRIPTION
go1.24.0 stamps versions with `+incompatible+dirty` which is an
invalid SemVer version. Add a fixup to correct this to SemVer
compliant buildinfo version of `+incompatible.dirty` with a test case.

Related:
- https://github.com/golang/go/issues/71971
- https://github.com/anchore/grype/issues/2482

```
$ ./mygrype ../docker/mydocker | grep docker/docker
 ✔ Indexed file system                                                                                                                 ../docker/mydocker 
 ✔ Cataloged contents                                                                    7c98bb9a0a89d26031d23927b57f88cbbf2f326491f10500c9481bc907c011d4 
   ├── ✔ Packages                        [174 packages]  
   ├── ✔ File digests                    [1 files]  
   ├── ✔ File metadata                   [1 locations]  
   └── ✔ Executables                     [1 executables]  
 ✔ Scanned for vulnerabilities     [21 vulnerability matches]  
   ├── by severity: 4 critical, 7 high, 9 medium, 1 low, 0 negligible
   └── by status:   21 fixed, 0 not-fixed, 0 ignored 
github.com/docker/docker                                                      v24.0.7+incompatible+dirty             25.0.6    go-module  GHSA-v23v-6jw2-98fq  Critical  
github.com/docker/docker                                                      v24.0.7+incompatible+dirty             24.0.9    go-module  GHSA-xw73-rw38-6vjc  Medium    
```

Seems to work. rebuilding grype with this change; and also rebuilding an old docker with local modifications, correctly finds CVEs. Bonus points that raw version is printed for humans yet handled correctly internally. Thus the internal mangling of "+incompatible.dirty" is not exposed to the users.