### PR TITLE
fix: properly escape CPE segments

### DIFF
--- a/grype/matcher/apk/matcher_test.go
+++ b/grype/matcher/apk/matcher_test.go
@@ -378,7 +378,8 @@ func TestNvdOnlyMatches(t *testing.T) {
 						},
 					},
 					Found: match.CPEResult{
-						CPEs:              []string{nvdVuln.CPEs[0].Attributes.BindToFmtString()},
+						// use .String() for proper escaping
+						CPEs:              []string{nvdVuln.CPEs[0].Attributes.String()},
 						VersionConstraint: nvdVuln.Constraint.String(),
 						VulnerabilityID:   "CVE-2020-1",
 					},
@@ -450,7 +451,7 @@ func TestNvdOnlyMatches_FixInNvd(t *testing.T) {
 						},
 					},
 					Found: match.CPEResult{
-						CPEs:              []string{vulnFound.CPEs[0].Attributes.BindToFmtString()},
+						CPEs:              []string{vulnFound.CPEs[0].Attributes.String()},
 						VersionConstraint: vulnFound.Constraint.String(),
 						VulnerabilityID:   "CVE-2020-1",
 					},
@@ -524,7 +525,7 @@ func TestNvdMatchesProperVersionFiltering(t *testing.T) {
 						},
 					},
 					Found: match.CPEResult{
-						CPEs:              []string{nvdVulnMatch.CPEs[0].Attributes.BindToFmtString()},
+						CPEs:              []string{nvdVulnMatch.CPEs[0].Attributes.String()},
 						VersionConstraint: nvdVulnMatch.Constraint.String(),
 						VulnerabilityID:   "CVE-2020-1",
 					},
@@ -882,7 +883,7 @@ func TestNVDMatchBySourceIndirection(t *testing.T) {
 						},
 					},
 					Found: match.CPEResult{
-						CPEs:              []string{nvdVuln.CPEs[0].Attributes.BindToFmtString()},
+						CPEs:              []string{nvdVuln.CPEs[0].Attributes.String()},
 						VersionConstraint: nvdVuln.Constraint.String(),
 						VulnerabilityID:   "CVE-2020-1",
 					},

--- a/grype/matcher/apk/matcher_test.go
+++ b/grype/matcher/apk/matcher_test.go
@@ -339,7 +339,7 @@ func TestNvdOnlyMatches(t *testing.T) {
 		PackageName: "libvncserver",
 		Constraint:  version.MustGetConstraint("<= 0.9.11", version.UnknownFormat),
 		CPEs: []cpe.CPE{
-			cpe.Must(`cpe:2.3:a:lib_vnc_project-\(server\):libvncserver:*:*:*:*:*:*:*:*`, ""),
+			cpe.Must(`cpe:2.3:a:lib_vnc_project-\(server\):lib/vncserver:*:*:*:*:*:*:*:*`, ""),
 		},
 	}
 	vp := mock.VulnerabilityProvider(nvdVuln)
@@ -356,7 +356,7 @@ func TestNvdOnlyMatches(t *testing.T) {
 		Type:    syftPkg.ApkPkg,
 		Distro:  d,
 		CPEs: []cpe.CPE{
-			cpe.Must("cpe:2.3:a:*:libvncserver:0.9.9:*:*:*:*:*:*:*", ""),
+			cpe.Must("cpe:2.3:a:*:lib/vncserver:0.9.9:*:*:*:*:*:*:*", ""),
 		},
 	}
 
@@ -370,7 +370,7 @@ func TestNvdOnlyMatches(t *testing.T) {
 					Type:       match.CPEMatch,
 					Confidence: 0.9,
 					SearchedBy: match.CPEParameters{
-						CPEs:      []string{"cpe:2.3:a:*:libvncserver:0.9.9:*:*:*:*:*:*:*"},
+						CPEs:      []string{"cpe:2.3:a:*:lib\\/vncserver:0.9.9:*:*:*:*:*:*:*"},
 						Namespace: "nvd:cpe",
 						Package: match.CPEPackageParameter{
 							Name:    "libvncserver",

--- a/grype/matcher/internal/cpe.go
+++ b/grype/matcher/internal/cpe.go
@@ -133,7 +133,8 @@ func addNewMatch(matchesByFingerprint map[match.Fingerprint]match.Match, vuln vu
 			SearchedBy: match.CPEParameters{
 				Namespace: vuln.Namespace,
 				CPEs: []string{
-					searchedByCPE.Attributes.BindToFmtString(),
+					// use .String() for proper escaping
+					searchedByCPE.Attributes.String(),
 				},
 				Package: match.CPEPackageParameter{
 					Name:    p.Name,
@@ -238,7 +239,8 @@ func toMatches(matchesByFingerprint map[match.Fingerprint]match.Match) (matches 
 func cpesToString(cpes []cpe.CPE) []string {
 	var strs = make([]string, len(cpes))
 	for idx, c := range cpes {
-		strs[idx] = c.Attributes.BindToFmtString()
+		// use .String() for proper escaping
+		strs[idx] = c.Attributes.String()
 	}
 	sort.Strings(strs)
 	return strs

--- a/grype/matcher/internal/cpe_test.go
+++ b/grype/matcher/internal/cpe_test.go
@@ -1075,7 +1075,8 @@ func TestFilterCPEsByVersion(t *testing.T) {
 			// format CPE objects to string...
 			actualStrs := make([]string, len(actual))
 			for idx, a := range actual {
-				actualStrs[idx] = a.Attributes.BindToFmtString()
+				// use .String() for proper escaping
+				actualStrs[idx] = a.Attributes.String()
 			}
 
 			assert.ElementsMatch(t, test.expected, actualStrs)

--- a/grype/pkg/upstream_package.go
+++ b/grype/pkg/upstream_package.go
@@ -35,6 +35,7 @@ func UpstreamPackages(p Package) (pkgs []Package) {
 				c.Attributes.Version = u.Version
 			}
 
+			// use BindToFmtString because we search against unescaped CPE strings
 			updatedCPEString := strings.ReplaceAll(c.Attributes.BindToFmtString(), p.Name, u.Name)
 
 			cpeStrings.Add(updatedCPEString)

--- a/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenterDir.golden
+++ b/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenterDir.golden
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:c7b9f230-9fb8-43f7-af7a-824cd878a853",
+  "serialNumber": "urn:uuid:89105aa1-e87c-409a-8281-48b46b36130d",
   "version": 1,
   "metadata": {
-    "timestamp": "2025-05-16T15:26:00-04:00",
+    "timestamp": "2025-06-16T10:43:00-04:00",
     "tools": {
       "components": [
         {
@@ -19,7 +19,7 @@
     "component": {
       "bom-ref": "163686ac6e30c752",
       "type": "file",
-      "name": "/var/folders/8y/ct5nbgtj4p30k10kfmq4p4s00000gn/T/TestCycloneDxPresenterDir76562573/001"
+      "name": "/var/folders/jc/fxkytj5j5sj8rwxsv7k5x1b80000gn/T/TestCycloneDxPresenterDir1134101579/001"
     }
   },
   "components": [
@@ -28,7 +28,7 @@
       "type": "library",
       "name": "package-1",
       "version": "1.1.1",
-      "cpe": "cpe:2.3:a:anchore:engine:0.9.2:*:*:en:*:*:*:*",
+      "cpe": "cpe:2.3:a:ancho\\:re:en\\/gine:0.9.2:*:*:en:*:*:*:*",
       "properties": [
         {
           "name": "syft:package:type",
@@ -89,7 +89,7 @@
   ],
   "vulnerabilities": [
     {
-      "bom-ref": "urn:uuid:983f094f-a20c-4aed-b6f1-d9b417c706cc",
+      "bom-ref": "urn:uuid:0919b596-a1af-43e2-96be-0d1800694c03",
       "id": "CVE-1999-0001",
       "source": {},
       "references": [
@@ -113,7 +113,7 @@
       ]
     },
     {
-      "bom-ref": "urn:uuid:ae00e132-f2c5-4d07-896d-31aaf91e04d1",
+      "bom-ref": "urn:uuid:2627386f-23ef-4beb-9b63-61e4ae4ccda7",
       "id": "CVE-1999-0002",
       "source": {},
       "references": [

--- a/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenterDir.golden
+++ b/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenterDir.golden
@@ -28,7 +28,7 @@
       "type": "library",
       "name": "package-1",
       "version": "1.1.1",
-      "cpe": "cpe:2.3:a:ancho\\:re:en\\/gine:0.9.2:*:*:en:*:*:*:*",
+      "cpe": "cpe:2.3:a:anchore\\:oss:anchore\\/engine:0.9.2:*:*:en:*:*:*:*",
       "properties": [
         {
           "name": "syft:package:type",

--- a/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenterImage.golden
+++ b/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenterImage.golden
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:e9977dcd-e35e-4053-ab49-932f99e4d240",
+  "serialNumber": "urn:uuid:cf63e8cb-edbd-4f38-87d0-f6767e1cbf0e",
   "version": 1,
   "metadata": {
-    "timestamp": "2025-05-16T15:26:00-04:00",
+    "timestamp": "2025-06-16T10:43:00-04:00",
     "tools": {
       "components": [
         {
@@ -29,7 +29,7 @@
       "type": "library",
       "name": "package-1",
       "version": "1.1.1",
-      "cpe": "cpe:2.3:a:anchore:engine:0.9.2:*:*:en:*:*:*:*",
+      "cpe": "cpe:2.3:a:ancho\\:re:en\\/gine:0.9.2:*:*:en:*:*:*:*",
       "properties": [
         {
           "name": "syft:package:type",
@@ -90,7 +90,7 @@
   ],
   "vulnerabilities": [
     {
-      "bom-ref": "urn:uuid:9f6e21d3-d245-4ee3-9558-cb5cc4936b32",
+      "bom-ref": "urn:uuid:49be00c6-7281-43fa-bdc1-bccc44694a72",
       "id": "CVE-1999-0001",
       "source": {},
       "references": [
@@ -114,7 +114,7 @@
       ]
     },
     {
-      "bom-ref": "urn:uuid:4fc03529-3b07-41e2-9bc9-c0b2989ccf8e",
+      "bom-ref": "urn:uuid:17b1f369-4435-43c3-a026-7ba5edfeff5c",
       "id": "CVE-1999-0002",
       "source": {},
       "references": [

--- a/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenterImage.golden
+++ b/grype/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxPresenterImage.golden
@@ -29,7 +29,7 @@
       "type": "library",
       "name": "package-1",
       "version": "1.1.1",
-      "cpe": "cpe:2.3:a:ancho\\:re:en\\/gine:0.9.2:*:*:en:*:*:*:*",
+      "cpe": "cpe:2.3:a:anchore\\:oss:anchore\\/engine:0.9.2:*:*:en:*:*:*:*",
       "properties": [
         {
           "name": "syft:package:type",

--- a/grype/presenter/internal/test_helpers.go
+++ b/grype/presenter/internal/test_helpers.go
@@ -390,8 +390,8 @@ func generatePackages(t *testing.T) []syftPkg.Package {
 				{
 					Attributes: cpe.Attributes{
 						Part:     "a",
-						Vendor:   "ancho:re",
-						Product:  "en/gine",
+						Vendor:   "anchore:oss",
+						Product:  "anchore/engine",
 						Version:  "0.9.2",
 						Language: "en",
 					},

--- a/grype/presenter/internal/test_helpers.go
+++ b/grype/presenter/internal/test_helpers.go
@@ -390,8 +390,8 @@ func generatePackages(t *testing.T) []syftPkg.Package {
 				{
 					Attributes: cpe.Attributes{
 						Part:     "a",
-						Vendor:   "anchore",
-						Product:  "engine",
+						Vendor:   "ancho:re",
+						Product:  "en/gine",
 						Version:  "0.9.2",
 						Language: "en",
 					},

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
@@ -70,7 +70,7 @@
     "language": "",
     "licenses": [],
     "cpes": [
-     "cpe:2.3:a:anchore:engine:0.9.2:*:*:en:*:*:*:*"
+     "cpe:2.3:a:ancho\\:re:en\\/gine:0.9.2:*:*:en:*:*:*:*"
     ],
     "purl": "",
     "upstreams": [],

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
@@ -70,7 +70,7 @@
     "language": "",
     "licenses": [],
     "cpes": [
-     "cpe:2.3:a:ancho\\:re:en\\/gine:0.9.2:*:*:en:*:*:*:*"
+     "cpe:2.3:a:anchore\\:oss:anchore\\/engine:0.9.2:*:*:en:*:*:*:*"
     ],
     "purl": "",
     "upstreams": [],

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
@@ -70,7 +70,7 @@
     "language": "",
     "licenses": [],
     "cpes": [
-     "cpe:2.3:a:anchore:engine:0.9.2:*:*:en:*:*:*:*"
+     "cpe:2.3:a:ancho\\:re:en\\/gine:0.9.2:*:*:en:*:*:*:*"
     ],
     "purl": "",
     "upstreams": [],

--- a/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
+++ b/grype/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
@@ -70,7 +70,7 @@
     "language": "",
     "licenses": [],
     "cpes": [
-     "cpe:2.3:a:ancho\\:re:en\\/gine:0.9.2:*:*:en:*:*:*:*"
+     "cpe:2.3:a:anchore\\:oss:anchore\\/engine:0.9.2:*:*:en:*:*:*:*"
     ],
     "purl": "",
     "upstreams": [],

--- a/grype/presenter/models/package.go
+++ b/grype/presenter/models/package.go
@@ -31,7 +31,8 @@ type UpstreamPackage struct {
 func newPackage(p pkg.Package) Package {
 	var cpes = make([]string, 0)
 	for _, c := range p.CPEs {
-		cpes = append(cpes, c.Attributes.BindToFmtString())
+		// use .String() to ensure proper escaping
+		cpes = append(cpes, c.Attributes.String())
 	}
 
 	licenses := p.Licenses

--- a/grype/presenter/template/test-fixtures/snapshot/TestPresenter_Present.golden
+++ b/grype/presenter/template/test-fixtures/snapshot/TestPresenter_Present.golden
@@ -2,7 +2,7 @@ Identified distro as centos version 8.0.
     Vulnerability: CVE-1999-0001
     Severity: Low
     Package: package-1 version 1.1.1 (rpm)
-    CPEs: ["cpe:2.3:a:anchore:engine:0.9.2:*:*:en:*:*:*:*"]
+    CPEs: ["cpe:2.3:a:ancho\\:re:en\\/gine:0.9.2:*:*:en:*:*:*:*"]
     Matched by: dpkg-matcher
     Vulnerability: CVE-1999-0002
     Severity: Critical

--- a/grype/presenter/template/test-fixtures/snapshot/TestPresenter_Present.golden
+++ b/grype/presenter/template/test-fixtures/snapshot/TestPresenter_Present.golden
@@ -2,7 +2,7 @@ Identified distro as centos version 8.0.
     Vulnerability: CVE-1999-0001
     Severity: Low
     Package: package-1 version 1.1.1 (rpm)
-    CPEs: ["cpe:2.3:a:ancho\\:re:en\\/gine:0.9.2:*:*:en:*:*:*:*"]
+    CPEs: ["cpe:2.3:a:anchore\\:oss:anchore\\/engine:0.9.2:*:*:en:*:*:*:*"]
     Matched by: dpkg-matcher
     Vulnerability: CVE-1999-0002
     Severity: Critical


### PR DESCRIPTION
This PR fixes an issue with JSON output where CPE segments are not properly escaped in the same way Syft outputs escaped CPE segments.