### PR TITLE
chore: update dockerfile base images to latest rolling tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM gcr.io/distroless/static-debian11@sha256:5759d194607e472ff80fff5833442d3991dd89b219c96552837a2c8f74058617 AS build
-
+FROM gcr.io/distroless/static-debian12:latest AS build
 
 FROM scratch
 # needed for version check HTTPS request

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,5 +1,4 @@
-FROM gcr.io/distroless/static-debian11:debug@sha256:c66a6ecb5aa7704a68c89d3ead1398adc7f16e214dda5f5f8e5d44351bcbf67d
-
+FROM gcr.io/distroless/static-debian12:debug
 
 # create the /tmp dir, which is needed for image content cache
 WORKDIR /tmp


### PR DESCRIPTION
# Description

An upstream issue with busy box was causing issues over in syft where users would see:
```
wget: TLS error from peer (alert code 40): handshake failure
wget: error getting response: Connection reset by peer
```

This could cause issues in ci pipelines where users needed the debug image of syft for running pre CI commands before the sbom functionality was invoked.

Similar bugs could be expected in grype given the same base images are in use here.

This PR moves grype forward to use the rolling tags for `latest` and `debug` images from distroless debian12. We also have upgraded from debian11

Here is a local demonstration of the fix. PR reviewers can pull down the branch and run `make snapshot` to build the docker images and test on their local:
```
[I] (base-image-updates)> docker run -it --rm --entrypoint /busybox/wget 13bd8f87c9d2 --no-check-certificate --spider https://www.google.com
Connecting to www.google.com (142.250.80.36:443)
remote file exists
[I](base-image-updates)> docker image ls | grep 13bd8f87c9d2
ghcr.io/anchore/grype                                        debug-arm64v8                                                      13bd8f87c9d2   2 minutes ago    72.1MB
ghcr.io/anchore/grype                                        v0.92.0-debug-arm64v8                                              13bd8f87c9d2   2 minutes ago    72.1MB
anchore/grype                                                debug-arm64v8                                                      13bd8f87c9d2   2 minutes ago    72.1MB
anchore/grype                                                v0.92.0-debug-arm64v8                                              13bd8f87c9d2   2 minutes ago    72.1MB
```

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
# Checklist:
- [x] I have tested my code in common scenarios and confirmed there are no regressions