### PR TITLE
fix:  use namespace with name when purl is ecosystem golang in purl decoder

### DIFF
--- a/grype/pkg/purl_provider.go
+++ b/grype/pkg/purl_provider.go
@@ -201,12 +201,17 @@ func purlToPackage(rawLine string) (*Package, *pkg.Package, string, string, erro
 		PURL:     purl.String(),
 		Language: pkg.LanguageByName(purl.Type),
 	}
+	// copy to avoid mutating the original purl object
+	name := purl.Name
+	if purl.Namespace != "" {
+		name = fmt.Sprintf("%s/%s", purl.Namespace, purl.Name)
+	}
 
 	syftPkg.SetID()
 	return &Package{
 		ID:        ID(purl.String()),
 		CPEs:      cpes,
-		Name:      purl.Name,
+		Name:      name,
 		Version:   version,
 		Type:      pkgType,
 		Language:  pkg.LanguageByName(purl.Type),

--- a/grype/pkg/purl_provider.go
+++ b/grype/pkg/purl_provider.go
@@ -194,7 +194,7 @@ func purlToPackage(rawLine string) (*Package, *pkg.Package, string, string, erro
 	}
 
 	name := purl.Name
-	if pkgType == pkg.GoModulePkg {
+	if pkgType == pkg.GoModulePkg && purl.Namespace != "" {
 		name = purl.Namespace + "/" + name
 	}
 

--- a/grype/pkg/purl_provider.go
+++ b/grype/pkg/purl_provider.go
@@ -193,18 +193,18 @@ func purlToPackage(rawLine string) (*Package, *pkg.Package, string, string, erro
 		version = fmt.Sprintf("%s:%s", epoch, purl.Version)
 	}
 
+	name := purl.Name
+	if pkgType == pkg.GoModulePkg {
+		name = purl.Namespace + "/" + name
+	}
+
 	syftPkg := pkg.Package{
-		Name:     purl.Name,
+		Name:     name,
 		Version:  version,
 		Type:     pkgType,
 		CPEs:     cpes,
 		PURL:     purl.String(),
 		Language: pkg.LanguageByName(purl.Type),
-	}
-	// copy to avoid mutating the original purl object
-	name := purl.Name
-	if purl.Namespace != "" {
-		name = fmt.Sprintf("%s/%s", purl.Namespace, purl.Name)
 	}
 
 	syftPkg.SetID()

--- a/grype/pkg/purl_provider_test.go
+++ b/grype/pkg/purl_provider_test.go
@@ -432,6 +432,34 @@ func Test_PurlProvider(t *testing.T) {
 			},
 		},
 		{
+			name:      "do not include namespace when given blank input blank",
+			userInput: "pkg:golang/wazuh@v4.5.0",
+			context: Context{
+				Source: &source.Description{
+					Metadata: PURLLiteralMetadata{PURL: "pkg:golang/wazuh@v4.5.0"},
+				},
+			},
+			pkgs: []Package{
+				{
+					Name:    "wazuh",
+					Version: "v4.5.0",
+					Type:    pkg.GoModulePkg,
+					PURL:    "pkg:golang/wazuh@v4.5.0",
+				},
+			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name:     "wazuh",
+						Version:  "v4.5.0",
+						Type:     pkg.GoModulePkg,
+						PURL:     "pkg:golang/wazuh@v4.5.0",
+						Language: pkg.Go,
+					}),
+				},
+			},
+		},
+		{
 			name:      "infer context when distro is present for multiple similar purls",
 			userInput: "purl:test-fixtures/purl/homogeneous-os.txt",
 			context: Context{

--- a/grype/pkg/purl_provider_test.go
+++ b/grype/pkg/purl_provider_test.go
@@ -376,6 +376,62 @@ func Test_PurlProvider(t *testing.T) {
 			},
 		},
 		{
+			name:      "include namespace in name when purl is type Golang",
+			userInput: "pkg:golang/k8s.io/ingress-nginx@v1.11.2",
+			context: Context{
+				Source: &source.Description{
+					Metadata: PURLLiteralMetadata{PURL: "pkg:golang/k8s.io/ingress-nginx@v1.11.2"},
+				},
+			},
+			pkgs: []Package{
+				{
+					Name:    "k8s.io/ingress-nginx",
+					Version: "v1.11.2",
+					Type:    pkg.GoModulePkg,
+					PURL:    "pkg:golang/k8s.io/ingress-nginx@v1.11.2",
+				},
+			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name:     "k8s.io/ingress-nginx",
+						Version:  "v1.11.2",
+						Type:     pkg.GoModulePkg,
+						Language: pkg.Go,
+						PURL:     "pkg:golang/k8s.io/ingress-nginx@v1.11.2",
+					}),
+				},
+			},
+		},
+		{
+			name:      "include complex namespace in name when purl is type Golang",
+			userInput: "pkg:golang/github.com/wazuh/wazuh@v4.5.0",
+			context: Context{
+				Source: &source.Description{
+					Metadata: PURLLiteralMetadata{PURL: "pkg:golang/github.com/wazuh/wazuh@v4.5.0"},
+				},
+			},
+			pkgs: []Package{
+				{
+					Name:    "github.com/wazuh/wazuh",
+					Version: "v4.5.0",
+					Type:    pkg.GoModulePkg,
+					PURL:    "pkg:golang/github.com/wazuh/wazuh@v4.5.0",
+				},
+			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name:     "github.com/wazuh/wazuh",
+						Version:  "v4.5.0",
+						Type:     pkg.GoModulePkg,
+						PURL:     "pkg:golang/github.com/wazuh/wazuh@v4.5.0",
+						Language: pkg.Go,
+					}),
+				},
+			},
+		},
+		{
 			name:      "infer context when distro is present for multiple similar purls",
 			userInput: "purl:test-fixtures/purl/homogeneous-os.txt",
 			context: Context{


### PR DESCRIPTION
not sure what i am doing. but this seems to fix #2580