### PR TITLE
Allow for reading listing from local FS

### DIFF
--- a/grype/db/v6/distribution/latest.go
+++ b/grype/db/v6/distribution/latest.go
@@ -74,6 +74,15 @@ func NewLatestFromReader(reader io.Reader) (*LatestDocument, error) {
 	return &l, nil
 }
 
+func NewLatestFromFile(fs afero.Fs, path string) (*LatestDocument, error) {
+	fh, err := fs.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read listing file: %w", err)
+	}
+	defer fh.Close()
+	return NewLatestFromReader(fh)
+}
+
 func NewArchive(path string, t time.Time, model, revision, addition int) (*Archive, error) {
 	checksum, err := calculateArchiveDigest(path)
 	if err != nil {


### PR DESCRIPTION
Before v0.88.0 release of grype you could specify a listing file on the local filesystem:
```
$ curl -fsSLO "https://grype.anchore.io/databases/listing.json"
$ export GRYPE_DB_UPDATE_URL=${PWD}/listing.json
$ grype db check
# works as expected (uses the listing file)
```

However with the release of v0.88.0 this stopped working:
```
$ curl -fsSLO "https://grype.anchore.io/databases/v6/latest.json"
$ export GRYPE_DB_UPDATE_URL=${PWD}/latest.json
$ grype db check
[0000] ERROR unable to check for vulnerability database update: check for vulnerability database update failed: unable to fetch latest.json: Get "file:///tmp/scratch/latest.json": unsupported protocol scheme ""
```
(same is true with the `file://` scheme)

This PR fixes this behavior, allowing for an assumed local path (no scheme) and an explicit `file` scheme.

Fixes #2507 