### PR TITLE
chore: remove disallowed characters from hostname before test fixture cert generation

### DIFF
--- a/grype/db/v5/distribution/test-fixtures/tls/generate-x509-cert-pair.sh
+++ b/grype/db/v5/distribution/test-fixtures/tls/generate-x509-cert-pair.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eux
 
+# we want to still use this on systems where there could be invalid characters in the hostname (e.g. ' or " characters)
+HOSTNAME=$(hostname | sed "s/['']/'/g" | sed 's/[^a-zA-Z0-9.-]/-/g')
+
 # create private key
 openssl genrsa -out server.key 2048
 
@@ -11,6 +14,5 @@ openssl req -new -x509 -sha256 \
     -days 3650 \
     -reqexts SAN \
     -extensions SAN \
-    -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=DNS:$(hostname).local")) \
-    -subj "/C=US/ST=Test/L=Test/O=Test/CN=$(hostname).local"
-
+    -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=DNS:$HOSTNAME.local")) \
+    -subj "/C=US/ST=Test/L=Test/O=Test/CN=$HOSTNAME.local"


### PR DESCRIPTION
Depending on where I run unit tests from I see this:
```
--- FAIL: Test_defaultHTTPClientHasCert (2.25s)
    --- FAIL: Test_defaultHTTPClientHasCert/should_use_single_custom_cert (2.25s)
        curator_test.go:136: Generating Key/Cert Fixture
        curator_test.go:164: out: ./generate-x509-cert-pair.sh
        curator_test.go:164: err: + openssl genrsa -out server.key 2048
        curator_test.go:164: err: ++ cat /etc/ssl/openssl.cnf /dev/fd/63
        curator_test.go:164: err: ++ hostname
        curator_test.go:164: err: ++++ hostname
        curator_test.go:164: err: +++ printf '[SAN]\nsubjectAltName=DNS:Alex's-MacBook-Pro.local'
        curator_test.go:164: err: + openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650 -reqexts SAN -extensions SAN -config /dev/fd/63 -subj $'/C=US/ST=Test/L=Test/O=Test/CN=Alex�\200\231s-MacBook-Pro.local'
        curator_test.go:115: 
                Error Trace:    /Users/wagoodman/code/grype/grype/db/v5/distribution/curator_test.go:115
                Error:          "[]" should have 1 item(s), but has 0
                Test:           Test_defaultHTTPClientHasCert/should_use_single_custom_cert
FAIL
```

The underlying problem is that quotes should not be allowed as the subject input when generating a certificate... and the subject is the developer's hostname. This updates the script to not allow for `'` and `"` characters at all when generating this test cert.