### PR TITLE
Remove v6 development configuration

### DIFF
--- a/test/quality/.grype.yaml
+++ b/test/quality/.grype.yaml
@@ -23,8 +23,3 @@ match:
   stock:
     using-cpes: true
 
-# while we are merging https://github.com/anchore/grype/pull/2494 to support v6 there are a few examples that are
-# worse, however, the overall matching behavior is correct, thus we should not block on these examples
-ignore:
-  - vulnerability: CVE-2012-0979
-  - vulnerability: CVE-2019-5736

--- a/test/quality/.yardstick.yaml
+++ b/test/quality/.yardstick.yaml
@@ -116,9 +116,7 @@ result-sets:
           # are testing with is not too stale.
           # version: git:current-commit+import-db=db.tar.zst
           # for local build of grype, use for example:
-# we need to disable this while we are in pre-release of v6 (restore after release of v6)
-#          version: path:../../+import-db=db.tar.zst
-          version: path:../../
+          version: path:../../+import-db=db.tar.zst
           takes: SBOM
           label: candidate
 
@@ -128,9 +126,7 @@ result-sets:
           # By pinning the DB the grype code itself becomes the independent variable under test (and not the
           # every-changing DB). That being said, we should be updating this DB periodically to ensure what we
           # are testing with is not too stale.
-# we need to disable this while we are in pre-release of v6 (restore after release of v6)
-#          version: latest+import-db=db.tar.zst
-          version: latest
+          version: latest+import-db=db.tar.zst
           takes: SBOM
           label: reference
   pr_vs_latest_via_sbom_2022:
@@ -161,9 +157,7 @@ result-sets:
           # are testing with is not too stale.
           # version: git:current-commit+import-db=db.tar.zst
           # for local build of grype, use for example:
-# we need to disable this while we are in pre-release of v6 (restore after release of v6)
-#          version: path:../../+import-db=db.tar.zst
-          version: path:../../
+          version: path:../../+import-db=db.tar.zst
           takes: SBOM
           label: candidate # is candidate better than the current baseline?
 
@@ -173,8 +167,6 @@ result-sets:
           # By pinning the DB the grype code itself becomes the independent variable under test (and not the
           # every-changing DB). That being said, we should be updating this DB periodically to ensure what we
           # are testing with is not too stale.
-# we need to disable this while we are in pre-release of v6 (restore after release of v6)
-#          version: latest+import-db=db.tar.zst
-          version: latest
+          version: latest+import-db=db.tar.zst
           takes: SBOM
           label: reference # this run is the current baseline


### PR DESCRIPTION
Now that v6 schema has been released we can go back to using pinned DBs for the quality gate (since both sides of the comparison are using the same DB, where during v6 development this was not true). We also no longer need to ignore the CVE-2012-0979 and CVE-2019-5736 records from quality gate results they will now be part of the baseline comparison (since there was a new release).