### PR TITLE
Remove getDB() from the v6 DB reader

### DIFF
--- a/grype/db/v6/db.go
+++ b/grype/db/v6/db.go
@@ -57,7 +57,6 @@ type Reader interface {
 	AffectedPackageStoreReader
 	AffectedCPEStoreReader
 	io.Closer
-	getDB() *gorm.DB
 	attachBlobValue(...blobable) error
 }
 

--- a/grype/db/v6/refs.go
+++ b/grype/db/v6/refs.go
@@ -2,6 +2,8 @@ package v6
 
 import (
 	"slices"
+
+	"gorm.io/gorm"
 )
 
 type ref[ID, T any] struct {
@@ -38,7 +40,7 @@ func fillRefs[T, R any](reader Reader, handles []*T, getRef refProvider[T, R], r
 
 	// load a map with all id -> ref results
 	var values []R
-	tx := reader.getDB().Where("id IN (?)", ids)
+	tx := reader.(lowLevelReader).GetDB().Where("id IN (?)", ids)
 	err := tx.Find(&values).Error
 	if err != nil {
 		return err
@@ -72,4 +74,8 @@ func ptrs[T any](values []T) []*T {
 		out[i] = &values[i]
 	}
 	return out
+}
+
+type lowLevelReader interface {
+	GetDB() *gorm.DB
 }

--- a/grype/db/v6/store.go
+++ b/grype/db/v6/store.go
@@ -23,7 +23,7 @@ type store struct {
 	writable  bool
 }
 
-func (s *store) getDB() *gorm.DB {
+func (s *store) GetDB() *gorm.DB {
 	return s.db
 }
 


### PR DESCRIPTION
This removes the unexported getDB() call from the v6 DB Reader interface and exports the method in the underlying implementation so that callers can type assert out the lower-level reader if they need.