### PR TITLE
feat: use namespace with name for golang purl decoder

### DIFF
--- a/grype/pkg/purl_provider.go
+++ b/grype/pkg/purl_provider.go
@@ -193,8 +193,13 @@ func purlToPackage(rawLine string) (*Package, *pkg.Package, string, string, erro
 		version = fmt.Sprintf("%s:%s", epoch, purl.Version)
 	}
 
+	name := purl.Name
+	if pkgType == pkg.GoModulePkg {
+		name = purl.Namespace + "/" + name
+	}
+
 	syftPkg := pkg.Package{
-		Name:     purl.Name,
+		Name:     name,
 		Version:  version,
 		Type:     pkgType,
 		CPEs:     cpes,
@@ -206,7 +211,7 @@ func purlToPackage(rawLine string) (*Package, *pkg.Package, string, string, erro
 	return &Package{
 		ID:        ID(purl.String()),
 		CPEs:      cpes,
-		Name:      purl.Name,
+		Name:      name,
 		Version:   version,
 		Type:      pkgType,
 		Language:  pkg.LanguageByName(purl.Type),

--- a/grype/pkg/purl_provider_test.go
+++ b/grype/pkg/purl_provider_test.go
@@ -376,6 +376,62 @@ func Test_PurlProvider(t *testing.T) {
 			},
 		},
 		{
+			name:      "include namespace in name when purl is type Golang",
+			userInput: "pkg:golang/k8s.io/ingress-nginx@v1.11.2",
+			context: Context{
+				Source: &source.Description{
+					Metadata: PURLLiteralMetadata{PURL: "pkg:golang/k8s.io/ingress-nginx@v1.11.2"},
+				},
+			},
+			pkgs: []Package{
+				{
+					Name:    "k8s.io/ingress-nginx",
+					Version: "v1.11.2",
+					Type:    pkg.GoModulePkg,
+					PURL:    "pkg:golang/k8s.io/ingress-nginx@v1.11.2",
+				},
+			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name:     "k8s.io/ingress-nginx",
+						Version:  "v1.11.2",
+						Type:     pkg.GoModulePkg,
+						Language: pkg.Go,
+						PURL:     "pkg:golang/k8s.io/ingress-nginx@v1.11.2",
+					}),
+				},
+			},
+		},
+		{
+			name:      "include complex namespace in name when purl is type Golang",
+			userInput: "pkg:golang/github.com/wazuh/wazuh@v4.5.0",
+			context: Context{
+				Source: &source.Description{
+					Metadata: PURLLiteralMetadata{PURL: "pkg:golang/github.com/wazuh/wazuh@v4.5.0"},
+				},
+			},
+			pkgs: []Package{
+				{
+					Name:    "github.com/wazuh/wazuh",
+					Version: "v4.5.0",
+					Type:    pkg.GoModulePkg,
+					PURL:    "pkg:golang/github.com/wazuh/wazuh@v4.5.0",
+				},
+			},
+			sbom: &sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(pkg.Package{
+						Name:     "github.com/wazuh/wazuh",
+						Version:  "v4.5.0",
+						Type:     pkg.GoModulePkg,
+						PURL:     "pkg:golang/github.com/wazuh/wazuh@v4.5.0",
+						Language: pkg.Go,
+					}),
+				},
+			},
+		},
+		{
 			name:      "infer context when distro is present for multiple similar purls",
 			userInput: "purl:test-fixtures/purl/homogeneous-os.txt",
 			context: Context{


### PR DESCRIPTION
Fixes #2580 

## Description
Currently the PURL decoder is too aggressive when constructing `name` for golang packages.

`pkg:golang/k8s.io/ingress-nginx@v1.11.2` will use `ingress-nginx` as the package name. When doing a search of the v6 db this would return `no results` for popular vulnerabilities like https://github.com/advisories/GHSA-mgvx-rpfc-9mpv.

These vulnerabilities are instead stored under:
```
k8s.io/ingress-nginx
``` 

More complex paths also exist as names like the following
```
github.com/wazuh/wazuh
```

These commands can be used to view the related vulnerability records in grype:
```
[I]  grype db search GHSA-hcrc-79hj-m3qh
VULNERABILITY        PACKAGE                 ECOSYSTEM  NAMESPACE           VERSION CONSTRAINT
GHSA-hcrc-79hj-m3qh  github.com/wazuh/wazuh  go-module  github:language:go  >=4.4.0,<4.9.1
[I] grype db search GHSA-mgvx-rpfc-9mpv

VULNERABILITY        PACKAGE                             ECOSYSTEM  NAMESPACE                             VERSION CONSTRAINT
GHSA-mgvx-rpfc-9mpv  ingress-nginx-controller-1.10       apk        chainguard:distro:chainguard:rolling  < 0
GHSA-mgvx-rpfc-9mpv  ingress-nginx-controller-1.11       apk        chainguard:distro:chainguard:rolling  < 1.11.5-r0
GHSA-mgvx-rpfc-9mpv  ingress-nginx-controller-1.12       apk        chainguard:distro:chainguard:rolling  < 1.12.1-r14
GHSA-mgvx-rpfc-9mpv  ingress-nginx-controller-1.12       apk        wolfi:distro:wolfi:rolling            < 1.12.1-r14
GHSA-mgvx-rpfc-9mpv  ingress-nginx-controller-fips-1.10  apk        chainguard:distro:chainguard:rolling  < 0
GHSA-mgvx-rpfc-9mpv  ingress-nginx-controller-fips-1.11  apk        chainguard:distro:chainguard:rolling  < 1.11.5-r0
GHSA-mgvx-rpfc-9mpv  ingress-nginx-controller-fips-1.12  apk        chainguard:distro:chainguard:rolling  < 1.12.1-r0
GHSA-mgvx-rpfc-9mpv  k8s.io/ingress-nginx                go-module  github:language:go                    <1.11.5
GHSA-mgvx-rpfc-9mpv  k8s.io/ingress-nginx                go-module  github:language:go                    >=1.12.0-beta.0,<1.12.1
[I] hal@Christophers-MacBook-Pro ~/d/grype (2580-purl-decoder-fix-golang)>
```

This PR updates the PURL provider to use namespace && name for the package name so searching the DB provides better results when submitting queries by PURL. 