### PR TITLE
fix: DB should hydrate for when the client has new features

### DIFF
--- a/grype/db/v6/installation/curator.go
+++ b/grype/db/v6/installation/curator.go
@@ -343,7 +343,7 @@ func isRehydrationNeeded(fs afero.Fs, dirPath string, currentDBVersion *schemave
 		return false, fmt.Errorf("unable to parse client version from import metadata: %w", err)
 	}
 
-	hydratedWithOldClient := clientHydrationVersion.LessThan(*currentDBVersion)
+	hydratedWithOldClient := clientHydrationVersion.LessThanOrEqualTo(*currentDBVersion)
 	haveNewerClient := clientHydrationVersion.LessThan(currentClientVersion)
 	doRehydrate := hydratedWithOldClient && haveNewerClient
 

--- a/grype/db/v6/installation/curator_test.go
+++ b/grype/db/v6/installation/curator_test.go
@@ -729,6 +729,16 @@ func Test_isRehydrationNeeded(t *testing.T) {
 			currentClientVer:   schemaver.New(6, 2, 0),
 			expectedResult:     false,
 		},
+		{
+			// there are cases where new features will result in new columns, thus an old client downloading and hydrating
+			// a DB should function, however, when the new client is downloaded it should trigger at least a rehydration
+			// of the existing DB (in cases where the new DB is not availabl for download yet).
+			name:               "rehydration needed - we have a new client version, with an old DB version",
+			currentDBVersion:   schemaver.New(6, 0, 2),
+			hydrationClientVer: schemaver.New(6, 0, 2),
+			currentClientVer:   schemaver.New(6, 0, 3),
+			expectedResult:     true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/schemaver/schema_ver.go
+++ b/internal/schemaver/schema_ver.go
@@ -83,6 +83,26 @@ func (s SchemaVer) LessThan(other SchemaVer) bool {
 	return s.Addition < other.Addition
 }
 
+func (s SchemaVer) LessThanOrEqualTo(other SchemaVer) bool {
+	return s.LessThan(other) || s.Equal(other)
+}
+
+func (s SchemaVer) Equal(other SchemaVer) bool {
+	return s.Model == other.Model && s.Revision == other.Revision && s.Addition == other.Addition
+}
+
+func (s SchemaVer) GreaterThan(other SchemaVer) bool {
+	if s.Model != other.Model {
+		return s.Model > other.Model
+	}
+
+	if s.Revision != other.Revision {
+		return s.Revision > other.Revision
+	}
+
+	return s.Addition > other.Addition
+}
+
 func (s SchemaVer) GreaterOrEqualTo(other SchemaVer) bool {
-	return !s.LessThan(other)
+	return s.GreaterThan(other) || s.Equal(other)
 }


### PR DESCRIPTION
Grype client should hydrate the DB when there are new client features.

For example: if a v6.0.2 client downloads a v6.0.2 DB and hydrates it, then a newer client (v6.0.3) runs a scan then the client should hydrate the DB (assuming there is no v6.0.3 DB available to download for whatever reason).

New clients may depend on new columns existing in the DB, and hydrating will auto-migrate the tables to include these new columns (with empty values). This doesn't mean that the client will logically perform the correct behavior if the new feature does not gracefully degrade, but it does prevent against SQL-level errors about columns not existing. Note that this would still allow for older clients to use the DB hydrated by the new client.