### PR TITLE
fix: exclude self from related vulnerability list

### DIFF
--- a/grype/db/v6/vulnerability.go
+++ b/grype/db/v6/vulnerability.go
@@ -104,7 +104,7 @@ func getRelatedVulnerabilities(vuln *VulnerabilityHandle, affected *AffectedPack
 	cveSet := strset.New()
 	var relatedVulnerabilities []vulnerability.Reference
 	for _, alias := range vuln.BlobValue.Aliases {
-		if cveSet.Has(alias) {
+		if cveSet.Has(alias) || strings.EqualFold(vuln.Name, alias) {
 			continue
 		}
 		if !strings.HasPrefix(strings.ToLower(alias), "cve-") {
@@ -118,7 +118,7 @@ func getRelatedVulnerabilities(vuln *VulnerabilityHandle, affected *AffectedPack
 	}
 	if affected != nil {
 		for _, cve := range affected.CVEs {
-			if cveSet.Has(cve) {
+			if cveSet.Has(cve) || strings.EqualFold(vuln.Name, cve) {
 				continue
 			}
 			if !strings.HasPrefix(strings.ToLower(cve), "cve-") {

--- a/grype/db/v6/vulnerability_test.go
+++ b/grype/db/v6/vulnerability_test.go
@@ -6,6 +6,9 @@ import (
 	"unicode"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/grype/grype/vulnerability"
 )
 
 func TestV5Namespace(t *testing.T) {
@@ -464,6 +467,68 @@ func TestV5Namespace(t *testing.T) {
 
 			result := MimicV5Namespace(vuln, pkg)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_getRelatedVulnerabilities(t *testing.T) {
+	tests := []struct {
+		name     string
+		vuln     VulnerabilityHandle
+		affected AffectedPackageBlob
+		expected []string
+	}{
+		{
+			name: "GHSA with related CVEs",
+			vuln: VulnerabilityHandle{
+				Name: "GHSA-1234",
+				BlobValue: &VulnerabilityBlob{
+					Aliases: []string{"CVE-2024-1"},
+				},
+			},
+			affected: AffectedPackageBlob{
+				CVEs: []string{"CVE-2024-2", "CVE-2024-3"},
+			},
+			expected: []string{"CVE-2024-1", "CVE-2024-2", "CVE-2024-3"},
+		},
+		{
+			name: "CVE with related CVEs",
+			vuln: VulnerabilityHandle{
+				Name: "CVE-2024-1234",
+				BlobValue: &VulnerabilityBlob{
+					Aliases: []string{"CVE-2024-1"},
+				},
+			},
+			affected: AffectedPackageBlob{
+				CVEs: []string{"CVE-2024-2", "CVE-2024-3"},
+			},
+			expected: []string{"CVE-2024-1", "CVE-2024-2", "CVE-2024-3"},
+		},
+		{
+			name: "CVE with related CVEs and self",
+			vuln: VulnerabilityHandle{
+				Name: "CVE-2024-1234",
+				BlobValue: &VulnerabilityBlob{
+					Aliases: []string{"CVE-2024-1", "CVE-2024-1234"},
+				},
+			},
+			affected: AffectedPackageBlob{
+				CVEs: []string{"CVE-2024-2", "CVE-2024-1234"},
+			},
+			expected: []string{"CVE-2024-1", "CVE-2024-2"}, // does not include "CVE-2024-1234"
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getRelatedVulnerabilities(&tt.vuln, &tt.affected)
+			var expected []vulnerability.Reference
+			for _, name := range tt.expected {
+				expected = append(expected, vulnerability.Reference{
+					ID:        name,
+					Namespace: v5NvdNamespace,
+				})
+			}
+			require.ElementsMatch(t, expected, got)
 		})
 	}
 }


### PR DESCRIPTION
This PR corrects an issue where the `relatedVulnerabilites` field was being populated with a record for the same vulnerability.

Fixes: #2514