### PR TITLE
ruby version specific comparator

### DIFF
--- a/grype/matcher/internal/cpe_test.go
+++ b/grype/matcher/internal/cpe_test.go
@@ -26,7 +26,7 @@ func newCPETestStore() vulnerability.Provider {
 				Namespace: "nvd:cpe",
 			},
 			PackageName: "activerecord",
-			Constraint:  version.MustGetConstraint("< 3.7.6", version.SemanticFormat),
+			Constraint:  version.MustGetConstraint("< 3.7.6", version.GemFormat),
 			CPEs:        []cpe.CPE{cpe.Must("cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*", "")},
 		},
 		{
@@ -35,7 +35,7 @@ func newCPETestStore() vulnerability.Provider {
 				Namespace: "nvd:cpe",
 			},
 			PackageName: "activerecord",
-			Constraint:  version.MustGetConstraint("< 3.7.4", version.SemanticFormat),
+			Constraint:  version.MustGetConstraint("< 3.7.4", version.GemFormat),
 			CPEs:        []cpe.CPE{cpe.Must("cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:ruby:*:*", "")},
 		},
 		{
@@ -155,7 +155,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							},
 							Found: match.CPEResult{
 								CPEs:              []string{"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*"},
-								VersionConstraint: "< 3.7.6 (semver)",
+								VersionConstraint: "< 3.7.6 (gem)",
 								VulnerabilityID:   "CVE-2017-fake-1",
 							},
 							Matcher: matcher,
@@ -206,7 +206,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							},
 							Found: match.CPEResult{
 								CPEs:              []string{"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*"},
-								VersionConstraint: "< 3.7.6 (semver)",
+								VersionConstraint: "< 3.7.6 (gem)",
 								VulnerabilityID:   "CVE-2017-fake-1",
 							},
 							Matcher: matcher,
@@ -260,7 +260,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							},
 							Found: match.CPEResult{
 								CPEs:              []string{"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*"},
-								VersionConstraint: "< 3.7.6 (semver)",
+								VersionConstraint: "< 3.7.6 (gem)",
 								VulnerabilityID:   "CVE-2017-fake-1",
 							},
 							Matcher: matcher,
@@ -297,7 +297,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							},
 							Found: match.CPEResult{
 								CPEs:              []string{"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:ruby:*:*"},
-								VersionConstraint: "< 3.7.4 (semver)",
+								VersionConstraint: "< 3.7.4 (gem)",
 								VulnerabilityID:   "CVE-2017-fake-2",
 							},
 							Matcher: matcher,
@@ -336,7 +336,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							},
 							Found: match.CPEResult{
 								CPEs:              []string{"cpe:2.3:*:activerecord:activerecord:4.0.1:*:*:*:*:*:*:*"},
-								VersionConstraint: "= 4.0.1 (semver)",
+								VersionConstraint: "= 4.0.1 (gem)",
 								VulnerabilityID:   "CVE-2017-fake-3",
 							},
 							Matcher: matcher,
@@ -404,7 +404,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							},
 							Found: match.CPEResult{
 								CPEs:              []string{"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*"},
-								VersionConstraint: "< 3.7.6 (semver)",
+								VersionConstraint: "< 3.7.6 (gem)",
 								VulnerabilityID:   "CVE-2017-fake-1",
 							},
 							Matcher: matcher,
@@ -441,7 +441,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							},
 							Found: match.CPEResult{
 								CPEs:              []string{"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:ruby:*:*"},
-								VersionConstraint: "< 3.7.4 (semver)",
+								VersionConstraint: "< 3.7.4 (gem)",
 								VulnerabilityID:   "CVE-2017-fake-2",
 							},
 							Matcher: matcher,
@@ -490,7 +490,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							},
 							Found: match.CPEResult{
 								CPEs:              []string{"cpe:2.3:*:activerecord:activerecord:4.0.1:*:*:*:*:*:*:*"},
-								VersionConstraint: "= 4.0.1 (semver)",
+								VersionConstraint: "= 4.0.1 (gem)",
 								VulnerabilityID:   "CVE-2017-fake-3",
 							},
 							Matcher: matcher,

--- a/grype/matcher/internal/language_test.go
+++ b/grype/matcher/internal/language_test.go
@@ -24,7 +24,7 @@ func newMockProviderByLanguage() vulnerability.Provider {
 			},
 			PackageName: "activerecord",
 			// make sure we find it with semVer constraint
-			Constraint: version.MustGetConstraint("< 3.7.6", version.SemanticFormat),
+			Constraint: version.MustGetConstraint("< 3.7.6", version.GemFormat),
 		},
 		{
 			Reference: vulnerability.Reference{
@@ -49,7 +49,7 @@ func newMockProviderByLanguage() vulnerability.Provider {
 				Namespace: "github:language:ruby",
 			},
 			PackageName: "nokogiri",
-			Constraint:  version.MustGetConstraint("< 1.7.4", version.SemanticFormat),
+			Constraint:  version.MustGetConstraint("< 1.7.4", version.GemFormat),
 		},
 	}...)
 }
@@ -90,7 +90,7 @@ func TestFindMatchesByPackageLanguage(t *testing.T) {
 		assertEmpty bool
 	}{
 		{
-			constraint: "< 3.7.6 (semver)",
+			constraint: "< 3.7.6 (gem)",
 			p: pkg.Package{
 				ID:       pkg.ID(uuid.NewString()),
 				Name:     "activerecord",
@@ -100,7 +100,7 @@ func TestFindMatchesByPackageLanguage(t *testing.T) {
 			},
 		},
 		{
-			constraint: "< 1.7.6 (semver)",
+			constraint: "< 1.7.6 (gem)",
 			p: pkg.Package{
 				ID:       pkg.ID(uuid.NewString()),
 				Name:     "nokogiri",

--- a/grype/version/constraint.go
+++ b/grype/version/constraint.go
@@ -13,10 +13,12 @@ func GetConstraint(constStr string, format Format) (Constraint, error) {
 	switch format {
 	case ApkFormat:
 		return newApkConstraint(constStr)
-	case SemanticFormat, GemFormat:
+	case SemanticFormat:
 		return newSemanticConstraint(constStr)
 	case DebFormat:
 		return newDebConstraint(constStr)
+	case GemFormat:
+		return newGemfileConstraint(constStr)
 	case GolangFormat:
 		return newGolangConstraint(constStr)
 	case MavenFormat:

--- a/grype/version/gemfile_constraint.go
+++ b/grype/version/gemfile_constraint.go
@@ -1,0 +1,15 @@
+package version
+
+import "fmt"
+
+func newGemfileConstraint(raw string) (Constraint, error) {
+	return newGenericConstraint(raw, newGemfileComparator, "gem")
+}
+
+func newGemfileComparator(unit constraintUnit) (Comparator, error) {
+	ver, err := newGemVersion(unit.version)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse Gemfile constraint version (%s): %w", unit.version, err)
+	}
+	return ver, nil
+}

--- a/grype/version/gemfile_constraint_test.go
+++ b/grype/version/gemfile_constraint_test.go
@@ -26,24 +26,21 @@ func TestGemfileConstraint(t *testing.T) {
 		{version: "1.2.0-x86-linux", constraint: "= 1.2.0", satisfied: true},
 		{version: "1.2.0-x86_64-linux", constraint: "= 1.2.0", satisfied: true},
 		{version: "1.2.0-x86_64-linux", constraint: "< 1.2.1", satisfied: true},
-		{version: "1.2.3----RC-SNAPSHOT.12.9.1--.12+788", constraint: "> 1.0.0", satisfied: true},
-		{version: "1.2.3----RC-SNAPSHOT.12.9.1--.12+788-armv7-darwin", constraint: "< 1.2.3", satisfied: true},
-		{version: "1.2.3----rc-snapshot.12.9.1--.12+788-armv7-darwin", constraint: "< 1.2.3", satisfied: true},
 		// https://semver.org/#spec-item-11
 		{version: "1.2.0-alpha-x86-linux", constraint: "<1.2.0", satisfied: true},
 		{version: "1.2.0-alpha-1-x86-linux", constraint: "<1.2.0", satisfied: true},
 		// gem versions seem to respect the order: {sem-version}+{meta}-{arch}-{os}
 		// but let's check the extraction works even when the order of {meta}-{arch} varies.
-		{version: "1.2.0-alpha-1-x86-linux+meta", constraint: "<1.2.0", satisfied: true},
-		{version: "1.2.0-alpha-1+meta-x86-linux", constraint: "<1.2.0", satisfied: true},
-		{version: "1.2.0-alpha-1-x86-linux+meta", constraint: ">1.1.0", satisfied: true},
-		{version: "1.2.0-alpha-1-arm-linux+meta", constraint: ">1.1.0", satisfied: true},
-		{version: "1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay", constraint: "<1.0.0", satisfied: true},
+		{version: "1.2.0-alpha-1-x86-linux-meta", constraint: "<1.2.0", satisfied: true},
+		{version: "1.2.0-alpha-1-meta-x86-linux", constraint: "<1.2.0", satisfied: true},
+		{version: "1.2.0-alpha-1-x86-linux-meta", constraint: ">1.1.0", satisfied: true},
+		{version: "1.2.0-alpha-1-arm-linux-meta", constraint: ">1.1.0", satisfied: true},
+		{version: "1.0.0-alpha-a.b-c-somethinglong-build.1-aef.1-its-okay", constraint: "<1.0.0", satisfied: true},
 	}
 
 	for _, test := range tests {
 		t.Run(test.tName(), func(t *testing.T) {
-			constraint, err := newSemanticConstraint(test.constraint)
+			constraint, err := newGemfileConstraint(test.constraint)
 			assert.NoError(t, err, "unexpected error from newSemanticConstraint: %v", err)
 
 			test.assertVersionConstraint(t, GemFormat, constraint)

--- a/grype/version/gemfile_version.go
+++ b/grype/version/gemfile_version.go
@@ -1,26 +1,302 @@
 package version
 
 import (
+	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 )
 
-// Gemfile.lock doesn't follow a spec, the best documentation comes
-// from `gem help platform`. Gemfile.lock versions may have "{cpu}-{os}"
-// or "{cpu}-{os}-{version}"
-// after the semvVer, for example, 12.2.1-alpha-x86_64-darwin-8, where `2.2.1-alpha`
-// is a valid and comparable semVer, and `x86_64-darwin-8` is not a semVer due to
-// the underscore. Also, we can't sort based on arch and OS in a way that make sense
-// for versions. SemVer is a characteristic of the code, not which arch OS it runs on.
-//
-// Bunlder's code: https://github.com/rubygems/rubygems/blob/2070231bf0c7c4654bbc2e4c08882bf414840360/bundler/spec/install/gemfile/platform_spec.rb offers more info on possible architecture values, for example `mswin32` may appead without arch.
-//
-// Spec for pre-release info: https://github.com/rubygems/rubygems/blob/2070231bf0c7c4654bbc2e4c08882bf414840360/bundler/spec/install/gemfile/path_spec.rb#L186
-//
-// CPU/arch is the most structured value present in gemfile.lock versions, we use it
-// to split the version info in half, the first half has semVer, and
-// the second half has arch and OS which we ignore.
-// When there is no arch we split the version string with: {java, delvik, mswin}
-func extractSemVer(raw string) string {
+var _ Comparator = (*rubyVersion)(nil)
+
+type rubyVersion struct {
+	original     string
+	segments     []any
+	canonical    []any
+	isPrerelease bool
+}
+
+const (
+	rubySegmentPattern     = `(\d+|[a-zA-Z]+)`
+	rubyCorrectnessPattern = `^[0-9a-zA-Z.\-]+$`
+)
+
+var (
+	segmentRegexp     = regexp.MustCompile(rubySegmentPattern)
+	correctnessRegexp = regexp.MustCompile(rubyCorrectnessPattern)
+)
+
+func trimTrailingZeros(segments []any) []any {
+	if len(segments) <= 1 {
+		if len(segments) == 1 {
+			if num, ok := segments[0].(int); ok && num == 0 {
+				return []any{0}
+			}
+		}
+		return segments
+	}
+
+	lastSignificantIdx := -1
+	for i := len(segments) - 1; i >= 0; i-- {
+		num, ok := segments[i].(int)
+		if !ok || num != 0 {
+			lastSignificantIdx = i
+			break
+		}
+		// It's a numeric zero, continue looking
+	}
+
+	if lastSignificantIdx == -1 {
+		return []any{0}
+	}
+	return segments[:lastSignificantIdx+1]
+}
+
+func trimIntermediateZeros(segments []any, isPrerelease bool) []any {
+	if !isPrerelease || len(segments) == 0 {
+		return segments
+	}
+
+	firstLetterIdx := -1
+	for i, seg := range segments {
+		if _, ok := seg.(string); ok {
+			firstLetterIdx = i
+			break
+		}
+	}
+
+	if firstLetterIdx == -1 {
+		return segments
+	}
+
+	segmentsBeforeLetter := []any{}
+	if firstLetterIdx > 0 {
+		segmentsBeforeLetter = segments[:firstLetterIdx]
+	}
+
+	trimmedPrefix := []any{}
+	if len(segmentsBeforeLetter) > 0 {
+		lastNonZeroInPrefixIdx := -1
+		for i := len(segmentsBeforeLetter) - 1; i >= 0; i-- {
+			num, ok := segmentsBeforeLetter[i].(int)
+			if !ok || num != 0 {
+				lastNonZeroInPrefixIdx = i
+				break
+			}
+		}
+		if lastNonZeroInPrefixIdx != -1 {
+			trimmedPrefix = segmentsBeforeLetter[:lastNonZeroInPrefixIdx+1]
+		}
+	}
+
+	reconstructed := make([]any, 0, len(trimmedPrefix)+len(segments)-firstLetterIdx)
+	reconstructed = append(reconstructed, trimmedPrefix...)
+	reconstructed = append(reconstructed, segments[firstLetterIdx:]...)
+
+	return reconstructed
+}
+
+func newGemVersion(raw string) (*rubyVersion, error) {
+	original := raw
+	processed := cleanArchFromVersion(raw)
+	if processed == "" || strings.TrimSpace(processed) == "" {
+		processed = "0"
+	} else {
+		processed = strings.TrimSpace(processed)
+	}
+
+	if !correctnessRegexp.MatchString(processed) {
+		return nil, fmt.Errorf("malformed version number string %q", original)
+	}
+	processed = strings.ReplaceAll(processed, "-", ".pre.")
+
+	isPrerelease := strings.ContainsAny(processed, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+	segments, err := partitionSegments(processed)
+	if err != nil {
+		return nil, fmt.Errorf("malformed version number string %q: %w", original, err)
+	}
+	if len(segments) == 0 {
+		if processed == "0" {
+			segments = []any{0}
+		} else {
+			return nil, fmt.Errorf("malformed version number string %q (no valid segments after processing)", original)
+		}
+	}
+	canonical := make([]any, len(segments))
+	copy(canonical, segments)
+
+	canonical = trimTrailingZeros(canonical)
+	canonical = trimIntermediateZeros(canonical, isPrerelease)
+
+	if len(canonical) == 0 {
+		canonical = []any{0}
+	}
+
+	return &rubyVersion{
+		original:     original,
+		segments:     segments,
+		canonical:    canonical,
+		isPrerelease: isPrerelease,
+	}, nil
+}
+
+func partitionSegments(versionString string) ([]any, error) {
+	if versionString == "" {
+		return []any{}, fmt.Errorf("cannot partition empty version string")
+	}
+	if strings.Contains(versionString, "..") {
+		return nil, fmt.Errorf("invalid version string (double dot): %q", versionString)
+	}
+	if (strings.HasPrefix(versionString, ".") && versionString != ".") ||
+		(strings.HasSuffix(versionString, ".") && versionString != ".") {
+		if len(versionString) > 1 {
+			return nil, fmt.Errorf("invalid version string (leading/trailing dot): %q", versionString)
+		}
+	}
+
+	parts := segmentRegexp.FindAllString(versionString, -1)
+	if len(parts) == 0 {
+		if versionString == "0" {
+			return []any{0}, nil
+		}
+		return nil, fmt.Errorf("no valid segments found in %q", versionString)
+	}
+
+	segments := make([]any, 0, len(parts))
+	for _, s := range parts {
+		if n, err := strconv.Atoi(s); err == nil {
+			segments = append(segments, n)
+		} else {
+			segments = append(segments, s)
+		}
+	}
+	return segments, nil
+}
+
+func compareSegments(left, right []any) (result int, allEqual bool, err error) {
+	limit := len(left)
+	if len(right) < limit {
+		limit = len(right)
+	}
+
+	for i := 0; i < limit; i++ {
+		l := left[i]
+		r := right[i]
+
+		lNum, lIsNum := l.(int)
+		lStr, lIsStr := l.(string)
+		rNum, rIsNum := r.(int)
+		rStr, rIsStr := r.(string)
+
+		if lIsNum && rIsNum {
+			if lNum != rNum {
+				if lNum < rNum {
+					return -1, false, nil
+				}
+				return 1, false, nil
+			}
+			continue
+		}
+
+		if lIsStr && rIsStr {
+			if cmp := strings.Compare(lStr, rStr); cmp != 0 {
+				return cmp, false, nil
+			}
+			continue
+		}
+
+		if lIsNum && rIsStr {
+			return 1, false, nil
+		}
+		if lIsStr && rIsNum {
+			return -1, false, nil
+		}
+
+		return 0, false, fmt.Errorf("internal comparison error: unexpected types %T vs %T", l, r)
+	}
+	return 0, true, nil
+}
+
+func compareLengths(left, right []any, commonResult int) int {
+	if commonResult != 0 {
+		return commonResult
+	}
+
+	lLen := len(left)
+	rLen := len(right)
+
+	if lLen == rLen {
+		return 0
+	}
+
+	if lLen > rLen {
+		for i := rLen; i < lLen; i++ {
+			seg := left[i]
+			if _, isStr := seg.(string); isStr {
+				return -1
+			}
+			if num, isNum := seg.(int); isNum && num != 0 {
+				return 1
+			}
+		}
+		return 0
+	}
+
+	for i := lLen; i < rLen; i++ {
+		seg := right[i]
+		if _, isStr := seg.(string); isStr {
+			return 1
+		}
+		if num, isNum := seg.(int); isNum && num != 0 {
+			return -1
+		}
+	}
+	return 0
+}
+
+func (v *rubyVersion) Compare(other *Version) (int, error) {
+	if other == nil {
+		return -1, fmt.Errorf("cannot compare with nil version")
+	}
+	if other.Format != GemFormat && other.Format != UnknownFormat {
+		return -1, fmt.Errorf("cannot compare Gem version %q with format %s", v.original, other.Format)
+	}
+
+	var otherRubyVer *rubyVersion
+	switch {
+	case other.rich.rubyVer != nil:
+		otherRubyVer = other.rich.rubyVer
+	case other.Format == UnknownFormat || other.Format == GemFormat:
+		var err error
+		otherRubyVer, err = newGemVersion(other.Raw)
+		if err != nil {
+			return -1, fmt.Errorf("cannot compare Gem version %q with unparsable version %q: %w", v.original, other.Raw, err)
+		}
+	default:
+		return -1, fmt.Errorf("internal error: other version (%s) is GemFormat but has no parsed data and could not be reparsed", other.Raw)
+	}
+
+	standardResult, commonSegmentsAreEqual, err := compareSegments(v.canonical, otherRubyVer.canonical)
+	if err != nil {
+		return -1, err
+	}
+
+	if commonSegmentsAreEqual {
+		standardResult = compareLengths(v.canonical, otherRubyVer.canonical, standardResult)
+	}
+
+	if standardResult == 0 {
+		return 0, nil
+	}
+	return -standardResult, nil
+}
+
+func (v *rubyVersion) String() string {
+	return v.original
+}
+
+func cleanArchFromVersion(raw string) string {
 	platforms := []string{"x86", "universal", "arm", "java", "dalvik", "x64", "powerpc", "sparc", "mswin"}
 	dash := "-"
 	for _, p := range platforms {
@@ -31,9 +307,4 @@ func extractSemVer(raw string) string {
 	}
 
 	return raw
-}
-
-func newGemfileVersion(raw string) (*semanticVersion, error) {
-	cleaned := extractSemVer(raw)
-	return newSemanticVersion(cleaned)
 }

--- a/grype/version/gemfile_version_test.go
+++ b/grype/version/gemfile_version_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func makeSemVer(t *testing.T, raw string) *semanticVersion {
@@ -13,49 +15,287 @@ func makeSemVer(t *testing.T, raw string) *semanticVersion {
 	return semVer
 }
 
-func Test_newGemfileVersion(t *testing.T) {
-
+func Test_cleanPlatformMakesEqualVersions(t *testing.T) {
 	tests := []struct {
-		input string
-		want  *semanticVersion
+		input   string
+		trimmed string
+		want    *rubyVersion
 	}{
-		{input: "1.13.1", want: makeSemVer(t, "1.13.1")},
-		{input: "1.13.1-arm-linux", want: makeSemVer(t, "1.13.1")},
-		{input: "1.13.1-armv6-linux", want: makeSemVer(t, "1.13.1")},
-		{input: "1.13.1-armv7-linux", want: makeSemVer(t, "1.13.1")},
-		{input: "1.13.1-java", want: makeSemVer(t, "1.13.1")},
-		{input: "1.13.1-dalvik", want: makeSemVer(t, "1.13.1")},
-		{input: "1.13.1-mswin32", want: makeSemVer(t, "1.13.1")},
-		{input: "1.13.1-x64-mswin64", want: makeSemVer(t, "1.13.1")},
-		{input: "1.13.1-sparc-unix", want: makeSemVer(t, "1.13.1")},
-		{input: "1.13.1-powerpc-darwin", want: makeSemVer(t, "1.13.1")},
-		{input: "1.13.1-x86-linux", want: makeSemVer(t, "1.13.1")},
-		{input: "1.13.1-x86_64-linux", want: makeSemVer(t, "1.13.1")},
-		{input: "1.13.1-x86-freebsd", want: makeSemVer(t, "1.13.1")},
-		{input: "1.13.1-x86-mswin32-80", want: makeSemVer(t, "1.13.1")},
-		{input: "1.13.1-universal-darwin-8", want: makeSemVer(t, "1.13.1")},
-		{input: "1.13.1-beta-universal-darwin-8", want: makeSemVer(t, "1.13.1.beta")},
-		{input: "1.13.1-alpha-1+meta-arm-linux", want: makeSemVer(t, "1.13.1.alpha-1+meta")},
-		{input: "1.13.1-alpha-1+build.12-arm-linux", want: makeSemVer(t, "1.13.1.alpha-1+build.12")},
-		{input: "1.2.3----RC-SNAPSHOT.12.9.1--.12+788-armv7-darwin", want: makeSemVer(t, "1.2.3----RC-SNAPSHOT.12.9.1--.12+788")},
-		{input: "1.2.3----rc-snapshot.12.9.1--.12+788-armv7-darwin", want: makeSemVer(t, "1.2.3----rc-snapshot.12.9.1--.12+788")},
+		{input: "1.13.1", trimmed: "1.13.1"},
+		{input: "1.13.1-arm-linux", trimmed: "1.13.1"},
+		{input: "1.13.1-armv6-linux", trimmed: "1.13.1"},
+		{input: "1.13.1-armv7-linux", trimmed: "1.13.1"},
+		{input: "1.13.1-java", trimmed: "1.13.1"},
+		{input: "1.13.1-dalvik", trimmed: "1.13.1"},
+		{input: "1.13.1-mswin32", trimmed: "1.13.1"},
+		{input: "1.13.1-x64-mswin64", trimmed: "1.13.1"},
+		{input: "1.13.1-sparc-unix", trimmed: "1.13.1"},
+		{input: "1.13.1-powerpc-darwin", trimmed: "1.13.1"},
+		{input: "1.13.1-x86-linux", trimmed: "1.13.1"},
+		{input: "1.13.1-x86_64-linux", trimmed: "1.13.1"},
+		{input: "1.13.1-x86-freebsd", trimmed: "1.13.1"},
+		{input: "1.13.1-x86-mswin32-80", trimmed: "1.13.1"},
+		{input: "1.13.1-universal-darwin-8", trimmed: "1.13.1"},
+		// ruby versions get the canonical segment "pre" if there are any segments that are all
+		// alphabetic characters.
+		{input: "1.13.1-beta-universal-darwin-8", trimmed: "1.13.1.pre.beta"},
+		{input: "1.13.1-alpha-1-meta-arm-linux", trimmed: "1.13.1-alpha-1-meta"},
+		{input: "1.13.1-alpha-1-build.12-arm-linux", trimmed: "1.13.1-alpha-1-build.12"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got, err := newGemfileVersion(tt.input)
-			if !assert.NoError(t, err, fmt.Sprintf("newGemfileVersion(%v)", tt.input)) {
-				return
+			original, err := NewVersion(tt.input, GemFormat)
+			require.NoError(t, err)
+			trimmed, err := NewVersion(tt.trimmed, GemFormat)
+			require.NoError(t, err)
+			comp, err := original.Compare(trimmed)
+			require.NoError(t, err)
+			assert.Equal(t, 0, comp)
+			comp, err = trimmed.Compare(original)
+			require.NoError(t, err)
+			assert.Equal(t, 0, comp)
+		})
+	}
+}
+
+func newTestGemVersion(t *testing.T, raw string) *Version {
+	t.Helper()
+	rv, err := newGemVersion(raw)
+	require.NoError(t, err, "Failed to create rubyVersion for testing: %s", raw)
+	return &Version{
+		Raw:    raw,
+		Format: GemFormat,
+		rich:   rich{rubyVer: rv},
+	}
+}
+
+// Helper to directly get a *rubyVersion, failing test on error.
+func mustNewRubyVersion(t *testing.T, raw string) *rubyVersion {
+	t.Helper()
+	rv, err := newGemVersion(raw)
+	require.NoError(t, err, "newGemVersion(%q) failed: %v", raw, err)
+	return rv
+}
+
+func TestNewRubyVersion_ValidInputs(t *testing.T) {
+	tests := []struct {
+		input              string
+		expectedOriginal   string // What v.original should be
+		expectedSegments   []any  // What v.segments should be (after .pre. processing)
+		expectedPrerelease bool
+	}{
+		{"1.0", "1.0", []any{1, 0}, false},
+		{"1.0 ", "1.0 ", []any{1, 0}, false}, // original preserves space
+		{" 1.0 ", " 1.0 ", []any{1, 0}, false},
+		{"1.2.3", "1.2.3", []any{1, 2, 3}, false},
+		{"1.2.3.a", "1.2.3.a", []any{1, 2, 3, "a"}, true},
+		{"1.2.3-b4", "1.2.3-b4", []any{1, 2, 3, "pre", "b", 4}, true},
+		{"1", "1", []any{1}, false},
+		{"0", "0", []any{0}, false},
+		{"", "", []any{0}, false},     // Empty string becomes "0" effectively, original is ""
+		{"  ", "  ", []any{0}, false}, // Whitespace string becomes "0" effectively
+		{"1.0-alpha", "1.0-alpha", []any{1, 0, "pre", "alpha"}, true},
+		{"1-1", "1-1", []any{1, "pre", 1}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Input_%s", tt.input), func(t *testing.T) {
+			v, err := newGemVersion(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedOriginal, v.original, "Original string mismatch")
+			assert.Equal(t, tt.expectedSegments, v.segments, "Initial segments mismatch")
+			assert.Equal(t, tt.expectedPrerelease, v.isPrerelease, "Prerelease flag mismatch")
+		})
+	}
+}
+
+func TestNewRubyVersion_InvalidInputs(t *testing.T) {
+	invalidVersions := []struct {
+		name           string
+		input          string
+		errorSubstring string
+	}{
+		//{"junk", "junk", "malformed version number string"},
+		{"newline", "1.0\n2.0", "malformed version number string"}, // Handled by correctness regex
+		{"double_dot", "1..2", "malformed version number string"},
+		{"space_separated", "1.2 3.4", "malformed version number string"},
+		{"trailing_dot_long", "1.2.", "leading/trailing dot"},
+		{"leading_dot_long", ".1.2", "leading/trailing dot"},
+		{"just_dot", ".", "no valid segments"},
+		{"double_hyphen", "--", "malformed version number string"},
+		{"hyphen_dot", "1.-2", "malformed version number string"},
+		{"dot_hyphen", "1.-pre", "malformed version number string"},
+		{"underscore", "1_2", "malformed version number string"},
+		{"empty_segments", "...", "malformed version number string"},
+		{"invalid_segment_char", "1.2.a@b", "malformed version number string"},
+	}
+
+	for _, tt := range invalidVersions {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newGemVersion(tt.input)
+			assert.Error(t, err)
+			if tt.errorSubstring != "" {
+				assert.Contains(t, err.Error(), tt.errorSubstring, "Error message mismatch for input: %s", tt.input)
 			}
-			assert.Equalf(t, tt.want, got, "newGemfileVersion(%v)", tt.input)
+		})
+	}
+}
 
-			// check that semantic versions are comaprable to gemfile versions
-			other, err := NewVersion(tt.want.verObj.String(), SemanticFormat)
-			assert.NoError(t, err)
+func TestRubyVersion_Compare(t *testing.T) {
+	tests := []struct {
+		v1   string
+		v2   string
+		want int // Expected result of v1.Compare(v2)
+	}{
+		// Basic comparisons (from Ruby's test_spaceship)
+		{"1.0", "1.0.0", 0},
+		{"1.0", "1.0.a", -1},
+		{"1.8.2", "0.0.0", -1},
+		{"1.8.2", "1.8.2.a", -1},
+		{"1.8.2.b", "1.8.2.a", -1},
+		{"1.8.2.a", "1.8.2", 1},
+		{"1.8.2.a10", "1.8.2.a9", -1},
+		{"", "0", 0}, // "" is treated as "0"
 
-			v, err := got.Compare(other)
-			assert.NoError(t, err)
-			// zero here means `other` and `got` are the same version
-			assert.Equal(t, 0, v)
+		// Canonicalization leading to equality
+		{"0.beta.1", "0.0.beta.1", 0}, // Ruby: 0.beta.1 <=> 0.0.beta.1 is 0. Canonical for both is ["beta", -1]
+		{"0.0.beta", "0.0.beta.1", 1}, // Ruby: 0.0.beta <=> 0.0.beta.1 is -1. Canonical ["beta"] vs ["beta", -1]
+
+		// String segments comparison
+		{"5.a", "5.0.0.rc2", 1},  // "a" < "rc"
+		{"5.x", "5.0.0.rc2", -1}, // "x" > "rc"
+
+		// Direct string comparison from Ruby test
+		{"1.9.3", "1.9.3", 0},
+		{"1.9.3", "1.9.2.99", -1},
+		{"1.9.3", "1.9.3.1", 1},
+
+		// Additional common cases
+		{"1.0", "1.1", 1},
+		{"1.1", "1.0", -1},
+		{"1", "1.0", 0},
+		{"1.0.1", "1.0.0", -1},
+		{"1.0.0", "1.0.1", 1},
+
+		// Prerelease vs Prerelease (length diff)
+		{"1.0.alpha.1", "1.0.alpha", -1},
+		{"1.0.alpha", "1.0.alpha.1", 1},
+
+		// Hyphen handling (SemVer-like via .pre.)
+		{"1.0.0-alpha", "1.0.0-alpha.1", 1},
+		{"1.0.0-alpha.1", "1.0.0-beta.2", 1},
+		{"1.0.0-beta.2", "1.0.0-beta.11", 1},
+		{"1.0.0-beta.11", "1.0.0-rc.1", 1}, // beta < rc
+		{"1.0.0-rc1", "1.0.0", 1},
+		{"1.0.0-1", "1", 1}, // 1.0.0.pre.1 vs 1
+		{"1-1", "1", 1},     // 1.pre.1 vs 1
+
+		// From Ruby's test_semver (some overlap, ensure coverage)
+		{"1.0.0-alpha", "1.0.0-alpha.1", 1},
+		{"1.0.0-alpha.1", "1.0.0-beta.2", 1}, // alpha < beta
+		{"1.0.0-beta.2", "1.0.0-beta.11", 1}, // 2 < 11
+		{"1.0.0-beta.11", "1.0.0-rc.1", 1},   // beta < rc
+		{"1.0.0-rc1", "1.0.0", 1},            // 1.0.0.pre.rc.1 < 1.0.0 (release)
+		{"1.0.0-1", "1", 1},                  // 1.0.0.pre.1 < 1 (release)
+
+		// Edge cases with canonicalization
+		{"1.0", "1", 0},
+		{"1.0.0", "1", 0},
+		{"1.a", "1.0.0.a", 0}, // Canonical [1,"a"] for both
+		{"1.a.0", "1.a", 0},   // Canonical [1,"a"] for both
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s_vs_%s", tt.v1, tt.v2), func(t *testing.T) {
+			ver1 := newTestGemVersion(t, tt.v1)
+			ver2 := newTestGemVersion(t, tt.v2)
+
+			// Test v1 vs v2
+			got1, err1 := ver1.rich.rubyVer.Compare(ver2)
+			require.NoError(t, err1, "v1.Compare(v2) failed for %s vs %s", tt.v1, tt.v2)
+			assert.Equal(t, tt.want, got1, "Compare(%q, %q) == %d, want %d", tt.v1, tt.v2, got1, tt.want)
+
+			// Test symmetry: v2 vs v1
+			expectedSymmetric := 0
+			if tt.want != 0 {
+				expectedSymmetric = -tt.want
+			}
+			got2, err2 := ver2.rich.rubyVer.Compare(ver1)
+			require.NoError(t, err2, "v2.Compare(v1) failed for %s vs %s", tt.v2, tt.v1)
+			assert.Equal(t, expectedSymmetric, got2, "Compare(%q, %q) == %d, want %d (symmetric)", tt.v2, tt.v1, got2, expectedSymmetric)
+
+			// Test reflexivity: v1 vs v1
+			gotReflexive1, errReflexive1 := ver1.rich.rubyVer.Compare(ver1)
+			require.NoError(t, errReflexive1, "v1.Compare(v1) failed for %s", tt.v1)
+			assert.Equal(t, 0, gotReflexive1, "Compare(%q, %q) == %d, want 0 (reflexive)", tt.v1, tt.v1, gotReflexive1)
+		})
+	}
+}
+
+func TestRubyVersion_Compare_Errors(t *testing.T) {
+	vGem1_0 := newTestGemVersion(t, "1.0")
+
+	t.Run("CompareWithNil", func(t *testing.T) {
+		_, err := vGem1_0.rich.rubyVer.Compare(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot compare with nil version")
+	})
+
+	t.Run("CompareWithDifferentFormat", func(t *testing.T) {
+		// Assuming SemanticFormat is a distinct, incompatible format
+		// and that the Format type has a String() method for user-friendly error messages.
+		vOther := &Version{Raw: "1.0.0", Format: SemanticFormat, rich: rich{}}
+		_, err := vGem1_0.rich.rubyVer.Compare(vOther)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot compare Gem version")
+		// Assuming SemanticFormat.String() would return "semver" or similar.
+		// Adjust if the actual string representation in the error is different.
+		assert.Contains(t, err.Error(), SemanticFormat.String())
+	})
+
+	t.Run("CompareWithUnknownFormat_ParsableAsGem", func(t *testing.T) {
+		vOther := &Version{Raw: "1.1", Format: UnknownFormat, rich: rich{}} // Parsable as Gem
+		res, err := vGem1_0.rich.rubyVer.Compare(vOther)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, res) // 1.0 < 1.1
+	})
+
+	t.Run("CompareWithUnknownFormat_UnparsableAsGem", func(t *testing.T) {
+		vOther := &Version{Raw: "invalid..version", Format: UnknownFormat, rich: rich{}}
+		_, err := vGem1_0.rich.rubyVer.Compare(vOther)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot compare Gem version")
+		assert.Contains(t, err.Error(), "unparsable version")
+		assert.Contains(t, err.Error(), "invalid..version")
+	})
+}
+
+func TestRubyVersion_canonical(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    []any
+	}{
+		// obtained from a simple ruby program like this:
+		/*
+			require 'rubygems/version'
+			v = Gem::Version.new(input)
+			v.canonical_segments
+		*/
+		{"simple ints", "1.2.3", []any{1, 2, 3}},
+		{"leading zeros preserved", "0.1.2", []any{0, 1, 2}},
+		{"drop intermediate zeros in pre-release", "5.0.0.a1", []any{5, "a", 1}},
+		{"preserve intermedia zeros in regular release", "1.0.0.1", []any{1, 0, 0, 1}},
+		{"drop trailing zeros", "1.0.0", []any{1}},
+		{"alpha version", "1.6.1.a", []any{1, 6, 1, "a"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := mustNewRubyVersion(t, tt.version)
+			if d := cmp.Diff(v.canonical, tt.want); d != "" {
+				t.Errorf("canonical mismatch (-want +got):\n%s", d)
+			}
 		})
 	}
 }

--- a/grype/version/version.go
+++ b/grype/version/version.go
@@ -25,6 +25,7 @@ type rich struct {
 	golangVersion *golangVersion
 	mavenVer      *mavenVersion
 	rpmVer        *rpmVersion
+	rubyVer       *rubyVersion
 	kbVer         *kbVersion
 	portVer       *portageVersion
 	pep440version *pep440Version
@@ -92,8 +93,8 @@ func (v *Version) populate() error {
 		v.rich.kbVer = &ver
 		return nil
 	case GemFormat:
-		ver, err := newGemfileVersion(v.Raw)
-		v.rich.semVer = ver
+		ver, err := newGemVersion(v.Raw)
+		v.rich.rubyVer = ver
 		return err
 	case PortageFormat:
 		ver := newPortageVersion(v.Raw)
@@ -156,7 +157,7 @@ func (v Version) compareSameFormat(other *Version) (int, error) {
 	case KBFormat:
 		return v.rich.kbVer.Compare(other)
 	case GemFormat:
-		return v.rich.semVer.verObj.Compare(other.rich.semVer.verObj), nil
+		return v.rich.rubyVer.Compare(other)
 	case PortageFormat:
 		return v.rich.portVer.Compare(other)
 	case JVMFormat:


### PR DESCRIPTION
RubyGems uses a version format similar to but not identical to semver. Previously, Grype used semver to compare the versions of ruby gems, which is usually correct but occasionally leads to failed comparisions or incorrect matching, especially with alphabetically labeled pre-releases. Switch to a new custom version comparator based on the comparison used by Ruby itself.

Fixes #2646 