### PR TITLE
Harden Container Runtime with Non-Root User

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -94,10 +94,10 @@ brews:
 
 dockers:
   - image_templates:
-      - anchore/grype:debug
-      - anchore/grype:{{.Tag}}-debug
-      - ghcr.io/anchore/grype:debug
-      - ghcr.io/anchore/grype:{{.Tag}}-debug
+      - anchore/grype:debug-amd64
+      - anchore/grype:{{.Tag}}-debug-amd64
+      - ghcr.io/anchore/grype:debug-amd64
+      - ghcr.io/anchore/grype:{{.Tag}}-debug-amd64
     goarch: amd64
     dockerfile: Dockerfile.debug
     use: buildx
@@ -154,10 +154,10 @@ dockers:
       - "--build-arg=VCS_URL={{.GitURL}}"
 
   - image_templates:
-      - anchore/grype:latest
-      - anchore/grype:{{.Tag}}
-      - ghcr.io/anchore/grype:latest
-      - ghcr.io/anchore/grype:{{.Tag}}
+      - anchore/grype:latest-amd64
+      - anchore/grype:{{.Tag}}-amd64
+      - ghcr.io/anchore/grype:latest-amd64
+      - ghcr.io/anchore/grype:{{.Tag}}-amd64
     goarch: amd64
     dockerfile: Dockerfile
     use: buildx
@@ -210,41 +210,42 @@ dockers:
 docker_manifests:
   - name_template: anchore/grype:latest
     image_templates:
-      - anchore/grype:{{.Tag}}
+      - anchore/grype:{{.Tag}}-amd64
       - anchore/grype:{{.Tag}}-arm64v8
       - anchore/grype:{{.Tag}}-ppc64le
       - anchore/grype:{{.Tag}}-s390x
 
   - name_template: anchore/grype:debug
-      - anchore/grype:{{.Tag}}-debug
+    image_templates:
+      - anchore/grype:{{.Tag}}-debug-amd64
       - anchore/grype:{{.Tag}}-debug-arm64v8
       - anchore/grype:{{.Tag}}-debug-ppc64le
       - anchore/grype:{{.Tag}}-debug-s390x
 
   - name_template: anchore/grype:{{.Tag}}
     image_templates:
-      - anchore/grype:{{.Tag}}
+      - anchore/grype:{{.Tag}}-amd64
       - anchore/grype:{{.Tag}}-arm64v8
       - anchore/grype:{{.Tag}}-ppc64le
       - anchore/grype:{{.Tag}}-s390x
 
   - name_template: ghcr.io/anchore/grype:latest
     image_templates:
-      - ghcr.io/anchore/grype:{{.Tag}}
+      - ghcr.io/anchore/grype:{{.Tag}}-amd64
       - ghcr.io/anchore/grype:{{.Tag}}-arm64v8
       - ghcr.io/anchore/grype:{{.Tag}}-ppc64le
       - ghcr.io/anchore/grype:{{.Tag}}-s390x
 
   - name_template: ghcr.io/anchore/grype:debug
     image_templates:
-      - ghcr.io/anchore/grype:{{.Tag}}-debug
+      - ghcr.io/anchore/grype:{{.Tag}}-debug-amd64
       - ghcr.io/anchore/grype:{{.Tag}}-debug-arm64v8
       - ghcr.io/anchore/grype:{{.Tag}}-debug-ppc64le
       - ghcr.io/anchore/grype:{{.Tag}}-debug-s390x
 
   - name_template: ghcr.io/anchore/grype:{{.Tag}}
     image_templates:
-      - ghcr.io/anchore/grype:{{.Tag}}
+      - ghcr.io/anchore/grype:{{.Tag}}-amd64
       - ghcr.io/anchore/grype:{{.Tag}}-arm64v8
       - ghcr.io/anchore/grype:{{.Tag}}-ppc64le
       - ghcr.io/anchore/grype:{{.Tag}}-s390x

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM gcr.io/distroless/static-debian12:latest AS build
-
-FROM scratch
-# needed for version check HTTPS request
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+FROM gcr.io/distroless/static-debian12:nonroot
 
 # create the /tmp dir, which is needed for image content cache
 WORKDIR /tmp

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static-debian12:debug
+FROM gcr.io/distroless/static-debian12:debug-nonroot
 
 # create the /tmp dir, which is needed for image content cache
 WORKDIR /tmp


### PR DESCRIPTION
This PR makes the following changes:
- uses `gcr.io/distroless/static-debian12` as the base image
- ensures the built containers are non-root users

In the process of working on this additional docker manifest updates were made:
- `image_templates` section was missing from the `debug` variant
- the top-level images should be the manifests and the tagged images should always be architecture specific (according to best practices)

This is the sister PR to https://github.com/anchore/syft/pull/3941

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

