### PR TITLE
Assume that empty versions should match on all possible versions

### DIFF
--- a/grype/match/matches.go
+++ b/grype/match/matches.go
@@ -100,7 +100,8 @@ func (r *Matches) addOrMerge(newMatch Match, newFp Fingerprint) {
 		// case A
 		if err := existingMatch.Merge(newMatch); err != nil {
 			log.WithFields("original", existingMatch.String(), "new", newMatch.String(), "error", err).Warn("unable to merge matches")
-			// TODO: dropped match in this case, we should figure a way to handle this
+			// at least capture the additional details
+			existingMatch.Details = append(existingMatch.Details, newMatch.Details...)
 		}
 
 		r.byFingerprint[newFp] = existingMatch
@@ -125,6 +126,8 @@ func (r *Matches) mergeCoreMatches(newMatch Match, newFp Fingerprint, existingFi
 			// case B1
 			if replaced := r.replace(newMatch, existingFp, newFp, existingMatch.Details...); !replaced {
 				log.WithFields("original", existingMatch.String(), "new", newMatch.String()).Trace("unable to replace match")
+				// at least capture the new details
+				existingMatch.Details = append(existingMatch.Details, newMatch.Details...)
 			} else {
 				return true
 			}
@@ -132,7 +135,9 @@ func (r *Matches) mergeCoreMatches(newMatch Match, newFp Fingerprint, existingFi
 
 		// case B2
 		if err := existingMatch.Merge(newMatch); err != nil {
-			log.WithFields("original", existingMatch.String(), "new", newMatch.String(), "error", err).Warn("unable to merge matches")
+			log.WithFields("original", existingMatch.String(), "new", newMatch.String(), "error", err).Trace("unable to merge matches")
+			// at least capture the new details
+			existingMatch.Details = append(existingMatch.Details, newMatch.Details...)
 		} else {
 			return true
 		}

--- a/grype/matcher/internal/cpe_test.go
+++ b/grype/matcher/internal/cpe_test.go
@@ -216,14 +216,144 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 			},
 		},
 		{
-			name: "suppress matching when missing version",
+			name: "return all possible matches when missing version",
 			p: pkg.Package{
 				CPEs: []cpe.CPE{
-					cpe.Must("cpe:2.3:*:activerecord:activerecord:unknown:rando1:*:ra:*:ruby:*:*", ""),
-					cpe.Must("cpe:2.3:*:activerecord:activerecord:unknown:rando4:*:re:*:rails:*:*", ""),
+					cpe.Must("cpe:2.3:*:activerecord:activerecord:*:rando1:*:ra:*:ruby:*:*", ""),
+					cpe.Must("cpe:2.3:*:activerecord:activerecord:*:rando4:*:re:*:rails:*:*", ""),
 				},
 				Name:     "activerecord",
 				Version:  "",
+				Language: syftPkg.Ruby,
+				Type:     syftPkg.GemPkg,
+			},
+			expected: []match.Match{
+				{
+
+					Vulnerability: vulnerability.Vulnerability{
+						Reference: vulnerability.Reference{ID: "CVE-2017-fake-1"},
+					},
+					Package: pkg.Package{
+						CPEs: []cpe.CPE{
+							cpe.Must("cpe:2.3:*:activerecord:activerecord:*:rando1:*:ra:*:ruby:*:*", ""),
+							cpe.Must("cpe:2.3:*:activerecord:activerecord:*:rando4:*:re:*:rails:*:*", ""),
+						},
+						Name:     "activerecord",
+						Version:  "", // important!
+						Language: syftPkg.Ruby,
+						Type:     syftPkg.GemPkg,
+					},
+
+					Details: []match.Detail{
+						{
+							Type:       match.CPEMatch,
+							Confidence: 0.9,
+							SearchedBy: match.CPEParameters{
+								CPEs: []string{
+									"cpe:2.3:*:activerecord:activerecord:*:rando4:*:re:*:rails:*:*", //important!
+								},
+								Namespace: "nvd:cpe",
+								Package: match.CPEPackageParameter{
+									Name:    "activerecord",
+									Version: "", // important!
+								},
+							},
+							Found: match.CPEResult{
+								CPEs:              []string{"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*"},
+								VersionConstraint: "< 3.7.6 (semver)",
+								VulnerabilityID:   "CVE-2017-fake-1",
+							},
+							Matcher: matcher,
+						},
+					},
+				},
+				{
+
+					Vulnerability: vulnerability.Vulnerability{
+						Reference: vulnerability.Reference{ID: "CVE-2017-fake-2"},
+					},
+					Package: pkg.Package{
+						CPEs: []cpe.CPE{
+							cpe.Must("cpe:2.3:*:activerecord:activerecord:*:rando1:*:ra:*:ruby:*:*", ""),
+							cpe.Must("cpe:2.3:*:activerecord:activerecord:*:rando4:*:re:*:rails:*:*", ""),
+						},
+						Name:     "activerecord",
+						Version:  "", // important!
+						Language: syftPkg.Ruby,
+						Type:     syftPkg.GemPkg,
+					},
+
+					Details: []match.Detail{
+						{
+							Type:       match.CPEMatch,
+							Confidence: 0.9,
+							SearchedBy: match.CPEParameters{
+								CPEs:      []string{"cpe:2.3:*:activerecord:activerecord:*:rando1:*:ra:*:ruby:*:*"}, //important!
+								Namespace: "nvd:cpe",
+								Package: match.CPEPackageParameter{
+									Name:    "activerecord",
+									Version: "", // important!
+								},
+							},
+							Found: match.CPEResult{
+								CPEs:              []string{"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:ruby:*:*"},
+								VersionConstraint: "< 3.7.4 (semver)",
+								VulnerabilityID:   "CVE-2017-fake-2",
+							},
+							Matcher: matcher,
+						},
+					},
+				},
+				{
+
+					Vulnerability: vulnerability.Vulnerability{
+						Reference: vulnerability.Reference{ID: "CVE-2017-fake-3"},
+					},
+					Package: pkg.Package{
+						CPEs: []cpe.CPE{
+							cpe.Must("cpe:2.3:*:activerecord:activerecord:*:rando1:*:ra:*:ruby:*:*", ""),
+							cpe.Must("cpe:2.3:*:activerecord:activerecord:*:rando4:*:re:*:rails:*:*", ""),
+						},
+						Name:     "activerecord",
+						Version:  "", // important!
+						Language: syftPkg.Ruby,
+						Type:     syftPkg.GemPkg,
+					},
+					Details: []match.Detail{
+						{
+							Type:       match.CPEMatch,
+							Confidence: 0.9,
+							SearchedBy: match.CPEParameters{
+								CPEs: []string{
+									"cpe:2.3:*:activerecord:activerecord:*:rando1:*:ra:*:ruby:*:*",  //important!
+									"cpe:2.3:*:activerecord:activerecord:*:rando4:*:re:*:rails:*:*", //important!
+								},
+								Namespace: "nvd:cpe",
+								Package: match.CPEPackageParameter{
+									Name:    "activerecord",
+									Version: "", // important!
+								},
+							},
+							Found: match.CPEResult{
+								CPEs:              []string{"cpe:2.3:*:activerecord:activerecord:4.0.1:*:*:*:*:*:*:*"},
+								VersionConstraint: "= 4.0.1 (semver)",
+								VulnerabilityID:   "CVE-2017-fake-3",
+							},
+							Matcher: matcher,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "suppress matching when version is unknown",
+			p: pkg.Package{
+				CPEs: []cpe.CPE{
+					cpe.Must("cpe:2.3:*:activerecord:activerecord:*:rando1:*:ra:*:ruby:*:*", ""),
+					cpe.Must("cpe:2.3:*:activerecord:activerecord:*:rando4:*:re:*:rails:*:*", ""),
+				},
+				Name:     "activerecord",
+				Version:  "unknown",
 				Language: syftPkg.Ruby,
 				Type:     syftPkg.GemPkg,
 			},
@@ -908,6 +1038,20 @@ func TestFilterCPEsByVersion(t *testing.T) {
 				"cpe:2.3:*:multiple:multiple:1.0:*:*:*:*:*:*:*",
 			},
 		},
+		{
+			name:    "do not filter on empty version",
+			version: "", // important!
+			vulnerabilityCPEs: []string{
+				"cpe:2.3:*:multiple:multiple:*:*:*:*:*:*:*:*",
+				"cpe:2.3:*:multiple:multiple:1.0:*:*:*:*:*:*:*",
+				"cpe:2.3:*:multiple:multiple:2.0:*:*:*:*:*:*:*",
+			},
+			expected: []string{
+				"cpe:2.3:*:multiple:multiple:*:*:*:*:*:*:*:*",
+				"cpe:2.3:*:multiple:multiple:1.0:*:*:*:*:*:*:*",
+				"cpe:2.3:*:multiple:multiple:2.0:*:*:*:*:*:*:*",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -918,13 +1062,15 @@ func TestFilterCPEsByVersion(t *testing.T) {
 				vulnerabilityCPEs[idx] = cpe.Must(c, "")
 			}
 
-			versionObj, err := version.NewVersion(test.version, version.UnknownFormat)
-			if err != nil {
-				t.Fatalf("unable to get version: %+v", err)
+			var versionObj *version.Version
+			var err error
+			if test.version != "" {
+				versionObj, err = version.NewVersion(test.version, version.UnknownFormat)
+				require.NoError(t, err)
 			}
 
 			// run the test subject...
-			actual := filterCPEsByVersion(*versionObj, vulnerabilityCPEs)
+			actual := filterCPEsByVersion(versionObj, vulnerabilityCPEs)
 
 			// format CPE objects to string...
 			actualStrs := make([]string, len(actual))

--- a/grype/matcher/internal/distro.go
+++ b/grype/matcher/internal/distro.go
@@ -23,13 +23,18 @@ func MatchPackageByDistro(provider vulnerability.Provider, p pkg.Package, upstre
 		return nil, nil, nil
 	}
 
-	verObj, err := version.NewVersionFromPkg(p)
-	if err != nil {
-		if errors.Is(err, version.ErrUnsupportedVersion) {
-			log.WithFields("error", err).Tracef("skipping package '%s@%s'", p.Name, p.Version)
-			return nil, nil, nil
+	var verObj *version.Version
+	var err error
+
+	if p.Version != "" {
+		verObj, err = version.NewVersionFromPkg(p)
+		if err != nil {
+			if errors.Is(err, version.ErrUnsupportedVersion) {
+				log.WithFields("error", err).Tracef("skipping package '%s@%s'", p.Name, p.Version)
+				return nil, nil, nil
+			}
+			return nil, nil, fmt.Errorf("matcher failed to parse version pkg=%q ver=%q: %w", p.Name, p.Version, err)
 		}
-		return nil, nil, fmt.Errorf("matcher failed to parse version pkg=%q ver=%q: %w", p.Name, p.Version, err)
 	}
 
 	var matches []match.Match
@@ -78,5 +83,5 @@ func MatchPackageByDistro(provider vulnerability.Provider, p pkg.Package, upstre
 }
 
 func isUnknownVersion(v string) bool {
-	return v == "" || strings.ToLower(v) == "unknown"
+	return strings.ToLower(v) == "unknown"
 }

--- a/grype/matcher/internal/only_vulnerable_versions.go
+++ b/grype/matcher/internal/only_vulnerable_versions.go
@@ -8,7 +8,7 @@ import (
 
 // onlyVulnerableVersion returns a criteria object that tests affected vulnerability ranges against the provided version
 func onlyVulnerableVersions(v *version.Version) vulnerability.Criteria {
-	if v == nil {
+	if v == nil || v.Raw == "" {
 		// if no version is provided, match everything
 		return search.ByFunc(func(_ vulnerability.Vulnerability) (bool, string, error) {
 			return true, "", nil


### PR DESCRIPTION
Searching with CPEs and PURLs with partial information should yield match results with version constraints not evaluated, however, today they are dropped entirely:

Before any code changes:
<img width="794" alt="Screenshot 2025-04-09 at 3 52 33 PM" src="https://github.com/user-attachments/assets/1fe60775-52b8-449f-9b2f-cd854cf79c07" />
<img width="776" alt="Screenshot 2025-04-09 at 4 46 04 PM" src="https://github.com/user-attachments/assets/34bd74bb-b79b-446a-9f78-e066925380d2" />



This change allows for empty versions, which will satisfy any version constraint; after the code changes:
<img width="858" alt="Screenshot 2025-04-09 at 4 46 21 PM" src="https://github.com/user-attachments/assets/ce95acd8-7d45-4359-adb3-58bf3637979d" />
<img width="872" alt="Screenshot 2025-04-09 at 4 46 36 PM" src="https://github.com/user-attachments/assets/08668f24-f5d7-4498-b7aa-4d400484908f" />

Note this is subtly different than a version being explicitly `unknown`, which should not satisfy any version constraints.

## PR stack
- https://github.com/anchore/grype/pull/2590