### PR TITLE
Remove pill pattern from table output

### DIFF
--- a/grype/presenter/table/__snapshots__/presenter_test.snap
+++ b/grype/presenter/table/__snapshots__/presenter_test.snap
@@ -9,7 +9,7 @@ package-2  2.2.2                            deb   CVE-1999-0002  Critical  8.0% 
 [TestTablePresenter/with_color - 1]
 NAME       INSTALLED  FIXED IN             TYPE  VULNERABILITY  SEVERITY  EPSS         RISK         
 package-1  1.1.1      1.2.1[38;5;240m, [0m[38;5;240m2.1.3[0m[38;5;240m, [0m[38;5;240m3.4.0[0m  rpm   CVE-1999-0001  [38;5;36mLow[0m       3.0% (42nd)  1.7          
-package-2  2.2.2                           deb   CVE-1999-0002  [1;38;5;198mCritical[0m  8.0% (53rd)  96.3  [1;38;5;198m[0m[1;7;38;5;198mKEV[0m[1;38;5;198m[0m  
+package-2  2.2.2                           deb   CVE-1999-0002  [1;38;5;198mCritical[0m  8.0% (53rd)  96.3  [1;7;38;5;198m KEV [0m  
 
 ---
 

--- a/grype/presenter/table/presenter.go
+++ b/grype/presenter/table/presenter.go
@@ -227,7 +227,7 @@ func (p *Presenter) newRow(m models.Match, extraAnnotation string, showDistro bo
 	var kev, annotation string
 	if len(m.Vulnerability.KnownExploited) > 0 {
 		if p.withColor {
-			kev = p.kevStyle.Reverse(false).Render("") + p.kevStyle.Render("KEV") + p.kevStyle.Reverse(false).Render("") // ⚡❋◆◉፨⿻⨳✖•
+			kev = p.kevStyle.Render(" KEV ") // ⚡❋◆◉፨⿻⨳✖• (requires non-standard fonts:  )
 		} else {
 			annotations = append([]string{"kev"}, annotations...)
 		}


### PR DESCRIPTION
Today KEV annotations are displayed using characters that require powerline glyphs, which requires either a special font or special terminal support to render. In order to increase portability this replaces the "pill" pattern with a simple block equivalent:

Before:
<img width="108" alt="Screenshot 2025-07-07 at 12 02 59 PM" src="https://github.com/user-attachments/assets/b3d948c7-b028-4009-883a-2976fffda84e" />

After (with PR changes):
<img width="120" alt="Screenshot 2025-07-07 at 12 03 17 PM" src="https://github.com/user-attachments/assets/4a970693-7d8f-4719-8230-8cf97cdb58be" />

There isn't a reliable way to detect when there is support for rendering these glyphs, so for now it is simpler to not use them (we already gracefully degrade to showing alternative formats when there is no tty available, however, that does not help in this case).