### PR TITLE
Ensure azure linux has 0 minor version

### DIFF
--- a/grype/db/v6/vulnerability.go
+++ b/grype/db/v6/vulnerability.go
@@ -156,12 +156,12 @@ func MimicV5Namespace(vuln *VulnerabilityHandle, affected *AffectedPackageHandle
 			family = "amazonlinux"
 		case "mariner":
 			major := strings.Split(ver, ".")[0]
+			if strings.Count(ver, ".") < 1 {
+				ver = fmt.Sprintf("%s.0", major)
+			}
 			switch major {
 			case "1", "2":
 				family = "mariner"
-				if strings.Count(ver, ".") < 1 {
-					ver = fmt.Sprintf("%s.0", major)
-				}
 			default:
 				family = "azurelinux"
 			}

--- a/grype/db/v6/vulnerability_test.go
+++ b/grype/db/v6/vulnerability_test.go
@@ -360,6 +360,13 @@ func TestV5Namespace(t *testing.T) {
 			expected:  "mariner:distro:azurelinux:3.0",
 		},
 		{
+			name:      "mariner azure version",
+			provider:  "mariner",
+			osName:    "mariner",
+			osVersion: "3",
+			expected:  "mariner:distro:azurelinux:3.0",
+		},
+		{
 			name:      "oracle linux distribution",
 			provider:  "oracle",
 			osName:    "oracle",


### PR DESCRIPTION
This is a follow up case to #2497 , namespaces that would resolve to `mariner:distro:azurelinux:3` must resolve to `mariner:distro:azurelinux:3.0` (to preserve legacy behavior)