### PR TITLE
fix: append vex ignore rules if vex doc is present

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -280,6 +280,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Delete snapshot cache
-        run: gh cache delete "snapshot-build-${{ github.run_id }}"
+        run: gh cache delete "snapshot-build-${{ github.run_id }}" || echo "Cache deletion failed or cache not found - continuing"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -173,7 +173,6 @@ func runGrype(app clio.Application, opts *options.Grype, userInput string) (errs
 			return nil
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -402,7 +401,9 @@ func validateRootArgs(cmd *cobra.Command, args []string) error {
 }
 
 func applyVexRules(opts *options.Grype) error {
-	if len(opts.Ignore) == 0 && len(opts.VexDocuments) > 0 {
+	// If any vex documents are provided, assume the user intends to ignore vulnerabilities that those
+	// vex documents list as "fixed" or "not_affected".
+	if len(opts.VexDocuments) > 0 {
 		opts.Ignore = append(opts.Ignore, ignoreVEXFixedNotAffected...)
 	}
 

--- a/cmd/grype/cli/commands/root_test.go
+++ b/cmd/grype/cli/commands/root_test.go
@@ -6,10 +6,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/clio"
 	"github.com/anchore/grype/cmd/grype/cli/options"
+	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vex"
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/cataloging"
@@ -83,6 +86,121 @@ func Test_getProviderConfig(t *testing.T) {
 			if d := cmp.Diff(tt.want, getProviderConfig(tt.opts), opts...); d != "" {
 				t.Errorf("getProviderConfig() mismatch (-want +got):\n%s", d)
 			}
+		})
+	}
+}
+
+func Test_applyVexRules(t *testing.T) {
+	tests := []struct {
+		name                   string
+		initialIgnoreRules     []match.IgnoreRule
+		vexDocuments           []string
+		vexAdd                 []string
+		expectedIgnoreRules    []match.IgnoreRule
+		expectError            bool
+		expectedErrorSubstring string
+	}{
+		{
+			name:                "no VEX documents provided - no rules added",
+			initialIgnoreRules:  []match.IgnoreRule{},
+			vexDocuments:        []string{},
+			vexAdd:              []string{},
+			expectedIgnoreRules: []match.IgnoreRule{},
+			expectError:         false,
+		},
+		{
+			name:               "VEX documents provided with empty ignore rules - automatic rules added",
+			initialIgnoreRules: []match.IgnoreRule{},
+			vexDocuments:       []string{"path/to/vex.json"},
+			vexAdd:             []string{},
+			expectedIgnoreRules: []match.IgnoreRule{
+				{VexStatus: string(vex.StatusNotAffected)},
+				{VexStatus: string(vex.StatusFixed)},
+			},
+			expectError: false,
+		},
+		{
+			name: "VEX documents provided with existing ignore rules - automatic rules still added",
+			initialIgnoreRules: []match.IgnoreRule{
+				{Vulnerability: "CVE-2023-1234"},
+			},
+			vexDocuments: []string{"path/to/vex.json"},
+			vexAdd:       []string{},
+			expectedIgnoreRules: []match.IgnoreRule{
+				{Vulnerability: "CVE-2023-1234"},
+				{VexStatus: string(vex.StatusNotAffected)},
+				{VexStatus: string(vex.StatusFixed)},
+			},
+			expectError: false,
+		},
+		{
+			name:               "vex-add with valid statuses",
+			initialIgnoreRules: []match.IgnoreRule{},
+			vexDocuments:       []string{"path/to/vex.json"},
+			vexAdd:             []string{"affected", "under_investigation"},
+			expectedIgnoreRules: []match.IgnoreRule{
+				{VexStatus: string(vex.StatusNotAffected)},
+				{VexStatus: string(vex.StatusFixed)},
+				{VexStatus: string(vex.StatusAffected)},
+				{VexStatus: string(vex.StatusUnderInvestigation)},
+			},
+			expectError: false,
+		},
+		{
+			name:                   "vex-add with invalid status",
+			initialIgnoreRules:     []match.IgnoreRule{},
+			vexDocuments:           []string{"path/to/vex.json"},
+			vexAdd:                 []string{"invalid_status"},
+			expectedIgnoreRules:    nil,
+			expectError:            true,
+			expectedErrorSubstring: "invalid VEX status in vex-add setting: invalid_status",
+		},
+		{
+			name:                   "vex-add attempting to use fixed status",
+			initialIgnoreRules:     []match.IgnoreRule{},
+			vexDocuments:           []string{"path/to/vex.json"},
+			vexAdd:                 []string{"fixed"},
+			expectedIgnoreRules:    nil,
+			expectError:            true,
+			expectedErrorSubstring: "invalid VEX status in vex-add setting: fixed",
+		},
+		{
+			name: "multiple VEX documents with existing rules",
+			initialIgnoreRules: []match.IgnoreRule{
+				{Vulnerability: "CVE-2023-1234"},
+				{FixState: "unknown"},
+			},
+			vexDocuments: []string{"vex1.json", "vex2.json"},
+			vexAdd:       []string{"affected"},
+			expectedIgnoreRules: []match.IgnoreRule{
+				{Vulnerability: "CVE-2023-1234"},
+				{FixState: "unknown"},
+				{VexStatus: string(vex.StatusNotAffected)},
+				{VexStatus: string(vex.StatusFixed)},
+				{VexStatus: string(vex.StatusAffected)},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &options.Grype{
+				Ignore:       append([]match.IgnoreRule{}, tt.initialIgnoreRules...),
+				VexDocuments: tt.vexDocuments,
+				VexAdd:       tt.vexAdd,
+			}
+
+			err := applyVexRules(opts)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrorSubstring)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedIgnoreRules, opts.Ignore)
 		})
 	}
 }


### PR DESCRIPTION
Previously, grype would disregard default vex behavior in the presence of other ignore rules. Instead, append default vex ignore rules if any vex documents are used, even if other ignore rules exist.

Fixes #1836 