### PR TITLE
Finalize migration to brew cask

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -91,6 +91,10 @@ homebrew_casks:
     homepage: *website
     description: *description
     license: "Apache License 2.0"
+    conflicts:
+      # claim that the previous grype formula (in the root of homebrew-grype) conflicts with the new cask
+      # see https://goreleaser.com/deprecations/#brews for more information
+      - formula: grype
 
 dockers:
   # production images...


### PR DESCRIPTION
With #https://github.com/anchore/grype/pull/2729 we've now moved from the root formula to a cask; in following the [recommendations](https://goreleaser.com/deprecations/#brews), the cask now claims it conflicts with the original formula.