### PR TITLE
Enumerate version ranges within a single match (don't duplicate)

### DIFF
--- a/grype/db/v6/vulnerability.go
+++ b/grype/db/v6/vulnerability.go
@@ -2,6 +2,7 @@ package v6
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/scylladb/go-set/strset"
@@ -18,7 +19,7 @@ import (
 
 const v5NvdNamespace = "nvd:cpe"
 
-func newVulnerabilityFromAffectedPackageHandle(affected AffectedPackageHandle, affectedRange AffectedRange) (*vulnerability.Vulnerability, error) {
+func newVulnerabilityFromAffectedPackageHandle(affected AffectedPackageHandle, affectedRanges []AffectedRange) (*vulnerability.Vulnerability, error) {
 	packageName := ""
 	if affected.Package != nil {
 		packageName = affected.Package.Name
@@ -28,25 +29,23 @@ func newVulnerabilityFromAffectedPackageHandle(affected AffectedPackageHandle, a
 		return nil, fmt.Errorf("nil data when attempting to create vulnerability from AffectedPackageHandle")
 	}
 
-	return newVulnerabilityFromParts(packageName, affected.Vulnerability, affected.BlobValue, affectedRange, &affected, nil)
+	return newVulnerabilityFromParts(packageName, affected.Vulnerability, affected.BlobValue, affectedRanges, &affected, nil)
 }
 
-func newVulnerabilityFromAffectedCPEHandle(affected AffectedCPEHandle, affectedRange AffectedRange) (*vulnerability.Vulnerability, error) {
+func newVulnerabilityFromAffectedCPEHandle(affected AffectedCPEHandle, affectedRanges []AffectedRange) (*vulnerability.Vulnerability, error) {
 	if affected.Vulnerability == nil || affected.Vulnerability.BlobValue == nil || affected.BlobValue == nil {
 		return nil, fmt.Errorf("nil data when attempting to create vulnerability from AffectedCPEHandle")
 	}
-	return newVulnerabilityFromParts(affected.CPE.Product, affected.Vulnerability, affected.BlobValue, affectedRange, nil, &affected)
+	return newVulnerabilityFromParts(affected.CPE.Product, affected.Vulnerability, affected.BlobValue, affectedRanges, nil, &affected)
 }
 
-func newVulnerabilityFromParts(packageName string, vuln *VulnerabilityHandle, affected *AffectedPackageBlob, affectedRange AffectedRange, affectedPackageHandle *AffectedPackageHandle, affectedCpeHandle *AffectedCPEHandle) (*vulnerability.Vulnerability, error) {
+func newVulnerabilityFromParts(packageName string, vuln *VulnerabilityHandle, affected *AffectedPackageBlob, affectedRanges []AffectedRange, affectedPackageHandle *AffectedPackageHandle, affectedCpeHandle *AffectedCPEHandle) (*vulnerability.Vulnerability, error) {
 	if vuln.BlobValue == nil {
 		return nil, fmt.Errorf("vuln has no blob value: %+v", vuln)
 	}
 
-	versionFormat := version.ParseFormat(affectedRange.Version.Type)
-	constraint, err := version.GetConstraint(affectedRange.Version.Constraint, versionFormat)
+	constraint, err := getVersionConstraint(affectedRanges)
 	if err != nil {
-		log.WithFields("error", err, "constraint", affectedRange.Version.Constraint).Debug("unable to parse constraint")
 		return nil, nil
 	}
 
@@ -62,10 +61,43 @@ func newVulnerabilityFromParts(packageName string, vuln *VulnerabilityHandle, af
 		Constraint:             constraint,
 		CPEs:                   toCPEs(affectedPackageHandle, affectedCpeHandle),
 		RelatedVulnerabilities: getRelatedVulnerabilities(vuln, affected),
-		Fix:                    toFix(affectedRange.Fix),
-		Advisories:             toAdvisories(affectedRange.Fix),
+		Fix:                    toFix(affectedRanges),
+		Advisories:             toAdvisories(affectedRanges),
 		Status:                 string(vuln.Status),
 	}, nil
+}
+
+func getVersionConstraint(affectedRanges []AffectedRange) (version.Constraint, error) {
+	var constraints []string
+	types := strset.New()
+	for _, r := range affectedRanges {
+		if r.Version.Constraint != "" {
+			if r.Version.Type != "" {
+				types.Add(r.Version.Type)
+			}
+
+			constraints = append(constraints, r.Version.Constraint)
+		}
+	}
+
+	if types.Size() > 1 {
+		log.WithFields("types", types.List()).Debug("multiple version formats found for a single vulnerability")
+	}
+
+	var ty string
+	if types.Size() >= 1 {
+		typeStrs := types.List()
+		sort.Strings(typeStrs)
+		ty = typeStrs[0]
+	}
+
+	versionFormat := version.ParseFormat(ty)
+	constraint, err := version.GetConstraint(strings.Join(constraints, ","), versionFormat)
+	if err != nil {
+		log.WithFields("error", err, "constraint", constraints).Debug("unable to parse constraint")
+		return nil, err
+	}
+	return constraint, nil
 }
 
 func getRelatedVulnerabilities(vuln *VulnerabilityHandle, affected *AffectedPackageBlob) []vulnerability.Reference {
@@ -214,30 +246,54 @@ func toPackageQualifiers(qualifiers *AffectedPackageQualifiers) []qualifier.Qual
 	return out
 }
 
-func toFix(fix *Fix) vulnerability.Fix {
-	if fix == nil || fix.Version == "" {
+func toFix(affectedRanges []AffectedRange) vulnerability.Fix {
+	var state vulnerability.FixState
+	var versions []string
+	for _, r := range affectedRanges {
+		if r.Fix == nil {
+			continue
+		}
+		switch r.Fix.State {
+		case FixedStatus:
+			state = vulnerability.FixStateFixed
+			versions = append(versions, r.Fix.Version)
+		case NotAffectedFixStatus:
+			// TODO: not handled yet
+		case WontFixStatus:
+			if state != vulnerability.FixStateFixed {
+				state = vulnerability.FixStateWontFix
+			}
+		case NotFixedStatus:
+			if state != vulnerability.FixStateFixed {
+				state = vulnerability.FixStateNotFixed
+			}
+		}
+	}
+	if len(versions) == 0 && state == "" {
 		return vulnerability.Fix{}
 	}
 	return vulnerability.Fix{
-		Versions: []string{fix.Version},
-		State:    vulnerability.FixState(fix.State),
+		Versions: versions,
+		State:    state,
 	}
 }
 
-func toAdvisories(fix *Fix) []vulnerability.Advisory {
-	if fix == nil || fix.Detail == nil {
-		return nil
-	}
-
+func toAdvisories(affectedRanges []AffectedRange) []vulnerability.Advisory {
 	var advisories []vulnerability.Advisory
-	for _, r := range fix.Detail.References {
-		if r.URL == "" {
+	for _, r := range affectedRanges {
+		if r.Fix == nil || r.Fix.Detail == nil {
 			continue
 		}
-		advisories = append(advisories, vulnerability.Advisory{
-			Link: r.URL,
-		})
+		for _, urlRef := range r.Fix.Detail.References {
+			if urlRef.URL == "" {
+				continue
+			}
+			advisories = append(advisories, vulnerability.Advisory{
+				Link: urlRef.URL,
+			})
+		}
 	}
+
 	return advisories
 }
 

--- a/grype/db/v6/vulnerability_provider.go
+++ b/grype/db/v6/vulnerability_provider.go
@@ -383,22 +383,21 @@ func (s vulnerabilityProvider) toVulnerabilities(packageHandles []AffectedPackag
 			continue
 		}
 		v, err := newVulnerabilityFromAffectedPackageHandle(packageHandle, packageHandle.BlobValue.Ranges)
-			if err != nil {
-				return nil, err
-			}
-			if v == nil {
-				continue
-			}
+		if err != nil {
+			return nil, err
+		}
+		if v == nil {
+			continue
+		}
 
-			meta, err := getMetadata(packageHandle.Vulnerability, v.Reference.Namespace)
-			if err != nil {
-				log.WithFields("error", err, "vulnerability", v.String()).Debug("unable to fetch metadata for vulnerability")
-			} else {
-				v.Metadata = meta
-			}
+		meta, err := getMetadata(packageHandle.Vulnerability, v.Reference.Namespace)
+		if err != nil {
+			log.WithFields("error", err, "vulnerability", v.String()).Debug("unable to fetch metadata for vulnerability")
+		} else {
+			v.Metadata = meta
+		}
 
-			out = append(out, *v)
-
+		out = append(out, *v)
 	}
 
 	for _, c := range cpeHandles {
@@ -407,22 +406,21 @@ func (s vulnerabilityProvider) toVulnerabilities(packageHandles []AffectedPackag
 			continue
 		}
 		v, err := newVulnerabilityFromAffectedCPEHandle(c, c.BlobValue.Ranges)
-			if err != nil {
-				return nil, err
-			}
-			if v == nil {
-				continue
-			}
+		if err != nil {
+			return nil, err
+		}
+		if v == nil {
+			continue
+		}
 
-			meta, err := getMetadata(c.Vulnerability, v.Reference.Namespace)
-			if err != nil {
-				log.WithFields("error", err, "vulnerability", v.String()).Debug("unable to fetch metadata for vulnerability")
-			} else {
-				v.Metadata = meta
-			}
+		meta, err := getMetadata(c.Vulnerability, v.Reference.Namespace)
+		if err != nil {
+			log.WithFields("error", err, "vulnerability", v.String()).Debug("unable to fetch metadata for vulnerability")
+		} else {
+			v.Metadata = meta
+		}
 
-			out = append(out, *v)
-
+		out = append(out, *v)
 	}
 
 	return out, nil

--- a/grype/db/v6/vulnerability_provider.go
+++ b/grype/db/v6/vulnerability_provider.go
@@ -382,8 +382,7 @@ func (s vulnerabilityProvider) toVulnerabilities(packageHandles []AffectedPackag
 			log.Debugf("unable to find blobValue for %+v", packageHandle)
 			continue
 		}
-		for _, rng := range packageHandle.BlobValue.Ranges {
-			v, err := newVulnerabilityFromAffectedPackageHandle(packageHandle, rng)
+		v, err := newVulnerabilityFromAffectedPackageHandle(packageHandle, packageHandle.BlobValue.Ranges)
 			if err != nil {
 				return nil, err
 			}
@@ -399,7 +398,7 @@ func (s vulnerabilityProvider) toVulnerabilities(packageHandles []AffectedPackag
 			}
 
 			out = append(out, *v)
-		}
+
 	}
 
 	for _, c := range cpeHandles {
@@ -407,8 +406,7 @@ func (s vulnerabilityProvider) toVulnerabilities(packageHandles []AffectedPackag
 			log.Debugf("unable to find blobValue for %+v", c)
 			continue
 		}
-		for _, rng := range c.BlobValue.Ranges {
-			v, err := newVulnerabilityFromAffectedCPEHandle(c, rng)
+		v, err := newVulnerabilityFromAffectedCPEHandle(c, c.BlobValue.Ranges)
 			if err != nil {
 				return nil, err
 			}
@@ -424,7 +422,7 @@ func (s vulnerabilityProvider) toVulnerabilities(packageHandles []AffectedPackag
 			}
 
 			out = append(out, *v)
-		}
+
 	}
 
 	return out, nil
@@ -453,23 +451,27 @@ func filterAffectedPackageVersions(constraintMatcher search.VersionConstraintMat
 	if constraintMatcher == nil {
 		return packages
 	}
+	var out []AffectedPackageHandle
 	for packageIdx := 0; packageIdx < len(packages); packageIdx++ {
 		handle := packages[packageIdx]
 		vuln := handle.vulnerability()
-		filterAffectedPackageRanges(constraintMatcher, handle.BlobValue)
-		if len(handle.BlobValue.Ranges) > 0 {
+		allDropped, unmatchedConstraints := filterAffectedPackageRanges(constraintMatcher, handle.BlobValue)
+		if !allDropped {
+			out = append(out, handle)
 			continue // keep this handle
 		}
 
-		logDroppedVulnerability(vuln, "package version not within vulnerability constraints", logger.Fields{
-			"affectedPackage": handle,
-		})
+		reason := fmt.Sprintf("not within vulnerability version constraints: %q", strings.Join(unmatchedConstraints, ", "))
+		f := make(logger.Fields)
+		if handle.Package != nil {
+			f["package"] = handle.Package.String()
+		} else {
+			f["affectedPackage"] = handle
+		}
 
-		// if we haven't matched a constraint, remove the package
-		packages = append(packages[0:packageIdx], packages[packageIdx+1:]...)
-		packageIdx--
+		logDroppedVulnerability(vuln, reason, f)
 	}
-	return packages
+	return out
 }
 
 func filterAffectedCPEVersions(constraintMatcher search.VersionConstraintMatcher, handles []AffectedCPEHandle, cpeSpec *cpe.Attributes) []AffectedCPEHandle {
@@ -481,28 +483,23 @@ func filterAffectedCPEVersions(constraintMatcher search.VersionConstraintMatcher
 	for i := range handles {
 		handle := handles[i]
 		vuln := handle.vulnerability()
-		droppedConstraints := filterAffectedPackageRanges(constraintMatcher, handle.BlobValue)
-		if len(handle.BlobValue.Ranges) > 0 {
+		allDropped, unmatchedConstraints := filterAffectedPackageRanges(constraintMatcher, handle.BlobValue)
+		if !allDropped {
 			out = append(out, handle)
 			continue // keep this handle
 		}
 
-		reason := fmt.Sprintf("not within vulnerability version constraints: %q", strings.Join(droppedConstraints, ", "))
-
+		reason := fmt.Sprintf("not within vulnerability version constraints: %q", strings.Join(unmatchedConstraints, ", "))
 		logDroppedVulnerability(vuln, reason, logger.Fields{
 			"cpe": cpeSpec.String(),
-			// the affected CPE handle seems like it would be good to show, however, we already have the CVE and the CPE
-			// so it's not adding any valuable info to the log and is taking up screen real estate
-			// "affectedCPE": handle,
 		})
 	}
 	return out
 }
 
 // filterAffectedPackageRanges returns true if all ranges removed
-func filterAffectedPackageRanges(matcher search.VersionConstraintMatcher, b *AffectedPackageBlob) []string {
-	var out []AffectedRange
-	var droppedConstraints []string
+func filterAffectedPackageRanges(matcher search.VersionConstraintMatcher, b *AffectedPackageBlob) (bool, []string) {
+	var unmatchedConstraints []string
 	for _, r := range b.Ranges {
 		v := r.Version
 		format := version.ParseFormat(v.Type)
@@ -516,13 +513,11 @@ func filterAffectedPackageRanges(matcher search.VersionConstraintMatcher, b *Aff
 			log.WithFields("error", err, "constraint", v.Constraint, "format", v.Type).Debug("match constraint error")
 		}
 		if matches {
-			out = append(out, r)
 			continue
 		}
-		droppedConstraints = append(droppedConstraints, v.Constraint)
+		unmatchedConstraints = append(unmatchedConstraints, v.Constraint)
 	}
-	b.Ranges = out
-	return droppedConstraints
+	return len(b.Ranges) == len(unmatchedConstraints), unmatchedConstraints
 }
 
 func toSeverityString(sev vulnerability.Severity) string {

--- a/grype/matcher/internal/cpe.go
+++ b/grype/matcher/internal/cpe.go
@@ -37,7 +37,7 @@ func alpineCPEComparableVersion(version string) string {
 var ErrEmptyCPEMatch = errors.New("attempted CPE match against package with no CPEs")
 
 // MatchPackageByCPEs retrieves all vulnerabilities that match any of the provided package's CPEs
-func MatchPackageByCPEs(store vulnerability.Provider, p pkg.Package, upstreamMatcher match.MatcherType) ([]match.Match, error) {
+func MatchPackageByCPEs(provider vulnerability.Provider, p pkg.Package, upstreamMatcher match.MatcherType) ([]match.Match, error) {
 	// we attempt to merge match details within the same matcher when searching by CPEs, in this way there are fewer duplicated match
 	// objects (and fewer duplicated match details).
 
@@ -80,7 +80,7 @@ func MatchPackageByCPEs(store vulnerability.Provider, p pkg.Package, upstreamMat
 		}
 
 		// find all vulnerability records in the DB for the given CPE (not including version comparisons)
-		vulns, err := store.FindVulnerabilities(
+		vulns, err := provider.FindVulnerabilities(
 			search.ByCPE(c),
 			onlyVulnerableTargets(p),
 			onlyQualifiedPackages(p),

--- a/grype/matcher/internal/distro.go
+++ b/grype/matcher/internal/distro.go
@@ -13,7 +13,7 @@ import (
 	"github.com/anchore/grype/internal/log"
 )
 
-func MatchPackageByDistro(store vulnerability.Provider, p pkg.Package, upstreamMatcher match.MatcherType) ([]match.Match, []match.IgnoredMatch, error) {
+func MatchPackageByDistro(provider vulnerability.Provider, p pkg.Package, upstreamMatcher match.MatcherType) ([]match.Match, []match.IgnoredMatch, error) {
 	if p.Distro == nil {
 		return nil, nil, nil
 	}
@@ -33,7 +33,7 @@ func MatchPackageByDistro(store vulnerability.Provider, p pkg.Package, upstreamM
 	}
 
 	var matches []match.Match
-	vulns, err := store.FindVulnerabilities(
+	vulns, err := provider.FindVulnerabilities(
 		search.ByPackageName(p.Name),
 		search.ByDistro(*p.Distro),
 		onlyQualifiedPackages(p),

--- a/grype/matcher/internal/language.go
+++ b/grype/matcher/internal/language.go
@@ -28,7 +28,7 @@ func MatchPackageByLanguage(store vulnerability.Provider, p pkg.Package, matcher
 	return matches, ignored, nil
 }
 
-func MatchPackageByEcosystemPackageName(store vulnerability.Provider, p pkg.Package, packageName string, matcherType match.MatcherType) ([]match.Match, []match.IgnoredMatch, error) {
+func MatchPackageByEcosystemPackageName(provider vulnerability.Provider, p pkg.Package, packageName string, matcherType match.MatcherType) ([]match.Match, []match.IgnoredMatch, error) {
 	if isUnknownVersion(p.Version) {
 		log.WithFields("package", p.Name).Trace("skipping package with unknown version")
 		return nil, nil, nil
@@ -44,7 +44,7 @@ func MatchPackageByEcosystemPackageName(store vulnerability.Provider, p pkg.Pack
 	}
 
 	var matches []match.Match
-	vulns, err := store.FindVulnerabilities(
+	vulns, err := provider.FindVulnerabilities(
 		search.ByEcosystem(p.Language, p.Type),
 		search.ByPackageName(packageName),
 		onlyQualifiedPackages(p),

--- a/test/integration/match_by_image_test.go
+++ b/test/integration/match_by_image_test.go
@@ -35,14 +35,14 @@ import (
 	"github.com/anchore/syft/syft/source"
 )
 
-func addAlpineMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider, theResult *match.Matches) {
+func addAlpineMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider, theResult *match.Matches) {
 	packages := catalog.PackagesByPath("/lib/apk/db/installed")
 	if len(packages) != 3 {
 		t.Logf("Alpine Packages: %+v", packages)
 		t.Fatalf("problem with upstream syft cataloger (alpine)")
 	}
 	thePkg := pkg.New(packages[0])
-	vulns, err := theStore.FindVulnerabilities(byNamespace("alpine:distro:alpine:3.12"), search.ByPackageName(thePkg.Name))
+	vulns, err := provider.FindVulnerabilities(byNamespace("alpine:distro:alpine:3.12"), search.ByPackageName(thePkg.Name))
 	require.NoError(t, err)
 	require.NotEmpty(t, vulns)
 	vulnObj := vulns[0]
@@ -98,14 +98,14 @@ func addAlpineMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Co
 	})
 }
 
-func addJavascriptMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider, theResult *match.Matches) {
+func addJavascriptMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider, theResult *match.Matches) {
 	packages := catalog.PackagesByPath("/javascript/pkg-json/package.json")
 	if len(packages) != 1 {
 		t.Logf("Javascript Packages: %+v", packages)
 		t.Fatalf("problem with upstream syft cataloger (javascript)")
 	}
 	thePkg := pkg.New(packages[0])
-	vulns, err := theStore.FindVulnerabilities(byNamespace("github:language:javascript"), search.ByPackageName(thePkg.Name))
+	vulns, err := provider.FindVulnerabilities(byNamespace("github:language:javascript"), search.ByPackageName(thePkg.Name))
 	require.NoError(t, err)
 	require.NotEmpty(t, vulns)
 	vulnObj := vulns[0]
@@ -135,7 +135,7 @@ func addJavascriptMatches(t *testing.T, theSource source.Source, catalog *syftPk
 	})
 }
 
-func addPythonMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider, theResult *match.Matches) {
+func addPythonMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider, theResult *match.Matches) {
 	packages := catalog.PackagesByPath("/python/dist-info/METADATA")
 	if len(packages) != 1 {
 		for _, p := range packages {
@@ -145,7 +145,7 @@ func addPythonMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Co
 		t.Fatalf("problem with upstream syft cataloger (python)")
 	}
 	thePkg := pkg.New(packages[0])
-	vulns, err := theStore.FindVulnerabilities(byNamespace("github:language:python"), search.ByPackageName(strings.ToLower(thePkg.Name)))
+	vulns, err := provider.FindVulnerabilities(byNamespace("github:language:python"), search.ByPackageName(strings.ToLower(thePkg.Name)))
 	require.NoError(t, err)
 	require.NotEmpty(t, vulns)
 	vulnObj := vulns[0]
@@ -175,7 +175,7 @@ func addPythonMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Co
 	})
 }
 
-func addDotnetMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider, theResult *match.Matches) {
+func addDotnetMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider, theResult *match.Matches) {
 	packages := catalog.PackagesByPath("/dotnet/TestLibrary.deps.json")
 	if len(packages) != 2 { // TestLibrary + AWSSDK.Core
 		for _, p := range packages {
@@ -185,7 +185,7 @@ func addDotnetMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Co
 		t.Fatalf("problem with upstream syft cataloger (dotnet)")
 	}
 	thePkg := pkg.New(packages[1])
-	vulns, err := theStore.FindVulnerabilities(byNamespace("github:language:dotnet"), search.ByPackageName(strings.ToLower(thePkg.Name)))
+	vulns, err := provider.FindVulnerabilities(byNamespace("github:language:dotnet"), search.ByPackageName(strings.ToLower(thePkg.Name)))
 	require.NoError(t, err)
 	require.NotEmpty(t, vulns)
 	vulnObj := vulns[0]
@@ -215,14 +215,14 @@ func addDotnetMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Co
 	})
 }
 
-func addRubyMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider, theResult *match.Matches) {
+func addRubyMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider, theResult *match.Matches) {
 	packages := catalog.PackagesByPath("/ruby/specifications/bundler.gemspec")
 	if len(packages) != 1 {
 		t.Logf("Ruby Packages: %+v", packages)
 		t.Fatalf("problem with upstream syft cataloger (ruby)")
 	}
 	thePkg := pkg.New(packages[0])
-	vulns, err := theStore.FindVulnerabilities(byNamespace("github:language:ruby"), search.ByPackageName(thePkg.Name))
+	vulns, err := provider.FindVulnerabilities(byNamespace("github:language:ruby"), search.ByPackageName(thePkg.Name))
 	require.NoError(t, err)
 	require.NotEmpty(t, vulns)
 	vulnObj := vulns[0]
@@ -252,7 +252,7 @@ func addRubyMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 	})
 }
 
-func addGolangMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider, theResult *match.Matches) {
+func addGolangMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider, theResult *match.Matches) {
 	modPackages := catalog.PackagesByPath("/golang/go.mod")
 	if len(modPackages) != 1 {
 		t.Logf("Golang Mod Packages: %+v", modPackages)
@@ -281,7 +281,7 @@ func addGolangMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Co
 		}
 
 		thePkg := pkg.New(p)
-		vulns, err := theStore.FindVulnerabilities(byNamespace("github:language:go"), search.ByPackageName(thePkg.Name))
+		vulns, err := provider.FindVulnerabilities(byNamespace("github:language:go"), search.ByPackageName(thePkg.Name))
 		require.NoError(t, err)
 		require.NotEmpty(t, vulns)
 		vulnObj := vulns[0]
@@ -313,7 +313,7 @@ func addGolangMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Co
 	}
 }
 
-func addJavaMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider, theResult *match.Matches) {
+func addJavaMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider, theResult *match.Matches) {
 	packages := make([]syftPkg.Package, 0)
 	for p := range catalog.Enumerate(syftPkg.JavaPkg) {
 		packages = append(packages, p)
@@ -328,7 +328,7 @@ func addJavaMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 	lookup := groupId + ":" + theSyftPkg.Name
 
 	thePkg := pkg.New(theSyftPkg)
-	vulns, err := theStore.FindVulnerabilities(byNamespace("github:language:java"), search.ByPackageName(lookup))
+	vulns, err := provider.FindVulnerabilities(byNamespace("github:language:java"), search.ByPackageName(lookup))
 	require.NoError(t, err)
 	require.NotEmpty(t, vulns)
 	vulnObj := vulns[0]
@@ -358,7 +358,7 @@ func addJavaMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 	})
 }
 
-func addDpkgMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider, theResult *match.Matches) {
+func addDpkgMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider, theResult *match.Matches) {
 	packages := catalog.PackagesByPath("/var/lib/dpkg/status")
 	if len(packages) != 1 {
 		t.Logf("Dpkg Packages: %+v", packages)
@@ -366,7 +366,7 @@ func addDpkgMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 	}
 	thePkg := pkg.New(packages[0])
 	// NOTE: this is an indirect match, in typical debian style
-	vulns, err := theStore.FindVulnerabilities(byNamespace("debian:distro:debian:8"), search.ByPackageName(thePkg.Name+"-dev"))
+	vulns, err := provider.FindVulnerabilities(byNamespace("debian:distro:debian:8"), search.ByPackageName(thePkg.Name+"-dev"))
 	require.NoError(t, err)
 	require.NotEmpty(t, vulns)
 	vulnObj := vulns[0]
@@ -399,14 +399,14 @@ func addDpkgMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 	})
 }
 
-func addPortageMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider, theResult *match.Matches) {
+func addPortageMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider, theResult *match.Matches) {
 	packages := catalog.PackagesByPath("/var/db/pkg/app-containers/skopeo-1.5.1/CONTENTS")
 	if len(packages) != 1 {
 		t.Logf("Portage Packages: %+v", packages)
 		t.Fatalf("problem with upstream syft cataloger (portage)")
 	}
 	thePkg := pkg.New(packages[0])
-	vulns, err := theStore.FindVulnerabilities(byNamespace("gentoo:distro:gentoo:2.8"), search.ByPackageName(thePkg.Name))
+	vulns, err := provider.FindVulnerabilities(byNamespace("gentoo:distro:gentoo:2.8"), search.ByPackageName(thePkg.Name))
 	require.NoError(t, err)
 	require.NotEmpty(t, vulns)
 	vulnObj := vulns[0]
@@ -439,14 +439,14 @@ func addPortageMatches(t *testing.T, theSource source.Source, catalog *syftPkg.C
 	})
 }
 
-func addRhelMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider, theResult *match.Matches) {
+func addRhelMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider, theResult *match.Matches) {
 	packages := catalog.PackagesByPath("/var/lib/rpm/Packages")
 	if len(packages) != 1 {
 		t.Logf("RPMDB Packages: %+v", packages)
 		t.Fatalf("problem with upstream syft cataloger (RPMDB)")
 	}
 	thePkg := pkg.New(packages[0])
-	vulns, err := theStore.FindVulnerabilities(byNamespace("redhat:distro:redhat:8"), search.ByPackageName(thePkg.Name))
+	vulns, err := provider.FindVulnerabilities(byNamespace("redhat:distro:redhat:8"), search.ByPackageName(thePkg.Name))
 	require.NoError(t, err)
 	require.NotEmpty(t, vulns)
 	vulnObj := vulns[0]
@@ -479,7 +479,7 @@ func addRhelMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 	})
 }
 
-func addSlesMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider, theResult *match.Matches) {
+func addSlesMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider, theResult *match.Matches) {
 	packages := catalog.PackagesByPath("/var/lib/rpm/Packages")
 	if len(packages) != 1 {
 		t.Logf("Sles Packages: %+v", packages)
@@ -487,7 +487,7 @@ func addSlesMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 	}
 	thePkg := pkg.New(packages[0])
 
-	vulns, err := theStore.FindVulnerabilities(byNamespace("redhat:distro:redhat:8"), search.ByPackageName(thePkg.Name))
+	vulns, err := provider.FindVulnerabilities(byNamespace("redhat:distro:redhat:8"), search.ByPackageName(thePkg.Name))
 	require.NoError(t, err)
 	require.NotEmpty(t, vulns)
 	vulnObj := vulns[0]
@@ -521,14 +521,14 @@ func addSlesMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 	})
 }
 
-func addHaskellMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider, theResult *match.Matches) {
+func addHaskellMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider, theResult *match.Matches) {
 	packages := catalog.PackagesByPath("/haskell/stack.yaml")
 	if len(packages) < 1 {
 		t.Logf("Haskell Packages: %+v", packages)
 		t.Fatalf("problem with upstream syft cataloger (haskell)")
 	}
 	thePkg := pkg.New(packages[0])
-	vulns, err := theStore.FindVulnerabilities(byNamespace("github:language:haskell"), search.ByPackageName(strings.ToLower(thePkg.Name)))
+	vulns, err := provider.FindVulnerabilities(byNamespace("github:language:haskell"), search.ByPackageName(strings.ToLower(thePkg.Name)))
 	require.NoError(t, err)
 	require.NotEmpty(t, vulns)
 	vulnObj := vulns[0]
@@ -558,7 +558,7 @@ func addHaskellMatches(t *testing.T, theSource source.Source, catalog *syftPkg.C
 	})
 }
 
-func addJvmMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider, theResult *match.Matches) {
+func addJvmMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider, theResult *match.Matches) {
 	packages := catalog.PackagesByPath("/opt/java/openjdk/release")
 	if len(packages) < 1 {
 		t.Logf("JVM Packages: %+v", packages)
@@ -567,7 +567,7 @@ func addJvmMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Colle
 
 	for _, p := range packages {
 		thePkg := pkg.New(p)
-		vulns, err := theStore.FindVulnerabilities(byNamespace("nvd:cpe"), search.ByPackageName(thePkg.Name))
+		vulns, err := provider.FindVulnerabilities(byNamespace("nvd:cpe"), search.ByPackageName(thePkg.Name))
 		require.NoError(t, err)
 		require.NotEmpty(t, vulns)
 		vulnObj := vulns[0]
@@ -605,7 +605,7 @@ func addJvmMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Colle
 	}
 }
 
-func addRustMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider, theResult *match.Matches) {
+func addRustMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider, theResult *match.Matches) {
 	packages := catalog.PackagesByPath("/hello-auditable")
 	if len(packages) < 1 {
 		t.Logf("Rust Packages: %+v", packages)
@@ -614,7 +614,7 @@ func addRustMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 
 	for _, p := range packages {
 		thePkg := pkg.New(p)
-		vulns, err := theStore.FindVulnerabilities(byNamespace("github:language:rust"), search.ByPackageName(thePkg.Name))
+		vulns, err := provider.FindVulnerabilities(byNamespace("github:language:rust"), search.ByPackageName(thePkg.Name))
 		require.NoError(t, err)
 		require.NotEmpty(t, vulns)
 		vulnObj := vulns[0]
@@ -658,65 +658,65 @@ func TestMatchByImage(t *testing.T) {
 	}{
 		{
 			name: "image-debian-match-coverage",
-			expectedFn: func(theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider) match.Matches {
+			expectedFn: func(theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider) match.Matches {
 				expectedMatches := match.NewMatches()
-				addPythonMatches(t, theSource, catalog, theStore, &expectedMatches)
-				addRubyMatches(t, theSource, catalog, theStore, &expectedMatches)
-				addJavaMatches(t, theSource, catalog, theStore, &expectedMatches)
-				addDpkgMatches(t, theSource, catalog, theStore, &expectedMatches)
-				addJavascriptMatches(t, theSource, catalog, theStore, &expectedMatches)
-				addDotnetMatches(t, theSource, catalog, theStore, &expectedMatches)
-				addGolangMatches(t, theSource, catalog, theStore, &expectedMatches)
-				addHaskellMatches(t, theSource, catalog, theStore, &expectedMatches)
+				addPythonMatches(t, theSource, catalog, provider, &expectedMatches)
+				addRubyMatches(t, theSource, catalog, provider, &expectedMatches)
+				addJavaMatches(t, theSource, catalog, provider, &expectedMatches)
+				addDpkgMatches(t, theSource, catalog, provider, &expectedMatches)
+				addJavascriptMatches(t, theSource, catalog, provider, &expectedMatches)
+				addDotnetMatches(t, theSource, catalog, provider, &expectedMatches)
+				addGolangMatches(t, theSource, catalog, provider, &expectedMatches)
+				addHaskellMatches(t, theSource, catalog, provider, &expectedMatches)
 				return expectedMatches
 			},
 		},
 		{
 			name: "image-centos-match-coverage",
-			expectedFn: func(theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider) match.Matches {
+			expectedFn: func(theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider) match.Matches {
 				expectedMatches := match.NewMatches()
-				addRhelMatches(t, theSource, catalog, theStore, &expectedMatches)
+				addRhelMatches(t, theSource, catalog, provider, &expectedMatches)
 				return expectedMatches
 			},
 		},
 		{
 			name: "image-alpine-match-coverage",
-			expectedFn: func(theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider) match.Matches {
+			expectedFn: func(theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider) match.Matches {
 				expectedMatches := match.NewMatches()
-				addAlpineMatches(t, theSource, catalog, theStore, &expectedMatches)
+				addAlpineMatches(t, theSource, catalog, provider, &expectedMatches)
 				return expectedMatches
 			},
 		},
 		{
 			name: "image-sles-match-coverage",
-			expectedFn: func(theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider) match.Matches {
+			expectedFn: func(theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider) match.Matches {
 				expectedMatches := match.NewMatches()
-				addSlesMatches(t, theSource, catalog, theStore, &expectedMatches)
+				addSlesMatches(t, theSource, catalog, provider, &expectedMatches)
 				return expectedMatches
 			},
 		},
 		// TODO: add this back in when #744 is fully implemented (see https://github.com/anchore/grype/issues/744#issuecomment-2448163737)
 		//{
 		//	name: "image-portage-match-coverage",
-		//	expectedFn: func(theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider) match.Matches {
+		//	expectedFn: func(theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider) match.Matches {
 		//		expectedMatches := match.NewMatches()
-		//		addPortageMatches(t, theSource, catalog, theStore, &expectedMatches)
+		//		addPortageMatches(t, theSource, catalog, provider, &expectedMatches)
 		//		return expectedMatches
 		//	},
 		//},
 		{
 			name: "image-rust-auditable-match-coverage",
-			expectedFn: func(theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider) match.Matches {
+			expectedFn: func(theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider) match.Matches {
 				expectedMatches := match.NewMatches()
-				addRustMatches(t, theSource, catalog, theStore, &expectedMatches)
+				addRustMatches(t, theSource, catalog, provider, &expectedMatches)
 				return expectedMatches
 			},
 		},
 		{
 			name: "image-jvm-match-coverage",
-			expectedFn: func(theSource source.Source, catalog *syftPkg.Collection, theStore vulnerability.Provider) match.Matches {
+			expectedFn: func(theSource source.Source, catalog *syftPkg.Collection, provider vulnerability.Provider) match.Matches {
 				expectedMatches := match.NewMatches()
-				addJvmMatches(t, theSource, catalog, theStore, &expectedMatches)
+				addJvmMatches(t, theSource, catalog, provider, &expectedMatches)
 				return expectedMatches
 			},
 		},


### PR DESCRIPTION
Today vulnerability objects are being duplicated for each element in a version range (introduced in the v6 schema development), this PR restores the original behavior in grype so that all version ranges within a vulnerability are still associated with that single vulnerability.

Before this change (we're filtering down to what is affected relative to the given package):
```
openjdk             17.0.13+11                17.0.14                  binary  CVE-2025-21502  Medium     
```

Also before this change, but tweaking the code to show how many matches get created when you ignore this filtering behavior and create vulnerabilities for all of them:
```
openjdk             17.0.13+11                1.8.0_441                binary  CVE-2025-21502  Medium      
openjdk             17.0.13+11                11.0.26                  binary  CVE-2025-21502  Medium      
openjdk             17.0.13+11                17.0.14                  binary  CVE-2025-21502  Medium      
openjdk             17.0.13+11                21.0.6                   binary  CVE-2025-21502  Medium      
openjdk             17.0.13+11                23.0.2                   binary  CVE-2025-21502  Medium      
openjdk             17.0.13+11                8.0.441                  binary  CVE-2025-21502  Medium      
```

After this change (original grype behavior from previous releases)
```
openjdk             17.0.13+11                1.8.0_441, 8.0.441, 11.0.26, 17.0.14, 21.0.6, 23.0.2  binary  CVE-2025-21502  Medium      
```