### PR TITLE
chore: improve release quality gate

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,6 +60,17 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
           checkName: "Integration tests"
+          timeoutSeconds: 1200 # 20 minutes, it sometimes takes that long
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Check integration test results
+        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
+        id: quality_tests
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
+          checkName: "Quality tests"
+          timeoutSeconds: 1200 # 20 minutes, it sometimes takes that long
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Check acceptance test results (linux)
@@ -90,11 +101,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Quality gate
-        if: steps.static-analysis.outputs.conclusion != 'success' || steps.unit.outputs.conclusion != 'success' || steps.integration.outputs.conclusion != 'success' || steps.cli-linux.outputs.conclusion != 'success' || steps.acceptance-linux.outputs.conclusion != 'success' || steps.acceptance-mac.outputs.conclusion != 'success'
+        if: steps.static-analysis.outputs.conclusion != 'success' || steps.unit.outputs.conclusion != 'success' || steps.integration.outputs.conclusion != 'success' || steps.quality_tests.outputs.conclusion != 'success' || steps.cli-linux.outputs.conclusion != 'success' || steps.acceptance-linux.outputs.conclusion != 'success' || steps.acceptance-mac.outputs.conclusion != 'success'
         run: |
           echo "Static Analysis Status: ${{ steps.static-analysis.conclusion }}"
           echo "Unit Test Status: ${{ steps.unit.outputs.conclusion }}"
           echo "Integration Test Status: ${{ steps.integration.outputs.conclusion }}"
+          echo "Quality Test Status: ${{ steps.quality_tests.outputs.conclusion }}"
           echo "Acceptance Test (Linux) Status: ${{ steps.acceptance-linux.outputs.conclusion }}"
           echo "Acceptance Test (Mac) Status: ${{ steps.acceptance-mac.outputs.conclusion }}"
           echo "CLI Test (Linux) Status: ${{ steps.cli-linux.outputs.conclusion }}"


### PR DESCRIPTION
The release quality gate step polls to make sure the commit to be released has a green CI run. However if a PR is merged immediately before the release job is run, this step often times out. Raise the timeout to 20 minutes, which covers the time taken by recent CI runs.

Additionally, include the "Quality tests" step from validations.yaml in the tests to block on. It should always have been included.