### PR TITLE
Add RedHat EUS channel version to config

### DIFF
--- a/cmd/grype/cli/options/fix_channels.go
+++ b/cmd/grype/cli/options/fix_channels.go
@@ -18,7 +18,11 @@ type FixChannels struct {
 }
 
 type FixChannel struct {
-	Apply string `yaml:"apply" json:"apply" mapstructure:"apply"` // whether this channel should be applied to the distro when matching
+	// Apply indicates how the channel should be applied to the distro
+	Apply string `yaml:"apply" json:"apply" mapstructure:"apply"`
+
+	// Versions specifies a constraint string indicating which versions of the distro this channel applies to (e.g. ">= 8.0" for RHEL 8 and above)
+	Versions string `yaml:"versions" json:"versions" mapstructure:"versions"`
 }
 
 func (o *FixChannel) PostLoad() error {
@@ -35,9 +39,24 @@ func (o *FixChannel) PostLoad() error {
 }
 
 func DefaultFixChannels() FixChannels {
+	var rhelEUS *distro.FixChannel
+
+	for _, fc := range distro.DefaultFixChannels() {
+		if fc.Name == "eus" {
+			rhelEUS = &fc
+			break
+		}
+	}
+
+	if rhelEUS == nil {
+		panic("default fix channels do not contain Red Hat EUS channel")
+	}
+
+	// use API defaults for the CLI configuration
 	return FixChannels{
 		RedHatEUS: FixChannel{
-			Apply: string(distro.ChannelConditionallyEnabled),
+			Apply:    string(rhelEUS.Apply),
+			Versions: rhelEUS.Versions.Value(),
 		},
 	}
 }


### PR DESCRIPTION
This is a follow up to #2446 that adds the version constraint for the EUS fix channel in the application configuration:
```diff
# .grype.yaml
fix-channel:
  redhat-eus:
    # whether fixes from this channel should be considered, options are "never", "always", or "auto" (conditionally applied based on SBOM data) (env: GRYPE_FIX_CHANNEL_REDHAT_EUS_APPLY)
    apply: 'auto'

+    # (env: GRYPE_FIX_CHANNEL_REDHAT_EUS_VERSIONS)
+    versions: '>= 8.0'
```