### PR TITLE
fix: use package language to search when type is unknown

### DIFF
--- a/grype/db/v6/vulnerability_provider.go
+++ b/grype/db/v6/vulnerability_provider.go
@@ -222,7 +222,7 @@ func (vp vulnerabilityProvider) FindVulnerabilities(criteria ...vulnerability.Cr
 					pkgSpec = &PackageSpecifier{}
 				}
 				// the v6 store normalizes ecosystems around the syft package type, so that field is preferred
-				if c.PackageType != "" {
+				if c.PackageType != "" && c.PackageType != syftPkg.UnknownPkg {
 					pkgSpec.Ecosystem = string(c.PackageType)
 					pkgType = c.PackageType
 				} else {

--- a/grype/db/v6/vulnerability_provider_mocks_test.go
+++ b/grype/db/v6/vulnerability_provider_mocks_test.go
@@ -103,6 +103,13 @@ func testVulnerabilityProvider(t *testing.T) vulnerability.Provider {
 				"cpe:2.3:*:awesome:awesome:*:*:*:*:*:*:*:*", // shouldn't match on this
 			},
 		},
+		{
+			PackageName:       "Newtonsoft.Json",
+			Namespace:         "github:language:dotnet",
+			ID:                "GHSA-5crp-9r3c-p9vr",
+			VersionFormat:     "unknown",
+			VersionConstraint: "<13.0.1",
+		},
 		// poison the well! this is not a valid entry, but we want the matching process to survive and find other good results...
 		{
 			PackageName:       "activerecord",

--- a/grype/db/v6/vulnerability_provider_test.go
+++ b/grype/db/v6/vulnerability_provider_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/anchore/grype/grype/version"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/syft/syft/cpe"
+	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
 func Test_FindVulnerabilitiesByDistro(t *testing.T) {
@@ -301,6 +302,14 @@ func Test_FindVulnerabilitiesByByID(t *testing.T) {
 	actual, err = provider.FindVulnerabilities(search.ByDistro(*d), search.ByID("CVE-2014-fake-3"))
 	require.NoError(t, err)
 	require.Empty(t, actual)
+}
+
+func Test_FindVulnerabilitiesByEcosystem_UnknownPackageType(t *testing.T) {
+	provider := testVulnerabilityProvider(t)
+	actual, err := provider.FindVulnerabilities(search.ByEcosystem(syftPkg.Dotnet, syftPkg.UnknownPkg))
+	require.NoError(t, err)
+	require.NotEmpty(t, actual)
+	require.Equal(t, actual[0].Reference.ID, "GHSA-5crp-9r3c-p9vr")
 }
 
 func Test_DataSource(t *testing.T) {


### PR DESCRIPTION
Previously, this fallback was only used when the package type was blank, but Syft will set the package type to unknown if there is no package type, causing the fallback to language never to be entered, which resulted in some incorrect matches.

Fixes #2608 