### PR TITLE
fix: label version distro matching

### DIFF
--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -263,10 +263,12 @@ func applyDistroHint(pkgs []pkg.Package, context *pkg.Context, opts *options.Gry
 	}
 
 	hasOSPackage := false
+loop:
 	for _, p := range pkgs {
 		switch p.Type {
 		case syftPkg.AlpmPkg, syftPkg.DebPkg, syftPkg.RpmPkg, syftPkg.KbPkg:
 			hasOSPackage = true
+			break loop
 		}
 	}
 

--- a/grype/db/v6/vulnerability_provider.go
+++ b/grype/db/v6/vulnerability_provider.go
@@ -253,6 +253,7 @@ func (vp vulnerabilityProvider) FindVulnerabilities(criteria ...vulnerability.Cr
 						Name:         d.Name(),
 						MajorVersion: d.MajorVersion(),
 						MinorVersion: d.MinorVersion(),
+						LabelVersion: d.LabelVersion,
 					})
 				}
 				applied = true

--- a/grype/distro/distro_test.go
+++ b/grype/distro/distro_test.go
@@ -18,6 +18,7 @@ func Test_NewDistroFromRelease(t *testing.T) {
 		release            linux.Release
 		expectedVersion    string
 		expectedRawVersion string
+		expectedLabel      string
 		expectedType       Type
 		expectErr          bool
 	}{
@@ -79,8 +80,80 @@ func Test_NewDistroFromRelease(t *testing.T) {
 				Name:            "Debian GNU/Linux",
 			},
 			expectedType:       Debian,
-			expectedRawVersion: "unstable",
+			expectedRawVersion: "",
 			expectedVersion:    "",
+			expectedLabel:      "unstable",
+		},
+		{
+			// syft -o json alpine:edge | jq .distro
+			name: "alpine edge",
+			release: linux.Release{
+				ID:         "alpine",
+				VersionID:  "3.22.0_alpha20250108",
+				Version:    "",
+				PrettyName: "Alpine Linux edge",
+				Name:       "Alpine Linux",
+			},
+			expectedType:       Alpine,
+			expectedRawVersion: "",
+			expectedVersion:    "",
+			expectedLabel:      "edge",
+		},
+		{
+			name: "wolfi",
+			release: linux.Release{
+				ID:         "wolfi",
+				VersionID:  "",
+				Version:    "",
+				PrettyName: "",
+				Name:       "",
+			},
+			expectedType:       Wolfi,
+			expectedRawVersion: "",
+			expectedVersion:    "",
+			expectedLabel:      "rolling",
+		},
+		{
+			name: "chainguard",
+			release: linux.Release{
+				ID:         "chainguard",
+				VersionID:  "",
+				Version:    "",
+				PrettyName: "",
+				Name:       "",
+			},
+			expectedType:       Chainguard,
+			expectedRawVersion: "",
+			expectedVersion:    "",
+			expectedLabel:      "rolling",
+		},
+		{
+			name: "arch",
+			release: linux.Release{
+				ID:         "arch",
+				VersionID:  "",
+				Version:    "",
+				PrettyName: "",
+				Name:       "",
+			},
+			expectedType:       ArchLinux,
+			expectedRawVersion: "",
+			expectedVersion:    "",
+			expectedLabel:      "rolling",
+		},
+		{
+			name: "gentoo",
+			release: linux.Release{
+				ID:         "gentoo",
+				VersionID:  "",
+				Version:    "",
+				PrettyName: "",
+				Name:       "",
+			},
+			expectedType:       Gentoo,
+			expectedRawVersion: "",
+			expectedVersion:    "",
+			expectedLabel:      "rolling",
 		},
 		{
 			name: "azure linux 3",
@@ -111,6 +184,7 @@ func Test_NewDistroFromRelease(t *testing.T) {
 			if test.expectedRawVersion != "" {
 				assert.Equal(t, test.expectedRawVersion, d.FullVersion())
 			}
+			assert.Equal(t, test.expectedLabel, d.LabelVersion)
 		})
 	}
 


### PR DESCRIPTION
This PR corrects an issue where "edge" OSes like `alpine:edge` and `debian:sid` were not properly matching OS records in the db.

Before:
```
$ grype -q alpine:edge
NAME        INSTALLED  FIXED-IN   TYPE  VULNERABILITY   SEVERITY                
libcrypto3  3.3.2-r4   3.3.3-r0   apk   CVE-2024-12797  Medium    (alpine:3.20)  
libcrypto3  3.3.2-r4   3.3.2-r5   apk   CVE-2024-13176  Medium    (alpine:3.21)  
libssl3     3.3.2-r4   3.3.3-r0   apk   CVE-2024-12797  Medium    (alpine:3.20)  
libssl3     3.3.2-r4   3.3.2-r5   apk   CVE-2024-13176  Medium    (alpine:3.21)  
musl        1.2.5-r9   1.2.5-r10  apk   CVE-2025-26519  High      (alpine:edge)  
musl-utils  1.2.5-r9   1.2.5-r10  apk   CVE-2025-26519  High      (alpine:edge)

$ grype -q debian:sid
No vulnerabilities found
```

After:
```
$ grype -q alpine:edge
NAME        INSTALLED  FIXED-IN   TYPE  VULNERABILITY   SEVERITY 
libcrypto3  3.3.2-r4   3.3.3-r0   apk   CVE-2024-12797  Medium    
libcrypto3  3.3.2-r4   3.3.2-r5   apk   CVE-2024-13176  Medium    
libssl3     3.3.2-r4   3.3.3-r0   apk   CVE-2024-12797  Medium    
libssl3     3.3.2-r4   3.3.2-r5   apk   CVE-2024-13176  Medium    
musl        1.2.5-r9   1.2.5-r10  apk   CVE-2025-26519  High      
musl-utils  1.2.5-r9   1.2.5-r10  apk   CVE-2025-26519  High

$ grype -q debian:sid
NAME                INSTALLED                  FIXED-IN  TYPE  VULNERABILITY     SEVERITY   
apt                 2.9.33                               deb   CVE-2011-3374     Negligible  
bsdutils            1:2.40.4-5                           deb   CVE-2022-0563     Negligible  
coreutils           9.5-1+b1                             deb   CVE-2016-2781     Low         
coreutils           9.5-1+b1                             deb   CVE-2017-18018    Negligible  
libapt-pkg7.0       2.9.33                               deb   CVE-2011-3374     Negligible  
libblkid1           2.40.4-5                             deb   CVE-2022-0563     Negligible  
libc-bin            2.41-6                               deb   CVE-2010-4756     Negligible  
libc-bin            2.41-6                               deb   CVE-2018-20796    Negligible  
libc-bin            2.41-6                               deb   CVE-2019-1010022  Negligible  
libc-bin            2.41-6                               deb   CVE-2019-1010023  Negligible  
libc-bin            2.41-6                               deb   CVE-2019-1010024  Negligible  
libc-bin            2.41-6                               deb   CVE-2019-1010025  Negligible  
libc-bin            2.41-6                               deb   CVE-2019-9192     Negligible  
libc6               2.41-6                               deb   CVE-2010-4756     Negligible  
libc6               2.41-6                               deb   CVE-2018-20796    Negligible  
libc6               2.41-6                               deb   CVE-2019-1010022  Negligible  
libc6               2.41-6                               deb   CVE-2019-1010023  Negligible  
libc6               2.41-6                               deb   CVE-2019-1010024  Negligible  
libc6               2.41-6                               deb   CVE-2019-1010025  Negligible  
libc6               2.41-6                               deb   CVE-2019-9192     Negligible  
libmount1           2.40.4-5                             deb   CVE-2022-0563     Negligible  
libpam-modules      1.7.0-3                              deb   CVE-2024-10963    High        
libpam-modules-bin  1.7.0-3                              deb   CVE-2024-10963    High        
libpam-runtime      1.7.0-3                              deb   CVE-2024-10963    High        
libpam0g            1.7.0-3                              deb   CVE-2024-10963    High        
libsmartcols1       2.40.4-5                             deb   CVE-2022-0563     Negligible  
libsystemd0         257.4-3                              deb   CVE-2013-4392     Negligible  
libsystemd0         257.4-3                              deb   CVE-2023-31437    Negligible  
libsystemd0         257.4-3                              deb   CVE-2023-31438    Negligible  
libsystemd0         257.4-3                              deb   CVE-2023-31439    Negligible  
libudev1            257.4-3                              deb   CVE-2013-4392     Negligible  
libudev1            257.4-3                              deb   CVE-2023-31437    Negligible  
libudev1            257.4-3                              deb   CVE-2023-31438    Negligible  
libudev1            257.4-3                              deb   CVE-2023-31439    Negligible  
libuuid1            2.40.4-5                             deb   CVE-2022-0563     Negligible  
login               1:4.16.0-2+really2.40.4-5            deb   CVE-2022-0563     Negligible  
login.defs          1:4.17.3-2                           deb   CVE-2024-56433    Low         
login.defs          1:4.17.3-2                           deb   CVE-2007-5686     Negligible  
mount               2.40.4-5                             deb   CVE-2022-0563     Negligible  
passwd              1:4.17.3-2                           deb   CVE-2024-56433    Low         
passwd              1:4.17.3-2                           deb   CVE-2007-5686     Negligible  
perl-base           5.40.1-2                             deb   CVE-2011-4116     Negligible  
tar                 1.35+dfsg-3.1                        deb   CVE-2005-2541     Negligible  
util-linux          2.40.4-5                             deb   CVE-2022-0563     Negligible
```