### PR TITLE
Always show results with json output for `db search` commands

### DIFF
--- a/cmd/grype/cli/commands/db_search.go
+++ b/cmd/grype/cli/commands/db_search.go
@@ -172,15 +172,14 @@ func runDBSearchMatches(opts dbSearchMatchOptions) error {
 		}
 	}
 
-	if len(rows) != 0 {
-		sb := &strings.Builder{}
-		err = presentDBSearchMatches(opts.Format.Output, rows, sb)
-		bus.Report(sb.String())
-		if err != nil {
-			return fmt.Errorf("unable to present search results: %w", err)
-		}
-	} else {
-		bus.Notify("No results found")
+	sb := &strings.Builder{}
+	err = presentDBSearchMatches(opts.Format.Output, rows, sb)
+	rep := sb.String()
+	if rep != "" {
+		bus.Report(rep)
+	}
+	if err != nil {
+		return fmt.Errorf("unable to present search results: %w", err)
 	}
 
 	return queryErr
@@ -189,6 +188,10 @@ func runDBSearchMatches(opts dbSearchMatchOptions) error {
 func presentDBSearchMatches(outputFormat string, structuredRows dbsearch.Matches, output io.Writer) error {
 	switch outputFormat {
 	case tableOutputFormat:
+		if len(structuredRows) == 0 {
+			bus.Notify("No results found")
+			return nil
+		}
 		rows := renderDBSearchPackagesTableRows(structuredRows.Flatten())
 
 		table := newTable(output)
@@ -197,6 +200,10 @@ func presentDBSearchMatches(outputFormat string, structuredRows dbsearch.Matches
 		table.AppendBulk(rows)
 		table.Render()
 	case jsonOutputFormat:
+		if structuredRows == nil {
+			// always allocate the top level collection
+			structuredRows = dbsearch.Matches{}
+		}
 		enc := json.NewEncoder(output)
 		enc.SetEscapeHTML(false)
 		enc.SetIndent("", " ")


### PR DESCRIPTION
Today if you use `db search [vuln] ID -o json` and the ID yields no results, then you will see:
```
No results found
```

However, the correct output should be an empty array:
```
[]
```

This PR fixes this behavior.