### PR TITLE
feat: adds ability to specify wildcard for distro version

### DIFF
--- a/grype/db/v6/vulnerability_provider.go
+++ b/grype/db/v6/vulnerability_provider.go
@@ -230,9 +230,10 @@ func (s vulnerabilityProvider) FindVulnerabilities(criteria ...vulnerability.Cri
 			case *search.DistroCriteria:
 				for _, d := range c.Distros {
 					osSpecs = append(osSpecs, &OSSpecifier{
-						Name:         d.Name(),
-						MajorVersion: d.MajorVersion(),
-						MinorVersion: d.MinorVersion(),
+						Name:          d.Name(),
+						MajorVersion:  d.MajorVersion(),
+						MinorVersion:  d.MinorVersion(),
+						AllowMultiple: d.HasAnyVersion(),
 					})
 				}
 				applied = true


### PR DESCRIPTION
This is a proof-of-concept PR to show a method to allow users that create sboms from other sources (not syft) where specific distro information may be challenging to acquire can have Grype execute a scan and return results for all versions of a given distro as long as the distro itself is known. This is indicated by the user setting the distro version to '*' exactly. There is no partial match or regex support, only '*' to indicate all versions. In the future it could be extended to partial matches such as 22.*" 

Example usage:
```
grype --distro 'ubuntu:*' sbom:./my_sbom.json
```

This does return noisy data, and there is no attempt in this PR to intelligently combine the results, but since the distro version is not known, the caller likely cannot assert a correct result or not and in this case I think the user would take the result back to the provider of the SBOM and the value is that it could show both the volume of noise that could be avoided if the version is made available or a way to see what vulnerabilities and fixes are available across the different versions.

This is just a PoC, and to get it fully ready if the concept is agreeable, I think a configuration option to allow this would be reasonable to ensure that existing users get the current level of input validation error behavior and this wildcard support would only be opt-in since it is not the common case.