### PR TITLE
fix: NVD related vulnerabilities

### DIFF
--- a/grype/db/v6/vulnerability.go
+++ b/grype/db/v6/vulnerability.go
@@ -17,7 +17,10 @@ import (
 	"github.com/anchore/syft/syft/pkg"
 )
 
-const v5NvdNamespace = "nvd:cpe"
+const (
+	nvdProvider    = "nvd"
+	v5NvdNamespace = "nvd:cpe"
+)
 
 func newVulnerabilityFromAffectedPackageHandle(affected AffectedPackageHandle, affectedRanges []AffectedRange) (*vulnerability.Vulnerability, error) {
 	packageName := ""
@@ -118,7 +121,10 @@ func getRelatedVulnerabilities(vuln *VulnerabilityHandle, affected *AffectedPack
 	}
 	if affected != nil {
 		for _, cve := range affected.CVEs {
-			if cveSet.Has(cve) || strings.EqualFold(vuln.Name, cve) {
+			if cveSet.Has(cve) {
+				continue
+			}
+			if vuln.ProviderID == nvdProvider && strings.EqualFold(vuln.Name, cve) {
 				continue
 			}
 			if !strings.HasPrefix(strings.ToLower(cve), "cve-") {

--- a/grype/db/v6/vulnerability_test.go
+++ b/grype/db/v6/vulnerability_test.go
@@ -565,7 +565,21 @@ func Test_getRelatedVulnerabilities(t *testing.T) {
 			expected: []string{"CVE-2024-1", "CVE-2024-2", "CVE-2024-3"},
 		},
 		{
-			name: "CVE with related CVEs and self",
+			name: "nvd CVE skips related CVEs to self",
+			vuln: VulnerabilityHandle{
+				Name:       "CVE-2024-1234",
+				ProviderID: nvdProvider,
+				BlobValue: &VulnerabilityBlob{
+					Aliases: []string{"CVE-2024-1", "CVE-2024-1234"},
+				},
+			},
+			affected: AffectedPackageBlob{
+				CVEs: []string{"CVE-2024-2", "CVE-2024-1234"},
+			},
+			expected: []string{"CVE-2024-1", "CVE-2024-2"}, // does not include "CVE-2024-1234"
+		},
+		{
+			name: "non-nvd CVE with related nvd CVEs to self",
 			vuln: VulnerabilityHandle{
 				Name: "CVE-2024-1234",
 				BlobValue: &VulnerabilityBlob{
@@ -575,7 +589,7 @@ func Test_getRelatedVulnerabilities(t *testing.T) {
 			affected: AffectedPackageBlob{
 				CVEs: []string{"CVE-2024-2", "CVE-2024-1234"},
 			},
-			expected: []string{"CVE-2024-1", "CVE-2024-2"}, // does not include "CVE-2024-1234"
+			expected: []string{"CVE-2024-1", "CVE-2024-2", "CVE-2024-1234"}, // does include "CVE-2024-1234"
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR corrects an issue that was filtering out NVD related vulnerabilities for non-NVD records.