### PR TITLE
fix: adjust version prefix check when excluding overlapping packages

### DIFF
--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -127,8 +127,8 @@ func excludePackage(comprehensiveDistroFeed bool, p syftPkg.Package, parent syft
 	// python      3.9.2      binary
 	// python3.9   3.9.2-1    deb
 
-	// If the version is not effectively the same, keep both
-	if !strings.HasPrefix(parent.Version, p.Version) {
+	// If the version is not approximately the same, keep both
+	if !strings.HasPrefix(parent.Version, p.Version) && !strings.HasPrefix(p.Version, parent.Version) {
 		return false
 	}
 

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -995,6 +995,27 @@ func Test_RemovePackagesByOverlap(t *testing.T) {
 				[]string{"rpm:python3-rpm@4.14.3-26.el8 -> python:rpm@4.14.3"}), "amzn"),
 			expectedPackages: []string{"rpm:python3-rpm@4.14.3-26.el8", "python:rpm@4.14.3"},
 		},
+		{
+			name: "remove overlapping package when parent version is prefix of child version",
+			sbom: withDistro(catalogWithOverlaps(
+				[]string{"rpm:kernel-rt-core@5.14.0-503.40.1.el9_5", "linux-kernel:linux-kernel@5.14.0-503.40.1.el9_5.x86_64+rt"},
+				[]string{"rpm:kernel-rt-core@5.14.0-503.40.1.el9_5 -> linux-kernel:linux-kernel@5.14.0-503.40.1.el9_5.x86_64+rt"}), "rhel"),
+			expectedPackages: []string{"rpm:kernel-rt-core@5.14.0-503.40.1.el9_5"},
+		},
+		{
+			name: "remove overlapping package when child version is prefix of parent version",
+			sbom: withDistro(catalogWithOverlaps(
+				[]string{"rpm:kernel-rt-core@5.14.0-503.40.1.el9_5+rt", "linux-kernel:linux-kernel@5.14.0-503.40.1.el9_5"},
+				[]string{"rpm:kernel-rt-core@5.14.0-503.40.1.el9_5+rt -> linux-kernel:linux-kernel@5.14.0-503.40.1.el9_5"}), "rhel"),
+			expectedPackages: []string{"rpm:kernel-rt-core@5.14.0-503.40.1.el9_5+rt"},
+		},
+		{
+			name: "do not remove overlapping package when versions are not similar",
+			sbom: withDistro(catalogWithOverlaps(
+				[]string{"rpm:kernel@5.14.0-503.40.1.el9_5", "linux-kernel:linux-kernel@6.17"},
+				[]string{"rpm:kernel@5.14.0-503.40.1.el9_5 -> linux-kernel:linux-kernel@6.17"}), "rhel"),
+			expectedPackages: []string{"rpm:kernel@5.14.0-503.40.1.el9_5", "linux-kernel:linux-kernel@6.17"},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Adjust the prefix check to allow removing an owned package if either version is a prefix of the other.