### PR TITLE
Fix severity field in `db search vuln`

### DIFF
--- a/cmd/grype/cli/commands/db_search_vuln_test.go
+++ b/cmd/grype/cli/commands/db_search_vuln_test.go
@@ -1,0 +1,228 @@
+package commands
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/grype/cmd/grype/cli/commands/internal/dbsearch"
+	v6 "github.com/anchore/grype/grype/db/v6"
+	"github.com/anchore/grype/grype/vulnerability"
+)
+
+func TestGetOSVersions(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []dbsearch.OperatingSystem
+		expected []string
+	}{
+		{
+			name:     "empty list",
+			input:    []dbsearch.OperatingSystem{},
+			expected: nil,
+		},
+		{
+			name: "single os",
+			input: []dbsearch.OperatingSystem{
+				{
+					Name:    "debian",
+					Version: "11",
+				},
+			},
+			expected: []string{"11"},
+		},
+		{
+			name: "multiple os",
+			input: []dbsearch.OperatingSystem{
+				{
+					Name:    "ubuntu",
+					Version: "16.04",
+				},
+				{
+					Name:    "ubuntu",
+					Version: "22.04",
+				},
+				{
+					Name:    "ubuntu",
+					Version: "24.04",
+				},
+			},
+			expected: []string{"16.04", "22.04", "24.04"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := getOSVersions(tt.input)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestGetPrimaryReference(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []v6.Reference
+		expected string
+	}{
+		{
+			name:     "empty list",
+			input:    []v6.Reference{},
+			expected: "",
+		},
+		{
+			name: "single reference",
+			input: []v6.Reference{
+				{
+					URL:  "https://example.com/vuln/123",
+					Tags: []string{"primary"},
+				},
+			},
+			expected: "https://example.com/vuln/123",
+		},
+		{
+			name: "multiple references",
+			input: []v6.Reference{
+				{
+					URL:  "https://example.com/vuln/123",
+					Tags: []string{"primary"},
+				},
+				{
+					URL:  "https://example.com/advisory/123",
+					Tags: []string{"secondary"},
+				},
+			},
+			expected: "https://example.com/vuln/123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := getPrimaryReference(tt.input)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestGetDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *time.Time
+		expected string
+	}{
+		{
+			name:     "nil time",
+			input:    nil,
+			expected: "",
+		},
+		{
+			name:     "zero time",
+			input:    &time.Time{},
+			expected: "",
+		},
+		{
+			name:     "valid time",
+			input:    timePtr(time.Date(2023, 5, 15, 0, 0, 0, 0, time.UTC)),
+			expected: "2023-05-15",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := getDate(tt.input)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestGetSeverity(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []v6.Severity
+		expected string
+	}{
+		{
+			name:     "empty list",
+			input:    []v6.Severity{},
+			expected: vulnerability.UnknownSeverity.String(),
+		},
+		{
+			name: "string severity",
+			input: []v6.Severity{
+				{
+					Scheme: "HML",
+					Value:  "high",
+					Source: "nvd@nist.gov",
+					Rank:   1,
+				},
+			},
+			expected: "high",
+		},
+		{
+			name: "CVSS severity",
+			input: []v6.Severity{
+				{
+					Scheme: "CVSS_V3",
+					Value: dbsearch.CVSSSeverity{
+						Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+						Version: "3.1",
+						Metrics: dbsearch.CvssMetrics{
+							BaseScore: 9.8,
+						},
+					},
+					Source: "nvd@nist.gov",
+					Rank:   1,
+				},
+			},
+			expected: "critical",
+		},
+		{
+			name: "other value type",
+			input: []v6.Severity{
+				{
+					Scheme: "OTHER",
+					Value:  42.0,
+					Source: "custom",
+					Rank:   1,
+				},
+			},
+			expected: "42",
+		},
+		{
+			name: "multiple severities",
+			input: []v6.Severity{
+				{
+					Scheme: "HML",
+					Value:  "high",
+					Source: "nvd@nist.gov",
+					Rank:   1,
+				},
+				{
+					Scheme: "CVSS_V3",
+					Value: dbsearch.CVSSSeverity{
+						Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+						Version: "3.1",
+						Metrics: dbsearch.CvssMetrics{
+							BaseScore: 9.8,
+						},
+					},
+					Source: "nvd@nist.gov",
+					Rank:   2,
+				},
+			},
+			expected: "high",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := getSeverity(tt.input)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}

--- a/internal/cvss/metrics.go
+++ b/internal/cvss/metrics.go
@@ -64,6 +64,24 @@ func ParseMetricsFromVector(vector string) (*vulnerability.CvssMetrics, error) {
 	}
 }
 
+func SeverityFromBaseScore(bs float64) vulnerability.Severity {
+	switch {
+	case bs >= 10.0:
+		return vulnerability.UnknownSeverity
+	case bs >= 9.0:
+		return vulnerability.CriticalSeverity
+	case bs >= 7.0:
+		return vulnerability.HighSeverity
+	case bs >= 4.0:
+		return vulnerability.MediumSeverity
+	case bs >= 0.1:
+		return vulnerability.LowSeverity
+	case bs > 0:
+		return vulnerability.NegligibleSeverity
+	}
+	return vulnerability.UnknownSeverity
+}
+
 // roundScore rounds the score to the nearest tenth based on first.org rounding rules
 // see https://www.first.org/cvss/v3.1/specification-document#Appendix-A---Floating-Point-Rounding
 func roundScore(score float64) float64 {

--- a/internal/cvss/metrics_test.go
+++ b/internal/cvss/metrics_test.go
@@ -110,6 +110,86 @@ func TestParseMetricsFromVector(t *testing.T) {
 	}
 }
 
+func TestSeverityFromBaseScore(t *testing.T) {
+	tests := []struct {
+		name     string
+		score    float64
+		expected vulnerability.Severity
+	}{
+		{
+			name:     "unknown severity (exactly 10.0)",
+			score:    10.0,
+			expected: vulnerability.UnknownSeverity,
+		},
+		{
+			name:     "unknown severity (greater than 10.0)",
+			score:    10.1,
+			expected: vulnerability.UnknownSeverity,
+		},
+		{
+			name:     "critical severity (lower bound)",
+			score:    9.0,
+			expected: vulnerability.CriticalSeverity,
+		},
+		{
+			name:     "critical severity (upper bound)",
+			score:    9.9,
+			expected: vulnerability.CriticalSeverity,
+		},
+		{
+			name:     "high severity (lower bound)",
+			score:    7.0,
+			expected: vulnerability.HighSeverity,
+		},
+		{
+			name:     "high severity (upper bound)",
+			score:    8.9,
+			expected: vulnerability.HighSeverity,
+		},
+		{
+			name:     "medium severity (lower bound)",
+			score:    4.0,
+			expected: vulnerability.MediumSeverity,
+		},
+		{
+			name:     "medium severity (upper bound)",
+			score:    6.9,
+			expected: vulnerability.MediumSeverity,
+		},
+		{
+			name:     "low severity (lower bound)",
+			score:    0.1,
+			expected: vulnerability.LowSeverity,
+		},
+		{
+			name:     "low severity (upper bound)",
+			score:    3.9,
+			expected: vulnerability.LowSeverity,
+		},
+		{
+			name:     "negligible severity (between 0 and 0.1)",
+			score:    0.05,
+			expected: vulnerability.NegligibleSeverity,
+		},
+		{
+			name:     "unknown severity (exactly zero)",
+			score:    0.0,
+			expected: vulnerability.UnknownSeverity,
+		},
+		{
+			name:     "unknown severity (negative)",
+			score:    -1.0,
+			expected: vulnerability.UnknownSeverity,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, SeverityFromBaseScore(tt.score))
+		})
+	}
+}
+
 func ptr(f float64) *float64 {
 	return &f
 }


### PR DESCRIPTION
Today there are raw `fmt.Sprintf("%v")` values without any stringer implemented (specifically when there is a CVSS as the primary severity entry). This PR fixes this behavior to show the string severity in this case.

<img width="1791" alt="Screenshot 2025-04-09 at 3 43 05 PM" src="https://github.com/user-attachments/assets/371d5086-3c73-4c12-bb70-7cc437a718f9" />
