### PR TITLE
fix: assume that a vulnerability with no ranges is always vulnerable

### DIFF
--- a/grype/db/v6/vulnerability_provider.go
+++ b/grype/db/v6/vulnerability_provider.go
@@ -528,6 +528,10 @@ func filterAffectedCPEVersions(constraintMatcher search.VersionConstraintMatcher
 
 // filterAffectedPackageRanges returns true if all ranges removed
 func filterAffectedPackageRanges(matcher search.VersionConstraintMatcher, b *AffectedPackageBlob) (bool, []string) {
+	if len(b.Ranges) == 0 {
+		// no ranges means that we're implicitly vulnerable to all versions
+		return false, nil
+	}
 	var unmatchedConstraints []string
 	for _, r := range b.Ranges {
 		v := r.Version

--- a/grype/db/v6/vulnerability_provider_test.go
+++ b/grype/db/v6/vulnerability_provider_test.go
@@ -470,6 +470,95 @@ func Test_DataSource(t *testing.T) {
 	}
 }
 
+func Test_filterAffectedPackageRanges(t *testing.T) {
+	tests := []struct {
+		name                     string
+		ranges                   []AffectedRange
+		matchesConstraint        func(constraint version.Constraint) (bool, error)
+		expectedAllRangesRemoved bool
+		expectedUnmatchedStrings []string
+	}{
+		{
+			name:                     "no ranges",
+			ranges:                   nil,
+			expectedAllRangesRemoved: false, // important! we assume that a vulnerability with no ranges is always vulnerable
+			expectedUnmatchedStrings: nil,
+		},
+		{
+			name: "has ranges within constraint",
+			ranges: []AffectedRange{
+				{
+					Version: AffectedVersion{
+						Type:       "rpm",
+						Constraint: "< 1.0.0",
+					},
+				},
+				{
+					Version: AffectedVersion{
+						Type:       "rpm",
+						Constraint: "< 2.0.0",
+					},
+				},
+			},
+			matchesConstraint: func(constraint version.Constraint) (bool, error) {
+				return true, nil
+			},
+			expectedAllRangesRemoved: false,
+			expectedUnmatchedStrings: nil,
+		},
+		{
+			name: "has ranges outside constraint",
+			ranges: []AffectedRange{
+				{
+					Version: AffectedVersion{
+						Type:       "rpm",
+						Constraint: "< 1.0.0",
+					},
+				},
+				{
+					Version: AffectedVersion{
+						Type:       "rpm",
+						Constraint: "< 2.0.0",
+					},
+				},
+			},
+			matchesConstraint: func(constraint version.Constraint) (bool, error) {
+				return false, nil
+			},
+			expectedAllRangesRemoved: true,
+			expectedUnmatchedStrings: []string{"< 1.0.0", "< 2.0.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockMatcher := &mockVersionConstraintMatcher{
+				matchesConstraintFunc: tt.matchesConstraint,
+			}
+
+			blob := &AffectedPackageBlob{
+				Ranges: tt.ranges,
+			}
+
+			allRangesRemoved, unmatchedConstraints := filterAffectedPackageRanges(mockMatcher, blob)
+
+			require.Equal(t, tt.expectedAllRangesRemoved, allRangesRemoved)
+			require.Equal(t, tt.expectedUnmatchedStrings, unmatchedConstraints)
+		})
+	}
+}
+
+type mockVersionConstraintMatcher struct {
+	matchesConstraintFunc func(constraint version.Constraint) (bool, error)
+}
+
+func (m *mockVersionConstraintMatcher) MatchesConstraint(constraint version.Constraint) (bool, error) {
+	if m.matchesConstraintFunc != nil {
+		return m.matchesConstraintFunc(constraint)
+	}
+	return false, nil
+}
+
 func cmpOpts() []cmp.Option {
 	return []cmp.Option{
 		// globally ignore unexported -- these are unexported structs we cannot reference here to use cmpopts.IgnoreUnexported


### PR DESCRIPTION
Today it is possible to have NVD entries that have no range information for a CVE, such as with [CVE-2010-4756](https://nvd.nist.gov/vuln/detail/CVE-2010-4756), however, the correct interpretation of this is that all versions are vulnerable. This looks like it was introduced in the v6 development effort (based on the data shape changes I'm seeing, this class of bugs makes sense) and it led to a reduction in FPs with the exception for one finding (which is why it was merged).