### PR TITLE
Add risk score to results and sort by risk by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ docker run --rm \
 $(ImageName):$(ImageTag)
 ```
 
-### Supported sources
+## Supported sources
 
 Grype can scan a variety of sources beyond those found in Docker.
 
@@ -209,6 +209,49 @@ use the `--distro <distro>:<version>` flag. A full example is:
 ```
 grype --add-cpes-if-none --distro alpine:3.10 sbom:some-alpine-3.10.spdx.json
 ```
+
+## Threat & Risk Prioritization
+
+This section explains the columns and UI cues that help you focus remediation efforts:
+
+- **Severity**: String severity based on CVSS scores and indicate the significance of a vulnerability in levels.
+  This balances concerns such as ease of exploitability, and the potential to affect 
+  confidentiality, integrity, and availability of software and services.
+
+- **EPSS**:
+  [Exploit Prediction Scoring System](https://www.first.org/epss/model) is a metric expressing the likelihood
+  that a vulnerability will be 
+  exploited in the wild over the next 30 days (on a 0–1 scale); higher values signal a greater likelihood of 
+  exploitation.
+  The table output shows the EPSS percentile, a one-way transform of the EPSS score showing the 
+  proportion of all scored vulnerabilities with an equal or lower probability.
+  Percentiles linearize a heavily skewed distribution, making threshold choice (e.g. “only CVEs above the 
+  90th percentile”) straightforward.
+
+- **KEV Indicator**: Flags entries from CISA’s [Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)
+  --an authoritative list of flaws observed being exploited in the wild.
+
+- **Risk Score**: A composite 0–100 metric calculated as:
+  ```markdown
+  risk = min(1, threat * average(severity)) * 100
+  ```
+  Where: 
+  - `severity` is the average of all CVSS scores and string severity for a vulnerability (scaled between 0–1).
+  - `threat` is the EPSS score (between 0–1). If the vulnerability is on the KEV list then `threat` is 
+    `1.05`, or `1.1` if the vulnerability is associated with a ransomware campaign.
+  This metric is one way to combine EPSS and CVSS suggested in the [EPSS user guide](https://www.first.org/epss/user-guide).
+
+- **Suggested Fixes**: All possible fixes for a package are listed, however, when multiple fixes are available, we de-emphasize all 
+  upgrade paths except for the minimal upgrade path (which highlights the smallest, safest version bump).
+
+Results default to sorting by Risk Score and can be overridden with `--sort-by <value>`:
+
+- `severity`: sort by severity
+- `epss`: sort by EPSS percentile (aka, "threat")
+- `risk`: sort by risk score
+- `kev`: just like risk, except that KEV entries are always above non-KEV entries
+- `package`: sort by package name, version, type
+- `vulnerability`: sort by vulnerability ID
 
 ### Supported versions
 
@@ -699,192 +742,240 @@ GRYPE_CONFIG=/path/to/config.yaml grype <image>
 Configuration options (example values are the default):
 
 ```yaml
-# enable/disable checking for application updates on startup
-# same as GRYPE_CHECK_FOR_APP_UPDATE env var
-check-for-app-update: true
-
-# allows users to specify which image source should be used to generate the sbom
-# valid values are: registry, docker, podman
-# same as GRYPE_DEFAULT_IMAGE_PULL_SOURCE env var
-default-image-pull-source: ""
-
-# same as --name; set the name of the target being analyzed
-name: ""
-
-# upon scanning, if a severity is found at or above the given severity then the return code will be 2
-# default is unset which will skip this validation (options: negligible, low, medium, high, critical)
-# same as --fail-on ; GRYPE_FAIL_ON_SEVERITY env var
-fail-on-severity: ""
-
 # the output format of the vulnerability report (options: table, template, json, cyclonedx)
-# when using template as the output type, you must also provide a value for 'output-template-file'
-# same as -o ; GRYPE_OUTPUT env var
-output: "table"
+# when using template as the output type, you must also provide a value for 'output-template-file' (env: GRYPE_OUTPUT)
+output: 'table'
 
 # if using template output, you must provide a path to a Go template file
 # see https://github.com/anchore/grype#using-templates for more information on template output
 # the default path to the template file is the current working directory
 # output-template-file: .grype/html.tmpl
+#
+# write output report to a file (default is to write to stdout) (env: GRYPE_FILE)
+file: ''
 
-# write output report to a file (default is to write to stdout)
-# same as --file; GRYPE_FILE env var
-file: ""
+# pretty-print JSON output (env: GRYPE_PRETTY)
+pretty: false
 
-# a list of globs to exclude from scanning, for example:
-# exclude:
-#   - '/etc/**'
-#   - './out/**/*.json'
-# same as --exclude ; GRYPE_EXCLUDE env var
-exclude: []
+# distro to match against in the format: <distro>:<version> (env: GRYPE_DISTRO)
+distro: ''
 
-# include matches on kernel-headers packages that are matched against upstream kernel package
-# if 'false' any such matches are marked as ignored
-match-upstream-kernel-headers: false
-
-# os and/or architecture to use when referencing container images (e.g. "windows/armv6" or "arm64")
-# same as --platform; GRYPE_PLATFORM env var
-platform: ""
-
-# If using SBOM input, automatically generate CPEs when packages have none
+# generate CPEs for packages with no CPE data (env: GRYPE_ADD_CPES_IF_NONE)
 add-cpes-if-none: false
 
-# Explicitly specify a linux distribution to use as <distro>:<version> like alpine:3.10
-distro:
+# specify the path to a Go template file (requires 'template' output to be selected) (env: GRYPE_OUTPUT_TEMPLATE_FILE)
+output-template-file: ''
+
+# enable/disable checking for application updates on startup (env: GRYPE_CHECK_FOR_APP_UPDATE)
+check-for-app-update: true
+
+# ignore matches for vulnerabilities that are not fixed (env: GRYPE_ONLY_FIXED)
+only-fixed: false
+
+# ignore matches for vulnerabilities that are fixed (env: GRYPE_ONLY_NOTFIXED)
+only-notfixed: false
+
+# ignore matches for vulnerabilities with specified comma separated fix states, options=[fixed not-fixed unknown wont-fix] (env: GRYPE_IGNORE_WONTFIX)
+ignore-wontfix: ''
+
+# an optional platform specifier for container image sources (e.g. 'linux/arm64', 'linux/arm64/v8', 'arm64', 'linux') (env: GRYPE_PLATFORM)
+platform: ''
+
+# upon scanning, if a severity is found at or above the given severity then the return code will be 1
+# default is unset which will skip this validation (options: negligible, low, medium, high, critical) (env: GRYPE_FAIL_ON_SEVERITY)
+fail-on-severity: ''
+
+# show suppressed/ignored vulnerabilities in the output (only supported with table output format) (env: GRYPE_SHOW_SUPPRESSED)
+show-suppressed: false
+
+# orient results by CVE instead of the original vulnerability ID when possible (env: GRYPE_BY_CVE)
+by-cve: false
+
+# sort the match results with the given strategy, options=[package severity epss risk kev vulnerability] (env: GRYPE_SORT_BY)
+sort-by: 'risk'
+
+# same as --name; set the name of the target being analyzed (env: GRYPE_NAME)
+name: ''
+
+# allows users to specify which image source should be used to generate the sbom
+# valid values are: registry, docker, podman (env: GRYPE_DEFAULT_IMAGE_PULL_SOURCE)
+default-image-pull-source: ''
+
+search:
+  # selection of layers to analyze, options=[squashed all-layers] (env: GRYPE_SEARCH_SCOPE)
+  scope: 'squashed'
+
+  # search within archives that do not contain a file index to search against (tar, tar.gz, tar.bz2, etc)
+  # note: enabling this may result in a performance impact since all discovered compressed tars will be decompressed
+  # note: for now this only applies to the java package cataloger (env: GRYPE_SEARCH_UNINDEXED_ARCHIVES)
+  unindexed-archives: false
+
+  # search within archives that do contain a file index to search against (zip)
+  # note: for now this only applies to the java package cataloger (env: GRYPE_SEARCH_INDEXED_ARCHIVES)
+  indexed-archives: true
+
+# A list of vulnerability ignore rules, one or more property may be specified and all matching vulnerabilities will be ignored.
+# This is the full set of supported rule fields:
+#   - vulnerability: CVE-2008-4318
+#     fix-state: unknown
+#     package:
+#       name: libcurl
+#       version: 1.5.1
+#       type: npm
+#       location: "/usr/local/lib/node_modules/**"
+#
+# VEX fields apply when Grype reads vex data:
+#   - vex-status: not_affected
+#     vex-justification: vulnerable_code_not_present
+ignore: []
+
+# a list of globs to exclude from scanning, for example:
+#   - '/etc/**'
+#   - './out/**/*.json'
+# same as --exclude (env: GRYPE_EXCLUDE)
+exclude: []
 
 external-sources:
+  # enable Grype searching network source for additional information (env: GRYPE_EXTERNAL_SOURCES_ENABLE)
   enable: false
+
   maven:
-    search-upstream-by-sha1: true
-    base-url: https://search.maven.org/solrsearch/select
+    # search for Maven artifacts by SHA1 (env: GRYPE_EXTERNAL_SOURCES_MAVEN_SEARCH_MAVEN_UPSTREAM)
+    search-maven-upstream: true
+
+    # base URL of the Maven repository to search (env: GRYPE_EXTERNAL_SOURCES_MAVEN_BASE_URL)
+    base-url: 'https://search.maven.org/solrsearch/select'
+
+    # (env: GRYPE_EXTERNAL_SOURCES_MAVEN_RATE_LIMIT)
     rate-limit: 300ms
 
+match:
+  java:
+    # use CPE matching to find vulnerabilities (env: GRYPE_MATCH_JAVA_USING_CPES)
+    using-cpes: false
+
+  jvm:
+    # (env: GRYPE_MATCH_JVM_USING_CPES)
+    using-cpes: true
+
+  dotnet:
+    # use CPE matching to find vulnerabilities (env: GRYPE_MATCH_DOTNET_USING_CPES)
+    using-cpes: false
+
+  golang:
+    # use CPE matching to find vulnerabilities (env: GRYPE_MATCH_GOLANG_USING_CPES)
+    using-cpes: false
+
+    # use CPE matching to find vulnerabilities for the Go standard library (env: GRYPE_MATCH_GOLANG_ALWAYS_USE_CPE_FOR_STDLIB)
+    always-use-cpe-for-stdlib: true
+
+    # allow comparison between main module pseudo-versions (e.g. v0.0.0-20240413-2b432cf643...) (env: GRYPE_MATCH_GOLANG_ALLOW_MAIN_MODULE_PSEUDO_VERSION_COMPARISON)
+    allow-main-module-pseudo-version-comparison: false
+
+  javascript:
+    # use CPE matching to find vulnerabilities (env: GRYPE_MATCH_JAVASCRIPT_USING_CPES)
+    using-cpes: false
+
+  python:
+    # use CPE matching to find vulnerabilities (env: GRYPE_MATCH_PYTHON_USING_CPES)
+    using-cpes: false
+
+  ruby:
+    # use CPE matching to find vulnerabilities (env: GRYPE_MATCH_RUBY_USING_CPES)
+    using-cpes: false
+
+  rust:
+    # use CPE matching to find vulnerabilities (env: GRYPE_MATCH_RUST_USING_CPES)
+    using-cpes: false
+
+  stock:
+    # use CPE matching to find vulnerabilities (env: GRYPE_MATCH_STOCK_USING_CPES)
+    using-cpes: true
+
+
+registry:
+  # skip TLS verification when communicating with the registry (env: GRYPE_REGISTRY_INSECURE_SKIP_TLS_VERIFY)
+  insecure-skip-tls-verify: false
+
+  # use http instead of https when connecting to the registry (env: GRYPE_REGISTRY_INSECURE_USE_HTTP)
+  insecure-use-http: false
+
+  # Authentication credentials for specific registries. Each entry describes authentication for a specific authority:
+  # -   authority: the registry authority URL the URL to the registry (e.g. "docker.io", "localhost:5000", etc.) (env: SYFT_REGISTRY_AUTH_AUTHORITY)
+  #     username: a username if using basic credentials (env: SYFT_REGISTRY_AUTH_USERNAME)
+  #     password: a corresponding password (env: SYFT_REGISTRY_AUTH_PASSWORD)
+  #     token: a token if using token-based authentication, mutually exclusive with username/password (env: SYFT_REGISTRY_AUTH_TOKEN)
+  #     tls-cert: filepath to the client certificate used for TLS authentication to the registry (env: SYFT_REGISTRY_AUTH_TLS_CERT)
+  #     tls-key: filepath to the client key used for TLS authentication to the registry (env: SYFT_REGISTRY_AUTH_TLS_KEY)
+  auth: []
+
+  # filepath to a CA certificate (or directory containing *.crt, *.cert, *.pem) used to generate the client certificate (env: GRYPE_REGISTRY_CA_CERT)
+  ca-cert: ''
+
+# a list of VEX documents to consider when producing scanning results (env: GRYPE_VEX_DOCUMENTS)
+vex-documents: []
+
+# VEX statuses to consider as ignored rules (env: GRYPE_VEX_ADD)
+vex-add: []
+
+# match kernel-header packages with upstream kernel as kernel vulnerabilities (env: GRYPE_MATCH_UPSTREAM_KERNEL_HEADERS)
+match-upstream-kernel-headers: false
+
 db:
-  # check for database updates on execution
-  # same as GRYPE_DB_AUTO_UPDATE env var
+  # location to write the vulnerability database cache (env: GRYPE_DB_CACHE_DIR)
+  cache-dir: '~/Library/Caches/grype/db'
+
+  # URL of the vulnerability database (env: GRYPE_DB_UPDATE_URL)
+  update-url: 'https://grype.anchore.io/databases'
+
+  # certificate to trust download the database and listing file (env: GRYPE_DB_CA_CERT)
+  ca-cert: ''
+
+  # check for database updates on execution (env: GRYPE_DB_AUTO_UPDATE)
   auto-update: true
 
-  # location to write the vulnerability database cache; defaults to $XDG_CACHE_HOME/grype/db
-  # same as GRYPE_DB_CACHE_DIR env var
-  cache-dir: ""
+  # validate the database matches the known hash each execution (env: GRYPE_DB_VALIDATE_BY_HASH_ON_START)
+  validate-by-hash-on-start: true
 
-  # URL of the vulnerability database
-  # same as GRYPE_DB_UPDATE_URL env var
-  update-url: "https://grype.anchore.io/databases"
-
-  # it ensures db build is no older than the max-allowed-built-age
-  # set to false to disable check
+  # ensure db build is no older than the max-allowed-built-age (env: GRYPE_DB_VALIDATE_AGE)
   validate-age: true
 
   # Max allowed age for vulnerability database,
   # age being the time since it was built
-  # Default max age is 120h (or five days)
-  max-allowed-built-age: "120h"
+  # Default max age is 120h (or five days) (env: GRYPE_DB_MAX_ALLOWED_BUILT_AGE)
+  max-allowed-built-age: 120h0m0s
+
+  # fail the scan if unable to check for database updates (env: GRYPE_DB_REQUIRE_UPDATE_CHECK)
+  require-update-check: false
 
   # Timeout for downloading GRYPE_DB_UPDATE_URL to see if the database needs to be downloaded
-  # This file is ~156KiB as of 2024-04-17 so the download should be quick; adjust as needed
-  update-available-timeout: "30s"
+  # This file is ~156KiB as of 2024-04-17 so the download should be quick; adjust as needed (env: GRYPE_DB_UPDATE_AVAILABLE_TIMEOUT)
+  update-available-timeout: 30s
 
   # Timeout for downloading actual vulnerability DB
-  # The DB is ~156MB as of 2024-04-17 so slower connections may exceed the default timeout; adjust as needed
-  update-download-timeout: "120s"
+  # The DB is ~156MB as of 2024-04-17 so slower connections may exceed the default timeout; adjust as needed (env: GRYPE_DB_UPDATE_DOWNLOAD_TIMEOUT)
+  update-download-timeout: 5m0s
 
-search:
-  # the search space to look for packages (options: all-layers, squashed)
-  # same as -s ; GRYPE_SEARCH_SCOPE env var
-  scope: "squashed"
-
-  # search within archives that do contain a file index to search against (zip)
-  # note: for now this only applies to the java package cataloger
-  # same as GRYPE_PACKAGE_SEARCH_INDEXED_ARCHIVES env var
-  indexed-archives: true
-
-  # search within archives that do not contain a file index to search against (tar, tar.gz, tar.bz2, etc)
-  # note: enabling this may result in a performance impact since all discovered compressed tars will be decompressed
-  # note: for now this only applies to the java package cataloger
-  # same as GRYPE_PACKAGE_SEARCH_UNINDEXED_ARCHIVES env var
-  unindexed-archives: false
-
-# options when pulling directly from a registry via the "registry:" scheme
-registry:
-  # skip TLS verification when communicating with the registry
-  # same as GRYPE_REGISTRY_INSECURE_SKIP_TLS_VERIFY env var
-  insecure-skip-tls-verify: false
-
-  # use http instead of https when connecting to the registry
-  # same as GRYPE_REGISTRY_INSECURE_USE_HTTP env var
-  insecure-use-http: false
-
-  # filepath to a CA certificate (or directory containing *.crt, *.cert, *.pem) used to generate the client certificate
-  # GRYPE_REGISTRY_CA_CERT env var
-  ca-cert: ""
-
-  # credentials for specific registries
-  auth:
-    # the URL to the registry (e.g. "docker.io", "localhost:5000", etc.)
-    # GRYPE_REGISTRY_AUTH_AUTHORITY env var
-    - authority: ""
-
-      # GRYPE_REGISTRY_AUTH_USERNAME env var
-      username: ""
-
-      # GRYPE_REGISTRY_AUTH_PASSWORD env var
-      password: ""
-
-      # note: token and username/password are mutually exclusive
-      # GRYPE_REGISTRY_AUTH_TOKEN env var
-      token: ""
-
-      # filepath to the client certificate used for TLS authentication to the registry
-      # GRYPE_REGISTRY_AUTH_TLS_CERT env var
-      tls-cert: ""
-
-      # filepath to the client key used for TLS authentication to the registry
-      # GRYPE_REGISTRY_AUTH_TLS_KEY env var
-      tls-key: ""
-
-    # - ... # note, more credentials can be provided via config file only (not env vars)
-
+  # Maximum frequency to check for vulnerability database updates (env: GRYPE_DB_MAX_UPDATE_CHECK_FREQUENCY)
+  max-update-check-frequency: 2h0m0s
 
 log:
-  # suppress all output (except for the vulnerability list)
-  # same as -q ; GRYPE_LOG_QUIET env var
+  # suppress all logging output (env: GRYPE_LOG_QUIET)
   quiet: false
 
-  # increase verbosity
-  # same as GRYPE_LOG_VERBOSITY env var
-  verbosity: 0
+  # explicitly set the logging level (available: [error warn info debug trace]) (env: GRYPE_LOG_LEVEL)
+  level: 'warn'
 
-  # the log level; note: detailed logging suppress the ETUI
-  # same as GRYPE_LOG_LEVEL env var
-  # Uses logrus logging levels: https://github.com/sirupsen/logrus#level-logging
-  level: "error"
+  # file path to write logs to (env: GRYPE_LOG_FILE)
+  file: ''
 
-  # location to write the log file (default is not to have a log file)
-  # same as GRYPE_LOG_FILE env var
-  file: ""
+dev:
+  # capture resource profiling data (available: [cpu, mem]) (env: GRYPE_DEV_PROFILE)
+  profile: ''
 
-match:
-  # sets the matchers below to use cpes when trying to find
-  # vulnerability matches. The stock matcher is the default
-  # when no primary matcher can be identified.
-  java:
-    using-cpes: false
-  python:
-    using-cpes: false
-  javascript:
-    using-cpes: false
-  ruby:
-    using-cpes: false
-  dotnet:
-    using-cpes: false
-  golang:
-    using-cpes: false
-    # even if CPE matching is disabled, make an exception when scanning for "stdlib".
-    always-use-cpe-for-stdlib: true
-    # allow main module pseudo versions, which may have only been "guessed at" by Syft, to be used in vulnerability matching
-    allow-main-module-pseudo-version-comparison: false
-  stock:
-    using-cpes: true
+  db:
+    # show sql queries in trace logging (requires -vv) (env: GRYPE_DEV_DB_DEBUG)
+    debug: false
 ```
 
 ## Future plans

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ grype --add-cpes-if-none --distro alpine:3.10 sbom:some-alpine-3.10.spdx.json
 
 ## Threat & Risk Prioritization
 
-This section explains the columns and UI cues that help you focus remediation efforts:
+This section explains the columns and UI cues that help prioritize remediation efforts:
 
 - **Severity**: String severity based on CVSS scores and indicate the significance of a vulnerability in levels.
   This balances concerns such as ease of exploitability, and the potential to affect 

--- a/cmd/grype/cli/cli.go
+++ b/cmd/grype/cli/cli.go
@@ -4,7 +4,10 @@ import (
 	"errors"
 	"os"
 	"runtime/debug"
+	"strings"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 
 	"github.com/anchore/clio"
@@ -39,6 +42,10 @@ func create(id clio.Identification) (clio.Application, *cobra.Command) {
 		WithUIConstructor(
 			// select a UI based on the logging configuration and state of stdin (if stdin is a tty)
 			func(cfg clio.Config) (*clio.UICollection, error) {
+				// remove CI var from consideration when determining if we should use the UI
+				lipgloss.SetDefaultRenderer(lipgloss.NewRenderer(os.Stdout, termenv.WithEnvironment(environWithoutCI{})))
+
+				// setup the UIs
 				noUI := ui.None(cfg.Log.Quiet)
 				if !cfg.Log.AllowUI(os.Stdin) || cfg.Log.Quiet {
 					return clio.NewUICollection(noUI), nil
@@ -121,4 +128,25 @@ func syftVersion() (string, any) {
 
 func dbVersion() (string, any) {
 	return "Supported DB Schema", v6.ModelVersion
+}
+
+type environWithoutCI struct {
+}
+
+func (e environWithoutCI) Environ() []string {
+	var out []string
+	for _, s := range os.Environ() {
+		if strings.HasPrefix(s, "CI=") {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func (e environWithoutCI) Getenv(s string) string {
+	if s == "CI" {
+		return ""
+	}
+	return os.Getenv(s)
 }

--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -209,7 +209,7 @@ func runGrype(app clio.Application, opts *options.Grype, userInput string) (errs
 	log.WithFields("time", time.Since(startTime)).Info("found vulnerability matches")
 	startTime = time.Now()
 
-	model, err := models.NewDocument(app.ID(), packages, pkgContext, *remainingMatches, ignoredMatches, vp, opts, dbInfo(status, vp), models.SortByPackage)
+	model, err := models.NewDocument(app.ID(), packages, pkgContext, *remainingMatches, ignoredMatches, vp, opts, dbInfo(status, vp), models.SortStrategy(opts.SortBy.Criteria))
 	if err != nil {
 		return fmt.Errorf("failed to create document: %w", err)
 	}

--- a/cmd/grype/cli/options/grype.go
+++ b/cmd/grype/cli/options/grype.go
@@ -31,6 +31,7 @@ type Grype struct {
 	Registry                   registry           `yaml:"registry" json:"registry" mapstructure:"registry"`
 	ShowSuppressed             bool               `yaml:"show-suppressed" json:"show-suppressed" mapstructure:"show-suppressed"`
 	ByCVE                      bool               `yaml:"by-cve" json:"by-cve" mapstructure:"by-cve"` // --by-cve, indicates if the original match vulnerability IDs should be preserved or the CVE should be used instead
+	SortBy                     SortBy             `yaml:",inline" json:",inline" mapstructure:",squash"`
 	Name                       string             `yaml:"name" json:"name" mapstructure:"name"`
 	DefaultImagePullSource     string             `yaml:"default-image-pull-source" json:"default-image-pull-source" mapstructure:"default-image-pull-source"`
 	VexDocuments               []string           `yaml:"vex-documents" json:"vex-documents" mapstructure:"vex-documents"`
@@ -64,6 +65,7 @@ func DefaultGrype(id clio.Identification) *Grype {
 		CheckForAppUpdate:          true,
 		VexAdd:                     []string{},
 		MatchUpstreamKernelHeaders: false,
+		SortBy:                     defaultSortBy(),
 	}
 }
 

--- a/cmd/grype/cli/options/sort_by.go
+++ b/cmd/grype/cli/options/sort_by.go
@@ -1,0 +1,47 @@
+package options
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/scylladb/go-set/strset"
+
+	"github.com/anchore/clio"
+	"github.com/anchore/fangs"
+	"github.com/anchore/grype/grype/presenter/models"
+)
+
+var _ interface {
+	fangs.FlagAdder
+	fangs.PostLoader
+} = (*SortBy)(nil)
+
+type SortBy struct {
+	Criteria         string   `yaml:"sort-by" json:"sort-by" mapstructure:"sort-by"`
+	AllowableOptions []string `yaml:"-" json:"-" mapstructure:"-"`
+}
+
+func defaultSortBy() SortBy {
+	var strategies []string
+	for _, s := range models.SortStrategies() {
+		strategies = append(strategies, strings.ToLower(s.String()))
+	}
+	return SortBy{
+		Criteria:         models.DefaultSortStrategy.String(),
+		AllowableOptions: strategies,
+	}
+}
+
+func (o *SortBy) AddFlags(flags clio.FlagSet) {
+	flags.StringVarP(&o.Criteria,
+		"sort-by", "",
+		fmt.Sprintf("sort the match results with the given strategy, options=%v", o.AllowableOptions),
+	)
+}
+
+func (o *SortBy) PostLoad() error {
+	if !strset.New(o.AllowableOptions...).Has(strings.ToLower(o.Criteria)) {
+		return fmt.Errorf("invalid sort-by criteria: %q (allowable: %s)", o.Criteria, strings.Join(o.AllowableOptions, ", "))
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/adrg/xdg v0.5.3
 	github.com/anchore/archiver/v3 v3.5.3-0.20241210171143-5b1d8d1c7c51
 	github.com/anchore/bubbly v0.0.0-20231115134915-def0aba654a9
-	github.com/anchore/clio v0.0.0-20250401141128-4c1d6bd1e872
+	github.com/anchore/clio v0.0.0-20250408180537-ec8fa27f0d9f
 	github.com/anchore/go-collections v0.0.0-20240216171411-9321230ce537
 	github.com/anchore/go-homedir v0.0.0-20250319154043-c29668562e4d
 	github.com/anchore/go-logger v0.0.0-20250318195838-07ae343dd722
@@ -71,6 +71,8 @@ require (
 	gorm.io/gorm v1.26.0
 )
 
+require github.com/anchore/fangs v0.0.0-20250402135612-96e29e45f3fe
+
 require (
 	cel.dev/expr v0.16.1 // indirect
 	cloud.google.com/go v0.116.0 // indirect
@@ -97,7 +99,6 @@ require (
 	github.com/STARRY-S/zip v0.2.1 // indirect
 	github.com/acobaugh/osrelease v0.1.0 // indirect
 	github.com/agext/levenshtein v1.2.1 // indirect
-	github.com/anchore/fangs v0.0.0-20250326231402-da263204d38e // indirect
 	github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb // indirect
 	github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 // indirect
 	github.com/anchore/go-sync v0.0.0-20250326131806-4eda43a485b6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/anchore/archiver/v3 v3.5.3-0.20241210171143-5b1d8d1c7c51
 	github.com/anchore/bubbly v0.0.0-20231115134915-def0aba654a9
 	github.com/anchore/clio v0.0.0-20250408180537-ec8fa27f0d9f
+	github.com/anchore/fangs v0.0.0-20250402135612-96e29e45f3fe
 	github.com/anchore/go-collections v0.0.0-20240216171411-9321230ce537
 	github.com/anchore/go-homedir v0.0.0-20250319154043-c29668562e4d
 	github.com/anchore/go-logger v0.0.0-20250318195838-07ae343dd722
@@ -70,8 +71,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/gorm v1.26.0
 )
-
-require github.com/anchore/fangs v0.0.0-20250402135612-96e29e45f3fe
 
 require (
 	cel.dev/expr v0.16.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -686,10 +686,10 @@ github.com/anchore/archiver/v3 v3.5.3-0.20241210171143-5b1d8d1c7c51 h1:yhk+P8lF3
 github.com/anchore/archiver/v3 v3.5.3-0.20241210171143-5b1d8d1c7c51/go.mod h1:nwuGSd7aZp0rtYt79YggCGafz1RYsclE7pi3fhLwvuw=
 github.com/anchore/bubbly v0.0.0-20231115134915-def0aba654a9 h1:p0ZIe0htYOX284Y4axJaGBvXHU0VCCzLN5Wf5XbKStU=
 github.com/anchore/bubbly v0.0.0-20231115134915-def0aba654a9/go.mod h1:3ZsFB9tzW3vl4gEiUeuSOMDnwroWxIxJelOOHUp8dSw=
-github.com/anchore/clio v0.0.0-20250401141128-4c1d6bd1e872 h1:iEF0xhHUuh3J8FrlPsZAQVaMpTa2j4lvLRI5XrXzge4=
-github.com/anchore/clio v0.0.0-20250401141128-4c1d6bd1e872/go.mod h1:Utb9i4kwiCWvqAIxZaJeMIXFO9uOgQXlvH2BfbfO/zI=
-github.com/anchore/fangs v0.0.0-20250326231402-da263204d38e h1:9hXsNmfBqo2exA4a90Qw33Edb+OROVmeibe9RzgS1wA=
-github.com/anchore/fangs v0.0.0-20250326231402-da263204d38e/go.mod h1:vrcYMDps9YXwwx2a9AsvipM6Fi5H9//9bymGb8G8BIQ=
+github.com/anchore/clio v0.0.0-20250408180537-ec8fa27f0d9f h1:jTeN+fKTXz1VFo3Zj7Msnx//s5kD6Htd+SS0z9/o7Ss=
+github.com/anchore/clio v0.0.0-20250408180537-ec8fa27f0d9f/go.mod h1:jQ+jv7v9RQnc5oA+Z0rAyXsQfaCAZHwY/CJZiLVggQ4=
+github.com/anchore/fangs v0.0.0-20250402135612-96e29e45f3fe h1:qv/xxpjF5RdKPqZjx8RM0aBi3HUCAO0DhRBMs2xhY1I=
+github.com/anchore/fangs v0.0.0-20250402135612-96e29e45f3fe/go.mod h1:vrcYMDps9YXwwx2a9AsvipM6Fi5H9//9bymGb8G8BIQ=
 github.com/anchore/go-collections v0.0.0-20240216171411-9321230ce537 h1:GjNGuwK5jWjJMyVppBjYS54eOiiSNv4Ba869k4wh72Q=
 github.com/anchore/go-collections v0.0.0-20240216171411-9321230ce537/go.mod h1:1aiktV46ATCkuVg0O573ZrH56BUawTECPETbZyBcqT8=
 github.com/anchore/go-homedir v0.0.0-20250319154043-c29668562e4d h1:gT69osH9AsdpOfqxbRwtxcNnSZ1zg4aKy2BevO3ZBdc=

--- a/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenterDir.golden
+++ b/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenterDir.golden
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:d78e14f4-ade8-4948-991c-73318b661114",
+  "serialNumber": "urn:uuid:8a92c7a6-641a-4fe8-8cb7-1636323af3d9",
   "version": 1,
   "metadata": {
-    "timestamp": "2025-02-27T13:15:13-05:00",
+    "timestamp": "2025-04-09T12:16:17-04:00",
     "tools": {
       "components": [
         {
@@ -19,7 +19,7 @@
     "component": {
       "bom-ref": "163686ac6e30c752",
       "type": "file",
-      "name": "/var/folders/c0/4y79v5k56bz8v34chcmvq2k80000gp/T/TestCycloneDxPresenterDir3112352663/001"
+      "name": "/var/folders/c0/4y79v5k56bz8v34chcmvq2k80000gp/T/TestCycloneDxPresenterDir3422104391/001"
     }
   },
   "components": [
@@ -89,28 +89,23 @@
   ],
   "vulnerabilities": [
     {
-      "bom-ref": "urn:uuid:e47db483-7ab2-4177-a82b-416b5a37bf93",
+      "bom-ref": "urn:uuid:9179966d-ddc9-445e-83f4-a8fdfd6c4ef3",
       "id": "CVE-1999-0001",
-      "source": {
-        "name": "source-1"
-      },
+      "source": {},
       "references": [
         {
           "id": "CVE-1999-0001",
-          "source": {
-            "name": "source-1"
-          }
+          "source": {}
         }
       ],
       "ratings": [
         {
-          "score": 4,
+          "score": 8.2,
           "severity": "low",
-          "method": "CVSSv3",
-          "vector": "another vector"
+          "method": "CVSSv31",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:H"
         }
       ],
-      "description": "1999-01 description",
       "affects": [
         {
           "ref": "9baa2db122fea516"
@@ -118,28 +113,23 @@
       ]
     },
     {
-      "bom-ref": "urn:uuid:3e3fbcf0-8dda-41a7-97ed-d1122923bf79",
+      "bom-ref": "urn:uuid:fe57d7f2-08c1-4446-8424-0f9d2c1e2b13",
       "id": "CVE-1999-0002",
-      "source": {
-        "name": "source-2"
-      },
+      "source": {},
       "references": [
         {
           "id": "CVE-1999-0002",
-          "source": {
-            "name": "source-2"
-          }
+          "source": {}
         }
       ],
       "ratings": [
         {
-          "score": 1,
+          "score": 8.5,
           "severity": "critical",
-          "method": "CVSSv2",
-          "vector": "vector"
+          "method": "CVSSv31",
+          "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H"
         }
       ],
-      "description": "1999-02 description",
       "affects": [
         {
           "ref": "pkg:deb/package-2@2.2.2?package-id=7bb53d560434bc7f"

--- a/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenterImage.golden
+++ b/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenterImage.golden
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:24d4fb73-8881-462c-940a-61b6d37b579d",
+  "serialNumber": "urn:uuid:04f27880-9830-4cfa-b9a5-9e8b9b4fee04",
   "version": 1,
   "metadata": {
-    "timestamp": "2025-02-27T13:15:13-05:00",
+    "timestamp": "2025-04-09T12:16:17-04:00",
     "tools": {
       "components": [
         {
@@ -90,28 +90,23 @@
   ],
   "vulnerabilities": [
     {
-      "bom-ref": "urn:uuid:638bc45b-a838-4017-b690-dc5d8d3cfe8d",
+      "bom-ref": "urn:uuid:0f1e7161-0591-4f58-928e-184e8c8184c0",
       "id": "CVE-1999-0001",
-      "source": {
-        "name": "source-1"
-      },
+      "source": {},
       "references": [
         {
           "id": "CVE-1999-0001",
-          "source": {
-            "name": "source-1"
-          }
+          "source": {}
         }
       ],
       "ratings": [
         {
-          "score": 4,
+          "score": 8.2,
           "severity": "low",
-          "method": "CVSSv3",
-          "vector": "another vector"
+          "method": "CVSSv31",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:H"
         }
       ],
-      "description": "1999-01 description",
       "affects": [
         {
           "ref": "9baa2db122fea516"
@@ -119,28 +114,23 @@
       ]
     },
     {
-      "bom-ref": "urn:uuid:6592d365-1128-49a0-8a68-570d8188965a",
+      "bom-ref": "urn:uuid:757bf3c1-b03d-482b-b1a1-8b7a3fd5346f",
       "id": "CVE-1999-0002",
-      "source": {
-        "name": "source-2"
-      },
+      "source": {},
       "references": [
         {
           "id": "CVE-1999-0002",
-          "source": {
-            "name": "source-2"
-          }
+          "source": {}
         }
       ],
       "ratings": [
         {
-          "score": 1,
+          "score": 8.5,
           "severity": "critical",
-          "method": "CVSSv2",
-          "vector": "vector"
+          "method": "CVSSv31",
+          "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H"
         }
       ],
-      "description": "1999-02 description",
       "affects": [
         {
           "ref": "pkg:deb/package-2@2.2.2?package-id=7bb53d560434bc7f"

--- a/grype/presenter/internal/test_helpers.go
+++ b/grype/presenter/internal/test_helpers.go
@@ -99,7 +99,7 @@ func Redact(s []byte) []byte {
 	return s
 }
 
-func generateMatches(t *testing.T, p1, p2 pkg.Package) match.Matches {
+func generateMatches(t *testing.T, p1, p2 pkg.Package) match.Matches { // nolint:funlen
 	t.Helper()
 
 	matches := []match.Match{
@@ -113,6 +113,29 @@ func generateMatches(t *testing.T, p1, p2 pkg.Package) match.Matches {
 				Fix: vulnerability.Fix{
 					Versions: []string{"1.2.1", "2.1.3", "3.4.0"},
 					State:    vulnerability.FixStateFixed,
+				},
+				Metadata: &vulnerability.Metadata{
+					ID:       "CVE-1999-0001",
+					Severity: "Low",
+					Cvss: []vulnerability.Cvss{
+						{
+							Source:  "nvd",
+							Type:    "CVSS",
+							Version: "3.1",
+							Vector:  "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:H",
+							Metrics: vulnerability.CvssMetrics{
+								BaseScore: 8.2,
+							},
+						},
+					},
+					KnownExploited: nil,
+					EPSS: []vulnerability.EPSS{
+						{
+							CVE:        "CVE-1999-0001",
+							EPSS:       0.03,
+							Percentile: 0.42,
+						},
+					},
 				},
 			},
 			Package: p1,
@@ -138,6 +161,34 @@ func generateMatches(t *testing.T, p1, p2 pkg.Package) match.Matches {
 				Reference: vulnerability.Reference{
 					ID:        "CVE-1999-0002",
 					Namespace: "source-2",
+				},
+				Metadata: &vulnerability.Metadata{
+					ID:       "CVE-1999-0002",
+					Severity: "Critical",
+					Cvss: []vulnerability.Cvss{
+						{
+							Source:  "nvd",
+							Type:    "CVSS",
+							Version: "3.1",
+							Vector:  "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H",
+							Metrics: vulnerability.CvssMetrics{
+								BaseScore: 8.5,
+							},
+						},
+					},
+					KnownExploited: []vulnerability.KnownExploited{
+						{
+							CVE:                        "CVE-1999-0002",
+							KnownRansomwareCampaignUse: "Known",
+						},
+					},
+					EPSS: []vulnerability.EPSS{
+						{
+							CVE:        "CVE-1999-0002",
+							EPSS:       0.08,
+							Percentile: 0.53,
+						},
+					},
 				},
 			},
 			Package: p2,
@@ -173,6 +224,29 @@ func generateIgnoredMatches(t *testing.T, p pkg.Package) []match.IgnoredMatch {
 						ID:        "CVE-1999-0001",
 						Namespace: "source-1",
 					},
+					Metadata: &vulnerability.Metadata{
+						ID:       "CVE-1999-0001",
+						Severity: "Low",
+						Cvss: []vulnerability.Cvss{
+							{
+								Source:  "nvd",
+								Type:    "CVSS",
+								Version: "3.1",
+								Vector:  "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:H",
+								Metrics: vulnerability.CvssMetrics{
+									BaseScore: 8.2,
+								},
+							},
+						},
+						KnownExploited: nil,
+						EPSS: []vulnerability.EPSS{
+							{
+								CVE:        "CVE-1999-0001",
+								EPSS:       0.03,
+								Percentile: 0.42,
+							},
+						},
+					},
 				},
 				Package: p,
 				Details: []match.Detail{
@@ -200,6 +274,34 @@ func generateIgnoredMatches(t *testing.T, p pkg.Package) []match.IgnoredMatch {
 						ID:        "CVE-1999-0002",
 						Namespace: "source-2",
 					},
+					Metadata: &vulnerability.Metadata{
+						ID:       "CVE-1999-0002",
+						Severity: "Critical",
+						Cvss: []vulnerability.Cvss{
+							{
+								Source:  "nvd",
+								Type:    "CVSS",
+								Version: "3.1",
+								Vector:  "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H",
+								Metrics: vulnerability.CvssMetrics{
+									BaseScore: 8.5,
+								},
+							},
+						},
+						KnownExploited: []vulnerability.KnownExploited{
+							{
+								CVE:                        "CVE-1999-0002",
+								KnownRansomwareCampaignUse: "Known",
+							},
+						},
+						EPSS: []vulnerability.EPSS{
+							{
+								CVE:        "CVE-1999-0002",
+								EPSS:       0.08,
+								Percentile: 0.53,
+							},
+						},
+					},
 				},
 				Package: p,
 				Details: []match.Detail{
@@ -223,6 +325,28 @@ func generateIgnoredMatches(t *testing.T, p pkg.Package) []match.IgnoredMatch {
 					Reference: vulnerability.Reference{
 						ID:        "CVE-1999-0004",
 						Namespace: "source-2",
+					},
+					Metadata: &vulnerability.Metadata{
+						ID:       "CVE-1999-0004",
+						Severity: "High",
+						Cvss: []vulnerability.Cvss{
+							{
+								Source:  "nvd",
+								Type:    "CVSS",
+								Version: "3.1",
+								Vector:  "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:L/A:L",
+								Metrics: vulnerability.CvssMetrics{
+									BaseScore: 7.2,
+								},
+							},
+						},
+						EPSS: []vulnerability.EPSS{
+							{
+								CVE:        "CVE-1999-0004",
+								EPSS:       0.03,
+								Percentile: 0.75,
+							},
+						},
 					},
 				},
 				Package: p,

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
@@ -4,18 +4,26 @@
    "vulnerability": {
     "id": "CVE-1999-0001",
     "dataSource": "",
-    "namespace": "source-1",
     "severity": "Low",
     "urls": [],
-    "description": "1999-01 description",
     "cvss": [
      {
-      "version": "3.0",
-      "vector": "another vector",
+      "source": "nvd",
+      "type": "CVSS",
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:H",
       "metrics": {
-       "baseScore": 4
+       "baseScore": 8.2
       },
       "vendorMetadata": {}
+     }
+    ],
+    "epss": [
+     {
+      "cve": "CVE-1999-0001",
+      "epss": 0.03,
+      "percentile": 0.42,
+      "date": "0001-01-01"
      }
     ],
     "fix": {
@@ -26,7 +34,8 @@
      ],
      "state": "fixed"
     },
-    "advisories": []
+    "advisories": [],
+    "risk": 1.68
    },
    "relatedVulnerabilities": [],
    "matchDetails": [
@@ -76,30 +85,40 @@
    "vulnerability": {
     "id": "CVE-1999-0002",
     "dataSource": "",
-    "namespace": "source-2",
     "severity": "Critical",
     "urls": [],
-    "description": "1999-02 description",
     "cvss": [
      {
-      "version": "2.0",
-      "vector": "vector",
+      "source": "nvd",
+      "type": "CVSS",
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H",
       "metrics": {
-       "baseScore": 1,
-       "exploitabilityScore": 2,
-       "impactScore": 3
+       "baseScore": 8.5
       },
-      "vendorMetadata": {
-       "BaseSeverity": "Low",
-       "Status": "verified"
-      }
+      "vendorMetadata": {}
+     }
+    ],
+    "knownExploited": [
+     {
+      "cve": "CVE-1999-0002",
+      "knownRansomwareCampaignUse": "Known"
+     }
+    ],
+    "epss": [
+     {
+      "cve": "CVE-1999-0002",
+      "epss": 0.08,
+      "percentile": 0.53,
+      "date": "0001-01-01"
      }
     ],
     "fix": {
      "versions": [],
      "state": ""
     },
-    "advisories": []
+    "advisories": [],
+    "risk": 96.25000000000001
    },
    "relatedVulnerabilities": [],
    "matchDetails": [

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
@@ -4,18 +4,26 @@
    "vulnerability": {
     "id": "CVE-1999-0001",
     "dataSource": "",
-    "namespace": "source-1",
     "severity": "Low",
     "urls": [],
-    "description": "1999-01 description",
     "cvss": [
      {
-      "version": "3.0",
-      "vector": "another vector",
+      "source": "nvd",
+      "type": "CVSS",
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:H",
       "metrics": {
-       "baseScore": 4
+       "baseScore": 8.2
       },
       "vendorMetadata": {}
+     }
+    ],
+    "epss": [
+     {
+      "cve": "CVE-1999-0001",
+      "epss": 0.03,
+      "percentile": 0.42,
+      "date": "0001-01-01"
      }
     ],
     "fix": {
@@ -26,7 +34,8 @@
      ],
      "state": "fixed"
     },
-    "advisories": []
+    "advisories": [],
+    "risk": 1.68
    },
    "relatedVulnerabilities": [],
    "matchDetails": [
@@ -76,30 +85,40 @@
    "vulnerability": {
     "id": "CVE-1999-0002",
     "dataSource": "",
-    "namespace": "source-2",
     "severity": "Critical",
     "urls": [],
-    "description": "1999-02 description",
     "cvss": [
      {
-      "version": "2.0",
-      "vector": "vector",
+      "source": "nvd",
+      "type": "CVSS",
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H",
       "metrics": {
-       "baseScore": 1,
-       "exploitabilityScore": 2,
-       "impactScore": 3
+       "baseScore": 8.5
       },
-      "vendorMetadata": {
-       "BaseSeverity": "Low",
-       "Status": "verified"
-      }
+      "vendorMetadata": {}
+     }
+    ],
+    "knownExploited": [
+     {
+      "cve": "CVE-1999-0002",
+      "knownRansomwareCampaignUse": "Known"
+     }
+    ],
+    "epss": [
+     {
+      "cve": "CVE-1999-0002",
+      "epss": 0.08,
+      "percentile": 0.53,
+      "date": "0001-01-01"
      }
     ],
     "fix": {
      "versions": [],
      "state": ""
     },
-    "advisories": []
+    "advisories": [],
+    "risk": 96.25000000000001
    },
    "relatedVulnerabilities": [],
    "matchDetails": [

--- a/grype/presenter/models/sort_test.go
+++ b/grype/presenter/models/sort_test.go
@@ -4,16 +4,154 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestSortMatches(t *testing.T) {
-	matches := []Match{
+func TestSortStrategies(t *testing.T) {
+	strategies := SortStrategies()
+	expected := []SortStrategy{
+		SortByPackage,
+		SortBySeverity,
+		SortByThreat,
+		SortByRisk,
+		SortByKEV,
+		SortByVulnerability,
+	}
+	assert.Equal(t, expected, strategies)
+}
+
+func TestSortStrategyString(t *testing.T) {
+	assert.Equal(t, "package", SortByPackage.String())
+	assert.Equal(t, "severity", SortBySeverity.String())
+	assert.Equal(t, "epss", SortByThreat.String())
+	assert.Equal(t, "risk", SortByRisk.String())
+	assert.Equal(t, "kev", SortByKEV.String())
+	assert.Equal(t, "vulnerability", SortByVulnerability.String())
+}
+
+func TestGetSortStrategy(t *testing.T) {
+	tests := []struct {
+		name         string
+		strategyName SortStrategy
+		expected     bool
+	}{
 		{
+			name:         "Valid strategy",
+			strategyName: SortByPackage,
+			expected:     true,
+		},
+		{
+			name:         "Invalid strategy",
+			strategyName: "invalid",
+			expected:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			strategy := getSortStrategy(tt.strategyName)
+			validStrategy, _ := matchSortStrategy[tt.strategyName]
+
+			if tt.expected {
+				require.NotNil(t, strategy)
+				assert.Equal(t, validStrategy, strategy)
+			} else {
+				// Should fallback to default strategy
+				assert.NotNil(t, strategy)
+				assert.Equal(t, matchSortStrategy[DefaultSortStrategy], strategy)
+			}
+		})
+	}
+}
+
+func TestEPSSPercentile(t *testing.T) {
+	tests := []struct {
+		name     string
+		epss     []EPSS
+		expected float64
+	}{
+		{
+			name:     "Empty slice",
+			epss:     []EPSS{},
+			expected: 0.0,
+		},
+		{
+			name: "Single item",
+			epss: []EPSS{
+				{Percentile: 0.75},
+			},
+			expected: 0.75,
+		},
+		{
+			name: "Multiple items, already sorted",
+			epss: []EPSS{
+				{Percentile: 0.95},
+				{Percentile: 0.75},
+				{Percentile: 0.50},
+			},
+			expected: 0.95,
+		},
+		{
+			name: "Multiple items, unsorted",
+			epss: []EPSS{
+				{Percentile: 0.50},
+				{Percentile: 0.95},
+				{Percentile: 0.75},
+			},
+			expected: 0.95,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := epssPercentile(tt.epss)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSeverityPriority(t *testing.T) {
+	tests := []struct {
+		severity string
+		expected int
+	}{
+		{"critical", 1},
+		{"CRITICAL", 1},
+		{"high", 2},
+		{"HIGH", 2},
+		{"medium", 3},
+		{"MEDIUM", 3},
+		{"low", 4},
+		{"LOW", 4},
+		{"negligible", 5},
+		{"NEGLIGIBLE", 5},
+		{"unknown", 100},
+		{"", 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.severity, func(t *testing.T) {
+			result := severityPriority(tt.severity)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func createTestMatches() []Match {
+	return []Match{
+		{
+			// match 0: medium severity, high risk, high EPSS, no KEV
 			Vulnerability: Vulnerability{
 				VulnerabilityMetadata: VulnerabilityMetadata{
 					ID:       "CVE-2023-1111",
 					Severity: "medium",
+					EPSS: []EPSS{
+						{Percentile: 0.90},
+					},
+					KnownExploited: []KnownExploited{}, // empty KEV
 				},
+				Risk: 75.0,
 			},
 			Artifact: Package{
 				Name:    "package-b",
@@ -22,11 +160,17 @@ func TestSortMatches(t *testing.T) {
 			},
 		},
 		{
+			// match 1: critical severity, medium risk, medium EPSS, no KEV
 			Vulnerability: Vulnerability{
 				VulnerabilityMetadata: VulnerabilityMetadata{
 					ID:       "CVE-2023-2222",
 					Severity: "critical",
+					EPSS: []EPSS{
+						{Percentile: 0.70},
+					},
+					KnownExploited: []KnownExploited{}, // empty KEV
 				},
+				Risk: 50.0,
 			},
 			Artifact: Package{
 				Name:    "package-a",
@@ -35,11 +179,19 @@ func TestSortMatches(t *testing.T) {
 			},
 		},
 		{
+			// match 2: high severity, low risk, low EPSS, has KEV
 			Vulnerability: Vulnerability{
 				VulnerabilityMetadata: VulnerabilityMetadata{
 					ID:       "CVE-2023-3333",
 					Severity: "high",
+					EPSS: []EPSS{
+						{Percentile: 0.30},
+					},
+					KnownExploited: []KnownExploited{
+						{CVE: "CVE-2023-3333", KnownRansomwareCampaignUse: "No"},
+					}, // has KEV
 				},
+				Risk: 25.0,
 			},
 			Artifact: Package{
 				Name:    "package-a",
@@ -48,11 +200,17 @@ func TestSortMatches(t *testing.T) {
 			},
 		},
 		{
+			// match 3: low severity, very low risk, very low EPSS, no KEV
 			Vulnerability: Vulnerability{
 				VulnerabilityMetadata: VulnerabilityMetadata{
 					ID:       "CVE-2023-4444",
 					Severity: "low",
+					EPSS: []EPSS{
+						{Percentile: 0.10},
+					},
+					KnownExploited: []KnownExploited{}, // empty KEV
 				},
+				Risk: 10.0,
 			},
 			Artifact: Package{
 				Name:    "package-c",
@@ -61,11 +219,20 @@ func TestSortMatches(t *testing.T) {
 			},
 		},
 		{
+			// match 4: critical severity, very low risk, medium EPSS, has KEV with ransomware
 			Vulnerability: Vulnerability{
 				VulnerabilityMetadata: VulnerabilityMetadata{
 					ID:       "CVE-2023-5555",
 					Severity: "critical",
+					EPSS: []EPSS{
+						{Percentile: 0.50},
+					},
+					KnownExploited: []KnownExploited{
+						{CVE: "CVE-2023-5555", KnownRansomwareCampaignUse: "Known"},
+						{CVE: "CVE-2023-5555", KnownRansomwareCampaignUse: "Known", Product: "Different Product"},
+					}, // has multiple KEV entries with ransomware
 				},
+				Risk: 5.0,
 			},
 			Artifact: Package{
 				Name:    "package-a",
@@ -74,120 +241,260 @@ func TestSortMatches(t *testing.T) {
 			},
 		},
 	}
+}
 
-	t.Run("SortByPackage", func(t *testing.T) {
-		testMatches := deepCopyMatches(matches)
-		SortMatches(testMatches, SortByPackage)
+func TestAllSortStrategies(t *testing.T) {
+	matches := createTestMatches()
 
-		expected := []Match{
-			// package-a with 1.0.0 version, docker type first (alphabetical)
-			matches[4], // package-a, 1.0.0, docker, critical
-			matches[2], // package-a, 1.0.0, npm, high
-			matches[1], // package-a, 2.0.0, docker, critical
-			matches[0], // package-b, 1.2.0, npm, medium
-			matches[3], // package-c, 3.1.0, gem, low
+	tests := []struct {
+		strategy SortStrategy
+		expected []int // indexes into the original matches slice
+	}{
+		{
+			strategy: SortByPackage,
+			expected: []int{4, 2, 1, 0, 3}, // sorted by package name, version, type
+		},
+		{
+			strategy: SortByVulnerability,
+			expected: []int{0, 1, 2, 3, 4}, // sorted by vulnerability ID
+		},
+		{
+			strategy: SortBySeverity,
+			expected: []int{1, 4, 2, 0, 3}, // sorted by severity: critical, critical, high, medium, low
+		},
+		{
+			strategy: SortByThreat,
+			expected: []int{0, 1, 4, 2, 3}, // sorted by EPSS percentile: 0.90, 0.70, 0.50, 0.30, 0.10
+		},
+		{
+			strategy: SortByRisk,
+			expected: []int{0, 1, 2, 3, 4}, // sorted by risk: 75.0, 50.0, 25.0, 10.0, 5.0
+		},
+		{
+			strategy: SortByKEV,
+			expected: []int{4, 2, 0, 1, 3}, // sorted by KEV count: 2, 1, 0, 0, 0 (with ties broken by risk)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.strategy), func(t *testing.T) {
+			testMatches := deepCopyMatches(matches)
+			SortMatches(testMatches, tt.strategy)
+
+			expected := make([]Match, len(tt.expected))
+			for i, idx := range tt.expected {
+				expected[i] = matches[idx]
+			}
+
+			if diff := cmp.Diff(expected, testMatches); diff != "" {
+				t.Errorf("%s mismatch (-want +got):\n%s", tt.strategy, diff)
+			}
+		})
+	}
+}
+
+func TestIndividualCompareFunctions(t *testing.T) {
+	ms := createTestMatches()
+	m0 := ms[0] // medium severity, high risk, high EPSS, no KEV
+	m1 := ms[1] // critical severity, medium risk, medium EPSS, no KEV
+	m2 := ms[2] // high severity, low risk, low EPSS, has KEV
+	m3 := ms[3] // low severity, very low risk, very low EPSS, no KEV
+	m4 := ms[4] // critical severity, very low risk, medium EPSS, has KEV with ransomware
+
+	tests := []struct {
+		name        string
+		compareFunc compareFunc
+		pairs       []struct {
+			a, b     Match
+			expected int
 		}
+	}{
+		{
+			name:        "compareByVulnerabilityID",
+			compareFunc: compareByVulnerabilityID,
+			pairs: []struct {
+				a, b     Match
+				expected int
+			}{
+				{m0, m1, -1}, // CVE-2023-1111 < CVE-2023-2222
+				{m1, m0, 1},  // CVE-2023-2222 > CVE-2023-1111
+				{m0, m0, 0},  // Same ID
+			},
+		},
+		{
+			name:        "compareBySeverity",
+			compareFunc: compareBySeverity,
+			pairs: []struct {
+				a, b     Match
+				expected int
+			}{
+				{m0, m1, 1},  // medium > critical
+				{m1, m0, -1}, // critical < medium
+				{m1, m4, 0},  // both critical
+				{m2, m3, -1}, // high < low
+			},
+		},
+		{
+			name:        "compareByEPSSPercentile",
+			compareFunc: compareByEPSSPercentile,
+			pairs: []struct {
+				a, b     Match
+				expected int
+			}{
+				{m0, m1, -1}, // 0.90 > 0.70
+				{m1, m0, 1},  // 0.70 < 0.90
+				{m1, m4, -1}, // 0.70 > 0.50
+				{m4, m1, 1},  // 0.50 < 0.70
+			},
+		},
+		{
+			name:        "compareByPackageName",
+			compareFunc: compareByPackageName,
+			pairs: []struct {
+				a, b     Match
+				expected int
+			}{
+				{m0, m1, 1},  // package-b > package-a
+				{m1, m0, -1}, // package-a < package-b
+				{m1, m2, 0},  // both package-a
+			},
+		},
+		{
+			name:        "compareByPackageVersion",
+			compareFunc: compareByPackageVersion,
+			pairs: []struct {
+				a, b     Match
+				expected int
+			}{
+				{m1, m2, 1},  // 2.0.0 > 1.0.0
+				{m2, m1, -1}, // 1.0.0 < 2.0.0
+				{m2, m4, 0},  // both 1.0.0
+			},
+		},
+		{
+			name:        "compareByPackageType",
+			compareFunc: compareByPackageType,
+			pairs: []struct {
+				a, b     Match
+				expected int
+			}{
+				{m0, m1, 1},  // npm > docker
+				{m1, m0, -1}, // docker < npm
+				{m0, m2, 0},  // both npm
+			},
+		},
+		{
+			name:        "compareByRisk",
+			compareFunc: compareByRisk,
+			pairs: []struct {
+				a, b     Match
+				expected int
+			}{
+				{m0, m1, -1}, // 75.0 > 50.0
+				{m1, m0, 1},  // 50.0 < 75.0
+				{m3, m4, -1}, // 10.0 > 5.0
+			},
+		},
+		{
+			name:        "compareByKEV",
+			compareFunc: compareByKEV,
+			pairs: []struct {
+				a, b     Match
+				expected int
+			}{
+				{m0, m2, 1},  // 0 < 1 KEV entry
+				{m2, m0, -1}, // 1 > 0 KEV entry
+				{m2, m4, 1},  // 1 < 2 KEV entries
+				{m4, m2, -1}, // 2 > 1 KEV entry
+				{m0, m1, 0},  // both 0 KEV entries
+			},
+		},
+	}
 
-		if diff := cmp.Diff(expected, testMatches); diff != "" {
-			t.Errorf("SortByPackage mismatch (-want +got):\n%s", diff)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, pair := range tt.pairs {
+				result := tt.compareFunc(pair.a, pair.b)
+				assert.Equal(t, pair.expected, result, "comparing %v and %v", pair.a.Vulnerability.ID, pair.b.Vulnerability.ID)
+			}
+		})
+	}
+}
+
+func TestCombinedCompareFunctions(t *testing.T) {
+	ms := createTestMatches()
+	m0 := ms[0] // medium severity, high risk, high EPSS, no KEV, package-b
+	m1 := ms[1] // critical severity, medium risk, medium EPSS, no KEV, package-a
+	m2 := ms[2] // high severity, low risk, low EPSS, has KEV, package-a
+
+	t.Run("compareVulnerabilityAttributes", func(t *testing.T) {
+		result := compareVulnerabilityAttributes(m0, m1)
+		assert.Equal(t, -1, result, "CVE-2023-1111 should come before CVE-2023-2222")
+
+		result = compareVulnerabilityAttributes(m1, m0)
+		assert.Equal(t, 1, result, "CVE-2023-2222 should come after CVE-2023-1111")
 	})
 
-	t.Run("UnknownStrategy", func(t *testing.T) {
-		testMatches := deepCopyMatches(matches)
-		// should use default (package) strategy for unknown strategy names
-		SortMatches(testMatches, "unknown")
+	t.Run("comparePackageAttributes", func(t *testing.T) {
+		result := comparePackageAttributes(m0, m1)
+		assert.Equal(t, 1, result, "package-b should come after package-a")
 
-		expected := []Match{
-			matches[4], // package-a, 1.0.0, docker
-			matches[2], // package-a, 1.0.0, npm
-			matches[1], // package-a, 2.0.0, docker
-			matches[0], // package-b, 1.2.0, npm
-			matches[3], // package-c, 3.1.0, gem
-		}
+		result = comparePackageAttributes(m1, m2)
+		assert.Equal(t, 1, result, "package-a 2.0.0 should come after package-a 1.0.0")
 
-		if diff := cmp.Diff(expected, testMatches); diff != "" {
-			t.Errorf("Unknown strategy mismatch (-want +got):\n%s", diff)
-		}
+		result = comparePackageAttributes(m1, m1)
+		assert.Equal(t, 0, result, "same package should be equal")
+	})
+
+	t.Run("combine function", func(t *testing.T) {
+		// create a combined function that first compares by severity, then by risk if severity is equal
+		combined := combine(compareBySeverity, compareByRisk)
+
+		result := combined(m0, m1)
+		assert.Equal(t, 1, result, "medium should come after critical regardless of risk")
+
+		// create two matches with the same severity but different risk
+		m5 := m1 // critical severity, risk 50.0
+		m6 := m1
+		m6.Vulnerability.Risk = 60.0 // critical severity, risk 60.0
+
+		result = combined(m5, m6)
+		assert.Equal(t, 1, result, "with equal severity, lower risk (50.0) should come after higher risk (60.0)")
+
+		result = combined(m6, m5)
+		assert.Equal(t, -1, result, "with equal severity, higher risk (60.0) should come before lower risk (50.0)")
 	})
 }
 
-func TestEdgeCases(t *testing.T) {
-	t.Run("EmptySlice", func(t *testing.T) {
-		matches := []Match{}
-		// should not panic on empty slice
-		SortMatches(matches, SortByPackage)
+func TestSortWithStrategy(t *testing.T) {
+	matches := createTestMatches()
 
-		expected := []Match{}
-		if diff := cmp.Diff(expected, matches); diff != "" {
-			t.Errorf("Empty slice mismatch (-want +got):\n%s", diff)
-		}
-	})
+	// create a custom strategy that sorts only by vulnerability ID
+	customStrategy := sortStrategyImpl{compareByVulnerabilityID}
 
-	t.Run("SingleItem", func(t *testing.T) {
-		matches := []Match{
-			{
-				Vulnerability: Vulnerability{
-					VulnerabilityMetadata: VulnerabilityMetadata{
-						ID:       "CVE-2023-1111",
-						Severity: "medium",
-					},
-				},
-				Artifact: Package{
-					Name:    "package-a",
-					Version: "1.0.0",
-				},
-			},
-		}
-		expected := deepCopyMatches(matches)
-		// should not change anything with a single item
-		SortMatches(matches, SortByPackage)
+	expected := []Match{
+		matches[0], // CVE-2023-1111
+		matches[1], // CVE-2023-2222
+		matches[2], // CVE-2023-3333
+		matches[3], // CVE-2023-4444
+		matches[4], // CVE-2023-5555
+	}
 
-		if diff := cmp.Diff(expected, matches); diff != "" {
-			t.Errorf("Single item mismatch (-want +got):\n%s", diff)
-		}
-	})
+	testMatches := deepCopyMatches(matches)
+	sortWithStrategy(testMatches, customStrategy)
 
-	t.Run("NilValues", func(t *testing.T) {
-		matches := []Match{
-			{
-				Vulnerability: Vulnerability{
-					VulnerabilityMetadata: VulnerabilityMetadata{
-						ID:       "CVE-2023-1111",
-						Severity: "",
-					},
-				},
-				Artifact: Package{
-					Name:    "",
-					Version: "",
-				},
-			},
-			{
-				Vulnerability: Vulnerability{
-					VulnerabilityMetadata: VulnerabilityMetadata{
-						ID:       "CVE-2023-2222",
-						Severity: "low",
-					},
-				},
-				Artifact: Package{
-					Name:    "package-a",
-					Version: "1.0.0",
-				},
-			},
-		}
+	if diff := cmp.Diff(expected, testMatches); diff != "" {
+		t.Errorf("sortWithStrategy mismatch (-want +got):\n%s", diff)
+	}
 
-		expected := []Match{
-			matches[0], // empty name comes first alphabetically
-			matches[1], // "package-a"
-		}
+	// create an empty strategy (should not change the order)
+	emptyStrategy := sortStrategyImpl{}
+	originalMatches := deepCopyMatches(matches)
+	sortWithStrategy(originalMatches, emptyStrategy)
 
-		// should handle empty strings properly
-		SortMatches(matches, SortByPackage)
-
-		if diff := cmp.Diff(expected, matches); diff != "" {
-			t.Errorf("Nil values mismatch (-want +got):\n%s", diff)
-		}
-	})
+	if diff := cmp.Diff(matches, originalMatches); diff != "" {
+		t.Errorf("Empty strategy should not change order (-original +after):\n%s", diff)
+	}
 }
 
 func deepCopyMatches(matches []Match) []Match {

--- a/grype/presenter/models/vulnerability.go
+++ b/grype/presenter/models/vulnerability.go
@@ -12,6 +12,7 @@ type Vulnerability struct {
 	VulnerabilityMetadata
 	Fix        Fix        `json:"fix"`
 	Advisories []Advisory `json:"advisories"`
+	Risk       float64    `json:"risk"`
 }
 
 type Fix struct {
@@ -52,6 +53,7 @@ func NewVulnerability(vuln vulnerability.Vulnerability, metadata *vulnerability.
 			State:    string(vuln.Fix.State),
 		},
 		Advisories: advisories,
+		Risk:       metadata.RiskScore(),
 	}
 }
 func sortVersions(fixedVersions []string, format version.Format) []string {

--- a/grype/presenter/models/vulnerability_metadata.go
+++ b/grype/presenter/models/vulnerability_metadata.go
@@ -71,9 +71,9 @@ func toKnownExploited(knownExploited []vulnerability.KnownExploited) []KnownExpl
 			CVE:                        ke.CVE,
 			VendorProject:              ke.VendorProject,
 			Product:                    ke.Product,
-			DateAdded:                  ke.DateAdded.Format(time.DateOnly),
+			DateAdded:                  formatDate(ke.DateAdded),
 			RequiredAction:             ke.RequiredAction,
-			DueDate:                    ke.DueDate.Format(time.DateOnly),
+			DueDate:                    formatDate(ke.DueDate),
 			KnownRansomwareCampaignUse: ke.KnownRansomwareCampaignUse,
 			Notes:                      ke.Notes,
 			URLs:                       ke.URLs,
@@ -81,6 +81,13 @@ func toKnownExploited(knownExploited []vulnerability.KnownExploited) []KnownExpl
 		}
 	}
 	return result
+}
+
+func formatDate(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.Format(time.DateOnly)
 }
 
 func toEPSS(epss []vulnerability.EPSS) []EPSS {

--- a/grype/presenter/sarif/presenter_test.go
+++ b/grype/presenter/sarif/presenter_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,7 +18,7 @@ import (
 	"github.com/anchore/syft/syft/source/directorysource"
 )
 
-var updateSnapshot = flag.Bool("update-sarif", false, "update .golden files for sarif presenters")
+var updateSnapshot = flag.Bool("update", false, "update .golden files for sarif presenters")
 var validatorImage = "ghcr.io/anchore/sarif-validator:0.1.0@sha256:a0729d695e023740f5df6bcb50d134e88149bea59c63a896a204e88f62b564c6"
 
 func TestSarifPresenter(t *testing.T) {
@@ -57,8 +58,8 @@ func TestSarifPresenter(t *testing.T) {
 			actual = internal.Redact(actual)
 			expected = internal.Redact(expected)
 
-			if !bytes.Equal(expected, actual) {
-				assert.JSONEq(t, string(expected), string(actual))
+			if d := cmp.Diff(string(expected), string(actual)); d != "" {
+				t.Fatalf("(-want +got):\n%s", d)
 			}
 		})
 	}

--- a/grype/presenter/sarif/test-fixtures/snapshot/TestSarifPresenter_directory.golden
+++ b/grype/presenter/sarif/test-fixtures/snapshot/TestSarifPresenter_directory.golden
@@ -16,15 +16,15 @@
                 "text": "CVE-1999-0001 low vulnerability for package-1 package"
               },
               "fullDescription": {
-                "text": "1999-01 description"
+                "text": "Version 1.1.1 is affected with an available fix in versions 1.2.1,2.1.3,3.4.0"
               },
               "helpUri": "https://github.com/anchore/grype",
               "help": {
-                "text": "Vulnerability CVE-1999-0001\nSeverity: low\nPackage: package-1\nVersion: 1.1.1\nFix Version: 1.2.1,2.1.3,3.4.0\nType: rpm\nLocation: /some/path/somefile-1.txt\nData Namespace: source-1\nLink: CVE-1999-0001",
-                "markdown": "**Vulnerability CVE-1999-0001**\n| Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |\n| --- | --- | --- | --- | --- | --- | --- | --- |\n| low  | package-1  | 1.1.1  | 1.2.1,2.1.3,3.4.0  | rpm  | /some/path/somefile-1.txt  | source-1  | CVE-1999-0001  |\n"
+                "text": "Vulnerability CVE-1999-0001\nSeverity: low\nPackage: package-1\nVersion: 1.1.1\nFix Version: 1.2.1,2.1.3,3.4.0\nType: rpm\nLocation: /some/path/somefile-1.txt\nData Namespace: \nLink: CVE-1999-0001",
+                "markdown": "**Vulnerability CVE-1999-0001**\n| Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |\n| --- | --- | --- | --- | --- | --- | --- | --- |\n| low  | package-1  | 1.1.1  | 1.2.1,2.1.3,3.4.0  | rpm  | /some/path/somefile-1.txt  |   | CVE-1999-0001  |\n"
               },
               "properties": {
-                "security-severity": "4.0"
+                "security-severity": "8.2"
               }
             },
             {
@@ -34,18 +34,18 @@
                 "text": "CVE-1999-0002 critical vulnerability for package-2 package"
               },
               "fullDescription": {
-                "text": "1999-02 description"
+                "text": "Version 2.2.2 is affected with no fixes reported yet."
               },
               "helpUri": "https://github.com/anchore/grype",
               "help": {
-                "text": "Vulnerability CVE-1999-0002\nSeverity: critical\nPackage: package-2\nVersion: 2.2.2\nFix Version: \nType: deb\nLocation: /some/path/somefile-2.txt\nData Namespace: source-2\nLink: CVE-1999-0002",
-                "markdown": "**Vulnerability CVE-1999-0002**\n| Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |\n| --- | --- | --- | --- | --- | --- | --- | --- |\n| critical  | package-2  | 2.2.2  |   | deb  | /some/path/somefile-2.txt  | source-2  | CVE-1999-0002  |\n"
+                "text": "Vulnerability CVE-1999-0002\nSeverity: critical\nPackage: package-2\nVersion: 2.2.2\nFix Version: \nType: deb\nLocation: /some/path/somefile-2.txt\nData Namespace: \nLink: CVE-1999-0002",
+                "markdown": "**Vulnerability CVE-1999-0002**\n| Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |\n| --- | --- | --- | --- | --- | --- | --- | --- |\n| critical  | package-2  | 2.2.2  |   | deb  | /some/path/somefile-2.txt  |   | CVE-1999-0002  |\n"
               },
               "properties": {
                 "purls": [
                   "pkg:deb/package-2@2.2.2"
                 ],
-                "security-severity": "1.0"
+                "security-severity": "8.5"
               }
             }
           ]

--- a/grype/presenter/sarif/test-fixtures/snapshot/TestSarifPresenter_image.golden
+++ b/grype/presenter/sarif/test-fixtures/snapshot/TestSarifPresenter_image.golden
@@ -16,15 +16,15 @@
                 "text": "CVE-1999-0001 low vulnerability for package-1 package"
               },
               "fullDescription": {
-                "text": "1999-01 description"
+                "text": "Version 1.1.1 is affected with an available fix in versions 1.2.1,2.1.3,3.4.0"
               },
               "helpUri": "https://github.com/anchore/grype",
               "help": {
-                "text": "Vulnerability CVE-1999-0001\nSeverity: low\nPackage: package-1\nVersion: 1.1.1\nFix Version: 1.2.1,2.1.3,3.4.0\nType: rpm\nLocation: somefile-1.txt\nData Namespace: source-1\nLink: CVE-1999-0001",
-                "markdown": "**Vulnerability CVE-1999-0001**\n| Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |\n| --- | --- | --- | --- | --- | --- | --- | --- |\n| low  | package-1  | 1.1.1  | 1.2.1,2.1.3,3.4.0  | rpm  | somefile-1.txt  | source-1  | CVE-1999-0001  |\n"
+                "text": "Vulnerability CVE-1999-0001\nSeverity: low\nPackage: package-1\nVersion: 1.1.1\nFix Version: 1.2.1,2.1.3,3.4.0\nType: rpm\nLocation: somefile-1.txt\nData Namespace: \nLink: CVE-1999-0001",
+                "markdown": "**Vulnerability CVE-1999-0001**\n| Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |\n| --- | --- | --- | --- | --- | --- | --- | --- |\n| low  | package-1  | 1.1.1  | 1.2.1,2.1.3,3.4.0  | rpm  | somefile-1.txt  |   | CVE-1999-0001  |\n"
               },
               "properties": {
-                "security-severity": "4.0"
+                "security-severity": "8.2"
               }
             },
             {
@@ -34,18 +34,18 @@
                 "text": "CVE-1999-0002 critical vulnerability for package-2 package"
               },
               "fullDescription": {
-                "text": "1999-02 description"
+                "text": "Version 2.2.2 is affected with no fixes reported yet."
               },
               "helpUri": "https://github.com/anchore/grype",
               "help": {
-                "text": "Vulnerability CVE-1999-0002\nSeverity: critical\nPackage: package-2\nVersion: 2.2.2\nFix Version: \nType: deb\nLocation: somefile-2.txt\nData Namespace: source-2\nLink: CVE-1999-0002",
-                "markdown": "**Vulnerability CVE-1999-0002**\n| Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |\n| --- | --- | --- | --- | --- | --- | --- | --- |\n| critical  | package-2  | 2.2.2  |   | deb  | somefile-2.txt  | source-2  | CVE-1999-0002  |\n"
+                "text": "Vulnerability CVE-1999-0002\nSeverity: critical\nPackage: package-2\nVersion: 2.2.2\nFix Version: \nType: deb\nLocation: somefile-2.txt\nData Namespace: \nLink: CVE-1999-0002",
+                "markdown": "**Vulnerability CVE-1999-0002**\n| Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |\n| --- | --- | --- | --- | --- | --- | --- | --- |\n| critical  | package-2  | 2.2.2  |   | deb  | somefile-2.txt  |   | CVE-1999-0002  |\n"
               },
               "properties": {
                 "purls": [
                   "pkg:deb/package-2@2.2.2"
                 ],
-                "security-severity": "1.0"
+                "security-severity": "8.5"
               }
             }
           ]

--- a/grype/presenter/table/__snapshots__/presenter_test.snap
+++ b/grype/presenter/table/__snapshots__/presenter_test.snap
@@ -1,15 +1,15 @@
 
 [TestTablePresenter/no_color - 1]
-NAME       INSTALLED  FIXED-IN              TYPE  VULNERABILITY  SEVERITY 
-package-1  1.1.1      *1.2.1, 2.1.3, 3.4.0  rpm   CVE-1999-0001  Low       
-package-2  2.2.2                            deb   CVE-1999-0002  Critical  
+NAME       INSTALLED  FIXED-IN              TYPE  VULNERABILITY  SEVERITY  EPSS%  RISK         
+package-1  1.1.1      *1.2.1, 2.1.3, 3.4.0  rpm   CVE-1999-0001  Low       42.00    1.7  
+package-2  2.2.2                            deb   CVE-1999-0002  Critical  53.00   96.3  (kev)  
 
 ---
 
 [TestTablePresenter/with_color - 1]
-NAME       INSTALLED  FIXED-IN             TYPE  VULNERABILITY  SEVERITY 
-package-1  1.1.1      [1;4;36;4m1[0m[1;4;36;4m.[0m[1;4;36;4m2[0m[1;4;36;4m.[0m[1;4;36;4m1[0m, 2.1.3, 3.4.0  rpm   CVE-1999-0001  [0;32mLow[0m       
-package-2  2.2.2                           deb   CVE-1999-0002  [1;31mCritical[0m  
+NAME       INSTALLED  FIXED-IN             TYPE  VULNERABILITY  SEVERITY  EPSS%  RISK          
+package-1  1.1.1      1.2.1[38;5;240m, [0m[38;5;240m2.1.3[0m[38;5;240m, [0m[38;5;240m3.4.0[0m  rpm   CVE-1999-0001  [38;5;36mLow[0m       42.00    1.7  
+package-2  2.2.2                           deb   CVE-1999-0002  [1;38;5;198mCritical[0m  53.00   96.3  [1;38;5;198m[0m[1;7;38;5;198mKEV[0m[1;38;5;198m[0m   
 
 ---
 
@@ -19,35 +19,35 @@ No vulnerabilities found
 ---
 
 [TestHidesIgnoredMatches - 1]
-NAME       INSTALLED  FIXED-IN              TYPE  VULNERABILITY  SEVERITY 
-package-1  1.1.1      *1.2.1, 2.1.3, 3.4.0  rpm   CVE-1999-0001  Low       
-package-2  2.2.2                            deb   CVE-1999-0002  Critical  
+NAME       INSTALLED  FIXED-IN              TYPE  VULNERABILITY  SEVERITY  EPSS%  RISK         
+package-1  1.1.1      *1.2.1, 2.1.3, 3.4.0  rpm   CVE-1999-0001  Low       42.00    1.7  
+package-2  2.2.2                            deb   CVE-1999-0002  Critical  53.00   96.3  (kev)  
 
 ---
 
 [TestDisplaysIgnoredMatches - 1]
-NAME       INSTALLED  FIXED-IN              TYPE  VULNERABILITY  SEVERITY                      
-package-1  1.1.1      *1.2.1, 2.1.3, 3.4.0  rpm   CVE-1999-0001  Low       
-package-2  2.2.2                            deb   CVE-1999-0002  Critical  
-package-2  2.2.2                            deb   CVE-1999-0001  Low       (suppressed)         
-package-2  2.2.2                            deb   CVE-1999-0002  Critical  (suppressed)         
-package-2  2.2.2                            deb   CVE-1999-0004  Critical  (suppressed by VEX)  
+NAME       INSTALLED  FIXED-IN              TYPE  VULNERABILITY  SEVERITY  EPSS%  RISK                       
+package-1  1.1.1      *1.2.1, 2.1.3, 3.4.0  rpm   CVE-1999-0001  Low       42.00    1.7  
+package-2  2.2.2                            deb   CVE-1999-0002  Critical  53.00   96.3  (kev)                
+package-2  2.2.2                            deb   CVE-1999-0001  Low       42.00    1.7  (suppressed)         
+package-2  2.2.2                            deb   CVE-1999-0002  Critical  53.00   96.3  (kev, suppressed)    
+package-2  2.2.2                            deb   CVE-1999-0004  High      75.00    2.2  (suppressed by VEX)  
 
 ---
 
 [TestDisplaysDistro - 1]
-NAME       INSTALLED  FIXED-IN              TYPE  VULNERABILITY  SEVERITY               
-package-1  1.1.1      *1.2.1, 2.1.3, 3.4.0  rpm   CVE-1999-0001  Low       (ubuntu:2.5)  
-package-2  2.2.2                            deb   CVE-1999-0002  Critical  (ubuntu:3.5)  
+NAME       INSTALLED  FIXED-IN              TYPE  VULNERABILITY  SEVERITY  EPSS%  RISK                     
+package-1  1.1.1      *1.2.1, 2.1.3, 3.4.0  rpm   CVE-1999-0001  Low       42.00    1.7  (ubuntu:2.5)       
+package-2  2.2.2                            deb   CVE-1999-0002  Critical  53.00   96.3  (kev, ubuntu:3.5)  
 
 ---
 
 [TestDisplaysIgnoredMatchesAndDistro - 1]
-NAME       INSTALLED  FIXED-IN              TYPE  VULNERABILITY  SEVERITY                           
-package-1  1.1.1      *1.2.1, 2.1.3, 3.4.0  rpm   CVE-1999-0001  Low       (ubuntu:2.5)              
-package-2  2.2.2                            deb   CVE-1999-0002  Critical  (ubuntu:3.5)              
-package-2  2.2.2                            deb   CVE-1999-0001  Low       (ubuntu:2.5, suppressed)  
-package-2  2.2.2                            deb   CVE-1999-0002  Critical  (ubuntu:3.5, suppressed)  
-package-2  2.2.2                            deb   CVE-1999-0004  Critical  (suppressed by VEX)       
+NAME       INSTALLED  FIXED-IN              TYPE  VULNERABILITY  SEVERITY  EPSS%  RISK                                 
+package-1  1.1.1      *1.2.1, 2.1.3, 3.4.0  rpm   CVE-1999-0001  Low       42.00    1.7  (ubuntu:2.5)                   
+package-2  2.2.2                            deb   CVE-1999-0002  Critical  53.00   96.3  (kev, ubuntu:3.5)              
+package-2  2.2.2                            deb   CVE-1999-0001  Low       42.00    1.7  (ubuntu:2.5, suppressed)       
+package-2  2.2.2                            deb   CVE-1999-0002  Critical  53.00   96.3  (kev, ubuntu:3.5, suppressed)  
+package-2  2.2.2                            deb   CVE-1999-0004  High      75.00    2.2  (suppressed by VEX)            
 
 ---

--- a/grype/presenter/table/presenter.go
+++ b/grype/presenter/table/presenter.go
@@ -26,6 +26,14 @@ type Presenter struct {
 	withColor      bool
 
 	recommendedFixStyle lipgloss.Style
+	kevStyle            lipgloss.Style
+	criticalStyle       lipgloss.Style
+	highStyle           lipgloss.Style
+	mediumStyle         lipgloss.Style
+	lowStyle            lipgloss.Style
+	negligibleStyle     lipgloss.Style
+	auxiliaryStyle      lipgloss.Style
+	unknownStyle        lipgloss.Style
 }
 
 type rows []row
@@ -37,7 +45,25 @@ type row struct {
 	PackageType     string
 	VulnerabilityID string
 	Severity        string
+	EPSS            epss
+	Risk            string
 	Annotation      string
+}
+
+type epss struct {
+	Score      float64
+	Percentile float64
+}
+
+func (e epss) String() string {
+	percentile := e.Percentile * 100
+	switch {
+	case percentile == 0:
+		return "  N/A"
+	case percentile < 0.1:
+		return "< 0.1%"
+	}
+	return fmt.Sprintf("%5.2f", percentile)
 }
 
 // NewPresenter is a *Presenter constructor
@@ -45,13 +71,22 @@ func NewPresenter(pb models.PresenterConfig, showSuppressed bool) *Presenter {
 	withColor := supportsColor()
 	fixStyle := lipgloss.NewStyle().Border(lipgloss.Border{Left: "*"}, false, false, false, true)
 	if withColor {
-		fixStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true).Underline(true)
+		fixStyle = lipgloss.NewStyle()
 	}
 	return &Presenter{
 		document:            pb.Document,
 		showSuppressed:      showSuppressed,
 		withColor:           withColor,
 		recommendedFixStyle: fixStyle,
+		negligibleStyle:     lipgloss.NewStyle().Foreground(lipgloss.Color("240")),                          // dark gray
+		lowStyle:            lipgloss.NewStyle().Foreground(lipgloss.Color("36")),                           // cyan/teal
+		mediumStyle:         lipgloss.NewStyle().Foreground(lipgloss.Color("178")),                          // gold/amber
+		highStyle:           lipgloss.NewStyle().Foreground(lipgloss.Color("203")),                          // salmon/light red
+		criticalStyle:       lipgloss.NewStyle().Foreground(lipgloss.Color("198")).Bold(true),               // bright pink
+		kevStyle:            lipgloss.NewStyle().Foreground(lipgloss.Color("198")).Reverse(true).Bold(true), // white on bright pink
+		//kevStyle:       lipgloss.NewStyle().Foreground(lipgloss.Color("198")),             // bright pink
+		auxiliaryStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("240")), // dark gray
+		unknownStyle:   lipgloss.NewStyle().Foreground(lipgloss.Color("12")),  // light blue
 	}
 }
 
@@ -65,7 +100,7 @@ func (p *Presenter) Present(output io.Writer) error {
 	}
 
 	table := tablewriter.NewWriter(output)
-	table.SetHeader([]string{"Name", "Installed", "Fixed-In", "Type", "Vulnerability", "Severity"})
+	table.SetHeader([]string{"Name", "Installed", "Fixed-In", "Type", "Vulnerability", "Severity", "EPSS%", "Risk"})
 	table.SetAutoWrapText(false)
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
@@ -81,15 +116,16 @@ func (p *Presenter) Present(output io.Writer) error {
 
 	if p.withColor {
 		for _, row := range rs.Deduplicate() {
-			severityColor := getSeverityColor(row.Severity)
 			table.Rich(row.Columns(), []tablewriter.Colors{
-				{},              // name
-				{},              // version
-				{},              // fix
-				{},              // package type
-				{},              // vulnerability ID
-				severityColor,   // severity
-				annotationColor, // annotations
+				{}, // name
+				{}, // version
+				{}, // fix
+				{}, // package type
+				{}, // vulnerability ID
+				{}, // severity
+				{}, // epss,
+				{}, // risk
+				{}, // annotations
 			})
 		}
 	} else {
@@ -143,22 +179,34 @@ func supportsColor() bool {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Render("") != ""
 }
 
-func (p *Presenter) newRow(m models.Match, severitySuffix string, showDistro bool) row {
+func (p *Presenter) newRow(m models.Match, extraAnnotation string, showDistro bool) row {
 	var annotations []string
 
 	if showDistro {
 		if d, err := distro.FromString(m.Vulnerability.Namespace); err == nil {
-			annotations = append(annotations, fmt.Sprintf("%s:%s", d.DistroType(), d.Version()))
+			annotations = append(annotations, p.auxiliaryStyle.Render(fmt.Sprintf("%s:%s", d.DistroType(), d.Version())))
 		}
 	}
 
-	if severitySuffix != "" {
-		annotations = append(annotations, severitySuffix)
+	if extraAnnotation != "" {
+		annotations = append(annotations, p.auxiliaryStyle.Render(extraAnnotation))
 	}
 
-	annotation := ""
+	var kev, annotation string
+	if len(m.Vulnerability.KnownExploited) > 0 {
+		if p.withColor {
+			kev = p.kevStyle.Reverse(false).Render("") + p.kevStyle.Render("KEV") + p.kevStyle.Reverse(false).Render("") // ⚡❋◆◉፨⿻⨳✖•
+		} else {
+			annotations = append([]string{"kev"}, annotations...)
+		}
+	}
+
 	if len(annotations) > 0 {
-		annotation = fmt.Sprintf("(%s)", strings.Join(annotations, ", "))
+		annotation = p.auxiliaryStyle.Render("(") + strings.Join(annotations, p.auxiliaryStyle.Render(", ")) + p.auxiliaryStyle.Render(")")
+	}
+
+	if kev != "" {
+		annotation = kev + " " + annotation
 	}
 
 	return row{
@@ -167,12 +215,58 @@ func (p *Presenter) newRow(m models.Match, severitySuffix string, showDistro boo
 		Fix:             p.formatFix(m),
 		PackageType:     string(m.Artifact.Type),
 		VulnerabilityID: m.Vulnerability.ID,
-		Severity:        m.Vulnerability.Severity,
+		Severity:        p.formatSeverity(m.Vulnerability.Severity),
+		EPSS:            newEPSS(m.Vulnerability.EPSS),
+		Risk:            p.formatRisk(m.Vulnerability.Risk),
 		Annotation:      annotation,
 	}
 }
 
+func newEPSS(es []models.EPSS) epss {
+	if len(es) == 0 {
+		return epss{}
+	}
+	return epss{
+		Score:      es[0].EPSS,
+		Percentile: es[0].Percentile,
+	}
+}
+
+func (p *Presenter) formatSeverity(severity string) string {
+	var severityStyle *lipgloss.Style
+	switch strings.ToLower(severity) {
+	case "critical":
+		severityStyle = &p.criticalStyle
+	case "high":
+		severityStyle = &p.highStyle
+	case "medium":
+		severityStyle = &p.mediumStyle
+	case "low":
+		severityStyle = &p.lowStyle
+	case "negligible":
+		severityStyle = &p.negligibleStyle
+	}
+
+	if severityStyle == nil {
+		severityStyle = &p.unknownStyle
+	}
+
+	return severityStyle.Render(severity)
+}
+
+func (p *Presenter) formatRisk(risk float64) string {
+	// TODO: add color to risk?
+	switch {
+	case risk == 0:
+		return "  N/A"
+	case risk < 0.1:
+		return "< 0.1"
+	}
+	return fmt.Sprintf("%5.1f", risk)
+}
+
 func (p *Presenter) formatFix(m models.Match) string {
+	// adjust the model fix state values for better presentation
 	switch m.Vulnerability.Fix.State {
 	case vulnerability.FixStateWontFix.String():
 		return "(won't fix)"
@@ -180,6 +274,19 @@ func (p *Presenter) formatFix(m models.Match) string {
 		return ""
 	}
 
+	// do our best to summarize the fixed versions, de-epmhasize non-recommended versions
+	// also, since there is not a lot of screen real estate, we will truncate the list of fixed versions
+	// to ~30 characters (or so) to avoid wrapping.
+	return p.applyTruncation(
+		p.formatVersionsToDisplay(
+			m,
+			getRecommendedVersions(m),
+		),
+		m.Vulnerability.Fix.Versions,
+	)
+}
+
+func getRecommendedVersions(m models.Match) *strset.Set {
 	recommended := strset.New()
 	for _, d := range m.MatchDetails {
 		if d.Fix == nil {
@@ -189,25 +296,72 @@ func (p *Presenter) formatFix(m models.Match) string {
 			recommended.Add(d.Fix.SuggestedVersion)
 		}
 	}
+	return recommended
+}
 
-	var vers []string
+const maxVersionFieldLength = 30
+
+func (p *Presenter) formatVersionsToDisplay(m models.Match, recommendedVersions *strset.Set) []string {
 	hasMultipleVersions := len(m.Vulnerability.Fix.Versions) > 1
+	shouldHighlightRecommended := hasMultipleVersions && recommendedVersions.Size() > 0
+
+	var currentCharacterCount int
+	added := strset.New()
+	var vers []string
+
 	for _, v := range m.Vulnerability.Fix.Versions {
-		if hasMultipleVersions && recommended.Has(v) {
-			vers = append(vers, p.recommendedFixStyle.Render(v))
-			continue
+		if added.Has(v) {
+			continue // skip duplicates
 		}
-		vers = append(vers, v)
+
+		if shouldHighlightRecommended {
+			if recommendedVersions.Has(v) {
+				// recommended versions always get added
+				added.Add(v)
+				currentCharacterCount += len(v)
+				vers = append(vers, p.recommendedFixStyle.Render(v))
+				continue
+			}
+
+			// skip not-necessarily-recommended versions if we're running out of space
+			if currentCharacterCount+len(v) > maxVersionFieldLength {
+				continue
+			}
+
+			// add not-necessarily-recommended versions with auxiliary styling
+			currentCharacterCount += len(v)
+			added.Add(v)
+			vers = append(vers, p.auxiliaryStyle.Render(v))
+		} else {
+			// when not prioritizing, add all versions
+			added.Add(v)
+			vers = append(vers, v)
+		}
 	}
 
-	return strings.Join(vers, ", ")
+	return vers
+}
+
+func (p *Presenter) applyTruncation(formattedVersions []string, allVersions []string) string {
+	finalVersions := strings.Join(formattedVersions, p.auxiliaryStyle.Render(", "))
+
+	var characterCount int
+	for _, v := range allVersions {
+		characterCount += len(v)
+	}
+
+	if characterCount > maxVersionFieldLength && len(allVersions) > 1 {
+		finalVersions += p.auxiliaryStyle.Render(", ...")
+	}
+
+	return finalVersions
 }
 
 func (r row) Columns() []string {
 	if r.Annotation != "" {
-		return []string{r.Name, r.Version, r.Fix, r.PackageType, r.VulnerabilityID, r.Severity, r.Annotation}
+		return []string{r.Name, r.Version, r.Fix, r.PackageType, r.VulnerabilityID, r.Severity, r.EPSS.String(), r.Risk, r.Annotation}
 	}
-	return []string{r.Name, r.Version, r.Fix, r.PackageType, r.VulnerabilityID, r.Severity}
+	return []string{r.Name, r.Version, r.Fix, r.PackageType, r.VulnerabilityID, r.Severity, r.EPSS.String(), r.Risk}
 }
 
 func (r row) String() string {
@@ -242,25 +396,3 @@ func (rs rows) Deduplicate() []row {
 	// render final columns
 	return deduped
 }
-
-func getSeverityColor(severity string) tablewriter.Colors {
-	severityFontType, severityColor := tablewriter.Normal, tablewriter.Normal
-
-	switch strings.ToLower(severity) {
-	case "critical":
-		severityFontType = tablewriter.Bold
-		severityColor = tablewriter.FgRedColor
-	case "high":
-		severityColor = tablewriter.FgRedColor
-	case "medium":
-		severityColor = tablewriter.FgYellowColor
-	case "low":
-		severityColor = tablewriter.FgGreenColor
-	case "negligible":
-		severityColor = tablewriter.FgBlueColor
-	}
-
-	return tablewriter.Colors{severityFontType, severityColor}
-}
-
-var annotationColor = tablewriter.Colors{tablewriter.FgWhiteColor}

--- a/grype/presenter/table/presenter.go
+++ b/grype/presenter/table/presenter.go
@@ -114,23 +114,7 @@ func (p *Presenter) Present(output io.Writer) error {
 	table.SetTablePadding("  ")
 	table.SetNoWhiteSpace(true)
 
-	if p.withColor {
-		for _, row := range rs.Deduplicate() {
-			table.Rich(row.Columns(), []tablewriter.Colors{
-				{}, // name
-				{}, // version
-				{}, // fix
-				{}, // package type
-				{}, // vulnerability ID
-				{}, // severity
-				{}, // epss,
-				{}, // risk
-				{}, // annotations
-			})
-		}
-	} else {
-		table.AppendBulk(rs.Render())
-	}
+	table.AppendBulk(rs.Render())
 
 	table.Render()
 

--- a/grype/vulnerability/metadata.go
+++ b/grype/vulnerability/metadata.go
@@ -1,6 +1,7 @@
 package vulnerability
 
 import (
+	"strings"
 	"time"
 )
 
@@ -14,6 +15,111 @@ type Metadata struct {
 	Cvss           []Cvss
 	KnownExploited []KnownExploited
 	EPSS           []EPSS
+
+	// calculated as-needed
+	risk float64
+}
+
+// RiskScore computes a basic quantitative risk by combining threat and severity.
+// Threat is represented by epss (likelihood of exploitation), and severity by the cvss base score + string severity.
+// Impact is currently fixed at 1 and may be integrated into the calculation in future versions.
+// Raw risk is epss * (cvss / 10) * impact, then scaled to 0–100 for readability.
+// If a vulnerability appears in the KEV list, apply an additional boost to reflect known exploitation.
+// Known ransomware campaigns receive a further, distinct boost.
+func (m *Metadata) RiskScore() float64 {
+	if m == nil {
+		return 0
+	}
+	if m.risk != 0 {
+		return m.risk
+	}
+	m.risk = riskScore(*m)
+	return m.risk
+}
+
+func riskScore(m Metadata) float64 {
+	return min(threat(m)*severity(m)*kevModifier(m), 1.0) * 100.0
+}
+
+func kevModifier(m Metadata) float64 {
+	if len(m.KnownExploited) > 0 {
+		for _, kev := range m.KnownExploited {
+			if strings.ToLower(kev.KnownRansomwareCampaignUse) == "known" {
+				// consider ransomware campaigns to be a greater kevModifier than other KEV threats
+				return 1.1
+			}
+		}
+		return 1.05 // boost the final result, as if there is a greater kevModifier inherently from KEV threats
+	}
+	return 1.0
+}
+
+func threat(m Metadata) float64 {
+	if len(m.KnownExploited) > 0 {
+		// per the EPSS guidance, any evidence of exploitation in the wild (not just PoC) should be considered over EPSS data
+		return 1.0
+	}
+	if len(m.EPSS) == 0 {
+		return 0.0
+	}
+	return m.EPSS[0].EPSS
+}
+
+// severity returns a 0-1 value, which is a combination of the string severity and the average of the cvss base scores.
+// If there are no cvss scores, the string severity is used. Some vendors only update the string severity and not the
+// cvss scores, so it's important to consider all sources. We are also not biasing towards any one source (multiple
+// cvss scores won't over-weigh the string severity).
+func severity(m Metadata) float64 {
+	// TODO: summarization should take a policy: prefer NVD over CNA or vice versa...
+
+	stringSeverityScore := severityToScore(m.Severity) / 10.0
+	avgBaseScore := average(validBaseScores(m.Cvss...)...) / 10.0
+	if avgBaseScore == 0 {
+		return stringSeverityScore
+	}
+	return average(stringSeverityScore, avgBaseScore)
+}
+
+func severityToScore(severity string) float64 {
+	// use the middle of the range for each severity
+	switch strings.ToLower(severity) {
+	case "negligible":
+		return 0.5
+	case "low":
+		return 3.0
+	case "medium":
+		return 5.0
+	case "high":
+		return 7.5
+	case "critical":
+		return 9.0
+	}
+	// the severity value might be "unknown" or an unexpected value. These should not be lost
+	// in the noise and placed at the bottom of the list... instead we compromise to the middle of the list.
+	return 5.0
+}
+
+func validBaseScores(as ...Cvss) []float64 {
+	var out []float64
+	for _, a := range as {
+		if a.Metrics.BaseScore == 0 {
+			// this is a mistake... base scores cannot be 0. Don't include this value and bring down the average
+			continue
+		}
+		out = append(out, a.Metrics.BaseScore)
+	}
+	return out
+}
+
+func average(as ...float64) float64 {
+	if len(as) == 0 {
+		return 0
+	}
+	sum := 0.0
+	for _, a := range as {
+		sum += a
+	}
+	return sum / float64(len(as))
 }
 
 type Cvss struct {

--- a/grype/vulnerability/metadata_test.go
+++ b/grype/vulnerability/metadata_test.go
@@ -1,0 +1,457 @@
+package vulnerability
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRiskScore(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata Metadata
+		expected float64
+	}{
+		{
+			name:     "nil metadata",
+			metadata: Metadata{},
+			expected: 0,
+		},
+		{
+			name: "already calculated risk",
+			metadata: Metadata{
+				risk: 42.5,
+			},
+			expected: 42.5,
+		},
+		{
+			name: "no EPSS data, no KEV",
+			metadata: Metadata{
+				Severity: "high",
+				Cvss: []Cvss{
+					{
+						Metrics: CvssMetrics{
+							BaseScore: 7.5,
+						},
+					},
+				},
+			},
+			expected: 0, // threat is 0 without EPSS or KEV
+		},
+		{
+			name: "with EPSS data, no KEV",
+			metadata: Metadata{
+				Severity: "high",
+				EPSS: []EPSS{
+					{
+						EPSS:       0.5,
+						Percentile: 0.95,
+					},
+				},
+				Cvss: []Cvss{
+					{
+						Metrics: CvssMetrics{
+							BaseScore: 7.5,
+						},
+					},
+				},
+			},
+			expected: 37.5, // 0.5 * (7.5/10) * 1 * 100
+		},
+		{
+			name: "with KEV, no EPSS",
+			metadata: Metadata{
+				Severity: "high",
+				KnownExploited: []KnownExploited{
+					{
+						CVE:                        "CVE-2023-1234",
+						KnownRansomwareCampaignUse: "No",
+					},
+				},
+				Cvss: []Cvss{
+					{
+						Metrics: CvssMetrics{
+							BaseScore: 7.5,
+						},
+					},
+				},
+			},
+			expected: 78.75, // 1.0 * (7.5/10) * 1.05* 100
+		},
+		{
+			name: "with KEV ransomware",
+			metadata: Metadata{
+				Severity: "high",
+				KnownExploited: []KnownExploited{
+					{
+						CVE:                        "CVE-2023-1234",
+						KnownRansomwareCampaignUse: "Known",
+					},
+				},
+				Cvss: []Cvss{
+					{
+						Metrics: CvssMetrics{
+							BaseScore: 7.5,
+						},
+					},
+				},
+			},
+			expected: 82.5, // 1.0 * (7.5/10) * 1.1 * 100
+		},
+		{
+			name: "with severity string only",
+			metadata: Metadata{
+				Severity: "critical",
+				EPSS: []EPSS{
+					{
+						EPSS:       0.8,
+						Percentile: 0.99,
+					},
+				},
+			},
+			expected: 72, // 0.8 * (9.0/10) * 1.0 * 100
+		},
+		{
+			name: "with multiple CVSS scores + string severity",
+			metadata: Metadata{
+				Severity: "medium",
+				EPSS: []EPSS{
+					{
+						EPSS:       0.6,
+						Percentile: 0.90,
+					},
+				},
+				Cvss: []Cvss{
+					{
+						Source: "NVD",
+						Metrics: CvssMetrics{
+							BaseScore: 6.5,
+						},
+					},
+					{
+						Source: "Vendor",
+						Metrics: CvssMetrics{
+							BaseScore: 5.5,
+						},
+					},
+				},
+			},
+			expected: 33, // 0.6 * ( (((6.5+5.5)/2)+5)/2 /10) * 1.0 * 100
+		},
+		{
+			name: "with some invalid CVSS scores + string severity",
+			metadata: Metadata{
+				Severity: "medium",
+				EPSS: []EPSS{
+					{
+						EPSS:       0.4,
+						Percentile: 0.85,
+					},
+				},
+				Cvss: []Cvss{
+					{
+						Source: "NVD",
+						Metrics: CvssMetrics{
+							BaseScore: 0, // invalid, should be ignored
+						},
+					},
+					{
+						Source: "Vendor",
+						Metrics: CvssMetrics{
+							BaseScore: 6.0,
+						},
+					},
+				},
+			},
+			expected: 22, // 0.4 * ((6.0+5)/2 /10) * 1.0 * 100
+		},
+		{
+			name: "unknown severity",
+			metadata: Metadata{
+				Severity: "unknown",
+				EPSS: []EPSS{
+					{
+						EPSS:       0.3,
+						Percentile: 0.80,
+					},
+				},
+			},
+			expected: 15, // 0.3 * (5.0/10) * 1.0 * 100
+		},
+		{
+			name: "maximum risk clamp",
+			metadata: Metadata{
+				Severity: "critical",
+				KnownExploited: []KnownExploited{
+					{
+						CVE:                        "CVE-2023-1234",
+						KnownRansomwareCampaignUse: "Known",
+					},
+				},
+				Cvss: []Cvss{
+					{
+						Metrics: CvssMetrics{
+							BaseScore: 10.0,
+						},
+					},
+				},
+			},
+			expected: 100, // clamped to 100 as it would be 1.0 * 1.0 * 1.1 * 100 = 120
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.metadata.RiskScore()
+			assert.InDelta(t, tt.expected, result, 0.01, "RiskScore method returned incorrect value")
+
+			// test the calculated value is cached
+			if tt.name != "already calculated risk" && tt.name != "nil metadata" {
+				require.InDelta(t, tt.expected, tt.metadata.risk, 0.01, "risk was not cached")
+			}
+
+			// test the standalone function
+			if tt.name != "nil metadata" && tt.name != "already calculated risk" {
+				funcResult := riskScore(tt.metadata)
+				assert.InDelta(t, tt.expected, funcResult, 0.0001, "riskScore function returned incorrect value")
+			}
+		})
+	}
+}
+
+func TestSeverityToScore(t *testing.T) {
+	tests := []struct {
+		severity string
+		expected float64
+	}{
+		{"negligible", 0.5},
+		{"NEGLIGIBLE", 0.5},
+		{"low", 3.0},
+		{"LOW", 3.0},
+		{"medium", 5.0},
+		{"MEDIUM", 5.0},
+		{"high", 7.5},
+		{"HIGH", 7.5},
+		{"critical", 9.0},
+		{"CRITICAL", 9.0},
+		{"unknown", 5.0},
+		{"", 5.0},
+		{"something-else", 5.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.severity, func(t *testing.T) {
+			result := severityToScore(tt.severity)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestAverageCVSS(t *testing.T) {
+	tests := []struct {
+		name     string
+		cvss     []Cvss
+		expected float64
+	}{
+		{
+			name:     "empty slice",
+			cvss:     []Cvss{},
+			expected: 0,
+		},
+		{
+			name: "single valid score",
+			cvss: []Cvss{
+				{Metrics: CvssMetrics{BaseScore: 7.5}},
+			},
+			expected: 7.5,
+		},
+		{
+			name: "multiple valid scores",
+			cvss: []Cvss{
+				{Metrics: CvssMetrics{BaseScore: 7.5}},
+				{Metrics: CvssMetrics{BaseScore: 8.5}},
+				{Metrics: CvssMetrics{BaseScore: 9.0}},
+			},
+			expected: 8.33333,
+		},
+		{
+			name: "with invalid scores",
+			cvss: []Cvss{
+				{Metrics: CvssMetrics{BaseScore: 0}}, // invalid
+				{Metrics: CvssMetrics{BaseScore: 7.5}},
+				{Metrics: CvssMetrics{BaseScore: 0}}, // invalid
+				{Metrics: CvssMetrics{BaseScore: 8.5}},
+			},
+			expected: 8.0,
+		},
+		{
+			name: "all invalid scores",
+			cvss: []Cvss{
+				{Metrics: CvssMetrics{BaseScore: 0}},
+				{Metrics: CvssMetrics{BaseScore: 0}},
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := average(validBaseScores(tt.cvss...)...)
+			assert.InDelta(t, tt.expected, result, 0.00001)
+		})
+	}
+}
+
+func TestThreat(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata Metadata
+		expected float64
+	}{
+		{
+			name:     "no EPSS, no KEV",
+			metadata: Metadata{},
+			expected: 0,
+		},
+		{
+			name: "with EPSS, no KEV",
+			metadata: Metadata{
+				EPSS: []EPSS{
+					{EPSS: 0.75},
+				},
+			},
+			expected: 0.75,
+		},
+		{
+			name: "with KEV, no EPSS",
+			metadata: Metadata{
+				KnownExploited: []KnownExploited{
+					{CVE: "CVE-2023-1234"},
+				},
+			},
+			expected: 1.0,
+		},
+		{
+			name: "with KEV and EPSS",
+			metadata: Metadata{
+				EPSS: []EPSS{
+					{EPSS: 0.5},
+				},
+				KnownExploited: []KnownExploited{
+					{CVE: "CVE-2023-1234"},
+				},
+			},
+			expected: 1.0, // KEV takes precedence
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := threat(tt.metadata)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestImpact(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata Metadata
+		expected float64
+	}{
+		{
+			name:     "no KEV",
+			metadata: Metadata{},
+			expected: 1.0,
+		},
+		{
+			name: "KEV without ransomware",
+			metadata: Metadata{
+				KnownExploited: []KnownExploited{
+					{KnownRansomwareCampaignUse: "No"},
+				},
+			},
+			expected: 1.05,
+		},
+		{
+			name: "KEV with ransomware",
+			metadata: Metadata{
+				KnownExploited: []KnownExploited{
+					{KnownRansomwareCampaignUse: "Known"},
+				},
+			},
+			expected: 1.1,
+		},
+		{
+			name: "KEV with case insensitive ransomware",
+			metadata: Metadata{
+				KnownExploited: []KnownExploited{
+					{KnownRansomwareCampaignUse: "KNOWN"},
+				},
+			},
+			expected: 1.1,
+		},
+		{
+			name: "multiple KEV entries, one with ransomware",
+			metadata: Metadata{
+				KnownExploited: []KnownExploited{
+					{KnownRansomwareCampaignUse: "No"},
+					{KnownRansomwareCampaignUse: "Known"},
+				},
+			},
+			expected: 1.1, // highest wins
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := kevModifier(tt.metadata)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSeverity(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata Metadata
+		expected float64
+	}{
+		{
+			name: "no CVSS, medium severity",
+			metadata: Metadata{
+				Severity: "medium",
+			},
+			expected: 0.5,
+		},
+		{
+			name: "with CVSS + severity string",
+			metadata: Metadata{
+				Severity: "medium",
+				Cvss: []Cvss{
+					{Metrics: CvssMetrics{BaseScore: 8.0}},
+				},
+			},
+			expected: 0.65,
+		},
+		{
+			name: "multiple CVSS scores + severity string",
+			metadata: Metadata{
+				Severity: "medium",
+				Cvss: []Cvss{
+					{Metrics: CvssMetrics{BaseScore: 6.0}},
+					{Metrics: CvssMetrics{BaseScore: 8.0}},
+				},
+			},
+			expected: 0.6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := severity(tt.metadata)
+			assert.InDelta(t, tt.expected, result, 0.00001)
+		})
+	}
+}


### PR DESCRIPTION
<img width="860" alt="Screenshot 2025-04-30 at 9 17 57 AM" src="https://github.com/user-attachments/assets/b87a5329-8b02-472a-883c-25baad5bab23" />


This adds a new `risk` metric to the grype results, allowing us to show prioritized vulnerability mathces in a way that helps users remediate the most "important" vulnerabilities first. 

The new `risk` metric is defined as `risk ~= threat * severity`, where:
- `threat` is the EPSS score for the CVE matched with (between 0-1), or if present on the KEV  list, then boosted by 5% (10% if the vulnerability is being used in ransomeware)
- `severity` is the average CVSS base score + string severity on the vulnerability record (scaled to between 0-1)
- the entire result is scaled to be a result from 0-100

**Grype results, regardless of the format, will be sorted by highest-risk-first by default**. Also the raw risk value will be added to the table and json output formats.

A new `--sort-by <value>` flag is being added with the following available options:

- `severity`: sort by severity
- `epss`: sort by EPSS percentile (aka, "threat")
- `risk`: sort by risk score (default)
- `kev`: just like risk, except that KEV entries are always above non-KEV entries
- `package`: sort by package name, version, type
- `vulnerability`: sort by vulnerability ID

Further adjustments have been made to the table output to help users with remediation:

- **add a new EPSS percentile column**: teams typically need to balance risk tolerance and budget when choosing how many vulnerabilities to remediate from the full set of results. The [EPSS documentation](https://www.first.org/epss/model) illustrates that selecting EPSS percentile cutoff could be a good way to maximize coverage and minimize effort relative to your teams needs. Exposing this raw metric makes following this advise much easier.

- **add KEV "pill" annotations next to table rows**: though presence on the KEV list typically means that the vulnerability has a high risk score (thus will float to the top of the results) it does **not** guarantee that a) there are non-KEV entries above it, or b) it is within your teams remediation cutoff (however you choose this). From this perspective it makes sense to make this "exploited in the wild" dimension more visible and not depend on purely sorting methods. If you want a high coupling of KEV evidence and the sort method, I'd recommend using `--sort-by kev`. 

- **emphasize the minimum version upgrade path**: this is really de-emphasizing other upgrade paths and truncating the `fixes` column in the table output when there are several updates (the JSON output will show all values). This better focuses users toward useful information by removing flashier formatting.

Fixes #1511
Fixes #1973