### PR TITLE
Fix CPE update field handling for non-JVM packages

### DIFF
--- a/grype/matcher/internal/cpe.go
+++ b/grype/matcher/internal/cpe.go
@@ -76,9 +76,8 @@ func MatchPackageByCPEs(vulnProvider vulnerability.Provider, p pkg.Package, upst
 
 		format := pkg.VersionFormat(p)
 
-		if format == version.JVMFormat {
-			searchVersion = transformJvmVersion(searchVersion, c.Attributes.Update)
-		}
+		// Apply version and update field combination for all package types
+		searchVersion = combineVersionAndUpdate(searchVersion, c.Attributes.Update, format)
 
 		var verObj *version.Version
 		var err error
@@ -130,6 +129,27 @@ func transformJvmVersion(searchVersion, updateCpeField string) string {
 		searchVersion = fmt.Sprintf("%s_%s", searchVersion, strings.TrimPrefix(updateCpeField, "update"))
 	}
 	return searchVersion
+}
+
+func combineVersionAndUpdate(searchVersion, updateCpeField string, format version.Format) string {
+	// Handle empty or wildcard update fields
+	if updateCpeField == "" || updateCpeField == wfn.NA || updateCpeField == wfn.Any {
+		return searchVersion
+	}
+
+	// Don't combine if the version is empty or a wildcard - these should remain as is
+	if searchVersion == "" || searchVersion == wfn.NA || searchVersion == wfn.Any {
+		return searchVersion
+	}
+
+	// Special handling for JVM packages
+	if format == version.JVMFormat {
+		return transformJvmVersion(searchVersion, updateCpeField)
+	}
+
+	// For other packages, combine version and update field directly
+	// This handles cases like NTP where version="4.2.8" and update="p18" should become "4.2.8p18"
+	return fmt.Sprintf("%s%s", searchVersion, updateCpeField)
 }
 
 func addNewMatch(matchesByFingerprint map[match.Fingerprint]match.Match, vuln vulnerability.Vulnerability, p pkg.Package, searchVersion *version.Version, upstreamMatcher match.MatcherType, searchedByCPE cpe.CPE) {
@@ -226,11 +246,8 @@ func filterCPEsByVersion(pkgVersion *version.Version, allCPEs []cpe.CPE) (matche
 
 		ver := c.Attributes.Version
 
-		if pkgVersion.Format == version.JVMFormat {
-			if c.Attributes.Update != wfn.Any && c.Attributes.Update != wfn.NA {
-				ver = transformJvmVersion(ver, c.Attributes.Update)
-			}
-		}
+		// Apply version and update field combination for all package types
+		ver = combineVersionAndUpdate(ver, c.Attributes.Update, pkgVersion.Format)
 
 		constraint, err := version.GetConstraint(ver, pkgVersion.Format)
 		if err != nil {

--- a/grype/matcher/internal/cpe.go
+++ b/grype/matcher/internal/cpe.go
@@ -147,8 +147,9 @@ func combineVersionAndUpdate(searchVersion, updateCpeField string, format versio
 		return transformJvmVersion(searchVersion, updateCpeField)
 	}
 
-	// For other packages, combine version and update field directly
-	// This handles cases like NTP where version="4.2.8" and update="p18" should become "4.2.8p18"
+	// Combine version and update field without separator, matching the NTP-style pN patch notation.
+	// Using a dash would trigger semver prerelease semantics (4.2.8-p18 < 4.2.8), causing false positives.
+	// e.g. version="4.2.8", update="p18" → "4.2.8p18"
 	return fmt.Sprintf("%s%s", searchVersion, updateCpeField)
 }
 

--- a/grype/matcher/internal/cpe_test.go
+++ b/grype/matcher/internal/cpe_test.go
@@ -1083,6 +1083,101 @@ func TestFilterCPEsByVersion(t *testing.T) {
 	}
 }
 
+func TestCombineVersionAndUpdate(t *testing.T) {
+	tests := []struct {
+		name            string
+		searchVersion   string
+		updateCpeField  string
+		format          version.Format
+		expectedVersion string
+	}{
+		{
+			name:            "non-JVM package with update field (NTP example)",
+			searchVersion:   "4.2.8",
+			updateCpeField:  "p18",
+			format:          version.UnknownFormat,
+			expectedVersion: "4.2.8p18",
+		},
+		{
+			name:            "non-JVM package without update field",
+			searchVersion:   "1.2.3",
+			updateCpeField:  "",
+			format:          version.UnknownFormat,
+			expectedVersion: "1.2.3",
+		},
+		{
+			name:            "non-JVM package with Any update field",
+			searchVersion:   "1.2.3",
+			updateCpeField:  "",
+			format:          version.UnknownFormat,
+			expectedVersion: "1.2.3",
+		},
+		{
+			name:            "non-JVM package with NA update field",
+			searchVersion:   "1.2.3",
+			updateCpeField:  "-",
+			format:          version.UnknownFormat,
+			expectedVersion: "1.2.3",
+		},
+		{
+			name:            "JVM package with update field",
+			searchVersion:   "1.8.0",
+			updateCpeField:  "update400",
+			format:          version.JVMFormat,
+			expectedVersion: "1.8.0_400",
+		},
+		{
+			name:            "JVM package without update field (Any)",
+			searchVersion:   "1.8.0",
+			updateCpeField:  "",
+			format:          version.JVMFormat,
+			expectedVersion: "1.8.0",
+		},
+		{
+			name:            "JVM package without update field (NA)",
+			searchVersion:   "1.8.0",
+			updateCpeField:  "-",
+			format:          version.JVMFormat,
+			expectedVersion: "1.8.0",
+		},
+		{
+			name:            "semantic package with patch update",
+			searchVersion:   "2.4.1",
+			updateCpeField:  "rc1",
+			format:          version.SemanticFormat,
+			expectedVersion: "2.4.1rc1",
+		},
+		{
+			name:            "debian package with update",
+			searchVersion:   "1.0.0",
+			updateCpeField:  "deb1",
+			format:          version.DebFormat,
+			expectedVersion: "1.0.0deb1",
+		},
+		{
+			name:            "non-JVM package with wildcard version should not combine",
+			searchVersion:   "",
+			updateCpeField:  "update123",
+			format:          version.UnknownFormat,
+			expectedVersion: "",
+		},
+		{
+			name:            "non-JVM package with NA version should not combine",
+			searchVersion:   "-",
+			updateCpeField:  "update123",
+			format:          version.UnknownFormat,
+			expectedVersion: "-",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := combineVersionAndUpdate(test.searchVersion, test.updateCpeField, test.format)
+			assert.Equal(t, test.expectedVersion, result)
+		})
+	}
+}
+
 func TestAddMatchDetails(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/grype/matcher/internal/cpe_test.go
+++ b/grype/matcher/internal/cpe_test.go
@@ -103,6 +103,16 @@ func newCPETestStore() vulnerability.Provider {
 			Constraint:  version.MustGetConstraint("< 4.7.7", version.UnknownFormat),
 			CPEs:        []cpe.CPE{cpe.Must("cpe:2.3:a:handlebarsjs:handlebars:*:*:*:*:*:node.js:*:*", "")},
 		},
+		// NTP-like vulnerability with update field — constraint uses combined "version+update" no-dash format
+		{
+			Reference: vulnerability.Reference{
+				ID:        "CVE-2017-fake-ntp",
+				Namespace: "nvd:cpe",
+			},
+			PackageName: "ntp",
+			Constraint:  version.MustGetConstraint("= 4.2.8p9", version.UnknownFormat),
+			CPEs:        []cpe.CPE{cpe.Must("cpe:2.3:a:ntp:ntp:*:*:*:*:*:*:*:*", "")},
+		},
 	}...)
 }
 
@@ -995,6 +1005,64 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "package with CPE update field matches vulnerability using combined version",
+			p: pkg.Package{
+				CPEs: []cpe.CPE{
+					cpe.Must("cpe:2.3:a:ntp:ntp:4.2.8:p9:*:*:*:*:*:*", ""),
+				},
+				Name:    "ntp",
+				Version: "4.2.8p9",
+				Type:    syftPkg.UnknownPkg,
+			},
+			expected: []match.Match{
+				{
+					Vulnerability: vulnerability.Vulnerability{
+						Reference: vulnerability.Reference{ID: "CVE-2017-fake-ntp"},
+					},
+					Package: pkg.Package{
+						CPEs: []cpe.CPE{
+							cpe.Must("cpe:2.3:a:ntp:ntp:4.2.8:p9:*:*:*:*:*:*", ""),
+						},
+						Name:    "ntp",
+						Version: "4.2.8p9",
+						Type:    syftPkg.UnknownPkg,
+					},
+					Details: []match.Detail{
+						{
+							Type:       match.CPEMatch,
+							Confidence: 0.9,
+							SearchedBy: match.CPEParameters{
+								Namespace: "nvd:cpe",
+								CPEs:      []string{"cpe:2.3:a:ntp:ntp:4.2.8:p9:*:*:*:*:*:*"},
+								Package: match.PackageParameter{
+									Name:    "ntp",
+									Version: "4.2.8p9",
+								},
+							},
+							Found: match.CPEResult{
+								CPEs:              []string{"cpe:2.3:a:ntp:ntp:*:*:*:*:*:*:*:*"},
+								VersionConstraint: "= 4.2.8p9 (unknown)",
+								VulnerabilityID:   "CVE-2017-fake-ntp",
+							},
+							Matcher: matcher,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "package with CPE update field does not match when version differs",
+			p: pkg.Package{
+				CPEs: []cpe.CPE{
+					cpe.Must("cpe:2.3:a:ntp:ntp:4.2.8:p18:*:*:*:*:*:*", ""),
+				},
+				Name:    "ntp",
+				Version: "4.2.8p18",
+				Type:    syftPkg.UnknownPkg,
+			},
+			expected: []match.Match{},
 		},
 	}
 


### PR DESCRIPTION
# Fix CPE update field handling for non-JVM packages

## Problem
The CPE matching logic was only considering the `update` field for JVM packages, but it should also handle other packages where the update field contains important version information. For example, with NTP and OpenSSH:

```
cpe:2.3:a:ntp:ntp:4.2.8:p18:*:*:*:*:*:*
```

The current code would only use `4.2.8` for version matching, ignoring the `p18` update field, which should be combined to form the complete version `4.2.8p18`.

## Solution
- Created a general `combineVersionAndUpdate` function that handles CPE version and update field combinations for all package types
- Updated `MatchPackageByCPEs` and `filterCPEsByVersion` functions to use the new general function
- Maintained existing JVM-specific behavior using the original `transformJvmVersion` function
- Added proper handling for wildcard/empty values to prevent incorrect combinations

## Changes
- **Added**: `combineVersionAndUpdate` function in `grype/matcher/internal/cpe.go`
- **Updated**: CPE matching logic to use the new function for all package types

## Testing
- All existing tests pass
- Added new test cases to verify correct behavior for non-JVM packages
- Verified that JVM package behavior remains unchanged

## Before
```sh
ntp                                            4.2.8p18                                  *4.2.8p9, 4.3.94  UnknownPackage  CVE-2016-7434     High      61.2% (98th)   41.0
ntp                                            4.2.8p18                                  4.2.8, *4.3.77    UnknownPackage  CVE-2015-7704     High      57.0% (98th)   39.2
ntp                                            4.2.8p18                                  4.2.8, *4.3.94    UnknownPackage  CVE-2016-7426     High      47.2% (97th)   31.6
ntp                                            4.2.8p18                                  4.2.8, *4.3.77    UnknownPackage  CVE-2015-7855     Medium    48.4% (97th)   24.8
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2015-7978     High      33.4% (96th)   23.0
ntp                                            4.2.8p18                                  4.2.8, *4.3.77    UnknownPackage  CVE-2015-7705     Critical  25.7% (96th)   22.7
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2015-7979     High      22.5% (95th)   15.4
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2016-7433     Medium    28.3% (96th)   14.4
ntp                                            4.2.8p18                                  4.2.8, *4.3.93    UnknownPackage  CVE-2016-4953     High      19.2% (95th)   13.2
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2016-2516     Medium    23.4% (95th)   13.1
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2015-5300     High      17.8% (94th)   12.2
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2015-8140     Medium    23.5% (95th)   12.1
ntp                                            4.2.8p18                                  4.2.8, *4.3.77    UnknownPackage  CVE-2015-7853     Critical  12.8% (93rd)   11.3
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2016-9311     Medium    19.4% (95th)   11.2
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2016-7429     Low       28.5% (96th)   10.0
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2015-8139     Medium    17.9% (94th)   9.1
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2015-8158     Medium    17.9% (94th)   9.1
ntp                                            4.2.8p18                                  4.2.8             UnknownPackage  CVE-2014-9750     Medium    11.5% (93rd)   6.2
ntp                                            4.2.8p18                                  4.2.8             UnknownPackage  CVE-2018-7185     High      8.8% (92nd)    6.1
ntp                                            4.2.8p18                                  4.2.8             UnknownPackage  CVE-2019-8936     High      8.7% (92nd)    6.0
ntp                                            4.2.8p18                                  4.3.90            UnknownPackage  CVE-2015-7977     Medium    11.6% (93rd)   5.9
ntp                                            4.2.8p18                                  4.2.8             UnknownPackage  CVE-2014-9751     Medium    9.7% (92nd)    5.7
ntp                                            4.2.8p18                                  4.2.8, *4.3.93    UnknownPackage  CVE-2016-4954     High      8.0% (91st)    5.5
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2016-9310     Medium    8.7% (92nd)    5.0
ntp                                            4.2.8p18                                  4.2.8, *4.3.77    UnknownPackage  CVE-2015-7701     High      6.3% (90th)    4.3
ntp                                            4.2.8p18                                  4.2.8, *4.3.90    UnknownPackage  CVE-2015-7973     Medium    7.6% (91st)    4.2
ntp                                            4.2.8p18                                  4.2.8, *4.3.77    UnknownPackage  CVE-2015-7691     High      5.7% (90th)    3.9
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2016-9312     High      5.7% (90th)    3.9
ntp                                            4.2.8p18                                  4.2.8, *4.3.94    UnknownPackage  CVE-2017-6458     High      4.9% (89th)    3.7
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2016-2519     Medium    7.1% (91st)    3.7
ntp                                            4.2.8p18                                  4.2.8, *4.3.90    UnknownPackage  CVE-2015-7974     High      5.1% (89th)    3.4
ntp                                            4.2.8p18                                  4.2.8, *4.3.77    UnknownPackage  CVE-2015-7849     High      4.4% (88th)    3.3
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2015-8138     Medium    6.1% (90th)    3.1
ntp                                            4.2.8p18                                  4.2.8, *4.3.77    UnknownPackage  CVE-2015-7692     High      4.2% (88th)    2.9
ntp                                            4.2.8p18                                  4.2.8, *4.3.77    UnknownPackage  CVE-2015-7854     High      3.6% (87th)    2.7
ntp                                            4.2.8p18                                  4.2.8, *4.3.93    UnknownPackage  CVE-2016-4955     Medium    4.7% (88th)    2.4
ntp                                            4.2.8p18                                  4.2.8, *4.3.77    UnknownPackage  CVE-2015-7703     High      3.2% (86th)    2.1
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2016-2517     Medium    3.8% (87th)    1.9
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2015-7976     Medium    4.2% (88th)    1.9
ntp                                            4.2.8p18                                  4.2.8, *4.3.77    UnknownPackage  CVE-2015-7852     Medium    3.2% (86th)    1.6
ntp                                            4.2.8p18                                  4.2.8, *4.3.77    UnknownPackage  CVE-2015-7850     Medium    2.6% (85th)    1.3
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2019-11331    High      1.4% (79th)    1.0
ntp                                            4.2.8p18                                  4.2.8, *4.3.93    UnknownPackage  CVE-2016-4956     Medium    2.0% (83rd)    1.0
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2015-5146     Medium    1.9% (82nd)    0.9
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2016-1547     Medium    1.3% (78th)    0.6
ntp                                            4.2.8p18                                  4.2.8, *4.3.92    UnknownPackage  CVE-2018-7170     Medium    1.3% (78th)    0.6
ntp                                            4.2.8p18                                  4.2.8, *4.3.77    UnknownPackage  CVE-2015-7848     High      0.9% (74th)    0.6
ntp                                            4.2.8p18                                  4.2.8, *4.3.77    UnknownPackage  CVE-2015-7702     Medium    1.0% (75th)    0.5
ntp                                            4.2.8p18                                  4.3.100           UnknownPackage  CVE-2020-11868    High      0.6% (68th)    0.4
ntp                                            4.2.8p18                                  4.2.8, *4.3.92    UnknownPackage  CVE-2016-2518     Medium    0.8% (72nd)    0.4
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2015-7975     Medium    0.6% (69th)    0.3
ntp                                            4.2.8p18                                  4.2.8, *4.3.100   UnknownPackage  CVE-2020-13817    High      0.4% (58th)    0.3
```

## After

```
ntp                                            4.2.8p18                                  *4.2.8p9, 4.3.94  UnknownPackage  CVE-2016-7434     High      61.2% (98th)   41.0
ntp                                            4.2.8p18                                                    UnknownPackage  CVE-2019-11331    High      1.4% (79th)    1.0
```