### PR TITLE
Cover mariner and ubuntu namespace conversion

### DIFF
--- a/grype/db/v6/vulnerability.go
+++ b/grype/db/v6/vulnerability.go
@@ -155,11 +155,24 @@ func MimicV5Namespace(vuln *VulnerabilityHandle, affected *AffectedPackageHandle
 		case "amazon":
 			family = "amazonlinux"
 		case "mariner":
-			switch ver {
-			case "1.0", "2.0":
+			major := strings.Split(ver, ".")[0]
+			switch major {
+			case "1", "2":
 				family = "mariner"
+				if strings.Count(ver, ".") < 1 {
+					ver = fmt.Sprintf("%s.0", major)
+				}
 			default:
 				family = "azurelinux"
+			}
+		case "ubuntu":
+			if strings.Count(ver, ".") == 1 {
+				// convert 20.4 to 20.04
+				fields := strings.Split(ver, ".")
+				major, minor := fields[0], fields[1]
+				if len(minor) == 1 {
+					ver = fmt.Sprintf("%s.0%s", major, minor)
+				}
 			}
 		case "oracle":
 			family = "oraclelinux"

--- a/grype/db/v6/vulnerability_test.go
+++ b/grype/db/v6/vulnerability_test.go
@@ -276,6 +276,13 @@ func TestV5Namespace(t *testing.T) {
 			expected:  "ubuntu:distro:ubuntu:22.04",
 		},
 		{
+			name:      "ubuntu distribution (trimmed 0s)",
+			provider:  "ubuntu",
+			osName:    "ubuntu",
+			osVersion: "22.4",
+			expected:  "ubuntu:distro:ubuntu:22.04",
+		},
+		{
 			name:      "redhat distribution",
 			provider:  "rhel",
 			osName:    "redhat",
@@ -330,6 +337,20 @@ func TestV5Namespace(t *testing.T) {
 			osName:    "mariner",
 			osVersion: "2.0",
 			expected:  "mariner:distro:mariner:2.0",
+		},
+		{
+			name:      "mariner regular version (not exact match)",
+			provider:  "mariner",
+			osName:    "mariner",
+			osVersion: "2.1",
+			expected:  "mariner:distro:mariner:2.1",
+		},
+		{
+			name:      "mariner regular version (auto fill minor version)",
+			provider:  "mariner",
+			osName:    "mariner",
+			osVersion: "1",
+			expected:  "mariner:distro:mariner:1.0",
 		},
 		{
 			name:      "mariner azure version",


### PR DESCRIPTION
Updates the namespace generation logic to consider:
- mariner/azurelinux ID overrides should be more resilient when matching on version 1 & 2
- ubuntu should left pad minor versions with `0` (e.g. `ubuntu:distro:ubuntu:19.04` not `ubuntu:distro:ubuntu:19.4`)