### PR TITLE
chore: add source completion testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4
 	github.com/anchore/packageurl-go v0.1.1-0.20250220190351-d62adb6e1115
 	github.com/anchore/stereoscope v0.1.7-0.20250716200927-94c6f92877d4
-	github.com/anchore/syft v1.29.0
+	github.com/anchore/syft v1.29.1-0.20250723134947-f0a990b85f24
 	github.com/aquasecurity/go-pep440-version v0.0.1
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/bitnami/go-version v0.0.0-20250131085805-b1f57a8634ef

--- a/go.sum
+++ b/go.sum
@@ -712,8 +712,8 @@ github.com/anchore/packageurl-go v0.1.1-0.20250220190351-d62adb6e1115 h1:ZyRCmiE
 github.com/anchore/packageurl-go v0.1.1-0.20250220190351-d62adb6e1115/go.mod h1:KoYIv7tdP5+CC9VGkeZV4/vGCKsY55VvoG+5dadg4YI=
 github.com/anchore/stereoscope v0.1.7-0.20250716200927-94c6f92877d4 h1:5UGwBBUAK8i06gDA5JD74vT3qcz4lR7BfLXudpD5y8w=
 github.com/anchore/stereoscope v0.1.7-0.20250716200927-94c6f92877d4/go.mod h1:ejAlYkAb/cRvSMlxQlrG2dMruqQpcJAh4w2Fu02FEYQ=
-github.com/anchore/syft v1.29.0 h1:zQqajGHCX4vO2uaybjdSXL8q3uxXepo1s7ySIK+i5v4=
-github.com/anchore/syft v1.29.0/go.mod h1:nXCGVo6kikMi74cXrvYlSSbv/zP8mR4PuMwpUn0vSZ4=
+github.com/anchore/syft v1.29.1-0.20250723134947-f0a990b85f24 h1:5ZXi0BK84rdq/wagWtqCBsDjpmC7NQwTenkRfSppCsw=
+github.com/anchore/syft v1.29.1-0.20250723134947-f0a990b85f24/go.mod h1:nXCGVo6kikMi74cXrvYlSSbv/zP8mR4PuMwpUn0vSZ4=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/brotli v1.1.2-0.20250424173009-453214e765f3 h1:8PmGpDEZl9yDpcdEr6Odf23feCxK3LNUNMxjXg41pZQ=

--- a/grype/presenter/models/source_test.go
+++ b/grype/presenter/models/source_test.go
@@ -8,9 +8,20 @@ import (
 
 	"github.com/anchore/grype/grype/pkg"
 	syftSource "github.com/anchore/syft/syft/source"
+	"github.com/anchore/syft/syft/testutil"
 )
 
 func TestNewSource(t *testing.T) {
+	// there isn't a great way to programmatically find only source metadata types in the pkg package, so we'll add them here.
+	grypeOnlySources := []any{
+		pkg.SBOMFileMetadata{},
+		pkg.PURLLiteralMetadata{},
+		pkg.CPELiteralMetadata{},
+	}
+
+	tracker := testutil.NewSourceMetadataCompletionTester(t)
+	tracker.Expect(grypeOnlySources...)
+
 	testCases := []struct {
 		name     string
 		metadata syftSource.Description
@@ -128,6 +139,7 @@ func TestNewSource(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, testCase.expected, actual)
+			tracker.Tested(t, testCase.metadata.Metadata)
 		})
 	}
 }


### PR DESCRIPTION
A follow up to https://github.com/anchore/syft/pull/4077 and https://github.com/anchore/grype/pull/2821 to prevent issues like described in https://github.com/anchore/grype/issues/2819 from being released in grype when we add new sources in syft.