### PR TITLE
fix: panic and improve non-db-v6 error messaging

### DIFF
--- a/grype/db/v6/db.go
+++ b/grype/db/v6/db.go
@@ -102,7 +102,9 @@ func Hydrater() func(string) error {
 		// we don't pass any data initialization here because the data is already in the db archive and we do not want
 		// to affect the entries themselves, only indexes and schema.
 		s, err := newStore(Config{DBDirPath: path}, false, true)
-		log.CloseAndLogError(s, path)
+		if s != nil {
+			log.CloseAndLogError(s, path)
+		}
 		return err
 	}
 }

--- a/grype/db/v6/db_metadata_store_test.go
+++ b/grype/db/v6/db_metadata_store_test.go
@@ -19,6 +19,17 @@ func TestDbMetadataStore_empty(t *testing.T) {
 	require.NotNil(t, actualMetadata)
 }
 
+func TestDbMetadataStore_oldDb(t *testing.T) {
+	db := setupTestStore(t).db
+	require.NoError(t, db.Where("true").Model(DBMetadata{}).Update("Model", "5").Error) // old database version
+	s := newDBMetadataStore(db)
+
+	// attempt to fetch a non-existent record
+	actualMetadata, err := s.GetDBMetadata()
+	require.NoError(t, err)
+	require.NotNil(t, actualMetadata)
+}
+
 func TestDbMetadataStore(t *testing.T) {
 	s := newDBMetadataStore(setupTestStore(t).db)
 

--- a/grype/db/v6/store.go
+++ b/grype/db/v6/store.go
@@ -65,17 +65,16 @@ func newStore(cfg Config, empty, writable bool) (*store, error) {
 	}
 
 	meta, err := metadataStore.GetDBMetadata()
-	if err != nil {
+	if err != nil || meta == nil || meta.Model != ModelVersion {
 		// db.Close must be called, or we will get stale reads
 		d, _ := db.DB()
 		if d != nil {
 			_ = d.Close()
 		}
-		return nil, fmt.Errorf("failed to get db metadata: %w", err)
-	}
-
-	if meta == nil {
-		return nil, fmt.Errorf("no DB metadata found")
+		if err != nil {
+			return nil, fmt.Errorf("not a v%d database: %w", ModelVersion, err)
+		}
+		return nil, fmt.Errorf("not a v%d database", ModelVersion)
 	}
 
 	dbVersion := newSchemaVerFromDBMetadata(*meta)

--- a/grype/db/v6/store_test.go
+++ b/grype/db/v6/store_test.go
@@ -1,10 +1,12 @@
 package v6
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func TestStoreClose(t *testing.T) {
@@ -53,4 +55,24 @@ func TestStoreClose(t *testing.T) {
 		s.db.Raw(`SELECT name FROM sqlite_master WHERE type = 'index' AND name NOT LIKE 'sqlite_autoindex%'`).Scan(&indexes)
 		assert.Empty(t, indexes)
 	})
+}
+
+func Test_oldDbV5(t *testing.T) {
+	s := setupTestStore(t)
+	require.NoError(t, s.db.Where("true").Delete(&DBMetadata{}).Error) // delete all existing records
+	require.NoError(t, s.Close())
+	s, err := newStore(s.config, false, true)
+	require.Nil(t, s)
+	require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+	require.ErrorContains(t, err, fmt.Sprintf("not a v%d database", ModelVersion))
+}
+
+func Test_oldDbWithMetadata(t *testing.T) {
+	s := setupTestStore(t)
+	require.NoError(t, s.db.Where("true").Model(DBMetadata{}).Update("Model", "5").Error) // old database version
+	require.NoError(t, s.Close())
+	s, err := newStore(s.config, false, true)
+	require.Nil(t, s)
+	require.NotErrorIs(t, err, gorm.ErrRecordNotFound)
+	require.ErrorContains(t, err, fmt.Sprintf("not a v%d database", ModelVersion))
 }


### PR DESCRIPTION
This PR fixes a panic due to attempting to close a nil pointer when a non-v6 database is used. Additionally, this improves the messaging to help users understand that they are using an incompatible database version. Example:
```
$ grype db import $(pwd)/v5vulnerability.db
 ✔ Vulnerability DB                [hydrating]  
[0007] ERROR unable to import vulnerability database: failed to hydrate database: not a v6 database: record not found
exit status 1
```

Fixes #2542