### PR TITLE
chore: add FP issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/false_positive.md
+++ b/.github/ISSUE_TEMPLATE/false_positive.md
@@ -1,0 +1,32 @@
+---
+name: False Positive
+about: Report an incorrect vulnerability match
+title: ''
+labels: [ bug, false-positive ]
+assignees: ''
+
+---
+
+**Vulnerability ID**:
+
+**Package URL (PURL) or steps to reproduce**:
+<!--
+If possible, please provide a PURL.
+
+If the issue can't be reproduced with a PURL, link to an artifact grype can scan or provide other instructions to reproduce.
+
+Some suggestions:
+1. Link to Dockerhub, GitHub, GitLab, maven central, quay.io, etc to a public
+   artifact we can try scanning
+2. A Dockerfile that we can build and scan
+3. A simple script that creates a directory exhibiting the issue, for example a
+   list of `npm install` commands
+
+Please also include the grype command and any configuration used.
+-->
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Output of `grype version`:
+- OS (e.g: `cat /etc/os-release` or similar):


### PR DESCRIPTION
This PR adds a new issue template to report false positives that both labels them appropriately and encourages providing a PURL to make analysis simpler.