### PR TITLE
feat: add Bitnami matcher

### DIFF
--- a/grype/db/v6/data.go
+++ b/grype/db/v6/data.go
@@ -72,6 +72,8 @@ func KnownPackageSpecifierOverrides() []PackageSpecifierOverride {
 
 		// jenkins plugins are a special case since they are always considered to be within the java ecosystem
 		{Ecosystem: string(pkg.JenkinsPluginPkg), ReplacementEcosystem: ptr(string(pkg.JavaPkg))},
+		// Bitnami is a special case since it's not a language ecosystem but is a package type
+		{Ecosystem: "bitnami", ReplacementEcosystem: ptr(string(pkg.BitnamiPkg))},
 	}
 
 	// remap package URL types to syft package types

--- a/grype/match/matcher_type.go
+++ b/grype/match/matcher_type.go
@@ -16,6 +16,7 @@ const (
 	GoModuleMatcher    MatcherType = "go-module-matcher"
 	OpenVexMatcher     MatcherType = "openvex-matcher"
 	RustMatcher        MatcherType = "rust-matcher"
+	BitnamiMatcher     MatcherType = "bitnami-matcher"
 )
 
 var AllMatcherTypes = []MatcherType{
@@ -32,6 +33,7 @@ var AllMatcherTypes = []MatcherType{
 	GoModuleMatcher,
 	OpenVexMatcher,
 	RustMatcher,
+	BitnamiMatcher,
 }
 
 type MatcherType string

--- a/grype/matcher/bitnami/matcher.go
+++ b/grype/matcher/bitnami/matcher.go
@@ -1,0 +1,27 @@
+package bitnami
+
+import (
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/matcher/internal"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+type Matcher struct{}
+
+func (m *Matcher) PackageTypes() []syftPkg.Type {
+	return []syftPkg.Type{syftPkg.BitnamiPkg}
+}
+
+func (m *Matcher) Type() match.MatcherType {
+	return match.BitnamiMatcher
+}
+
+func (m *Matcher) Match(store vulnerability.Provider, p pkg.Package) ([]match.Match, []match.IgnoredMatch, error) {
+	// Bitnami packages' metadata are built from the package URL (instead of CPE, hence CPE match is not supported)
+	// ref: https://github.com/anchore/syft/blob/main/syft/pkg/bitnami.go#L3-L13
+	// ref: https://github.com/anchore/syft/blob/main/syft/pkg/cataloger/bitnami/package.go#L18-L45
+	return internal.MatchPackageByEcosystemAndCPEs(store, p, m.Type(), false)
+}

--- a/grype/matcher/matchers.go
+++ b/grype/matcher/matchers.go
@@ -3,6 +3,7 @@ package matcher
 import (
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/matcher/apk"
+	"github.com/anchore/grype/grype/matcher/bitnami"
 	"github.com/anchore/grype/grype/matcher/dotnet"
 	"github.com/anchore/grype/grype/matcher/dpkg"
 	"github.com/anchore/grype/grype/matcher/golang"
@@ -44,5 +45,6 @@ func NewDefaultMatchers(mc Config) []match.Matcher {
 		&portage.Matcher{},
 		rust.NewRustMatcher(mc.Rust),
 		stock.NewStockMatcher(mc.Stock),
+		&bitnami.Matcher{},
 	}
 }


### PR DESCRIPTION
# Summary

After https://github.com/anchore/vunnel/pull/447, https://github.com/anchore/grype-db/pull/217 and https://github.com/anchore/syft/issues/3065 this PR attempts to use Bitmani vulndb data for matching package vulnerabilities.

- fixes https://github.com/anchore/grype/issues/1609