### PR TITLE
fix: fall back to fuzzy constraint units

### DIFF
--- a/grype/version/constraint_expression.go
+++ b/grype/version/constraint_expression.go
@@ -7,6 +7,8 @@ import (
 	"text/scanner"
 )
 
+var ErrFallbackToFuzzy = fmt.Errorf("falling back to fuzzy version matching")
+
 type constraintExpression struct {
 	units       [][]constraintUnit // only supports or'ing a group of and'ed groups
 	comparators [][]Comparator     // only supports or'ing a group of and'ed groups
@@ -20,7 +22,7 @@ func newConstraintExpression(phrase string, genFn comparatorGenerator) (constrai
 
 	orUnits := make([][]constraintUnit, len(orParts))
 	orComparators := make([][]Comparator, len(orParts))
-
+	var fuzzyErr error
 	for orIdx, andParts := range orParts {
 		andUnits := make([]constraintUnit, len(andParts))
 		andComparators := make([]Comparator, len(andParts))
@@ -36,7 +38,16 @@ func newConstraintExpression(phrase string, genFn comparatorGenerator) (constrai
 
 			comparator, err := genFn(*unit)
 			if err != nil {
-				return constraintExpression{}, fmt.Errorf("failed to create comparator for '%s': %w", unit, err)
+				// this is a version constraint that could not be parsed as its
+				// specified type. Try falling back to fuzzy matching so that
+				// a match can still be attempted.
+				comparator, err = newFuzzyComparator(*unit)
+				if err != nil {
+					return constraintExpression{}, fmt.Errorf("failed to create comparator for '%s': %w", unit, err)
+				}
+				// Tell the caller we had to fallback from the specified
+				// version constraint format
+				fuzzyErr = ErrFallbackToFuzzy
 			}
 			andComparators[andIdx] = comparator
 		}
@@ -48,7 +59,7 @@ func newConstraintExpression(phrase string, genFn comparatorGenerator) (constrai
 	return constraintExpression{
 		units:       orUnits,
 		comparators: orComparators,
-	}, nil
+	}, fuzzyErr
 }
 
 func (c *constraintExpression) satisfied(other *Version) (bool, error) {

--- a/grype/version/constraint_expression_test.go
+++ b/grype/version/constraint_expression_test.go
@@ -1,6 +1,8 @@
 package version
 
 import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -85,4 +87,92 @@ func TestScanExpression(t *testing.T) {
 
 		})
 	}
+}
+
+func TestNewConstraintExpression(t *testing.T) {
+	tests := []struct {
+		name     string
+		phrase   string
+		genFn    comparatorGenerator
+		expected constraintExpression
+		wantErr  error
+	}{
+		{
+			name:   "single valid constraint",
+			phrase: "<1.1.1",
+			genFn:  newGolangComparator,
+			expected: constraintExpression{
+				units: [][]constraintUnit{
+					{constraintUnit{
+						rangeOperator: LT,
+						version:       "1.1.1",
+					}},
+				},
+				comparators: [][]Comparator{
+					{mustGolangComparator(t, constraintUnit{
+						rangeOperator: LT,
+						version:       "1.1.1",
+					})},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name:   "fall back to fuzzy on invalid semver",
+			phrase: ">9.6.0b1",
+			genFn:  newGolangComparator,
+			expected: constraintExpression{
+				units: [][]constraintUnit{
+					{constraintUnit{
+						rangeOperator: GT,
+						version:       "9.6.0b1",
+					}},
+				},
+				comparators: [][]Comparator{
+					{mustFuzzyComparator(t, constraintUnit{
+						rangeOperator: GT,
+						version:       "9.6.0b1",
+					})},
+				},
+			},
+			wantErr: ErrFallbackToFuzzy,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := newConstraintExpression(test.phrase, test.genFn)
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			opts := []cmp.Option{
+				cmp.AllowUnexported(constraintExpression{},
+					constraintUnit{}, golangVersion{}, fuzzyVersion{}, semanticVersion{}),
+			}
+			if diff := cmp.Diff(test.expected, actual, opts...); diff != "" {
+				t.Errorf("actual does not match expected, diff: %s", diff)
+			}
+		})
+	}
+}
+
+func mustGolangComparator(t *testing.T, unit constraintUnit) Comparator {
+	t.Helper()
+	c, err := newGolangComparator(unit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func mustFuzzyComparator(t *testing.T, unit constraintUnit) Comparator {
+	t.Helper()
+	c, err := newFuzzyComparator(unit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
 }

--- a/grype/version/pep440_constraint.go
+++ b/grype/version/pep440_constraint.go
@@ -44,7 +44,7 @@ func newPep440Constraint(raw string) (pep440Constraint, error) {
 
 	constraints, err := newConstraintExpression(raw, newPep440Comparator)
 	if err != nil {
-		return pep440Constraint{}, fmt.Errorf("unable to parse pep440 constrain phrase %w", err)
+		return pep440Constraint{}, fmt.Errorf("unable to parse pep440 constraint phrase %w", err)
 	}
 
 	return pep440Constraint{


### PR DESCRIPTION
If a given constraint unit cannot be parsed as its labeled type, try parsing it as a fuzzy version. In this way matching can be attempted even in the face of surprising upstream data.

See #2642 for a discussion of why. A companion grype-db PR will be up in a moment to write these range entries into the database as fuzzy entries.

The core issue here is how to handle GHSA entries whose version constraint is not a valid version for the language ecosystem that the affected package belongs to. The heuristic implemented in this PR helps with the Go and Python GHSAs that we are aware of, but doesn't help with the Ruby GHSAs. Follow #2646 for the Ruby-specific work needed here.
