### PR TITLE
feat: specify distro without version

### DIFF
--- a/cmd/grype/cli/options/database_search_os.go
+++ b/cmd/grype/cli/options/database_search_os.go
@@ -32,9 +32,6 @@ func (o *DBSearchOSs) PostLoad() error {
 		if err != nil {
 			return err
 		}
-		if spec != nil {
-			spec.AllowMultiple = true
-		}
 		specs = append(specs, spec)
 	}
 	o.Specs = specs

--- a/cmd/grype/cli/options/database_search_os_test.go
+++ b/cmd/grype/cli/options/database_search_os_test.go
@@ -27,7 +27,7 @@ func TestDBSearchOSsPostLoad(t *testing.T) {
 				OSs: []string{"ubuntu"},
 			},
 			expectedSpecs: []*v6.OSSpecifier{
-				{Name: "ubuntu", AllowMultiple: true},
+				{Name: "ubuntu"},
 			},
 		},
 		{
@@ -36,7 +36,7 @@ func TestDBSearchOSsPostLoad(t *testing.T) {
 				OSs: []string{"ubuntu@20"},
 			},
 			expectedSpecs: []*v6.OSSpecifier{
-				{Name: "ubuntu", MajorVersion: "20", AllowMultiple: true},
+				{Name: "ubuntu", MajorVersion: "20"},
 			},
 		},
 		{
@@ -45,7 +45,7 @@ func TestDBSearchOSsPostLoad(t *testing.T) {
 				OSs: []string{"ubuntu@20.04"},
 			},
 			expectedSpecs: []*v6.OSSpecifier{
-				{Name: "ubuntu", MajorVersion: "20", MinorVersion: "04", AllowMultiple: true},
+				{Name: "ubuntu", MajorVersion: "20", MinorVersion: "04"},
 			},
 		},
 		{
@@ -54,7 +54,7 @@ func TestDBSearchOSsPostLoad(t *testing.T) {
 				OSs: []string{"ubuntu@focal"},
 			},
 			expectedSpecs: []*v6.OSSpecifier{
-				{Name: "ubuntu", LabelVersion: "focal", AllowMultiple: true},
+				{Name: "ubuntu", LabelVersion: "focal"},
 			},
 		},
 		{
@@ -70,7 +70,7 @@ func TestDBSearchOSsPostLoad(t *testing.T) {
 				OSs: []string{"ubuntu:20"},
 			},
 			expectedSpecs: []*v6.OSSpecifier{
-				{Name: "ubuntu", MajorVersion: "20", AllowMultiple: true},
+				{Name: "ubuntu", MajorVersion: "20"},
 			},
 		},
 		{

--- a/grype/db/v6/affected_package_store_test.go
+++ b/grype/db/v6/affected_package_store_test.go
@@ -817,28 +817,15 @@ func TestAffectedPackageStore_GetAffectedPackages(t *testing.T) {
 			expected: []AffectedPackageHandle{*pkg2d1},
 		},
 		{
-			name: "distro major version only (allow multiple)",
+			name: "distro major version only",
 			pkg:  pkgFromName(pkg2d1.Package.Name),
 			options: &GetAffectedPackageOptions{
 				OSs: []*OSSpecifier{{
-					Name:          "ubuntu",
-					MajorVersion:  "20",
-					AllowMultiple: true,
+					Name:         "ubuntu",
+					MajorVersion: "20",
 				}},
 			},
 			expected: []AffectedPackageHandle{*pkg2d1, *pkg2d2},
-		},
-		{
-			name: "distro major version only (default)",
-			pkg:  pkgFromName(pkg2d1.Package.Name),
-			options: &GetAffectedPackageOptions{
-				OSs: []*OSSpecifier{{
-					Name:          "ubuntu",
-					MajorVersion:  "20",
-					AllowMultiple: false,
-				}},
-			},
-			wantErr: expectErrIs(t, ErrMultipleOSMatches),
 		},
 		{
 			name: "distro codename",

--- a/grype/presenter/table/__snapshots__/presenter_test.snap
+++ b/grype/presenter/table/__snapshots__/presenter_test.snap
@@ -26,11 +26,28 @@ package-2  2.2.2                            deb   CVE-1999-0002  Critical
 ---
 
 [TestDisplaysIgnoredMatches - 1]
-NAME       INSTALLED  FIXED-IN              TYPE  VULNERABILITY  SEVERITY                     
-package-1  1.1.1      *1.2.1, 2.1.3, 3.4.0  rpm   CVE-1999-0001  Low                           
-package-2  2.2.2                            deb   CVE-1999-0002  Critical                      
-package-2  2.2.2                            deb   CVE-1999-0001  Low (suppressed)              
-package-2  2.2.2                            deb   CVE-1999-0002  Critical (suppressed)         
-package-2  2.2.2                            deb   CVE-1999-0004  Critical (suppressed by VEX)  
+NAME       INSTALLED  FIXED-IN              TYPE  VULNERABILITY  SEVERITY                      
+package-1  1.1.1      *1.2.1, 2.1.3, 3.4.0  rpm   CVE-1999-0001  Low       
+package-2  2.2.2                            deb   CVE-1999-0002  Critical  
+package-2  2.2.2                            deb   CVE-1999-0001  Low       (suppressed)         
+package-2  2.2.2                            deb   CVE-1999-0002  Critical  (suppressed)         
+package-2  2.2.2                            deb   CVE-1999-0004  Critical  (suppressed by VEX)  
+
+---
+
+[TestDisplaysDistro - 1]
+NAME       INSTALLED  FIXED-IN              TYPE  VULNERABILITY  SEVERITY               
+package-1  1.1.1      *1.2.1, 2.1.3, 3.4.0  rpm   CVE-1999-0001  Low       (ubuntu:2.5)  
+package-2  2.2.2                            deb   CVE-1999-0002  Critical  (ubuntu:3.5)  
+
+---
+
+[TestDisplaysIgnoredMatchesAndDistro - 1]
+NAME       INSTALLED  FIXED-IN              TYPE  VULNERABILITY  SEVERITY                           
+package-1  1.1.1      *1.2.1, 2.1.3, 3.4.0  rpm   CVE-1999-0001  Low       (ubuntu:2.5)              
+package-2  2.2.2                            deb   CVE-1999-0002  Critical  (ubuntu:3.5)              
+package-2  2.2.2                            deb   CVE-1999-0001  Low       (ubuntu:2.5, suppressed)  
+package-2  2.2.2                            deb   CVE-1999-0002  Critical  (ubuntu:3.5, suppressed)  
+package-2  2.2.2                            deb   CVE-1999-0004  Critical  (suppressed by VEX)       
 
 ---


### PR DESCRIPTION
Before this PR, it was not possible to specify a distro without exact version information, such as `--distro alpine:3.17`. There are cases users want to specify the distro but do not know the exact distro version to use. This PR relaxes the requirement to only use a single distro, allowing for specifying without a version, such as `--distro ubuntu` or only a major version like `--distro alpine:3`. The JSON output includes namespace information already, so a user can understand where matches came from, this PR also detects when multiple distros are present in the results and adds annotations to the table view to make this clear to users, e.g.:
```
NAME          INSTALLED  FIXED-IN              TYPE  VULNERABILITY   SEVERITY                            
...
ssl_client    1.34.1-r7  1.35.0-r18            apk   CVE-2023-42366  Medium    (alpine:3.16)              
ssl_client    1.34.1-r7  1.35.0-r30            apk   CVE-2023-42366  Medium    (alpine:3.16)              
ssl_client    1.34.1-r7  1.36.1-r16            apk   CVE-2023-42366  Medium    (alpine:3.16)              
ssl_client    1.34.1-r7  1.36.1-r25            apk   CVE-2023-42366  Medium    (alpine:3.16)              
ssl_client    1.34.1-r7  1.36.1-r6             apk   CVE-2023-42366  Medium    (alpine:3.16)              
busybox       1.34.1-r7  1.36.1-r1             apk   CVE-2022-48174  Critical  (alpine:3.18, suppressed)  
busybox       1.34.1-r7  1.36.1-r2             apk   CVE-2022-48174  Critical  (alpine:3.18, suppressed)  
ssl_client    1.34.1-r7  1.36.1-r1             apk   CVE-2022-48174  Critical  (alpine:3.18, suppressed)  
```

Fixes: #2521 