### PR TITLE
fix: preserve target sw when unknown

### DIFF
--- a/grype/matcher/internal/only_vulnerable_targets.go
+++ b/grype/matcher/internal/only_vulnerable_targets.go
@@ -154,21 +154,27 @@ func matchesAttribute(a1, a2 string) bool {
 }
 
 func hasIntersectingTargetSoftware(set1, set2 *strset.Set) bool {
-	set1Pkg := pkgTypesFromTargetSoftware(set1.List())
-	set2Pkg := pkgTypesFromTargetSoftware(set2.List())
+	set1Pkg := normalizeTargetSoftwares(set1.List())
+	set2Pkg := normalizeTargetSoftwares(set2.List())
 	intersection := strset.Intersection(set1Pkg, set2Pkg)
 	return !intersection.IsEmpty()
 }
 
-func pkgTypesFromTargetSoftware(ts []string) *strset.Set {
-	pkgTypes := strset.New()
+func normalizeTargetSoftwares(ts []string) *strset.Set {
+	normalizedTargetSWs := strset.New()
 	for _, ts := range ts {
-		pt := internal.CPETargetSoftwareToPackageType(ts)
+		// Attempt to normalize target sw to package type, e.g. node and nodejs should match
+		pt := string(internal.CPETargetSoftwareToPackageType(ts))
+		if pt == "" && ts != "*" && ts != "?" {
+			// normalizing failed; preserve raw cpe target sw string as the type
+			// unless it is wildcard
+			pt = strings.ToLower(ts)
+		}
 		if pt != "" {
-			pkgTypes.Add(string(pt))
+			normalizedTargetSWs.Add(pt)
 		}
 	}
-	return pkgTypes
+	return normalizedTargetSWs
 }
 
 func packageElements(p pkg.Package, ts []string) string {

--- a/grype/matcher/internal/only_vulnerable_targets.go
+++ b/grype/matcher/internal/only_vulnerable_targets.go
@@ -165,7 +165,7 @@ func normalizeTargetSoftwares(ts []string) *strset.Set {
 	for _, ts := range ts {
 		// Attempt to normalize target sw to package type, e.g. node and nodejs should match
 		pt := string(internal.CPETargetSoftwareToPackageType(ts))
-		if pt == "" && ts != "*" && ts != "?" {
+		if pt == "" && ts != "*" && ts != "?" && ts != "-" {
 			// normalizing failed; preserve raw cpe target sw string as the type
 			// unless it is wildcard
 			pt = strings.ToLower(ts)

--- a/grype/matcher/internal/only_vulnerable_targets_test.go
+++ b/grype/matcher/internal/only_vulnerable_targets_test.go
@@ -280,85 +280,80 @@ func TestPkgTypesFromTargetSoftware(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    []string
-		expected []syftPkg.Type
+		expected []string
 	}{
 		{
 			name:     "empty input",
 			input:    []string{},
-			expected: []syftPkg.Type{},
+			expected: []string{},
 		},
 		{
 			name:     "single input with known mapping",
 			input:    []string{"node.js"},
-			expected: []syftPkg.Type{syftPkg.NpmPkg},
+			expected: []string{string(syftPkg.NpmPkg)},
 		},
 		{
 			name:     "multiple inputs with known mappings",
 			input:    []string{"python", "ruby", "java"},
-			expected: []syftPkg.Type{syftPkg.PythonPkg, syftPkg.GemPkg, syftPkg.JavaPkg},
+			expected: []string{string(syftPkg.PythonPkg), string(syftPkg.GemPkg), string(syftPkg.JavaPkg)},
 		},
 		{
 			name:     "case insensitive input",
 			input:    []string{"Python", "RUBY", "Java"},
-			expected: []syftPkg.Type{syftPkg.PythonPkg, syftPkg.GemPkg, syftPkg.JavaPkg},
+			expected: []string{string(syftPkg.PythonPkg), string(syftPkg.GemPkg), string(syftPkg.JavaPkg)},
 		},
 		{
 			name:     "mixed known and unknown inputs",
 			input:    []string{"python", "unknown", "ruby"},
-			expected: []syftPkg.Type{syftPkg.PythonPkg, syftPkg.GemPkg},
+			expected: []string{string(syftPkg.PythonPkg), "unknown", string(syftPkg.GemPkg)},
 		},
 		{
 			name:     "all unknown inputs",
 			input:    []string{"unknown1", "unknown2", "unknown3"},
-			expected: []syftPkg.Type{},
+			expected: []string{"unknown1", "unknown2", "unknown3"},
 		},
 		{
 			name:     "inputs with spaces and hyphens",
 			input:    []string{"redhat-enterprise-linux", "jenkins ci"},
-			expected: []syftPkg.Type{syftPkg.RpmPkg, syftPkg.JavaPkg},
+			expected: []string{string(syftPkg.RpmPkg), string(syftPkg.JavaPkg)},
 		},
 		{
 			name:     "aliases for the same package type",
 			input:    []string{"nodejs", "npm", "javascript"},
-			expected: []syftPkg.Type{syftPkg.NpmPkg},
+			expected: []string{string(syftPkg.NpmPkg)},
 		},
 		{
 			name:     "wildcards and special characters should be ignored",
 			input:    []string{"*", "?", ""},
-			expected: []syftPkg.Type{},
+			expected: []string{},
 		},
 		{
 			name:     "Linux distributions",
 			input:    []string{"alpine", "debian", "redhat", "gentoo"},
-			expected: []syftPkg.Type{syftPkg.ApkPkg, syftPkg.DebPkg, syftPkg.RpmPkg, syftPkg.PortagePkg},
+			expected: []string{string(syftPkg.ApkPkg), string(syftPkg.DebPkg), string(syftPkg.RpmPkg), string(syftPkg.PortagePkg)},
 		},
 		{
 			name:     ".NET ecosystem",
 			input:    []string{".net", "asp.net", "c#"},
-			expected: []syftPkg.Type{syftPkg.DotnetPkg},
+			expected: []string{string(syftPkg.DotnetPkg)},
 		},
 		{
 			name:     "JavaScript ecosystem",
 			input:    []string{"javascript", "node.js", "jquery"},
-			expected: []syftPkg.Type{syftPkg.NpmPkg},
+			expected: []string{string(syftPkg.NpmPkg)},
 		},
 		{
 			name:     "Java ecosystem",
 			input:    []string{"java", "maven", "kafka", "log4j"},
-			expected: []syftPkg.Type{syftPkg.JavaPkg},
+			expected: []string{string(syftPkg.JavaPkg)},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := pkgTypesFromTargetSoftware(test.input)
+			actual := normalizeTargetSoftwares(test.input)
 
-			var actualTypes []syftPkg.Type
-			for _, typeStr := range actual.List() {
-				actualTypes = append(actualTypes, syftPkg.Type(typeStr))
-			}
-
-			assert.ElementsMatch(t, test.expected, actualTypes, "package types should match")
+			assert.ElementsMatch(t, test.expected, actual.List(), "package types should match")
 		})
 	}
 }

--- a/grype/matcher/internal/only_vulnerable_targets_test.go
+++ b/grype/matcher/internal/only_vulnerable_targets_test.go
@@ -324,7 +324,7 @@ func TestPkgTypesFromTargetSoftware(t *testing.T) {
 		},
 		{
 			name:     "wildcards and special characters should be ignored",
-			input:    []string{"*", "?", ""},
+			input:    []string{"*", "?", "-", ""},
 			expected: []string{},
 		},
 		{


### PR DESCRIPTION
Normally, when matching CPEs with the target SW filled as a non-wild, Grype attempts to normalize the target SW field to a known package type, e.g. ".net" and "dotnet" both compare as "dotnet" at match time. However, this code dropped unknown target SW types, resulting in false negatives for target SW entries that did not correspond to a particular package type, e.g. "chromium". Therefore, if a target SW is not known to Grype, and not a wildcard, lowercase it and consider it for matching.

Fixes #2768