### PR TITLE
Parse java group ID and artifact ID from PURL when missing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4
 	github.com/anchore/packageurl-go v0.1.1-0.20250220190351-d62adb6e1115
 	github.com/anchore/stereoscope v0.1.4
-	github.com/anchore/syft v1.25.1
+	github.com/anchore/syft v1.25.2-0.20250520195608-ac883f52edb8
 	github.com/aquasecurity/go-pep440-version v0.0.1
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/bmatcuk/doublestar/v2 v2.0.4

--- a/go.sum
+++ b/go.sum
@@ -710,8 +710,8 @@ github.com/anchore/packageurl-go v0.1.1-0.20250220190351-d62adb6e1115 h1:ZyRCmiE
 github.com/anchore/packageurl-go v0.1.1-0.20250220190351-d62adb6e1115/go.mod h1:KoYIv7tdP5+CC9VGkeZV4/vGCKsY55VvoG+5dadg4YI=
 github.com/anchore/stereoscope v0.1.4 h1:e+iT9UdUzLBabWGe84hn5sTHDRioY+4IHsVzJXuJlek=
 github.com/anchore/stereoscope v0.1.4/go.mod h1:omWgXDEp/XfqCJlZXIByEo1c3ArZg/qTJ5LBKVLAIdw=
-github.com/anchore/syft v1.25.1 h1:HaG5/0r1UdZ7zyscEFeFz0pQsBLTXdCgEDXa5LqFjcg=
-github.com/anchore/syft v1.25.1/go.mod h1:xa15pYmHrXKe7IlvaO+EAD/krawWYUtILTpMcL/S+Gw=
+github.com/anchore/syft v1.25.2-0.20250520195608-ac883f52edb8 h1:v/sMVa0MB+/IET9Q2ACFFRTcuWFSQMuIHRuHPzJ8XH4=
+github.com/anchore/syft v1.25.2-0.20250520195608-ac883f52edb8/go.mod h1:xa15pYmHrXKe7IlvaO+EAD/krawWYUtILTpMcL/S+Gw=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/brotli v1.1.2-0.20250424173009-453214e765f3 h1:8PmGpDEZl9yDpcdEr6Odf23feCxK3LNUNMxjXg41pZQ=

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -842,6 +842,19 @@ func TestNew(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "pe binary metadata",
+			syftPkg: syftPkg.Package{
+				Metadata: syftPkg.PEBinary{
+					VersionResources: syftPkg.KeyValues{
+						{
+							Key:   "k",
+							Value: "k",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	// capture each observed metadata type, we should see all of them relate to what syft provides by the end of testing

--- a/grype/pkg/purl_provider_test.go
+++ b/grype/pkg/purl_provider_test.go
@@ -40,6 +40,29 @@ func Test_PurlProvider(t *testing.T) {
 			},
 		},
 		{
+			name:      "java metadata decoded from purl",
+			userInput: "pkg:maven/org.apache.commons/commons-lang3@3.12.0",
+			context: Context{
+				Source: &source.Description{
+					Metadata: PURLLiteralMetadata{
+						PURL: "pkg:maven/org.apache.commons/commons-lang3@3.12.0",
+					},
+				},
+			},
+			pkgs: []Package{
+				{
+					Name:    "commons-lang3",
+					Version: "3.12.0",
+					Type:    pkg.JavaPkg,
+					PURL:    "pkg:maven/org.apache.commons/commons-lang3@3.12.0",
+					Metadata: JavaMetadata{
+						PomArtifactID: "commons-lang3",
+						PomGroupID:    "org.apache.commons",
+					},
+				},
+			},
+		},
+		{
 			name:      "os with codename",
 			userInput: "pkg:deb/debian/sysv-rc@2.88dsf-59?arch=all&distro=debian-jessie&upstream=sysvinit",
 			context: Context{


### PR DESCRIPTION
This is a follow on to https://github.com/anchore/syft/pull/3922 where there will no longer be a `syftPkg.JavaArchive.PomProperties` to reliably read java group ID / artifact ID from on SBOM decode operations. Specifically, this can't be depended on in cases where we don't know if the data actually came from a `pom.properties` file. Instead this is done when creating a grype package when we detect the package represents a java package.

## PR stack
- https://github.com/anchore/syft/pull/3922 CI will fail until this is merged and incorporated here