### PR TITLE
fix: allow querying for CPE with only vendor or product

### DIFF
--- a/grype/db/v6/vulnerability_provider.go
+++ b/grype/db/v6/vulnerability_provider.go
@@ -206,8 +206,8 @@ func (s vulnerabilityProvider) FindVulnerabilities(criteria ...vulnerability.Cri
 					cpeSpec = &cpe.Attributes{}
 				}
 				*cpeSpec = c.CPE.Attributes
-				if cpeSpec.Product == cpe.Any || cpeSpec.Vendor == cpe.Any {
-					return nil, fmt.Errorf("must specify vendor and product to search by CPE; got: %s", c.CPE.Attributes.BindToFmtString())
+				if cpeSpec.Product == cpe.Any {
+					return nil, fmt.Errorf("must specify product to search by CPE; got: %s", c.CPE.Attributes.BindToFmtString())
 				}
 				if pkgSpec == nil {
 					pkgSpec = &PackageSpecifier{}

--- a/grype/db/v6/vulnerability_provider_test.go
+++ b/grype/db/v6/vulnerability_provider_test.go
@@ -159,10 +159,14 @@ func Test_FindVulnerabilitiesByCPE(t *testing.T) {
 				},
 			},
 		},
-
 		{
-			name: "dont allow any name",
-			cpe:  cpe.Must("cpe:2.3:*:couldntgetthisrightcouldyou:*:*:*:*:*:*:*:*:*", ""),
+			name: "allow query with only product",
+			cpe:  cpe.Must("cpe:2.3:*:product:*:*:*:*:*:*:*:*:*", ""),
+			err:  false,
+		},
+		{
+			name: "do not allow query without product",
+			cpe:  cpe.Must("cpe:2.3:v:*:*:*:*:*:*:*:*:*:*", ""),
 			err:  true,
 		},
 	}

--- a/grype/db/v6/vulnerability_provider_test.go
+++ b/grype/db/v6/vulnerability_provider_test.go
@@ -161,13 +161,17 @@ func Test_FindVulnerabilitiesByCPE(t *testing.T) {
 		},
 		{
 			name: "allow query with only product",
-			cpe:  cpe.Must("cpe:2.3:*:product:*:*:*:*:*:*:*:*:*", ""),
-			err:  false,
+			cpe:  cpe.Must("cpe:2.3:a:*:product:*:*:*:*:*:*:*:*", ""),
 		},
 		{
 			name: "do not allow query without product",
-			cpe:  cpe.Must("cpe:2.3:v:*:*:*:*:*:*:*:*:*:*", ""),
-			err:  true,
+			cpe: cpe.CPE{
+				Attributes: cpe.Attributes{
+					Part:   "a",
+					Vendor: "v",
+				},
+			},
+			err: true,
 		},
 	}
 
@@ -179,7 +183,8 @@ func Test_FindVulnerabilitiesByCPE(t *testing.T) {
 			if err != nil && !test.err {
 				t.Fatalf("expected no err, got: %+v", err)
 			} else if err == nil && test.err {
-				t.Fatalf("expected an err, got none")
+				t.Fatalf("expected an err, gots" +
+					" none")
 			}
 
 			require.Len(t, actual, len(test.expected))


### PR DESCRIPTION
Relax query by CPE constraints to allow queries by product with no vendor specified