### PR TITLE
Update README.md for Accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Results default to sorting by Risk Score and can be overridden with `--sort-by <
 - `epss`: sort by EPSS percentile (aka, "threat")
 - `risk`: sort by risk score
 - `kev`: just like risk, except that KEV entries are always above non-KEV entries
-- `package`: sort by package name, version, type
+- `package`: sort by package name
 - `vulnerability`: sort by vulnerability ID
 
 ### Supported versions


### PR DESCRIPTION
One cannot sort by the TYPE (package type) or INSTALLED (package version #) fields.

"sort by package name, version, type" should be changed by one of the following:
1. removing ", version, type"
2. changing this to "sort by package name (if there are multiple packages that have the same name, sorting preference is then done based on package version, then package type)"