### PR TITLE
Allow import DB from URL

### DIFF
--- a/cmd/grype/cli/commands/db_import.go
+++ b/cmd/grype/cli/commands/db_import.go
@@ -16,9 +16,9 @@ func DBImport(app clio.Application) *cobra.Command {
 	opts := options.DefaultDatabaseCommand(app.ID())
 
 	cmd := &cobra.Command{
-		Use:   "import FILE",
-		Short: "Import a vulnerability database or archive",
-		Long:  fmt.Sprintf("import a vulnerability database or archive from a local FILE.\nDB archives can be obtained from %q.", opts.DB.UpdateURL),
+		Use:   "import FILE | URL",
+		Short: "Import a vulnerability database or archive from a local file or URL",
+		Long:  fmt.Sprintf("import a vulnerability database archive from a local FILE or URL.\nDB archives can be obtained from %q (or running `db list`). If the URL has a `checksum` query parameter with a fully qualified digest (e.g. 'sha256:abc728...') then the archive/DB will be verified against this value.", opts.DB.UpdateURL),
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runDBImport(*opts, args[0])
@@ -33,7 +33,7 @@ func DBImport(app clio.Application) *cobra.Command {
 	return app.SetupCommand(cmd, &configWrapper{opts})
 }
 
-func runDBImport(opts options.DatabaseCommand, dbArchivePath string) error {
+func runDBImport(opts options.DatabaseCommand, reference string) error {
 	// TODO: tui update? better logging?
 	client, err := distribution.NewClient(opts.ToClientConfig())
 	if err != nil {
@@ -44,8 +44,8 @@ func runDBImport(opts options.DatabaseCommand, dbArchivePath string) error {
 		return fmt.Errorf("unable to create curator: %w", err)
 	}
 
-	log.WithFields("path", dbArchivePath).Infof("importing vulnerability database archive")
-	if err := c.Import(dbArchivePath); err != nil {
+	log.WithFields("reference", reference).Infof("importing vulnerability database archive")
+	if err := c.Import(reference); err != nil {
 		return fmt.Errorf("unable to import vulnerability database: %w", err)
 	}
 

--- a/grype/db/v6/distribution/client_test.go
+++ b/grype/db/v6/distribution/client_test.go
@@ -131,10 +131,6 @@ func TestClient_Latest(t *testing.T) {
 
 func TestClient_Download(t *testing.T) {
 	destDir := t.TempDir()
-	archive := &Archive{
-		Path:     "path/to/archive.tar.gz",
-		Checksum: "checksum123",
-	}
 
 	setup := func() (Client, *mockGetter) {
 		mg := new(mockGetter)
@@ -155,10 +151,9 @@ func TestClient_Download(t *testing.T) {
 		url := "http://localhost:8080/path/to/archive.tar.gz?checksum=checksum123"
 		mg.On("GetToDir", mock.Anything, url, mock.Anything).Return(nil)
 
-		tempDir, actualURL, err := c.Download(*archive, destDir, &progress.Manual{})
+		tempDir, err := c.Download(url, destDir, &progress.Manual{})
 		require.NoError(t, err)
 		require.True(t, len(tempDir) > 0)
-		assert.Equal(t, url, actualURL)
 
 		mg.AssertExpectations(t)
 	})
@@ -168,11 +163,10 @@ func TestClient_Download(t *testing.T) {
 		url := "http://localhost:8080/path/to/archive.tar.gz?checksum=checksum123"
 		mg.On("GetToDir", mock.Anything, url, mock.Anything).Return(errors.New("download failed"))
 
-		tempDir, actualURL, err := c.Download(*archive, destDir, &progress.Manual{})
+		tempDir, err := c.Download(url, destDir, &progress.Manual{})
 		require.Error(t, err)
 		require.Empty(t, tempDir)
 		require.Contains(t, err.Error(), "unable to download db")
-		assert.Empty(t, actualURL)
 
 		mg.AssertExpectations(t)
 	})
@@ -183,10 +177,9 @@ func TestClient_Download(t *testing.T) {
 		mg.On("GetToDir", mock.Anything, url, mock.Anything).Return(nil)
 
 		nestedPath := filepath.Join(destDir, "nested")
-		tempDir, actualURL, err := c.Download(*archive, nestedPath, &progress.Manual{})
+		tempDir, err := c.Download(url, nestedPath, &progress.Manual{})
 		require.NoError(t, err)
 		require.True(t, len(tempDir) > 0)
-		assert.Equal(t, url, actualURL)
 
 		mg.AssertExpectations(t)
 	})

--- a/grype/db/v6/installation/curator_test.go
+++ b/grype/db/v6/installation/curator_test.go
@@ -36,9 +36,13 @@ func (m *mockClient) IsUpdateAvailable(current *db.Description) (*distribution.A
 	return args.Get(0).(*distribution.Archive), nil
 }
 
-func (m *mockClient) Download(archive distribution.Archive, dest string, downloadProgress *progress.Manual) (string, string, error) {
-	args := m.Called(archive, dest, downloadProgress)
-	return args.String(0), "http://localhost/archive.tar.zst", args.Error(1)
+func (m *mockClient) ResolveArchiveURL(_ distribution.Archive) (string, error) {
+	return "http://localhost/archive.tar.zst", nil
+}
+
+func (m *mockClient) Download(url, dest string, downloadProgress *progress.Manual) (string, error) {
+	args := m.Called(url, dest, downloadProgress)
+	return args.String(0), args.Error(1)
 }
 
 func (m *mockClient) Latest() (*distribution.LatestDocument, error) {


### PR DESCRIPTION
Enables being able to import DBs from a URL (whereas today this must be a local file), so the user does not need to download them first:
```
$ grype db import https://grype.anchore.io/databases/v6/vulnerability-db_v6.0.2_2025-03-14T01:31:06Z_1741925227.tar.zst
 ⠴ Vulnerability DB                ━━━━━━━━━━━━━━━━━━━━  [62 MB / 66 MB]  
```

This means if you have a previous grype scan with a DB URL in it (added in #2529) you can quickly use that reference to import the DB:
```
$grype db import $(cat mygrype.json | jq '.descriptor.db.status.from')
 ✔ Vulnerability DB                [imported]  
```

The value in grype JSON documents has the checksum of the argument as a query parameter (`https://grype.anchore.io/databases/v6/vulnerability-db_v6.0.2_2025-03-14T01:31:06Z_1741925227.tar.zst?checksum=sha256%3Ad4654e3b212f1d8a1aaab979599691099af541568d687c4a7c4e7c1da079b9b8`), which allows for client side validation:
```
$ grype db import https://grype.anchore.io/databases/v6/vulnerability-db_v6.0.2_2025-03-14T01:31:06Z_1741925227.tar.zst?checksum=sha256%3Ad4654e3b212f1d8a1aaab979599691099af541568d687c4a7c4e7c1da079b9b7
 ✔ Vulnerability DB                [validating]  
[0004] ERROR unable to import vulnerability database: unable to update vulnerability database: unable to download db: Checksums did not match for /tmp/getter3555198916/archive.
Expected: d4654e3b212f1d8a1aaab979599691099af541568d687c4a7c4e7c1da079b9b7
Got:      8a179b9568141aad1092b899fe7c1da09af5a69d4654e3b21b97957c4a7c4d68
```

Closes #2134

## PR Stack
- #2529