### PR TITLE
Update GoReleaser configurations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -59,16 +59,16 @@ builds:
 
 archives:
   - id: linux-archives
-    builds:
+    ids:
       - linux-build
 
   - id: darwin-archives
-    builds:
+    ids:
       - darwin-build
 
   - id: windows-archives
-    format: zip
-    builds:
+    formats: [zip]
+    ids:
       - windows-build
 
 nfpms:
@@ -80,7 +80,7 @@ nfpms:
       - rpm
       - deb
 
-brews:
+homebrew_casks:
   - repository:
       owner: anchore
       name: homebrew-grype


### PR DESCRIPTION
# PR Summary
This small PR updates the GoReleaser configuration to resolve the following warning which you can find in the [CI logs](https://github.com/anchore/grype/actions/runs/15615274060/job/43986319068#step:7:1135): 
```
DEPRECATED: archives.builds should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
DEPRECATED: brews should not be used anymore, check https://goreleaser.com/deprecations#brews for more info
```