### PR TITLE
fix: populate vulnerability.Metadata.DataSource with first reference URL

### DIFF
--- a/grype/db/v6/vulnerability_provider.go
+++ b/grype/db/v6/vulnerability_provider.go
@@ -83,20 +83,14 @@ func newVulnerabilityMetadata(vuln *VulnerabilityHandle, namespace string, kevs 
 	sev, cvss, err := extractSeverities(vuln)
 	if err != nil {
 		log.WithFields("id", vuln.Name, "vulnerability", vuln.String()).Debug("unable to extract severity from vulnerability")
-		return &vulnerability.Metadata{
-			ID:         vuln.Name,
-			DataSource: strings.Split(namespace, ":")[0],
-			Namespace:  namespace,
-			Severity:   toSeverityString(vulnerability.UnknownSeverity),
-		}, nil
 	}
 
 	return &vulnerability.Metadata{
 		ID:             vuln.Name,
-		DataSource:     vuln.Provider.ID,
+		DataSource:     firstReferenceURL(vuln),
 		Namespace:      namespace,
 		Severity:       toSeverityString(sev),
-		URLs:           toURLs(vuln),
+		URLs:           lastReferenceURLs(vuln),
 		Description:    vuln.BlobValue.Description,
 		Cvss:           cvss,
 		KnownExploited: kevs,
@@ -522,9 +516,21 @@ func toSeverityString(sev vulnerability.Severity) string {
 	return strcase.ToCamel(sev.String())
 }
 
-func toURLs(vuln *VulnerabilityHandle) []string {
-	var out []string
+// returns the first reference url to populate the DataSource
+func firstReferenceURL(vuln *VulnerabilityHandle) string {
 	for _, v := range vuln.BlobValue.References {
+		return v.URL
+	}
+	return ""
+}
+
+// skip the first reference URL and return the remainder to populate the URLs
+func lastReferenceURLs(vuln *VulnerabilityHandle) []string {
+	var out []string
+	for i, v := range vuln.BlobValue.References {
+		if i == 0 {
+			continue
+		}
 		out = append(out, v.URL)
 	}
 	return out

--- a/grype/db/v6/vulnerability_provider_test.go
+++ b/grype/db/v6/vulnerability_provider_test.go
@@ -46,10 +46,10 @@ func Test_FindVulnerabilitiesByDistro(t *testing.T) {
 			Advisories:        []vulnerability.Advisory{},
 			Metadata: &vulnerability.Metadata{
 				ID:          "CVE-2014-fake-1",
-				DataSource:  "debian",
+				DataSource:  "http://somewhere/CVE-2014-fake-1",
 				Namespace:   "debian:distro:debian:8",
 				Severity:    "High",
-				URLs:        []string{"http://somewhere/CVE-2014-fake-1"},
+				URLs:        nil,
 				Description: "CVE-2014-fake-1-description",
 			},
 		},
@@ -65,10 +65,10 @@ func Test_FindVulnerabilitiesByDistro(t *testing.T) {
 			Advisories:        []vulnerability.Advisory{},
 			Metadata: &vulnerability.Metadata{
 				ID:          "CVE-2013-fake-2",
-				DataSource:  "debian",
+				DataSource:  "http://somewhere/CVE-2013-fake-2",
 				Namespace:   "debian:distro:debian:8",
 				Severity:    "High",
-				URLs:        []string{"http://somewhere/CVE-2013-fake-2"},
+				URLs:        nil,
 				Description: "CVE-2013-fake-2-description",
 			},
 		},
@@ -123,10 +123,10 @@ func Test_FindVulnerabilitiesByCPE(t *testing.T) {
 					Advisories:        []vulnerability.Advisory{},
 					Metadata: &vulnerability.Metadata{
 						ID:          "CVE-2014-fake-4",
-						DataSource:  "debian",
+						DataSource:  "http://somewhere/CVE-2014-fake-4",
 						Namespace:   "nvd:cpe",
 						Severity:    "High",
-						URLs:        []string{"http://somewhere/CVE-2014-fake-4"},
+						URLs:        nil,
 						Description: "CVE-2014-fake-4-description",
 					},
 				},
@@ -150,10 +150,10 @@ func Test_FindVulnerabilitiesByCPE(t *testing.T) {
 					Advisories:        []vulnerability.Advisory{},
 					Metadata: &vulnerability.Metadata{
 						ID:          "CVE-2014-fake-4",
-						DataSource:  "debian",
+						DataSource:  "http://somewhere/CVE-2014-fake-4",
 						Namespace:   "nvd:cpe",
 						Severity:    "High",
-						URLs:        []string{"http://somewhere/CVE-2014-fake-4"},
+						URLs:        nil,
 						Description: "CVE-2014-fake-4-description",
 					},
 				},
@@ -177,10 +177,10 @@ func Test_FindVulnerabilitiesByCPE(t *testing.T) {
 					Advisories:        []vulnerability.Advisory{},
 					Metadata: &vulnerability.Metadata{
 						ID:          "CVE-2014-fake-3",
-						DataSource:  "debian",
+						DataSource:  "http://somewhere/CVE-2014-fake-3",
 						Namespace:   "nvd:cpe",
 						Severity:    "High",
-						URLs:        []string{"http://somewhere/CVE-2014-fake-3"},
+						URLs:        nil,
 						Description: "CVE-2014-fake-3-description",
 					},
 				},
@@ -198,10 +198,10 @@ func Test_FindVulnerabilitiesByCPE(t *testing.T) {
 					Advisories:        []vulnerability.Advisory{},
 					Metadata: &vulnerability.Metadata{
 						ID:          "CVE-2014-fake-4",
-						DataSource:  "debian",
+						DataSource:  "http://somewhere/CVE-2014-fake-4",
 						Namespace:   "nvd:cpe",
 						Severity:    "High",
-						URLs:        []string{"http://somewhere/CVE-2014-fake-4"},
+						URLs:        nil,
 						Description: "CVE-2014-fake-4-description",
 					},
 				},
@@ -270,10 +270,10 @@ func Test_FindVulnerabilitiesByByID(t *testing.T) {
 			Advisories:        []vulnerability.Advisory{},
 			Metadata: &vulnerability.Metadata{
 				ID:          "CVE-2014-fake-1",
-				DataSource:  "debian",
+				DataSource:  "http://somewhere/CVE-2014-fake-1",
 				Namespace:   "debian:distro:debian:8",
 				Severity:    "High",
-				URLs:        []string{"http://somewhere/CVE-2014-fake-1"},
+				URLs:        nil,
 				Description: "CVE-2014-fake-1-description",
 			},
 		},
@@ -301,6 +301,98 @@ func Test_FindVulnerabilitiesByByID(t *testing.T) {
 	actual, err = provider.FindVulnerabilities(search.ByDistro(*d), search.ByID("CVE-2014-fake-3"))
 	require.NoError(t, err)
 	require.Empty(t, actual)
+}
+
+func Test_DataSource(t *testing.T) {
+	tests := []struct {
+		name     string
+		vuln     VulnerabilityHandle
+		expected vulnerability.Metadata
+	}{
+		{
+			name: "no reference urls",
+			vuln: VulnerabilityHandle{
+				BlobValue: &VulnerabilityBlob{
+					References: nil,
+				},
+			},
+			expected: vulnerability.Metadata{
+				DataSource: "",
+				URLs:       nil,
+			},
+		},
+		{
+			name: "one reference url",
+			vuln: VulnerabilityHandle{
+				BlobValue: &VulnerabilityBlob{
+					References: []Reference{
+						{
+							URL: "url1",
+						},
+					},
+				},
+			},
+			expected: vulnerability.Metadata{
+				DataSource: "url1",
+				URLs:       nil,
+			},
+		},
+		{
+			name: "two reference urls",
+			vuln: VulnerabilityHandle{
+				BlobValue: &VulnerabilityBlob{
+					References: []Reference{
+						{
+							URL: "url1",
+						},
+						{
+							URL: "url2",
+						},
+					},
+				},
+			},
+			expected: vulnerability.Metadata{
+				DataSource: "url1",
+				URLs:       []string{"url2"},
+			},
+		},
+		{
+			name: "many reference urls",
+			vuln: VulnerabilityHandle{
+				BlobValue: &VulnerabilityBlob{
+					References: []Reference{
+						{
+							URL: "url4",
+						},
+						{
+							URL: "url3",
+						},
+						{
+							URL: "url2",
+						},
+						{
+							URL: "url1",
+						},
+					},
+				},
+			},
+			expected: vulnerability.Metadata{
+				DataSource: "url4",
+				URLs:       []string{"url3", "url2", "url1"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newVulnerabilityMetadata(&tt.vuln, "", nil, nil)
+			got.Severity = ""
+			require.NoError(t, err)
+			if diff := cmp.Diff(&tt.expected, got, cmpOpts()...); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
 }
 
 func cmpOpts() []cmp.Option {

--- a/grype/vulnerability/metadata.go
+++ b/grype/vulnerability/metadata.go
@@ -6,10 +6,10 @@ import (
 
 type Metadata struct {
 	ID             string
-	DataSource     string
+	DataSource     string // the primary reference URL, i.e. where the data originated
 	Namespace      string
 	Severity       string
-	URLs           []string
+	URLs           []string // secondary reference URLs a vulnerability may provide
 	Description    string
 	Cvss           []Cvss
 	KnownExploited []KnownExploited


### PR DESCRIPTION
This PR fixes an issue where v6 providers were not correctly populating the `vulnerability.Metadata`.`DataSource` field, which is supposed to contain a URL where the data originated.

Fixes #2520