### PR TITLE
minor: add CPE source to the help text

### DIFF
--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -65,6 +65,7 @@ You can also explicitly specify the scheme to use:
     {{.appName}} registry:yourrepo/yourimage:tag        pull image directly from a registry (no container runtime required)
     {{.appName}} purl:path/to/purl/file                 read a newline separated file of package URLs from a path on disk
     {{.appName}} PURL                                   read a single package PURL directly (e.g. pkg:apk/openssl@3.2.1?distro=alpine-3.20.3)
+    {{.appName}} CPE                                    read a single CPE directly (e.g. cpe:2.3:a:openssl:openssl:3.0.14:*:*:*:*:*)
 
 You can also pipe in Syft JSON directly:
 	syft yourimage:tag -o json | {{.appName}}


### PR DESCRIPTION
The provider is supported, but was missing from the help text. I found out only after inspecting the source. I understand that matching with purl is more precise, but some applications cannot be represented as PURL.