### PR TITLE
feat: detect patch numbers in fuzzy version comparison

### DIFF
--- a/grype/version/fuzzy_constraint_test.go
+++ b/grype/version/fuzzy_constraint_test.go
@@ -59,6 +59,15 @@ func TestFuzzyVersionComparison(t *testing.T) {
 		{"8.0.456", "8.0.457", -1},
 		{"8.0.456+1", "8.0.456+2", -1},
 		{"8.0.456", "8.0.456+1", -1},
+		// Test case for fuzzy version comparison bug with patch numbers
+		// This should pass: 4.2.8p9 < 4.2.8p15 (p9 comes before p15 numerically)
+		// But currently fails due to lexicographic fallback where "p9" > "p15" (string comparison)
+		{"4.2.8p9", "4.2.8p15", -1},
+		// douple check openssl's unusual versioning
+		// 1.0.2k is an earlier patch release than 1.0.2l
+		{"1.0.2k", "1.0.2l", -1},
+		// 1.1.1w is a later patch on 1.1.1
+		{"1.1.1", "1.1.1w", -1},
 	}
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%q vs %q", c.v1, c.v2), func(t *testing.T) {


### PR DESCRIPTION
This makes version numbers that mix alphabetic and numeric components, like 4.2.8p14 and 4.2.8p2 compare correctly, e.g. 4.2.8p2 < 4.2.8p14 because 2 < 14. Previously, they would compare lexicogrpahically, occasionally resulting in a false positive or false negative.

A motivating real case:

``` sh
# latest
$ grype -q "cpe:2.3:a:*:ntp:4.2.8p15:*:*:*:*:*:*:*" | rg -e NAME -e CVE-2016-7434
NAME  INSTALLED  FIXED IN          VULNERABILITY   SEVERITY  EPSS          RISK  
ntp   4.2.8p15   *4.2.8p9, 4.3.94  CVE-2016-7434   High      61.2% (98th)  41.0 
# this branch 
$ go run ./cmd/grype -q "cpe:2.3:a:*:ntp:4.2.8p15:*:*:*:*:*:*:*" | rg -e NAME -e CVE-2016-7434
NAME  INSTALLED  VULNERABILITY   SEVERITY  EPSS         RISK  
# where database has
$ grype db search --provider nvd --vuln CVE-2016-7434
VULNERABILITY  PACKAGE                                 NAMESPACE  VERSION CONSTRAINT                            
CVE-2016-7434  cpe:2.3:a:hpe:hpux-ntp:*:*:*:*:*:*:*:*  nvd:cpe    >= b.11.31, < c.4.2.8.2.0                     
CVE-2016-7434  cpe:2.3:a:ntp:ntp:*:*:*:*:*:*:*:*       nvd:cpe    >= 4.2.7p22, < 4.2.8p9 || >= 4.3.0, < 4.3.94
```

