### PR TITLE
Create ignore regex objects conditionally

### DIFF
--- a/grype/db/v6/models_test.go
+++ b/grype/db/v6/models_test.go
@@ -1,9 +1,9 @@
 package v6
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
Today a user can configure ignore rules based on package names, which can include regexp patterns. However, if you start including thousands of rules, it can take a lot of time creating those objects (where the bottleneck is the `regexp.Compile`). 

<img width="596" height="469" alt="Screenshot 2025-07-17 at 10 35 16 AM" src="https://github.com/user-attachments/assets/2b480bdf-279c-4dbb-a8ce-83964cbeabb0" />

This PR makes creating those objects conditional; if we detect if the package name is likely a regexp expression without compiling with a one-time-compiled regexp, then use that on each example ignore rule to generate either a custom regexp or a simple string comparison. This will help in cases where the user has a set of rules that are simple names instead of expressions. 