### PR TITLE
Use shared workflow for CodeQL scans

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
 name: CodeQL Security Scan
 
 on:
@@ -18,62 +13,9 @@ on:
   schedule:
     - cron: '0 14 * * 4'
 
-env:
-  CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
-
-permissions:
-  contents: read
-
 jobs:
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
-
+  security-scan:
+    uses: anchore/workflows/.github/workflows/codeql.yaml@add-codeql
     permissions:
-      # required for all workflows
       security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        # Override automatic language detection by changing the below list
-        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        language: ['go', 'python']
-        # Learn more...
-        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-    - name: Set correct version of Golang to use during CodeQL run
-      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-      with:
-        go-version: '1.21'
-        check-latest: true
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-    # If this step fails, then you should remove it and run the build manually (see below)
-    # - name: Autobuild
-    # uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-    - name: Build grype for CodeQL
-      run: make build
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
+      contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,8 @@ on:
 jobs:
   security-scan:
     uses: anchore/workflows/.github/workflows/codeql.yaml@add-codeql
+    with:
+      build-command: 'make build'
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,8 +16,6 @@ on:
 jobs:
   security-scan:
     uses: anchore/workflows/.github/workflows/codeql.yaml@add-codeql
-    with:
-      build-command: 'make build'
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,8 +14,10 @@ on:
     - cron: '0 14 * * 4'
 
 jobs:
-  security-scan:
+  CodeQL:
     uses: anchore/workflows/.github/workflows/codeql.yaml@add-codeql
+    with:
+      entrypoint: "./cmd/${{ github.event.repository.name }}"
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   CodeQL:
-    uses: anchore/workflows/.github/workflows/codeql.yaml@add-codeql
+    uses: anchore/workflows/.github/workflows/codeql-go.yaml@main
     with:
       entrypoint: "./cmd/${{ github.event.repository.name }}"
     permissions:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -40,7 +40,13 @@ tasks:
 
   ## High-level tasks #################################
 
+  # note: the default task should not run levels of test, only build the project.
   default:
+    desc: Build the project
+    cmds:
+      - task: build
+
+  validate:
     desc: Run all validation tasks
     aliases:
       - pr-validations


### PR DESCRIPTION
This runs in the fraction of the time and resources, but still getting the same paths reported as on the runs on main today. This restricts the scans to only cover the golang code.