### PR TITLE
Configurable timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -980,6 +980,9 @@ dev:
   db:
     # show sql queries in trace logging (requires -vv) (env: GRYPE_DEV_DB_DEBUG)
     debug: false
+
+# include a timestamp (env: GRYPE_TIMESTAMP)
+timestamp: true
 ```
 
 ## Future plans

--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -230,7 +230,7 @@ func runGrype(app clio.Application, opts *options.Grype, userInput string) (errs
 	log.WithFields("time", time.Since(startTime)).Info("found vulnerability matches")
 	startTime = time.Now()
 
-	model, err := models.NewDocument(app.ID(), packages, pkgContext, *remainingMatches, ignoredMatches, vp, opts, dbInfo(status, vp), models.SortStrategy(opts.SortBy.Criteria))
+	model, err := models.NewDocument(app.ID(), packages, pkgContext, *remainingMatches, ignoredMatches, vp, opts, dbInfo(status, vp), models.SortStrategy(opts.SortBy.Criteria), opts.Timestamp)
 	if err != nil {
 		return fmt.Errorf("failed to create document: %w", err)
 	}

--- a/cmd/grype/cli/options/grype.go
+++ b/cmd/grype/cli/options/grype.go
@@ -38,6 +38,7 @@ type Grype struct {
 	VexAdd                     []string           `yaml:"vex-add" json:"vex-add" mapstructure:"vex-add"`                                                                   // GRYPE_VEX_ADD
 	MatchUpstreamKernelHeaders bool               `yaml:"match-upstream-kernel-headers" json:"match-upstream-kernel-headers" mapstructure:"match-upstream-kernel-headers"` // Show matches on kernel-headers packages where the match is on kernel upstream instead of marking them as ignored, default=false
 	FixChannel                 FixChannels        `yaml:"fix-channel" json:"fix-channel" mapstructure:"fix-channel"`                                                       // the fix channels to apply to the distro when matching
+	Timestamp                  bool               `yaml:"timestamp" json:"timestamp" mapstructure:"timestamp"`
 	DatabaseCommand            `yaml:",inline" json:",inline" mapstructure:",squash"`
 }
 
@@ -68,6 +69,7 @@ func DefaultGrype(id clio.Identification) *Grype {
 		VexAdd:                     []string{},
 		MatchUpstreamKernelHeaders: false,
 		SortBy:                     defaultSortBy(),
+		Timestamp:                  true,
 	}
 }
 

--- a/grype/presenter/internal/test_helpers.go
+++ b/grype/presenter/internal/test_helpers.go
@@ -58,7 +58,7 @@ func GenerateAnalysis(t *testing.T, scheme SyftSource) (*sbom.SBOM, models.Docum
 
 	matches := generateMatches(t, grypePackages[0], grypePackages[1])
 
-	doc, err := models.NewDocument(clio.Identification{Name: "grype", Version: "[not provided]"}, grypePackages, context, matches, nil, models.NewMetadataMock(), nil, nil, models.SortByPackage)
+	doc, err := models.NewDocument(clio.Identification{Name: "grype", Version: "[not provided]"}, grypePackages, context, matches, nil, models.NewMetadataMock(), nil, nil, models.SortByPackage, true)
 	require.NoError(t, err)
 
 	return s, doc
@@ -79,7 +79,7 @@ func GenerateAnalysisWithIgnoredMatches(t *testing.T, scheme SyftSource) models.
 	ignoredMatches := generateIgnoredMatches(t, grypePackages[1])
 	context := generateContext(t, scheme)
 
-	doc, err := models.NewDocument(clio.Identification{Name: "grype", Version: "devel"}, grypePackages, context, matches, ignoredMatches, models.NewMetadataMock(), nil, nil, models.SortByPackage)
+	doc, err := models.NewDocument(clio.Identification{Name: "grype", Version: "devel"}, grypePackages, context, matches, ignoredMatches, models.NewMetadataMock(), nil, nil, models.SortByPackage, true)
 	require.NoError(t, err)
 	return doc
 }

--- a/grype/presenter/json/presenter_test.go
+++ b/grype/presenter/json/presenter_test.go
@@ -92,7 +92,7 @@ func TestEmptyJsonPresenter(t *testing.T) {
 		},
 	}
 
-	doc, err := models.NewDocument(clio.Identification{Name: "grype", Version: "[not provided]"}, nil, ctx, match.NewMatches(), nil, models.NewMetadataMock(), nil, nil, models.SortByPackage)
+	doc, err := models.NewDocument(clio.Identification{Name: "grype", Version: "[not provided]"}, nil, ctx, match.NewMatches(), nil, models.NewMetadataMock(), nil, nil, models.SortByPackage, true)
 	require.NoError(t, err)
 
 	pb := models.PresenterConfig{

--- a/grype/presenter/models/descriptor.go
+++ b/grype/presenter/models/descriptor.go
@@ -6,5 +6,5 @@ type descriptor struct {
 	Version       string `json:"version"`
 	Configuration any    `json:"configuration,omitempty"`
 	DB            any    `json:"db,omitempty"`
-	Timestamp     string `json:"timestamp"`
+	Timestamp     string `json:"timestamp,omitempty"`
 }

--- a/grype/presenter/models/document.go
+++ b/grype/presenter/models/document.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/anchore/clio"
@@ -25,7 +24,7 @@ type Document struct {
 func NewDocument(id clio.Identification, packages []pkg.Package, context pkg.Context, matches match.Matches, ignoredMatches []match.IgnoredMatch, metadataProvider vulnerability.MetadataProvider, appConfig any, dbInfo any, strategy SortStrategy, outputTimestamp bool) (Document, error) {
 	var timestamp []byte
 
-	if !outputTimestamp || os.Getenv("GRYPE_TIMESTAMP") == "false" {
+	if !outputTimestamp {
 		// can't be nil in string() call
 		timestamp = []byte{}
 	} else {

--- a/grype/presenter/models/document.go
+++ b/grype/presenter/models/document.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"time"
+	"os"
 
 	"github.com/anchore/clio"
 	"github.com/anchore/grype/grype/distro"
@@ -21,10 +22,18 @@ type Document struct {
 }
 
 // NewDocument creates and populates a new Document struct, representing the populated JSON document.
-func NewDocument(id clio.Identification, packages []pkg.Package, context pkg.Context, matches match.Matches, ignoredMatches []match.IgnoredMatch, metadataProvider vulnerability.MetadataProvider, appConfig any, dbInfo any, strategy SortStrategy) (Document, error) {
-	timestamp, timestampErr := time.Now().Local().MarshalText()
-	if timestampErr != nil {
-		return Document{}, timestampErr
+func NewDocument(id clio.Identification, packages []pkg.Package, context pkg.Context, matches match.Matches, ignoredMatches []match.IgnoredMatch, metadataProvider vulnerability.MetadataProvider, appConfig any, dbInfo any, strategy SortStrategy, outputTimestamp bool) (Document, error) {
+	var timestamp []byte
+
+	if !outputTimestamp || os.Getenv("GRYPE_TIMESTAMP") == "false" {
+		// can't be nil in string() call
+		timestamp = []byte{}
+	} else {
+		var timestampErr error
+		timestamp, timestampErr = time.Now().Local().MarshalText()
+		if timestampErr != nil {
+			return Document{}, timestampErr
+		}
 	}
 
 	// we must preallocate the findings to ensure the JSON document does not show "null" when no matches are found

--- a/grype/presenter/models/document.go
+++ b/grype/presenter/models/document.go
@@ -2,8 +2,8 @@ package models
 
 import (
 	"fmt"
-	"time"
 	"os"
+	"time"
 
 	"github.com/anchore/clio"
 	"github.com/anchore/grype/grype/distro"

--- a/grype/presenter/models/document_test.go
+++ b/grype/presenter/models/document_test.go
@@ -75,7 +75,7 @@ func TestPackagesAreSorted(t *testing.T) {
 			Metadata: syftSource.DirectoryMetadata{},
 		},
 	}
-	doc, err := NewDocument(clio.Identification{}, packages, ctx, matches, nil, NewMetadataMock(), nil, nil, SortByPackage)
+	doc, err := NewDocument(clio.Identification{}, packages, ctx, matches, nil, NewMetadataMock(), nil, nil, SortByPackage, true)
 	if err != nil {
 		t.Fatalf("unable to get document: %+v", err)
 	}
@@ -131,7 +131,7 @@ func TestFixSuggestedVersion(t *testing.T) {
 			Metadata: syftSource.DirectoryMetadata{},
 		},
 	}
-	doc, err := NewDocument(clio.Identification{}, packages, ctx, matches, nil, NewMetadataMock(), nil, nil, SortByPackage)
+	doc, err := NewDocument(clio.Identification{}, packages, ctx, matches, nil, NewMetadataMock(), nil, nil, SortByPackage, true)
 	if err != nil {
 		t.Fatalf("unable to get document: %+v", err)
 	}
@@ -149,7 +149,7 @@ func TestTimestampValidFormat(t *testing.T) {
 		Source: nil,
 	}
 
-	doc, err := NewDocument(clio.Identification{}, nil, ctx, matches, nil, nil, nil, nil, SortByPackage)
+	doc, err := NewDocument(clio.Identification{}, nil, ctx, matches, nil, nil, nil, nil, SortByPackage, true)
 	if err != nil {
 		t.Fatalf("unable to get document: %+v", err)
 	}

--- a/grype/presenter/models/document_test.go
+++ b/grype/presenter/models/document_test.go
@@ -162,3 +162,20 @@ func TestTimestampValidFormat(t *testing.T) {
 	}
 
 }
+
+func TestConfigurableTimestamp(t *testing.T) {
+
+	matches := match.NewMatches()
+	ctx := pkg.Context{
+		Source: nil,
+		Distro: nil,
+	}
+
+	doc, err := NewDocument(clio.Identification{}, nil, ctx, matches, nil, nil, nil, nil, SortByPackage, false)
+	if err != nil {
+		t.Fatalf("unable to get document: %+v", err)
+	}
+
+	assert.Empty(t, doc.Descriptor.Timestamp)
+	
+}

--- a/grype/presenter/models/document_test.go
+++ b/grype/presenter/models/document_test.go
@@ -177,5 +177,5 @@ func TestConfigurableTimestamp(t *testing.T) {
 	}
 
 	assert.Empty(t, doc.Descriptor.Timestamp)
-	
+
 }

--- a/grype/presenter/table/presenter_test.go
+++ b/grype/presenter/table/presenter_test.go
@@ -149,7 +149,7 @@ func TestEmptyTablePresenter(t *testing.T) {
 
 	var buffer bytes.Buffer
 
-	doc, err := models.NewDocument(clio.Identification{}, nil, pkg.Context{}, match.NewMatches(), nil, nil, nil, nil, models.SortByPackage)
+	doc, err := models.NewDocument(clio.Identification{}, nil, pkg.Context{}, match.NewMatches(), nil, nil, nil, nil, models.SortByPackage, true)
 	require.NoError(t, err)
 	pb := models.PresenterConfig{
 		Document: doc,


### PR DESCRIPTION
Allows for configuring whether or not to include a timestamp in the final output via config option or env variable. Default is true. Resolves #522 