### PR TITLE
Recover from panic within a matcher

### DIFF
--- a/grype/vulnerability_matcher.go
+++ b/grype/vulnerability_matcher.go
@@ -3,6 +3,7 @@ package grype
 import (
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"strings"
 
 	"github.com/wagoodman/go-partybus"
@@ -179,7 +180,7 @@ func (m *VulnerabilityMatcher) searchDBForMatches(
 			matchAgainst = []match.Matcher{defaultMatcher}
 		}
 		for _, theMatcher := range matchAgainst {
-			matches, ignoredMatches, err := theMatcher.Match(m.VulnerabilityProvider, p)
+			matches, ignoredMatches, err := callMatcherSafely(theMatcher, m.VulnerabilityProvider, p)
 			if err != nil {
 				if match.IsFatalError(err) {
 					return match.Matches{}, err
@@ -221,6 +222,16 @@ func (m *VulnerabilityMatcher) searchDBForMatches(
 	progressMonitor.MatchesDiscovered.Set(int64(res.Count()))
 
 	return res, errors.Join(matcherErrs...)
+}
+
+func callMatcherSafely(m match.Matcher, vp vulnerability.Provider, p pkg.Package) (matches []match.Match, ignoredMatches []match.IgnoredMatch, err error) {
+	// handle individual matcher panics
+	defer func() {
+		if e := recover(); e != nil {
+			err = match.NewFatalError(m.Type(), fmt.Errorf("%v at:\n%s", e, string(debug.Stack())))
+		}
+	}()
+	return m.Match(vp, p)
 }
 
 func (m *VulnerabilityMatcher) findVEXMatches(context pkg.Context, remainingMatches *match.Matches, ignoredMatches []match.IgnoredMatch, progressMonitor *monitorWriter) (*match.Matches, []match.IgnoredMatch, error) {

--- a/grype/vulnerability_matcher_test.go
+++ b/grype/vulnerability_matcher_test.go
@@ -1385,6 +1385,34 @@ func Test_filterMatchesUsingDistroFalsePositives(t *testing.T) {
 	}
 }
 
+type panicyMatcher struct {
+	matcherType match.MatcherType
+}
+
+func (m *panicyMatcher) PackageTypes() []syftPkg.Type {
+	return nil
+}
+
+func (m *panicyMatcher) Type() match.MatcherType {
+	return m.matcherType
+}
+
+func (m *panicyMatcher) Match(_ vulnerability.Provider, _ pkg.Package) ([]match.Match, []match.IgnoredMatch, error) {
+	panic("test panic message")
+}
+
+func TestCallMatcherSafely_RecoverFromPanic(t *testing.T) {
+	matcher := &panicyMatcher{
+		matcherType: "test-matcher",
+	}
+	_, _, err := callMatcherSafely(matcher, nil, pkg.Package{})
+
+	require.Error(t, err)
+	assert.True(t, match.IsFatalError(err))
+	require.Contains(t, err.Error(), "test panic message", "missing message")
+	require.Contains(t, err.Error(), "test-matcher", "missing matcher name")
+}
+
 type busListener struct {
 	matching monitor.Matching
 }


### PR DESCRIPTION
Today it is possible to panic and not recover within a matcher. This PR fixes this by recovering so that the UI can be shutdown gracefully and report the error. This is considered a fatal error still so no vulnerability results are returned in this case (when there is a panic, even when recovered).

### Before
<img width="1283" alt="Screenshot 2025-04-09 at 4 13 29 PM" src="https://github.com/user-attachments/assets/f2623e32-5ab6-498d-8113-78f33647fd16" />


### After
<img width="1461" alt="Screenshot 2025-04-09 at 4 12 54 PM" src="https://github.com/user-attachments/assets/2831b6db-c943-4646-ab26-4480737255de" />
