### PR TITLE
fix: expand db cache dir homedir expressions

### DIFF
--- a/cmd/grype/cli/options/database.go
+++ b/cmd/grype/cli/options/database.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/anchore/clio"
+	"github.com/anchore/go-homedir"
 	"github.com/anchore/grype/grype/db/v6/distribution"
 	"github.com/anchore/grype/grype/db/v6/installation"
 )
@@ -25,6 +26,7 @@ type Database struct {
 
 var _ interface {
 	clio.FieldDescriber
+	clio.PostLoader
 } = (*Database)(nil)
 
 func DefaultDatabase(id clio.Identification) Database {
@@ -63,4 +65,10 @@ This file is ~156KiB as of 2024-04-17 so the download should be quick; adjust as
 	descriptions.Add(&cfg.UpdateDownloadTimeout, `Timeout for downloading actual vulnerability DB
 The DB is ~156MB as of 2024-04-17 so slower connections may exceed the default timeout; adjust as needed`)
 	descriptions.Add(&cfg.MaxUpdateCheckFrequency, `Maximum frequency to check for vulnerability database updates`)
+}
+
+func (cfg *Database) PostLoad() error {
+	var err error
+	cfg.Dir, err = homedir.Expand(cfg.Dir)
+	return err
 }


### PR DESCRIPTION
This PR just calls `homedir.Expand` on the configured DB cache dir. This fixes a longstanding issue that the user's homedir is replaced with `~` in `grype config`, but not expanded back properly as the user's homedir, but rather a subdirectory (`./~`).

Example:
```
$ GRYPE_DB_CACHE_DIR=~/grypedb go run ./cmd/grype alpine:3.15
...
$ ls -l ~/grypedb/6/vulnerability.db
-rw-r--r--@ 1 kzantow  staff  1118699520 Apr 16 08:28 /Users/kzantow/grypedb/6/vulnerability.db
```

Fixes #2024, #2599