### PR TITLE
chore: specify types for all match details

### DIFF
--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -261,11 +261,7 @@ func applyDistroHint(pkgs []pkg.Package, context *pkg.Context, opts *options.Gry
 		if len(split) > 1 {
 			v = split[1]
 		}
-		var err error
-		context.Distro, err = distro.NewFromNameVersion(d, v)
-		if err != nil {
-			log.WithFields("distro", opts.Distro, "error", err).Warn("unable to parse distro")
-		}
+		context.Distro = distro.NewFromNameVersion(d, v)
 	}
 
 	hasOSPackageWithoutDistro := false

--- a/grype/db/v6/vulnerability_provider_test.go
+++ b/grype/db/v6/vulnerability_provider_test.go
@@ -23,8 +23,7 @@ import (
 func Test_FindVulnerabilitiesByDistro(t *testing.T) {
 	provider := testVulnerabilityProvider(t)
 
-	d, err := distro.New(distro.Debian, "8", "")
-	require.NoError(t, err)
+	d := distro.New(distro.Debian, "8", "")
 
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),
@@ -276,8 +275,7 @@ func Test_FindVulnerabilitiesByCPE(t *testing.T) {
 func Test_FindVulnerabilitiesByID(t *testing.T) {
 	provider := testVulnerabilityProvider(t)
 
-	d, err := distro.New(distro.Debian, "8", "")
-	require.NoError(t, err)
+	d := distro.New(distro.Debian, "8", "")
 
 	// with distro
 	actual, err := provider.FindVulnerabilities(search.ByDistro(*d), search.ByID("CVE-2014-fake-1"))

--- a/grype/distro/distro.go
+++ b/grype/distro/distro.go
@@ -25,7 +25,7 @@ type Distro struct {
 }
 
 // New creates a new Distro object populated with the given values.
-func New(t Type, version, label string, idLikes ...string) (*Distro, error) {
+func New(t Type, version, label string, idLikes ...string) *Distro {
 	var major, minor, remaining string
 	if version != "" {
 		// if starts with a digit, then assume it's a version and extract the major, minor, and remaining versions
@@ -59,11 +59,11 @@ func New(t Type, version, label string, idLikes ...string) (*Distro, error) {
 		Version:   version,
 		Codename:  label,
 		IDLike:    idLikes,
-	}, nil
+	}
 }
 
 // NewFromNameVersion creates a new Distro object derived from the provided name and version
-func NewFromNameVersion(name, version string) (*Distro, error) {
+func NewFromNameVersion(name, version string) *Distro {
 	var codename string
 
 	// if there are no digits in the version, it is likely a codename
@@ -116,7 +116,7 @@ func NewFromRelease(release linux.Release) (*Distro, error) {
 		selectedVersion = release.VersionID
 	}
 
-	return New(t, selectedVersion, release.VersionCodename, release.IDLike...)
+	return New(t, selectedVersion, release.VersionCodename, release.IDLike...), nil
 }
 
 func (d Distro) Name() string {

--- a/grype/match/results.go
+++ b/grype/match/results.go
@@ -7,15 +7,15 @@ import (
 	"github.com/scylladb/go-set/strset"
 )
 
-type CPEPackageParameter struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+type CPEParameters struct {
+	Namespace string           `json:"namespace"`
+	CPEs      []string         `json:"cpes"`
+	Package   PackageParameter `json:"package"`
 }
 
-type CPEParameters struct {
-	Namespace string              `json:"namespace"`
-	CPEs      []string            `json:"cpes"`
-	Package   CPEPackageParameter `json:"package"`
+type PackageParameter struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
 }
 
 func (i *CPEParameters) Merge(other CPEParameters) error {
@@ -53,4 +53,71 @@ func (h CPEResult) Equals(other CPEResult) bool {
 	}
 
 	return true
+}
+
+type DistroParameters struct {
+	Distro    DistroIdentification `json:"distro"`
+	Package   PackageParameter     `json:"package"`
+	Namespace string               `json:"namespace"`
+}
+
+type DistroIdentification struct {
+	Type    string `json:"type"`
+	Version string `json:"version"`
+}
+
+func (d *DistroParameters) Merge(other DistroParameters) error {
+	if d.Namespace != other.Namespace {
+		return fmt.Errorf("namespaces do not match")
+	}
+	if d.Distro.Type != other.Distro.Type {
+		return fmt.Errorf("distro types do not match")
+	}
+	if d.Distro.Version != other.Distro.Version {
+		return fmt.Errorf("distro versions do not match")
+	}
+	if d.Package.Name != other.Package.Name {
+		return fmt.Errorf("package names do not match")
+	}
+	if d.Package.Version != other.Package.Version {
+		return fmt.Errorf("package versions do not match")
+	}
+	return nil
+}
+
+type DistroResult struct {
+	VulnerabilityID   string `json:"vulnerabilityID"`
+	VersionConstraint string `json:"versionConstraint"`
+}
+
+func (d DistroResult) Equals(other DistroResult) bool {
+	return d.VulnerabilityID == other.VulnerabilityID &&
+		d.VersionConstraint == other.VersionConstraint
+}
+
+type EcosystemParameters struct {
+	Language  string           `json:"language"`
+	Namespace string           `json:"namespace"`
+	Package   PackageParameter `json:"package"`
+}
+
+func (e *EcosystemParameters) Merge(other EcosystemParameters) error {
+	if e.Namespace != other.Namespace {
+		return fmt.Errorf("namespaces do not match")
+	}
+	if e.Language != other.Language {
+		return fmt.Errorf("languages do not match")
+	}
+	if e.Package.Name != other.Package.Name {
+		return fmt.Errorf("package names do not match")
+	}
+	if e.Package.Version != other.Package.Version {
+		return fmt.Errorf("package versions do not match")
+	}
+	return nil
+}
+
+type EcosystemResult struct {
+	VulnerabilityID   string `json:"vulnerabilityID"`
+	VersionConstraint string `json:"versionConstraint"`
 }

--- a/grype/matcher/apk/matcher.go
+++ b/grype/matcher/apk/matcher.go
@@ -14,8 +14,16 @@ import (
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
-type Matcher struct {
-}
+var (
+	nakVersionString = version.MustGetConstraint("< 0", version.ApkFormat).String()
+
+	// nakConstraint checks the exact version string for being an APK version with "< 0"
+	nakConstraint = search.ByConstraintFunc(func(c version.Constraint) (bool, error) {
+		return c.String() == nakVersionString, nil
+	})
+)
+
+type Matcher struct{}
 
 func (m *Matcher) PackageTypes() []syftPkg.Type {
 	return []syftPkg.Type{syftPkg.ApkPkg}
@@ -29,7 +37,7 @@ func (m *Matcher) Match(store vulnerability.Provider, p pkg.Package) ([]match.Ma
 	var matches []match.Match
 
 	// direct matches with package itself
-	directMatches, err := m.findMatchesForPackage(store, p)
+	directMatches, err := m.findMatchesForPackage(store, p, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -161,9 +169,9 @@ func vulnerabilitiesByID(vulns []vulnerability.Vulnerability) map[string][]vulne
 	return results
 }
 
-func (m *Matcher) findMatchesForPackage(store vulnerability.Provider, p pkg.Package) ([]match.Match, error) {
+func (m *Matcher) findMatchesForPackage(store vulnerability.Provider, p pkg.Package, catalogPkg *pkg.Package) ([]match.Match, error) {
 	// find SecDB matches for the given package name and version
-	secDBMatches, _, err := internal.MatchPackageByDistro(store, p, m.Type())
+	secDBMatches, _, err := internal.MatchPackageByDistro(store, p, catalogPkg, m.Type())
 	if err != nil {
 		return nil, err
 	}
@@ -185,11 +193,11 @@ func (m *Matcher) findMatchesForPackage(store vulnerability.Provider, p pkg.Pack
 	return matches, nil
 }
 
-func (m *Matcher) findMatchesForOriginPackage(store vulnerability.Provider, p pkg.Package) ([]match.Match, error) {
+func (m *Matcher) findMatchesForOriginPackage(store vulnerability.Provider, catalogPkg pkg.Package) ([]match.Match, error) {
 	var matches []match.Match
 
-	for _, indirectPackage := range pkg.UpstreamPackages(p) {
-		indirectMatches, err := m.findMatchesForPackage(store, indirectPackage)
+	for _, indirectPackage := range pkg.UpstreamPackages(catalogPkg) {
+		indirectMatches, err := m.findMatchesForPackage(store, indirectPackage, &catalogPkg)
 		if err != nil {
 			return nil, fmt.Errorf("failed to find vulnerabilities for apk upstream source package: %w", err)
 		}
@@ -198,7 +206,7 @@ func (m *Matcher) findMatchesForOriginPackage(store vulnerability.Provider, p pk
 
 	// we want to make certain that we are tracking the match based on the package from the SBOM (not the indirect package)
 	// however, we also want to keep the indirect package around for future reference
-	match.ConvertToIndirectMatches(matches, p)
+	match.ConvertToIndirectMatches(matches, catalogPkg)
 
 	return matches, nil
 }
@@ -261,11 +269,3 @@ func (m *Matcher) findNaksForPackage(provider vulnerability.Provider, p pkg.Pack
 
 	return ignores, nil
 }
-
-var (
-	nakVersionString = version.MustGetConstraint("< 0", version.ApkFormat).String()
-	// nakConstraint checks the exact version string for being an APK version with "< 0"
-	nakConstraint = search.ByConstraintFunc(func(c version.Constraint) (bool, error) {
-		return c.String() == nakVersionString, nil
-	})
-)

--- a/grype/matcher/apk/matcher_test.go
+++ b/grype/matcher/apk/matcher_test.go
@@ -33,10 +33,7 @@ func TestSecDBOnlyMatch(t *testing.T) {
 	vp := mock.VulnerabilityProvider(secDbVuln)
 
 	m := Matcher{}
-	d, err := distro.New(distro.Alpine, "3.12.0", "")
-	if err != nil {
-		t.Fatalf("failed to create a new distro: %+v", err)
-	}
+	d := distro.New(distro.Alpine, "3.12.0", "")
 
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),
@@ -58,20 +55,20 @@ func TestSecDBOnlyMatch(t *testing.T) {
 				{
 					Type:       match.ExactDirectMatch,
 					Confidence: 1.0,
-					SearchedBy: map[string]interface{}{
-						"distro": map[string]string{
-							"type":    d.Type.String(),
-							"version": d.Version,
+					SearchedBy: match.DistroParameters{
+						Distro: match.DistroIdentification{
+							Type:    d.Type.String(),
+							Version: d.Version,
 						},
-						"package": map[string]string{
-							"name":    "libvncserver",
-							"version": "0.9.9",
+						Package: match.PackageParameter{
+							Name:    "libvncserver",
+							Version: "0.9.9",
 						},
-						"namespace": "secdb:distro:alpine:3.12",
+						Namespace: "secdb:distro:alpine:3.12",
 					},
-					Found: map[string]interface{}{
-						"versionConstraint": secDbVuln.Constraint.String(),
-						"vulnerabilityID":   "CVE-2020-2",
+					Found: match.DistroResult{
+						VulnerabilityID:   "CVE-2020-2",
+						VersionConstraint: secDbVuln.Constraint.String(),
 					},
 					Matcher: match.ApkMatcher,
 				},
@@ -112,10 +109,7 @@ func TestBothSecdbAndNvdMatches(t *testing.T) {
 	vp := mock.VulnerabilityProvider(nvdVuln, secDbVuln)
 
 	m := Matcher{}
-	d, err := distro.New(distro.Alpine, "3.12.0", "")
-	if err != nil {
-		t.Fatalf("failed to create a new distro: %+v", err)
-	}
+	d := distro.New(distro.Alpine, "3.12.0", "")
 
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),
@@ -137,20 +131,20 @@ func TestBothSecdbAndNvdMatches(t *testing.T) {
 				{
 					Type:       match.ExactDirectMatch,
 					Confidence: 1.0,
-					SearchedBy: map[string]interface{}{
-						"distro": map[string]string{
-							"type":    d.Type.String(),
-							"version": d.Version,
+					SearchedBy: match.DistroParameters{
+						Distro: match.DistroIdentification{
+							Type:    d.Type.String(),
+							Version: d.Version,
 						},
-						"package": map[string]string{
-							"name":    "libvncserver",
-							"version": "0.9.9",
+						Package: match.PackageParameter{
+							Name:    "libvncserver",
+							Version: "0.9.9",
 						},
-						"namespace": "secdb:distro:alpine:3.12",
+						Namespace: "secdb:distro:alpine:3.12",
 					},
-					Found: map[string]interface{}{
-						"versionConstraint": secDbVuln.Constraint.String(),
-						"vulnerabilityID":   "CVE-2020-1",
+					Found: match.DistroResult{
+						VulnerabilityID:   "CVE-2020-1",
+						VersionConstraint: secDbVuln.Constraint.String(),
 					},
 					Matcher: match.ApkMatcher,
 				},
@@ -198,10 +192,7 @@ func TestBothSecdbAndNvdMatches_DifferentFixInfo(t *testing.T) {
 	}
 	vp := mock.VulnerabilityProvider(nvdVuln, secDbVuln)
 	m := Matcher{}
-	d, err := distro.New(distro.Alpine, "3.12.0", "")
-	if err != nil {
-		t.Fatalf("failed to create a new distro: %+v", err)
-	}
+	d := distro.New(distro.Alpine, "3.12.0", "")
 
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),
@@ -223,20 +214,20 @@ func TestBothSecdbAndNvdMatches_DifferentFixInfo(t *testing.T) {
 				{
 					Type:       match.ExactDirectMatch,
 					Confidence: 1.0,
-					SearchedBy: map[string]interface{}{
-						"distro": map[string]string{
-							"type":    d.Type.String(),
-							"version": d.Version,
+					SearchedBy: match.DistroParameters{
+						Distro: match.DistroIdentification{
+							Type:    d.Type.String(),
+							Version: d.Version,
 						},
-						"package": map[string]string{
-							"name":    "libvncserver",
-							"version": "0.9.9",
+						Package: match.PackageParameter{
+							Name:    "libvncserver",
+							Version: "0.9.9",
 						},
-						"namespace": "secdb:distro:alpine:3.12",
+						Namespace: "secdb:distro:alpine:3.12",
 					},
-					Found: map[string]interface{}{
-						"versionConstraint": secDbVuln.Constraint.String(),
-						"vulnerabilityID":   "CVE-2020-1",
+					Found: match.DistroResult{
+						VulnerabilityID:   "CVE-2020-1",
+						VersionConstraint: secDbVuln.Constraint.String(),
 					},
 					Matcher: match.ApkMatcher,
 				},
@@ -278,10 +269,8 @@ func TestBothSecdbAndNvdMatches_DifferentPackageName(t *testing.T) {
 	vp := mock.VulnerabilityProvider(nvdVuln, secDbVuln)
 
 	m := Matcher{}
-	d, err := distro.New(distro.Alpine, "3.12.0", "")
-	if err != nil {
-		t.Fatalf("failed to create a new distro: %+v", err)
-	}
+	d := distro.New(distro.Alpine, "3.12.0", "")
+
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),
 		Name:    "libvncserver",
@@ -303,20 +292,20 @@ func TestBothSecdbAndNvdMatches_DifferentPackageName(t *testing.T) {
 				{
 					Type:       match.ExactDirectMatch,
 					Confidence: 1.0,
-					SearchedBy: map[string]interface{}{
-						"distro": map[string]string{
-							"type":    d.Type.String(),
-							"version": d.Version,
+					SearchedBy: match.DistroParameters{
+						Distro: match.DistroIdentification{
+							Type:    d.Type.String(),
+							Version: d.Version,
 						},
-						"package": map[string]string{
-							"name":    "libvncserver",
-							"version": "0.9.9",
+						Package: match.PackageParameter{
+							Name:    "libvncserver",
+							Version: "0.9.9",
 						},
-						"namespace": "secdb:distro:alpine:3.12",
+						Namespace: "secdb:distro:alpine:3.12",
 					},
-					Found: map[string]interface{}{
-						"versionConstraint": secDbVuln.Constraint.String(),
-						"vulnerabilityID":   "CVE-2020-1",
+					Found: match.DistroResult{
+						VulnerabilityID:   "CVE-2020-1",
+						VersionConstraint: secDbVuln.Constraint.String(),
 					},
 					Matcher: match.ApkMatcher,
 				},
@@ -345,10 +334,8 @@ func TestNvdOnlyMatches(t *testing.T) {
 	vp := mock.VulnerabilityProvider(nvdVuln)
 
 	m := Matcher{}
-	d, err := distro.New(distro.Alpine, "3.12.0", "")
-	if err != nil {
-		t.Fatalf("failed to create a new distro: %+v", err)
-	}
+	d := distro.New(distro.Alpine, "3.12.0", "")
+
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),
 		Name:    "libvncserver",
@@ -372,7 +359,7 @@ func TestNvdOnlyMatches(t *testing.T) {
 					SearchedBy: match.CPEParameters{
 						CPEs:      []string{"cpe:2.3:a:*:lib\\/vncserver:0.9.9:*:*:*:*:*:*:*"},
 						Namespace: "nvd:cpe",
-						Package: match.CPEPackageParameter{
+						Package: match.PackageParameter{
 							Name:    "libvncserver",
 							Version: "0.9.9",
 						},
@@ -414,10 +401,8 @@ func TestNvdOnlyMatches_FixInNvd(t *testing.T) {
 	vp := mock.VulnerabilityProvider(nvdVuln)
 
 	m := Matcher{}
-	d, err := distro.New(distro.Alpine, "3.12.0", "")
-	if err != nil {
-		t.Fatalf("failed to create a new distro: %+v", err)
-	}
+	d := distro.New(distro.Alpine, "3.12.0", "")
+
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),
 		Name:    "libvncserver",
@@ -445,7 +430,7 @@ func TestNvdOnlyMatches_FixInNvd(t *testing.T) {
 					SearchedBy: match.CPEParameters{
 						CPEs:      []string{"cpe:2.3:a:*:libvncserver:0.9.9:*:*:*:*:*:*:*"},
 						Namespace: "nvd:cpe",
-						Package: match.CPEPackageParameter{
+						Package: match.PackageParameter{
 							Name:    "libvncserver",
 							Version: "0.9.9",
 						},
@@ -493,10 +478,8 @@ func TestNvdMatchesProperVersionFiltering(t *testing.T) {
 	vp := mock.VulnerabilityProvider(nvdVulnMatch, nvdVulnNoMatch)
 
 	m := Matcher{}
-	d, err := distro.New(distro.Alpine, "3.12.0", "")
-	if err != nil {
-		t.Fatalf("failed to create a new distro: %+v", err)
-	}
+	d := distro.New(distro.Alpine, "3.12.0", "")
+
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),
 		Name:    "libvncserver",
@@ -519,7 +502,7 @@ func TestNvdMatchesProperVersionFiltering(t *testing.T) {
 					SearchedBy: match.CPEParameters{
 						CPEs:      []string{"cpe:2.3:a:*:libvncserver:0.9.11:*:*:*:*:*:*:*"},
 						Namespace: "nvd:cpe",
-						Package: match.CPEPackageParameter{
+						Package: match.PackageParameter{
 							Name:    "libvncserver",
 							Version: "0.9.11-r10",
 						},
@@ -566,10 +549,8 @@ func TestNvdMatchesWithSecDBFix(t *testing.T) {
 	vp := mock.VulnerabilityProvider(nvdVuln, secDbVuln)
 
 	m := Matcher{}
-	d, err := distro.New(distro.Alpine, "3.12.0", "")
-	if err != nil {
-		t.Fatalf("failed to create a new distro: %+v", err)
-	}
+	d := distro.New(distro.Alpine, "3.12.0", "")
+
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),
 		Name:    "libvncserver",
@@ -614,10 +595,8 @@ func TestNvdMatchesNoConstraintWithSecDBFix(t *testing.T) {
 	vp := mock.VulnerabilityProvider(nvdVuln, secDbVuln)
 
 	m := Matcher{}
-	d, err := distro.New(distro.Alpine, "3.12.0", "")
-	if err != nil {
-		t.Fatalf("failed to create a new distro: %+v", err)
-	}
+	d := distro.New(distro.Alpine, "3.12.0", "")
+
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),
 		Name:    "libvncserver",
@@ -660,10 +639,8 @@ func TestNVDMatchCanceledByOriginPackageInSecDB(t *testing.T) {
 	vp := mock.VulnerabilityProvider(nvdVuln, secDBVuln)
 
 	m := Matcher{}
-	d, err := distro.New(distro.Wolfi, "", "")
-	if err != nil {
-		t.Fatalf("failed to create a new distro: %+v", err)
-	}
+	d := distro.New(distro.Wolfi, "", "")
+
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),
 		Name:    "php-8.3-fpm", // the package will not match anything
@@ -703,10 +680,8 @@ func TestDistroMatchBySourceIndirection(t *testing.T) {
 	vp := mock.VulnerabilityProvider(secDbVuln)
 
 	m := Matcher{}
-	d, err := distro.New(distro.Alpine, "3.12.0", "")
-	if err != nil {
-		t.Fatalf("failed to create a new distro: %+v", err)
-	}
+	d := distro.New(distro.Alpine, "3.12.0", "")
+
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),
 		Name:    "musl-utils",
@@ -732,20 +707,20 @@ func TestDistroMatchBySourceIndirection(t *testing.T) {
 				{
 					Type:       match.ExactIndirectMatch,
 					Confidence: 1.0,
-					SearchedBy: map[string]interface{}{
-						"distro": map[string]string{
-							"type":    d.Type.String(),
-							"version": d.Version,
+					SearchedBy: match.DistroParameters{
+						Distro: match.DistroIdentification{
+							Type:    d.Type.String(),
+							Version: d.Version,
 						},
-						"package": map[string]string{
-							"name":    "musl",
-							"version": p.Version,
+						Package: match.PackageParameter{
+							Name:    "musl",
+							Version: p.Version,
 						},
-						"namespace": "secdb:distro:alpine:3.12",
+						Namespace: "secdb:distro:alpine:3.12",
 					},
-					Found: map[string]interface{}{
-						"versionConstraint": secDbVuln.Constraint.String(),
-						"vulnerabilityID":   "CVE-2020-2",
+					Found: match.DistroResult{
+						VulnerabilityID:   "CVE-2020-2",
+						VersionConstraint: secDbVuln.Constraint.String(),
 					},
 					Matcher: match.ApkMatcher,
 				},
@@ -775,10 +750,7 @@ func TestSecDBMatchesStillCountedWithCpeErrors(t *testing.T) {
 	vp := mock.VulnerabilityProvider(secDbVuln)
 
 	m := Matcher{}
-	d, err := distro.New(distro.Alpine, "3.12.0", "")
-	if err != nil {
-		t.Fatalf("failed to create a new distro: %+v", err)
-	}
+	d := distro.New(distro.Alpine, "3.12.0", "")
 
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),
@@ -803,20 +775,20 @@ func TestSecDBMatchesStillCountedWithCpeErrors(t *testing.T) {
 				{
 					Type:       match.ExactIndirectMatch,
 					Confidence: 1.0,
-					SearchedBy: map[string]interface{}{
-						"distro": map[string]string{
-							"type":    d.Type.String(),
-							"version": d.Version,
+					SearchedBy: match.DistroParameters{
+						Distro: match.DistroIdentification{
+							Type:    d.Type.String(),
+							Version: d.Version,
 						},
-						"package": map[string]string{
-							"name":    "musl",
-							"version": p.Version,
+						Package: match.PackageParameter{
+							Name:    "musl",
+							Version: p.Version,
 						},
-						"namespace": "secdb:distro:alpine:3.12",
+						Namespace: "secdb:distro:alpine:3.12",
 					},
-					Found: map[string]interface{}{
-						"versionConstraint": secDbVuln.Constraint.String(),
-						"vulnerabilityID":   "CVE-2020-2",
+					Found: match.DistroResult{
+						VulnerabilityID:   "CVE-2020-2",
+						VersionConstraint: secDbVuln.Constraint.String(),
 					},
 					Matcher: match.ApkMatcher,
 				},
@@ -845,10 +817,8 @@ func TestNVDMatchBySourceIndirection(t *testing.T) {
 	vp := mock.VulnerabilityProvider(nvdVuln)
 
 	m := Matcher{}
-	d, err := distro.New(distro.Alpine, "3.12.0", "")
-	if err != nil {
-		t.Fatalf("failed to create a new distro: %+v", err)
-	}
+	d := distro.New(distro.Alpine, "3.12.0", "")
+
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),
 		Name:    "musl-utils",
@@ -877,7 +847,7 @@ func TestNVDMatchBySourceIndirection(t *testing.T) {
 					SearchedBy: match.CPEParameters{
 						CPEs:      []string{"cpe:2.3:a:musl:musl:1.3.2-r0:*:*:*:*:*:*:*"},
 						Namespace: "nvd:cpe",
-						Package: match.CPEPackageParameter{
+						Package: match.PackageParameter{
 							Name:    "musl",
 							Version: "1.3.2-r0",
 						},
@@ -944,12 +914,12 @@ func Test_nakConstraint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			matches, _, err := nakConstraint.MatchesVulnerability(tt.input)
-			wantErr := require.NoError
-			if tt.wantErr != nil {
-				wantErr = tt.wantErr
+			if tt.wantErr == nil {
+				tt.wantErr = require.NoError
 			}
-			wantErr(t, err)
+
+			matches, _, err := nakConstraint.MatchesVulnerability(tt.input)
+			tt.wantErr(t, err)
 			require.Equal(t, tt.matches, matches)
 		})
 	}

--- a/grype/matcher/dpkg/matcher.go
+++ b/grype/matcher/dpkg/matcher.go
@@ -30,7 +30,7 @@ func (m *Matcher) Match(store vulnerability.Provider, p pkg.Package) ([]match.Ma
 	}
 	matches = append(matches, sourceMatches...)
 
-	exactMatches, _, err := internal.MatchPackageByDistro(store, p, m.Type())
+	exactMatches, _, err := internal.MatchPackageByDistro(store, p, nil, m.Type())
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to match by exact package name: %w", err)
 	}
@@ -43,7 +43,7 @@ func (m *Matcher) matchUpstreamPackages(store vulnerability.Provider, p pkg.Pack
 	var matches []match.Match
 
 	for _, indirectPackage := range pkg.UpstreamPackages(p) {
-		indirectMatches, _, err := internal.MatchPackageByDistro(store, indirectPackage, m.Type())
+		indirectMatches, _, err := internal.MatchPackageByDistro(store, indirectPackage, &p, m.Type())
 		if err != nil {
 			return nil, fmt.Errorf("failed to find vulnerabilities for dpkg upstream source package: %w", err)
 		}

--- a/grype/matcher/dpkg/matcher_test.go
+++ b/grype/matcher/dpkg/matcher_test.go
@@ -17,10 +17,7 @@ import (
 func TestMatcherDpkg_matchBySourceIndirection(t *testing.T) {
 	matcher := Matcher{}
 
-	d, err := distro.New(distro.Debian, "8", "")
-	if err != nil {
-		t.Fatal("could not create distro: ", err)
-	}
+	d := distro.New(distro.Debian, "8", "")
 
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),

--- a/grype/matcher/internal/cpe.go
+++ b/grype/matcher/internal/cpe.go
@@ -123,30 +123,34 @@ func addNewMatch(matchesByFingerprint map[match.Fingerprint]match.Match, vuln vu
 	}
 
 	candidateMatch.Details = addMatchDetails(candidateMatch.Details,
-		match.Detail{
-			Type:       match.CPEMatch,
-			Confidence: 0.9, // TODO: this is hard coded for now
-			Matcher:    upstreamMatcher,
-			SearchedBy: match.CPEParameters{
-				Namespace: vuln.Namespace,
-				CPEs: []string{
-					// use .String() for proper escaping
-					searchedByCPE.Attributes.String(),
-				},
-				Package: match.CPEPackageParameter{
-					Name:    p.Name,
-					Version: p.Version,
-				},
-			},
-			Found: match.CPEResult{
-				VulnerabilityID:   vuln.ID,
-				VersionConstraint: vuln.Constraint.String(),
-				CPEs:              cpesToString(filterCPEsByVersion(searchVersion, vuln.CPEs)),
-			},
-		},
+		CPEMatchDetails(upstreamMatcher, vuln, searchedByCPE, p, searchVersion),
 	)
 
 	matchesByFingerprint[candidateMatch.Fingerprint()] = candidateMatch
+}
+
+func CPEMatchDetails(matcherType match.MatcherType, vuln vulnerability.Vulnerability, searchedByCPE cpe.CPE, p pkg.Package, searchVersion *version.Version) match.Detail {
+	return match.Detail{
+		Type:       match.CPEMatch,
+		Confidence: 0.9, // TODO: this is hard coded for now
+		Matcher:    matcherType,
+		SearchedBy: match.CPEParameters{
+			Namespace: vuln.Namespace,
+			CPEs: []string{
+				// use .String() for proper escaping
+				searchedByCPE.Attributes.String(),
+			},
+			Package: match.PackageParameter{
+				Name:    p.Name,
+				Version: p.Version,
+			},
+		},
+		Found: match.CPEResult{
+			VulnerabilityID:   vuln.ID,
+			VersionConstraint: vuln.Constraint.String(),
+			CPEs:              cpesToString(filterCPEsByVersion(searchVersion, vuln.CPEs)),
+		},
+	}
 }
 
 func addMatchDetails(existingDetails []match.Detail, newDetails match.Detail) []match.Detail {

--- a/grype/matcher/internal/cpe_test.go
+++ b/grype/matcher/internal/cpe_test.go
@@ -148,7 +148,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							SearchedBy: match.CPEParameters{
 								Namespace: "nvd:cpe",
 								CPEs:      []string{"cpe:2.3:*:activerecord:activerecord:3.7.5:rando4:*:re:*:rails:*:*"},
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "activerecord",
 									Version: "3.7.5",
 								},
@@ -199,7 +199,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							SearchedBy: match.CPEParameters{
 								Namespace: "nvd:cpe",
 								CPEs:      []string{"cpe:2.3:*:activerecord:activerecord:3.7.5:rando4:*:re:*:rails:*:*"},
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "activerecord",
 									Version: "3.7.5",
 								},
@@ -253,7 +253,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 									"cpe:2.3:*:activerecord:activerecord:*:rando4:*:re:*:rails:*:*", //important!
 								},
 								Namespace: "nvd:cpe",
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "activerecord",
 									Version: "", // important!
 								},
@@ -290,7 +290,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							SearchedBy: match.CPEParameters{
 								CPEs:      []string{"cpe:2.3:*:activerecord:activerecord:*:rando1:*:ra:*:ruby:*:*"}, //important!
 								Namespace: "nvd:cpe",
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "activerecord",
 									Version: "", // important!
 								},
@@ -329,7 +329,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 									"cpe:2.3:*:activerecord:activerecord:*:rando4:*:re:*:rails:*:*", //important!
 								},
 								Namespace: "nvd:cpe",
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "activerecord",
 									Version: "", // important!
 								},
@@ -397,7 +397,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 									"cpe:2.3:*:activerecord:activerecord:3.7.3:rando4:*:re:*:rails:*:*",
 								},
 								Namespace: "nvd:cpe",
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "activerecord",
 									Version: "3.7.3",
 								},
@@ -434,7 +434,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							SearchedBy: match.CPEParameters{
 								CPEs:      []string{"cpe:2.3:*:activerecord:activerecord:3.7.3:rando1:*:ra:*:ruby:*:*"},
 								Namespace: "nvd:cpe",
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "activerecord",
 									Version: "3.7.3",
 								},
@@ -483,7 +483,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							SearchedBy: match.CPEParameters{
 								CPEs:      []string{"cpe:2.3:*:*:activerecord:4.0.1:*:*:*:*:*:*:*"},
 								Namespace: "nvd:cpe",
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "activerecord",
 									Version: "4.0.1",
 								},
@@ -543,7 +543,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							SearchedBy: match.CPEParameters{
 								CPEs:      []string{"cpe:2.3:*:awesome:awesome:98SE1:rando1:*:ra:*:dunno:*:*"},
 								Namespace: "nvd:cpe",
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "awesome",
 									Version: "98SE1",
 								},
@@ -593,7 +593,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							SearchedBy: match.CPEParameters{
 								CPEs:      []string{"cpe:2.3:*:multiple:multiple:1.0:*:*:*:*:*:*:*"},
 								Namespace: "nvd:cpe",
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "multiple",
 									Version: "1.0",
 								},
@@ -657,7 +657,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							SearchedBy: match.CPEParameters{
 								CPEs:      []string{"cpe:2.3:*:sw:sw:0.1:*:*:*:*:*:*:*"},
 								Namespace: "nvd:cpe",
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "sw",
 									Version: "0.1",
 								},
@@ -713,7 +713,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							SearchedBy: match.CPEParameters{
 								CPEs:      []string{"cpe:2.3:*:funfun:funfun:5.2.1:*:*:*:*:python:*:*"},
 								Namespace: "nvd:cpe",
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "funfun",
 									Version: "5.2.1",
 								},
@@ -764,7 +764,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							SearchedBy: match.CPEParameters{
 								CPEs:      []string{"cpe:2.3:a:handlebarsjs:handlebars:0.1:*:*:*:*:*:*:*"},
 								Namespace: "nvd:cpe",
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "handlebars",
 									Version: "0.1",
 								},
@@ -814,7 +814,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							SearchedBy: match.CPEParameters{
 								CPEs:      []string{"cpe:2.3:a:handlebarsjs:handlebars:0.1:*:*:*:*:*:*:*"},
 								Namespace: "nvd:cpe",
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "handlebars",
 									Version: "0.1",
 								},
@@ -864,7 +864,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							SearchedBy: match.CPEParameters{
 								CPEs:      []string{"cpe:2.3:a:handlebarsjs:handlebars:0.1:*:*:*:*:*:*:*"},
 								Namespace: "nvd:cpe",
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "handlebars",
 									Version: "0.1",
 								},
@@ -914,7 +914,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							SearchedBy: match.CPEParameters{
 								CPEs:      []string{"cpe:2.3:a:handlebarsjs:handlebars:0.1:*:*:*:*:*:*:*"},
 								Namespace: "nvd:cpe",
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "handlebars",
 									Version: "0.1",
 								},
@@ -977,7 +977,7 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 							SearchedBy: match.CPEParameters{
 								CPEs:      []string{"cpe:2.3:a:handlebarsjs:handlebars:0.1:*:*:*:*:*:*:*"},
 								Namespace: "nvd:cpe",
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "handlebars",
 									Version: "0.1",
 								},

--- a/grype/matcher/internal/distro_test.go
+++ b/grype/matcher/internal/distro_test.go
@@ -51,10 +51,7 @@ func TestFindMatchesByPackageDistro(t *testing.T) {
 		},
 	}
 
-	d, err := distro.New(distro.Debian, "8", "")
-	if err != nil {
-		t.Fatal("could not create distro: ", err)
-	}
+	d := distro.New(distro.Debian, "8", "")
 	p.Distro = d
 
 	expected := []match.Match{
@@ -70,20 +67,20 @@ func TestFindMatchesByPackageDistro(t *testing.T) {
 				{
 					Type:       match.ExactDirectMatch,
 					Confidence: 1,
-					SearchedBy: map[string]interface{}{
-						"distro": map[string]string{
-							"type":    "debian",
-							"version": "8",
+					SearchedBy: match.DistroParameters{
+						Distro: match.DistroIdentification{
+							Type:    "debian",
+							Version: "8",
 						},
-						"package": map[string]string{
-							"name":    "neutron",
-							"version": "2014.1.3-6",
+						Package: match.PackageParameter{
+							Name:    "neutron",
+							Version: "2014.1.3-6",
 						},
-						"namespace": "secdb:distro:debian:8",
+						Namespace: "secdb:distro:debian:8",
 					},
-					Found: map[string]interface{}{
-						"versionConstraint": "< 2014.1.5-6 (deb)",
-						"vulnerabilityID":   "CVE-2014-fake-1",
+					Found: match.DistroResult{
+						VersionConstraint: "< 2014.1.5-6 (deb)",
+						VulnerabilityID:   "CVE-2014-fake-1",
 					},
 					Matcher: match.PythonMatcher,
 				},
@@ -92,14 +89,14 @@ func TestFindMatchesByPackageDistro(t *testing.T) {
 	}
 
 	store := newMockProviderByDistro()
-	actual, ignored, err := MatchPackageByDistro(store, p, match.PythonMatcher)
+	actual, ignored, err := MatchPackageByDistro(store, p, nil, match.PythonMatcher)
 	require.NoError(t, err)
 	require.Empty(t, ignored)
 	assertMatchesUsingIDsForVulnerabilities(t, expected, actual)
 
 	// prove we do not search for unknown versions
 	p.Version = "unknown"
-	actual, ignored, err = MatchPackageByDistro(store, p, match.PythonMatcher)
+	actual, ignored, err = MatchPackageByDistro(store, p, nil, match.PythonMatcher)
 	require.NoError(t, err)
 	require.Empty(t, ignored)
 	assert.Empty(t, actual)
@@ -118,10 +115,7 @@ func TestFindMatchesByPackageDistroSles(t *testing.T) {
 		},
 	}
 
-	d, err := distro.New(distro.SLES, "12.5", "")
-	if err != nil {
-		t.Fatal("could not create distro: ", err)
-	}
+	d := distro.New(distro.SLES, "12.5", "")
 	p.Distro = d
 
 	expected := []match.Match{
@@ -137,20 +131,20 @@ func TestFindMatchesByPackageDistroSles(t *testing.T) {
 				{
 					Type:       match.ExactDirectMatch,
 					Confidence: 1,
-					SearchedBy: map[string]interface{}{
-						"distro": map[string]string{
-							"type":    "sles",
-							"version": "12.5",
+					SearchedBy: match.DistroParameters{
+						Distro: match.DistroIdentification{
+							Type:    "sles",
+							Version: "12.5",
 						},
-						"package": map[string]string{
-							"name":    "sles_test_package",
-							"version": "2014.1.3-6",
+						Package: match.PackageParameter{
+							Name:    "sles_test_package",
+							Version: "2014.1.3-6",
 						},
-						"namespace": "secdb:distro:sles:12.5",
+						Namespace: "secdb:distro:sles:12.5",
 					},
-					Found: map[string]interface{}{
-						"versionConstraint": "< 2014.1.5-6 (rpm)",
-						"vulnerabilityID":   "CVE-2014-fake-4",
+					Found: match.DistroResult{
+						VersionConstraint: "< 2014.1.5-6 (rpm)",
+						VulnerabilityID:   "CVE-2014-fake-4",
 					},
 					Matcher: match.PythonMatcher,
 				},
@@ -159,7 +153,7 @@ func TestFindMatchesByPackageDistroSles(t *testing.T) {
 	}
 
 	store := newMockProviderByDistro()
-	actual, ignored, err := MatchPackageByDistro(store, p, match.PythonMatcher)
+	actual, ignored, err := MatchPackageByDistro(store, p, nil, match.PythonMatcher)
 	assert.NoError(t, err)
 	require.Empty(t, ignored)
 	assertMatchesUsingIDsForVulnerabilities(t, expected, actual)

--- a/grype/matcher/internal/language.go
+++ b/grype/matcher/internal/language.go
@@ -54,17 +54,17 @@ func MatchPackageByEcosystemPackageName(provider vulnerability.Provider, p pkg.P
 					Type:       match.ExactDirectMatch,
 					Confidence: 1.0, // TODO: this is hard coded for now
 					Matcher:    matcherType,
-					SearchedBy: map[string]interface{}{
-						"language":  string(p.Language),
-						"namespace": vuln.Namespace,
-						"package": map[string]string{
-							"name":    p.Name,
-							"version": p.Version,
+					SearchedBy: match.EcosystemParameters{
+						Language:  string(p.Language),
+						Namespace: vuln.Namespace,
+						Package: match.PackageParameter{
+							Name:    p.Name,
+							Version: p.Version,
 						},
 					},
-					Found: map[string]interface{}{
-						"vulnerabilityID":   vuln.ID,
-						"versionConstraint": vuln.Constraint.String(),
+					Found: match.EcosystemResult{
+						VulnerabilityID:   vuln.ID,
+						VersionConstraint: vuln.Constraint.String(),
 					},
 				},
 			},

--- a/grype/matcher/internal/language_test.go
+++ b/grype/matcher/internal/language_test.go
@@ -67,14 +67,14 @@ func expectedMatch(p pkg.Package, constraint string) []match.Match {
 				{
 					Type:       match.ExactDirectMatch,
 					Confidence: 1,
-					SearchedBy: map[string]interface{}{
-						"language":  "ruby",
-						"namespace": "github:language:ruby",
-						"package":   map[string]string{"name": p.Name, "version": p.Version},
+					SearchedBy: match.EcosystemParameters{
+						Language:  "ruby",
+						Namespace: "github:language:ruby",
+						Package:   match.PackageParameter{Name: p.Name, Version: p.Version},
 					},
-					Found: map[string]interface{}{
-						"versionConstraint": constraint,
-						"vulnerabilityID":   "CVE-2017-fake-1",
+					Found: match.EcosystemResult{
+						VulnerabilityID:   "CVE-2017-fake-1",
+						VersionConstraint: constraint,
 					},
 					Matcher: match.RubyGemMatcher,
 				},

--- a/grype/matcher/portage/matcher.go
+++ b/grype/matcher/portage/matcher.go
@@ -20,5 +20,5 @@ func (m *Matcher) Type() match.MatcherType {
 }
 
 func (m *Matcher) Match(store vulnerability.Provider, p pkg.Package) ([]match.Match, []match.IgnoreFilter, error) {
-	return internal.MatchPackageByDistro(store, p, m.Type())
+	return internal.MatchPackageByDistro(store, p, nil, m.Type())
 }

--- a/grype/matcher/portage/matcher_test.go
+++ b/grype/matcher/portage/matcher_test.go
@@ -16,10 +16,7 @@ import (
 func TestMatcherPortage_Match(t *testing.T) {
 	matcher := Matcher{}
 
-	d, err := distro.New(distro.Gentoo, "", "")
-	if err != nil {
-		t.Fatal("could not create distro: ", err)
-	}
+	d := distro.New(distro.Gentoo, "", "")
 
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),

--- a/grype/matcher/rpm/matcher.go
+++ b/grype/matcher/rpm/matcher.go
@@ -107,7 +107,7 @@ func (m *Matcher) matchUpstreamPackages(store vulnerability.Provider, p pkg.Pack
 	var matches []match.Match
 
 	for _, indirectPackage := range pkg.UpstreamPackages(p) {
-		indirectMatches, _, err := internal.MatchPackageByDistro(store, indirectPackage, m.Type())
+		indirectMatches, _, err := internal.MatchPackageByDistro(store, indirectPackage, &p, m.Type())
 		if err != nil {
 			return nil, fmt.Errorf("failed to find vulnerabilities for rpm upstream source package: %w", err)
 		}
@@ -127,7 +127,7 @@ func (m *Matcher) matchPackage(store vulnerability.Provider, p pkg.Package) ([]m
 
 	addEpochIfApplicable(&p)
 
-	matches, _, err := internal.MatchPackageByDistro(store, p, m.Type())
+	matches, _, err := internal.MatchPackageByDistro(store, p, nil, m.Type())
 	if err != nil {
 		return nil, fmt.Errorf("failed to find vulnerabilities by dpkg source indirection: %w", err)
 	}

--- a/grype/matcher/rpm/matcher_test.go
+++ b/grype/matcher/rpm/matcher_test.go
@@ -42,11 +42,7 @@ func TestMatcherRpm(t *testing.T) {
 			},
 			setup: func() (vulnerability.Provider, *distro.Distro, Matcher) {
 				matcher := Matcher{}
-				d, err := distro.New(distro.CentOS, "8", "")
-				if err != nil {
-					t.Fatal("could not create distro: ", err)
-				}
-
+				d := distro.New(distro.CentOS, "8", "")
 				store := newMockProvider("neutron-libs", "neutron", false, false)
 
 				return store, d, matcher
@@ -73,10 +69,7 @@ func TestMatcherRpm(t *testing.T) {
 			},
 			setup: func() (vulnerability.Provider, *distro.Distro, Matcher) {
 				matcher := Matcher{}
-				d, err := distro.New(distro.CentOS, "8", "")
-				if err != nil {
-					t.Fatal("could not create distro: ", err)
-				}
+				d := distro.New(distro.CentOS, "8", "")
 
 				store := newMockProvider("neutron", "neutron-devel", false, false)
 
@@ -103,10 +96,7 @@ func TestMatcherRpm(t *testing.T) {
 			},
 			setup: func() (vulnerability.Provider, *distro.Distro, Matcher) {
 				matcher := Matcher{}
-				d, err := distro.New(distro.CentOS, "8", "")
-				if err != nil {
-					t.Fatal("could not create distro: ", err)
-				}
+				d := distro.New(distro.CentOS, "8", "")
 
 				store := newMockProvider("neutron-libs", "neutron", false, false)
 
@@ -137,10 +127,7 @@ func TestMatcherRpm(t *testing.T) {
 			},
 			setup: func() (vulnerability.Provider, *distro.Distro, Matcher) {
 				matcher := Matcher{}
-				d, err := distro.New(distro.CentOS, "8", "")
-				if err != nil {
-					t.Fatal("could not create distro: ", err)
-				}
+				d := distro.New(distro.CentOS, "8", "")
 
 				store := newMockProvider("perl-Errno", "perl", true, false)
 
@@ -162,10 +149,7 @@ func TestMatcherRpm(t *testing.T) {
 			},
 			setup: func() (vulnerability.Provider, *distro.Distro, Matcher) {
 				matcher := Matcher{}
-				d, err := distro.New(distro.CentOS, "8", "")
-				if err != nil {
-					t.Fatal("could not create distro: ", err)
-				}
+				d := distro.New(distro.CentOS, "8", "")
 
 				store := newMockProvider("perl-Errno", "doesn't-matter", false, false)
 
@@ -186,10 +170,7 @@ func TestMatcherRpm(t *testing.T) {
 			},
 			setup: func() (vulnerability.Provider, *distro.Distro, Matcher) {
 				matcher := Matcher{}
-				d, err := distro.New(distro.CentOS, "8", "")
-				if err != nil {
-					t.Fatal("could not create distro: ", err)
-				}
+				d := distro.New(distro.CentOS, "8", "")
 
 				store := newMockProvider("perl-Errno", "doesn't-matter", true, false)
 
@@ -210,10 +191,7 @@ func TestMatcherRpm(t *testing.T) {
 			},
 			setup: func() (vulnerability.Provider, *distro.Distro, Matcher) {
 				matcher := Matcher{}
-				d, err := distro.New(distro.CentOS, "8", "")
-				if err != nil {
-					t.Fatal("could not create distro: ", err)
-				}
+				d := distro.New(distro.CentOS, "8", "")
 
 				store := newMockProvider("perl-Errno", "doesn't-matter", false, false)
 
@@ -234,10 +212,7 @@ func TestMatcherRpm(t *testing.T) {
 			},
 			setup: func() (vulnerability.Provider, *distro.Distro, Matcher) {
 				matcher := Matcher{}
-				d, err := distro.New(distro.CentOS, "8", "")
-				if err != nil {
-					t.Fatal("could not create distro: ", err)
-				}
+				d := distro.New(distro.CentOS, "8", "")
 
 				store := newMockProvider("perl-Errno", "doesn't-matter", true, false)
 
@@ -258,10 +233,7 @@ func TestMatcherRpm(t *testing.T) {
 			},
 			setup: func() (vulnerability.Provider, *distro.Distro, Matcher) {
 				matcher := Matcher{}
-				d, err := distro.New(distro.CentOS, "8", "")
-				if err != nil {
-					t.Fatal("could not create distro: ", err)
-				}
+				d := distro.New(distro.CentOS, "8", "")
 
 				store := newMockProvider("maniac", "doesn't-matter", false, true)
 
@@ -285,10 +257,7 @@ func TestMatcherRpm(t *testing.T) {
 			},
 			setup: func() (vulnerability.Provider, *distro.Distro, Matcher) {
 				matcher := Matcher{}
-				d, err := distro.New(distro.CentOS, "8", "")
-				if err != nil {
-					t.Fatal("could not create distro: ", err)
-				}
+				d := distro.New(distro.CentOS, "8", "")
 
 				store := newMockProvider("maniac", "doesn't-matter", false, true)
 
@@ -308,10 +277,7 @@ func TestMatcherRpm(t *testing.T) {
 			},
 			setup: func() (vulnerability.Provider, *distro.Distro, Matcher) {
 				matcher := Matcher{}
-				d, err := distro.New(distro.CentOS, "8", "")
-				if err != nil {
-					t.Fatal("could not create distro: ", err)
-				}
+				d := distro.New(distro.CentOS, "8", "")
 
 				store := newMockProvider("maniac", "doesn't-matter", false, true)
 

--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -535,12 +535,7 @@ func distroFromPURL(purl packageurl.PackageURL) (d *distro.Distro) {
 	}
 
 	if distroName != "" {
-		var err error
-		d, err = distro.NewFromNameVersion(distroName, distroVersion)
-		if err != nil {
-			log.WithFields("purl", purl, "error", err).Debug("unable to create distro from a release")
-			d = nil
-		}
+		d = distro.NewFromNameVersion(distroName, distroVersion)
 	}
 
 	return d

--- a/grype/pkg/qualifier/rpmmodularity/qualifier_test.go
+++ b/grype/pkg/qualifier/rpmmodularity/qualifier_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestRpmModularity_Satisfied(t *testing.T) {
-	oracle, _ := distro.New(distro.OracleLinux, "8", "")
+	oracle := distro.New(distro.OracleLinux, "8", "")
 
 	tests := []struct {
 		name          string

--- a/grype/search/distro_test.go
+++ b/grype/search/distro_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func Test_ByDistro(t *testing.T) {
-	deb8, err := distro.New(distro.Debian, "8", "")
-	require.NoError(t, err)
+	deb8 := distro.New(distro.Debian, "8", "")
 
 	tests := []struct {
 		name    string

--- a/grype/vulnerability_matcher_test.go
+++ b/grype/vulnerability_matcher_test.go
@@ -303,14 +303,14 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 					Details: match.Details{
 						{
 							Type: match.ExactDirectMatch,
-							SearchedBy: map[string]any{
-								"distro":    map[string]string{"type": "debian", "version": "8"},
-								"namespace": "debian:distro:debian:8",
-								"package":   map[string]string{"name": "neutron", "version": "2013.1.1-1"},
+							SearchedBy: match.DistroParameters{
+								Distro:    match.DistroIdentification{Type: "debian", Version: "8"},
+								Namespace: "debian:distro:debian:8",
+								Package:   match.PackageParameter{Name: "neutron", Version: "2013.1.1-1"},
 							},
-							Found: map[string]any{
-								"versionConstraint": "< 2014.1.3-6 (deb)",
-								"vulnerabilityID":   "CVE-2014-fake-1",
+							Found: match.DistroResult{
+								VulnerabilityID:   "CVE-2014-fake-1",
+								VersionConstraint: "< 2014.1.3-6 (deb)",
 							},
 							Matcher:    "dpkg-matcher",
 							Confidence: 1,
@@ -358,14 +358,14 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 					Details: match.Details{
 						{
 							Type: match.ExactDirectMatch,
-							SearchedBy: map[string]any{
-								"distro":    map[string]string{"type": "debian", "version": "8"},
-								"namespace": "debian:distro:debian:8",
-								"package":   map[string]string{"name": "neutron", "version": "2013.1.1-1"},
+							SearchedBy: match.DistroParameters{
+								Distro:    match.DistroIdentification{Type: "debian", Version: "8"},
+								Namespace: "debian:distro:debian:8",
+								Package:   match.PackageParameter{Name: "neutron", Version: "2013.1.1-1"},
 							},
-							Found: map[string]any{
-								"versionConstraint": "< 2014.1.3-6 (deb)",
-								"vulnerabilityID":   "CVE-2014-fake-1",
+							Found: match.DistroResult{
+								VulnerabilityID:   "CVE-2014-fake-1",
+								VersionConstraint: "< 2014.1.3-6 (deb)",
 							},
 							Matcher:    "dpkg-matcher",
 							Confidence: 1,
@@ -440,14 +440,14 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 						Details: match.Details{
 							{
 								Type: match.ExactDirectMatch,
-								SearchedBy: map[string]any{
-									"distro":    map[string]string{"type": "debian", "version": "8"},
-									"namespace": "debian:distro:debian:8",
-									"package":   map[string]string{"name": "neutron", "version": "2013.1.1-1"},
+								SearchedBy: match.DistroParameters{
+									Distro:    match.DistroIdentification{Type: "debian", Version: "8"},
+									Namespace: "debian:distro:debian:8",
+									Package:   match.PackageParameter{Name: "neutron", Version: "2013.1.1-1"},
 								},
-								Found: map[string]any{
-									"versionConstraint": "< 2014.1.3-6 (deb)",
-									"vulnerabilityID":   "CVE-2014-fake-1",
+								Found: match.DistroResult{
+									VulnerabilityID:   "CVE-2014-fake-1",
+									VersionConstraint: "< 2014.1.3-6 (deb)",
 								},
 								Matcher:    "dpkg-matcher",
 								Confidence: 1,
@@ -497,7 +497,7 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 								CPEs: []string{
 									"cpe:2.3:*:activerecord:activerecord:3.7.5:*:*:*:*:rails:*:*",
 								},
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "activerecord",
 									Version: "3.7.5",
 								},
@@ -536,14 +536,14 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 					Details: match.Details{
 						{
 							Type: match.ExactDirectMatch,
-							SearchedBy: map[string]any{
-								"language":  "ruby",
-								"namespace": "github:language:ruby",
-								"package":   map[string]string{"name": "activerecord", "version": "3.7.5"},
+							SearchedBy: match.EcosystemParameters{
+								Language:  "ruby",
+								Namespace: "github:language:ruby",
+								Package:   match.PackageParameter{Name: "activerecord", Version: "3.7.5"},
 							},
-							Found: map[string]any{
-								"versionConstraint": "< 3.7.6 (unknown)",
-								"vulnerabilityID":   "GHSA-2014-fake-3",
+							Found: match.EcosystemResult{
+								VulnerabilityID:   "GHSA-2014-fake-3",
+								VersionConstraint: "< 3.7.6 (unknown)",
 							},
 							Matcher:    "ruby-gem-matcher",
 							Confidence: 1,
@@ -597,14 +597,14 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 					Details: match.Details{
 						{
 							Type: match.ExactDirectMatch,
-							SearchedBy: map[string]any{
-								"language":  "ruby",
-								"namespace": "github:language:ruby",
-								"package":   map[string]string{"name": "activerecord", "version": "3.7.5"},
+							SearchedBy: match.EcosystemParameters{
+								Language:  "ruby",
+								Namespace: "github:language:ruby",
+								Package:   match.PackageParameter{Name: "activerecord", Version: "3.7.5"},
 							},
-							Found: map[string]any{
-								"versionConstraint": "< 3.7.6 (unknown)",
-								"vulnerabilityID":   "GHSA-2014-fake-3",
+							Found: match.EcosystemResult{
+								VulnerabilityID:   "GHSA-2014-fake-3",
+								VersionConstraint: "< 3.7.6 (unknown)",
 							},
 							Matcher:    "ruby-gem-matcher",
 							Confidence: 1,
@@ -616,7 +616,7 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 								CPEs: []string{
 									"cpe:2.3:*:activerecord:activerecord:3.7.5:*:*:*:*:rails:*:*",
 								},
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "activerecord",
 									Version: "3.7.5",
 								},
@@ -684,7 +684,7 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 								CPEs: []string{
 									"cpe:2.3:*:activerecord:activerecord:3.7.5:*:*:*:*:rails:*:*",
 								},
-								Package: match.CPEPackageParameter{
+								Package: match.PackageParameter{
 									Name:    "activerecord",
 									Version: "3.7.5",
 								},
@@ -727,14 +727,14 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 						Details: match.Details{
 							{
 								Type: match.ExactDirectMatch,
-								SearchedBy: map[string]any{
-									"language":  "ruby",
-									"namespace": "github:language:ruby",
-									"package":   map[string]string{"name": "activerecord", "version": "3.7.5"},
+								SearchedBy: match.EcosystemParameters{
+									Language:  "ruby",
+									Namespace: "github:language:ruby",
+									Package:   match.PackageParameter{Name: "activerecord", Version: "3.7.5"},
 								},
-								Found: map[string]any{
-									"versionConstraint": "< 3.7.6 (unknown)",
-									"vulnerabilityID":   "GHSA-2014-fake-3",
+								Found: match.EcosystemResult{
+									VulnerabilityID:   "GHSA-2014-fake-3",
+									VersionConstraint: "< 3.7.6 (unknown)",
 								},
 								Matcher:    "ruby-gem-matcher",
 								Confidence: 1,
@@ -799,7 +799,7 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 									CPEs: []string{
 										"cpe:2.3:*:activerecord:activerecord:3.7.5:*:*:*:*:rails:*:*",
 									},
-									Package: match.CPEPackageParameter{
+									Package: match.PackageParameter{
 										Name:    "activerecord",
 										Version: "3.7.5",
 									},
@@ -850,14 +850,14 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 						Details: match.Details{
 							{
 								Type: match.ExactDirectMatch,
-								SearchedBy: map[string]any{
-									"language":  "ruby",
-									"namespace": "github:language:ruby",
-									"package":   map[string]string{"name": "activerecord", "version": "3.7.5"},
+								SearchedBy: match.EcosystemParameters{
+									Language:  "ruby",
+									Namespace: "github:language:ruby",
+									Package:   match.PackageParameter{Name: "activerecord", Version: "3.7.5"},
 								},
-								Found: map[string]any{
-									"versionConstraint": "< 3.7.6 (unknown)",
-									"vulnerabilityID":   "GHSA-2014-fake-3",
+								Found: match.EcosystemResult{
+									VulnerabilityID:   "GHSA-2014-fake-3",
+									VersionConstraint: "< 3.7.6 (unknown)",
 								},
 								Matcher:    "ruby-gem-matcher",
 								Confidence: 1,
@@ -910,14 +910,14 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 					Details: match.Details{
 						{
 							Type: match.ExactDirectMatch,
-							SearchedBy: map[string]any{
-								"language":  "ruby",
-								"namespace": "github:language:ruby",
-								"package":   map[string]string{"name": "activerecord", "version": "3.7.5"},
+							SearchedBy: match.EcosystemParameters{
+								Language:  "ruby",
+								Namespace: "github:language:ruby",
+								Package:   match.PackageParameter{Name: "activerecord", Version: "3.7.5"},
 							},
-							Found: map[string]any{
-								"versionConstraint": "< 3.7.6 (unknown)",
-								"vulnerabilityID":   "GHSA-2014-fake-3",
+							Found: match.EcosystemResult{
+								VulnerabilityID:   "GHSA-2014-fake-3",
+								VersionConstraint: "< 3.7.6 (unknown)",
 							},
 							Matcher:    "ruby-gem-matcher",
 							Confidence: 1,
@@ -955,7 +955,7 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 									CPEs: []string{
 										"cpe:2.3:*:activerecord:activerecord:3.7.5:*:*:*:*:rails:*:*",
 									},
-									Package: match.CPEPackageParameter{
+									Package: match.PackageParameter{
 										Name:    "activerecord",
 										Version: "3.7.5",
 									},

--- a/test/integration/match_by_image_test.go
+++ b/test/integration/match_by_image_test.go
@@ -56,42 +56,42 @@ func addAlpineMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Co
 			{
 				Type:       match.ExactDirectMatch,
 				Confidence: 1.0,
-				SearchedBy: map[string]any{
-					"distro": map[string]string{
-						"type":    "alpine",
-						"version": "3.12.0",
+				SearchedBy: match.DistroParameters{
+					Distro: match.DistroIdentification{
+						Type:    "alpine",
+						Version: "3.12.0",
 					},
-					"namespace": "alpine:distro:alpine:3.12",
-					"package": map[string]string{
-						"name":    "libvncserver",
-						"version": "0.9.9",
+					Namespace: "alpine:distro:alpine:3.12",
+					Package: match.PackageParameter{
+						Name:    "libvncserver",
+						Version: "0.9.9",
 					},
 				},
-				Found: map[string]any{
-					"versionConstraint": "< 0.9.10 (unknown)",
-					"vulnerabilityID":   vulnObj.ID,
+				Found: match.DistroResult{
+					VersionConstraint: "< 0.9.10 (unknown)",
+					VulnerabilityID:   vulnObj.ID,
 				},
 				Matcher: match.ApkMatcher,
 			},
 			{
 				// note: the input pURL has an upstream reference (redundant)
-				Type: "exact-indirect-match",
-				SearchedBy: map[string]any{
-					"distro": map[string]string{
-						"type":    "alpine",
-						"version": "3.12.0",
+				Type: match.ExactIndirectMatch,
+				SearchedBy: match.DistroParameters{
+					Distro: match.DistroIdentification{
+						Type:    "alpine",
+						Version: "3.12.0",
 					},
-					"namespace": "alpine:distro:alpine:3.12",
-					"package": map[string]string{
-						"name":    "libvncserver",
-						"version": "0.9.9",
+					Namespace: "alpine:distro:alpine:3.12",
+					Package: match.PackageParameter{
+						Name:    "libvncserver",
+						Version: "0.9.9",
 					},
 				},
-				Found: map[string]any{
-					"versionConstraint": "< 0.9.10 (unknown)",
-					"vulnerabilityID":   "CVE-alpine-libvncserver",
+				Found: match.DistroResult{
+					VersionConstraint: "< 0.9.10 (unknown)",
+					VulnerabilityID:   "CVE-alpine-libvncserver",
 				},
-				Matcher:    "apk-matcher",
+				Matcher:    match.ApkMatcher,
 				Confidence: 1,
 			},
 		},
@@ -117,17 +117,17 @@ func addJavascriptMatches(t *testing.T, theSource source.Source, catalog *syftPk
 			{
 				Type:       match.ExactDirectMatch,
 				Confidence: 1.0,
-				SearchedBy: map[string]any{
-					"language":  "javascript",
-					"namespace": "github:language:javascript",
-					"package": map[string]string{
-						"name":    thePkg.Name,
-						"version": thePkg.Version,
+				SearchedBy: match.EcosystemParameters{
+					Language:  "javascript",
+					Namespace: "github:language:javascript",
+					Package: match.PackageParameter{
+						Name:    thePkg.Name,
+						Version: thePkg.Version,
 					},
 				},
-				Found: map[string]any{
-					"versionConstraint": "> 5, < 7.2.1 (unknown)",
-					"vulnerabilityID":   vulnObj.ID,
+				Found: match.EcosystemResult{
+					VersionConstraint: "> 5, < 7.2.1 (unknown)",
+					VulnerabilityID:   vulnObj.ID,
 				},
 				Matcher: match.JavascriptMatcher,
 			},
@@ -157,17 +157,17 @@ func addPythonMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Co
 			{
 				Type:       match.ExactDirectMatch,
 				Confidence: 1.0,
-				SearchedBy: map[string]any{
-					"language":  "python",
-					"namespace": "github:language:python",
-					"package": map[string]string{
-						"name":    thePkg.Name,
-						"version": thePkg.Version,
+				SearchedBy: match.EcosystemParameters{
+					Language:  "python",
+					Namespace: "github:language:python",
+					Package: match.PackageParameter{
+						Name:    thePkg.Name,
+						Version: thePkg.Version,
 					},
 				},
-				Found: map[string]any{
-					"versionConstraint": "< 2.6.2 (python)",
-					"vulnerabilityID":   vulnObj.ID,
+				Found: match.EcosystemResult{
+					VersionConstraint: "< 2.6.2 (python)",
+					VulnerabilityID:   vulnObj.ID,
 				},
 				Matcher: match.PythonMatcher,
 			},
@@ -211,17 +211,17 @@ func addDotnetMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Co
 			{
 				Type:       match.ExactDirectMatch,
 				Confidence: 1.0,
-				SearchedBy: map[string]any{
-					"language":  "dotnet",
-					"namespace": "github:language:dotnet",
-					"package": map[string]string{
-						"name":    thePkg.Name,
-						"version": thePkg.Version,
+				SearchedBy: match.EcosystemParameters{
+					Language:  "dotnet",
+					Namespace: "github:language:dotnet",
+					Package: match.PackageParameter{
+						Name:    thePkg.Name,
+						Version: thePkg.Version,
 					},
 				},
-				Found: map[string]any{
-					"versionConstraint": ">= 3.7.0.0, < 3.7.12.0 (unknown)",
-					"vulnerabilityID":   vulnObj.ID,
+				Found: match.EcosystemResult{
+					VersionConstraint: ">= 3.7.0.0, < 3.7.12.0 (unknown)",
+					VulnerabilityID:   vulnObj.ID,
 				},
 				Matcher: match.DotnetMatcher,
 			},
@@ -248,17 +248,17 @@ func addRubyMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 			{
 				Type:       match.ExactDirectMatch,
 				Confidence: 1.0,
-				SearchedBy: map[string]any{
-					"language":  "ruby",
-					"namespace": "github:language:ruby",
-					"package": map[string]string{
-						"name":    thePkg.Name,
-						"version": thePkg.Version,
+				SearchedBy: match.EcosystemParameters{
+					Language:  "ruby",
+					Namespace: "github:language:ruby",
+					Package: match.PackageParameter{
+						Name:    thePkg.Name,
+						Version: thePkg.Version,
 					},
 				},
-				Found: map[string]any{
-					"versionConstraint": "> 2.0.0, <= 2.1.4 (unknown)",
-					"vulnerabilityID":   vulnObj.ID,
+				Found: match.EcosystemResult{
+					VersionConstraint: "> 2.0.0, <= 2.1.4 (unknown)",
+					VulnerabilityID:   vulnObj.ID,
 				},
 				Matcher: match.RubyGemMatcher,
 			},
@@ -307,17 +307,17 @@ func addGolangMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Co
 				{
 					Type:       match.ExactDirectMatch,
 					Confidence: 1.0,
-					SearchedBy: map[string]any{
-						"language":  "go",
-						"namespace": "github:language:go",
-						"package": map[string]string{
-							"name":    thePkg.Name,
-							"version": thePkg.Version,
+					SearchedBy: match.EcosystemParameters{
+						Language:  "go",
+						Namespace: "github:language:go",
+						Package: match.PackageParameter{
+							Name:    thePkg.Name,
+							Version: thePkg.Version,
 						},
 					},
-					Found: map[string]any{
-						"versionConstraint": "< 1.4.0 (unknown)",
-						"vulnerabilityID":   vulnObj.ID,
+					Found: match.EcosystemResult{
+						VersionConstraint: "< 1.4.0 (unknown)",
+						VulnerabilityID:   vulnObj.ID,
 					},
 					Matcher: match.GoModuleMatcher,
 				},
@@ -354,17 +354,17 @@ func addJavaMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 			{
 				Type:       match.ExactDirectMatch,
 				Confidence: 1.0,
-				SearchedBy: map[string]any{
-					"language":  "java",
-					"namespace": "github:language:java",
-					"package": map[string]string{
-						"name":    thePkg.Name,
-						"version": thePkg.Version,
+				SearchedBy: match.EcosystemParameters{
+					Language:  "java",
+					Namespace: "github:language:java",
+					Package: match.PackageParameter{
+						Name:    thePkg.Name,
+						Version: thePkg.Version,
 					},
 				},
-				Found: map[string]any{
-					"versionConstraint": ">= 0.0.1, < 1.2.0 (unknown)",
-					"vulnerabilityID":   vulnObj.ID,
+				Found: match.EcosystemResult{
+					VersionConstraint: ">= 0.0.1, < 1.2.0 (unknown)",
+					VulnerabilityID:   vulnObj.ID,
 				},
 				Matcher: match.JavaMatcher,
 			},
@@ -392,20 +392,20 @@ func addDpkgMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 			{
 				Type:       match.ExactIndirectMatch,
 				Confidence: 1.0,
-				SearchedBy: map[string]any{
-					"distro": map[string]string{
-						"type":    "debian",
-						"version": "8",
+				SearchedBy: match.DistroParameters{
+					Distro: match.DistroIdentification{
+						Type:    "debian",
+						Version: "8",
 					},
-					"namespace": "debian:distro:debian:8",
-					"package": map[string]string{
-						"name":    "apt-dev",
-						"version": "1.8.2",
+					Namespace: "debian:distro:debian:8",
+					Package: match.PackageParameter{
+						Name:    "apt-dev",
+						Version: "1.8.2",
 					},
 				},
-				Found: map[string]any{
-					"versionConstraint": "<= 1.8.2 (deb)",
-					"vulnerabilityID":   vulnObj.ID,
+				Found: match.DistroResult{
+					VersionConstraint: "<= 1.8.2 (deb)",
+					VulnerabilityID:   vulnObj.ID,
 				},
 				Matcher: match.DpkgMatcher,
 			},
@@ -432,20 +432,20 @@ func addPortageMatches(t *testing.T, theSource source.Source, catalog *syftPkg.C
 			{
 				Type:       match.ExactDirectMatch,
 				Confidence: 1.0,
-				SearchedBy: map[string]any{
-					"distro": map[string]string{
-						"type":    "gentoo",
-						"version": "2.8",
+				SearchedBy: match.DistroParameters{
+					Distro: match.DistroIdentification{
+						Type:    "gentoo",
+						Version: "2.8",
 					},
-					"namespace": "gentoo:distro:gentoo:2.8",
-					"package": map[string]string{
-						"name":    "app-containers/skopeo",
-						"version": "1.5.1",
+					Namespace: "gentoo:distro:gentoo:2.8",
+					Package: match.PackageParameter{
+						Name:    "app-containers/skopeo",
+						Version: "1.5.1",
 					},
 				},
-				Found: map[string]any{
-					"versionConstraint": "< 1.6.0 (unknown)",
-					"vulnerabilityID":   vulnObj.ID,
+				Found: match.DistroResult{
+					VersionConstraint: "< 1.6.0 (unknown)",
+					VulnerabilityID:   vulnObj.ID,
 				},
 				Matcher: match.PortageMatcher,
 			},
@@ -472,20 +472,20 @@ func addRhelMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 			{
 				Type:       match.ExactDirectMatch,
 				Confidence: 1.0,
-				SearchedBy: map[string]any{
-					"distro": map[string]string{
-						"type":    "centos",
-						"version": "8",
+				SearchedBy: match.DistroParameters{
+					Distro: match.DistroIdentification{
+						Type:    "centos",
+						Version: "8",
 					},
-					"namespace": "redhat:distro:redhat:8",
-					"package": map[string]string{
-						"name":    "dive",
-						"version": "0:0.9.2-1",
+					Namespace: "redhat:distro:redhat:8",
+					Package: match.PackageParameter{
+						Name:    "dive",
+						Version: "0:0.9.2-1",
 					},
 				},
-				Found: map[string]any{
-					"versionConstraint": "<= 1.0.42 (rpm)",
-					"vulnerabilityID":   vulnObj.ID,
+				Found: match.DistroResult{
+					VersionConstraint: "<= 1.0.42 (rpm)",
+					VulnerabilityID:   vulnObj.ID,
 				},
 				Matcher: match.RpmMatcher,
 			},
@@ -514,20 +514,20 @@ func addSlesMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 			{
 				Type:       match.ExactDirectMatch,
 				Confidence: 1.0,
-				SearchedBy: map[string]any{
-					"distro": map[string]string{
-						"type":    "sles",
-						"version": "12.5",
+				SearchedBy: match.DistroParameters{
+					Distro: match.DistroIdentification{
+						Type:    "sles",
+						Version: "12.5",
 					},
-					"namespace": "sles:distro:sles:12.5",
-					"package": map[string]string{
-						"name":    "dive",
-						"version": "0:0.9.2-1",
+					Namespace: "sles:distro:sles:12.5",
+					Package: match.PackageParameter{
+						Name:    "dive",
+						Version: "0:0.9.2-1",
 					},
 				},
-				Found: map[string]any{
-					"versionConstraint": "<= 1.0.42 (rpm)",
-					"vulnerabilityID":   vulnObj.ID,
+				Found: match.DistroResult{
+					VersionConstraint: "<= 1.0.42 (rpm)",
+					VulnerabilityID:   vulnObj.ID,
 				},
 				Matcher: match.RpmMatcher,
 			},
@@ -554,17 +554,17 @@ func addHaskellMatches(t *testing.T, theSource source.Source, catalog *syftPkg.C
 			{
 				Type:       match.ExactDirectMatch,
 				Confidence: 1.0,
-				SearchedBy: map[string]any{
-					"language":  "haskell",
-					"namespace": "github:language:haskell",
-					"package": map[string]string{
-						"name":    thePkg.Name,
-						"version": thePkg.Version,
+				SearchedBy: match.EcosystemParameters{
+					Language:  "haskell",
+					Namespace: "github:language:haskell",
+					Package: match.PackageParameter{
+						Name:    thePkg.Name,
+						Version: thePkg.Version,
 					},
 				},
-				Found: map[string]any{
-					"versionConstraint": "< 0.9.0 (unknown)",
-					"vulnerabilityID":   "CVE-haskell-sample",
+				Found: match.EcosystemResult{
+					VersionConstraint: "< 0.9.0 (unknown)",
+					VulnerabilityID:   "CVE-haskell-sample",
 				},
 				Matcher: match.StockMatcher,
 			},
@@ -603,7 +603,7 @@ func addJvmMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Colle
 						CPEs: []string{
 							"cpe:2.3:a:oracle:jdk:1.8.0:update400:*:*:*:*:*:*",
 						},
-						Package: match.CPEPackageParameter{Name: "jdk", Version: "1.8.0_400-b07"},
+						Package: match.PackageParameter{Name: "jdk", Version: "1.8.0_400-b07"},
 					},
 					Found: match.CPEResult{
 						VulnerabilityID:   "CVE-jdk",
@@ -640,17 +640,17 @@ func addRustMatches(t *testing.T, theSource source.Source, catalog *syftPkg.Coll
 				{
 					Type:       match.ExactDirectMatch,
 					Confidence: 1.0,
-					SearchedBy: map[string]any{
-						"language":  "rust",
-						"namespace": "github:language:rust",
-						"package": map[string]string{
-							"name":    thePkg.Name,
-							"version": thePkg.Version,
+					SearchedBy: match.EcosystemParameters{
+						Language:  "rust",
+						Namespace: "github:language:rust",
+						Package: match.PackageParameter{
+							Name:    thePkg.Name,
+							Version: thePkg.Version,
 						},
 					},
-					Found: map[string]any{
-						"versionConstraint": vulnObj.Constraint.String(),
-						"vulnerabilityID":   vulnObj.ID,
+					Found: match.EcosystemResult{
+						VersionConstraint: vulnObj.Constraint.String(),
+						VulnerabilityID:   vulnObj.ID,
 					},
 					Matcher: match.RustMatcher,
 				},
@@ -901,23 +901,23 @@ func testIgnoredMatches() []match.IgnoredMatch {
 				},
 				Details: []match.Detail{
 					{
-						Type: "exact-indirect-match",
-						SearchedBy: map[string]any{
-							"distro": map[string]string{
-								"type":    "alpine",
-								"version": "3.12.0",
+						Type: match.ExactIndirectMatch,
+						SearchedBy: match.DistroParameters{
+							Distro: match.DistroIdentification{
+								Type:    "alpine",
+								Version: "3.12.0",
 							},
-							"namespace": "alpine:distro:alpine:3.12",
-							"package": map[string]string{
-								"name":    "libvncserver",
-								"version": "0.9.9",
+							Namespace: "alpine:distro:alpine:3.12",
+							Package: match.PackageParameter{
+								Name:    "libvncserver",
+								Version: "0.9.9",
 							},
 						},
-						Found: map[string]any{
-							"versionConstraint": "< 0.9.10 (unknown)",
-							"vulnerabilityID":   "CVE-alpine-libvncserver",
+						Found: match.DistroResult{
+							VersionConstraint: "< 0.9.10 (unknown)",
+							VulnerabilityID:   "CVE-alpine-libvncserver",
 						},
-						Matcher:    "apk-matcher",
+						Matcher:    match.ApkMatcher,
 						Confidence: 1,
 					},
 				},

--- a/test/integration/match_by_sbom_document_test.go
+++ b/test/integration/match_by_sbom_document_test.go
@@ -30,14 +30,14 @@ func TestMatchBySBOMDocument(t *testing.T) {
 			expectedDetails: []match.Detail{
 				{
 					Type: match.ExactDirectMatch,
-					SearchedBy: map[string]interface{}{
-						"language":  "idris",
-						"namespace": "github:language:idris",
-						"package":   map[string]string{"name": "my-package", "version": "1.0.5"},
+					SearchedBy: match.EcosystemParameters{
+						Language:  "idris",
+						Namespace: "github:language:idris",
+						Package:   match.PackageParameter{Name: "my-package", Version: "1.0.5"},
 					},
-					Found: map[string]interface{}{
-						"versionConstraint": "< 2.0 (unknown)",
-						"vulnerabilityID":   "CVE-bogus-my-package-2-idris",
+					Found: match.EcosystemResult{
+						VersionConstraint: "< 2.0 (unknown)",
+						VulnerabilityID:   "CVE-bogus-my-package-2-idris",
 					},
 					Matcher:    match.StockMatcher,
 					Confidence: 1,


### PR DESCRIPTION
This PR makes two changes (peeling off work from #2540 to make it smaller):
- adds struct types for all possible `SearchedBy` and `Found` field values within match details
- removes returning an error from `distro.New()` (not used)

Partially addresses #2446