### PR TITLE
feat(debian): move debian 13 (trixie) to released and debian 14 (forky) to testing/sid/unstable

### DIFF
--- a/grype/db/v6/data.go
+++ b/grype/db/v6/data.go
@@ -45,22 +45,22 @@ func KnownOperatingSystemSpecifierOverrides() []OperatingSystemSpecifierOverride
 		{Alias: "amazon", ReplacementName: strRef("amzn")},                   // non-standard, but common
 		{Alias: "amazonlinux", ReplacementName: strRef("amzn")},              // non-standard, but common (dockerhub uses "amazonlinux")
 		{Alias: "echo", Rolling: true},
-		// TODO: trixie is a placeholder for now, but should be updated to sid when the time comes
+		// TODO: forky is a placeholder for now, but should be updated to sid when the time comes
 		// this needs to be automated, but isn't clear how to do so since you'll see things like this:
 		//
 		// ❯ docker run --rm debian:sid cat /etc/os-release | grep VERSION_CODENAME
-		//   VERSION_CODENAME=trixie
+		//   VERSION_CODENAME=forky
 		// ❯ docker run --rm debian:testing cat /etc/os-release | grep VERSION_CODENAME
-		//   VERSION_CODENAME=trixie
+		//   VERSION_CODENAME=forky
 		//
 		// ❯ curl -s http://deb.debian.org/debian/dists/testing/Release | grep '^Codename:'
-		//   Codename: trixie
+		//   Codename: forky
 		// ❯ curl -s http://deb.debian.org/debian/dists/sid/Release | grep '^Codename:'
 		//   Codename: sid
 		//
 		// depending where the team is during the development cycle you will see different behavior, making automating
 		// this a little challenging.
-		{Alias: "debian", Codename: "trixie", Rolling: true, ReplacementLabelVersion: strRef("unstable")}, // is currently sid, which is considered rolling
+		{Alias: "debian", Codename: "forky", Rolling: true, ReplacementLabelVersion: strRef("unstable")}, // is currently sid, which is considered rolling
 	}
 }
 

--- a/grype/db/v6/operating_system_store_test.go
+++ b/grype/db/v6/operating_system_store_test.go
@@ -22,6 +22,7 @@ func TestOperatingSystemStore_ResolveOperatingSystem(t *testing.T) {
 	rhel8 := &OperatingSystem{Name: "rhel", ReleaseID: "rhel", MajorVersion: "8"}
 	rhel81 := &OperatingSystem{Name: "rhel", ReleaseID: "rhel", MajorVersion: "8", MinorVersion: "1"}
 	debian10 := &OperatingSystem{Name: "debian", ReleaseID: "debian", MajorVersion: "10"}
+	debian13 := &OperatingSystem{Name: "debian", ReleaseID: "debian", MajorVersion: "13", Codename: "trixie"}
 	echo := &OperatingSystem{Name: "echo", ReleaseID: "echo", MajorVersion: "1"}
 	alpine318 := &OperatingSystem{Name: "alpine", ReleaseID: "alpine", MajorVersion: "3", MinorVersion: "18"}
 	alpineEdge := &OperatingSystem{Name: "alpine", ReleaseID: "alpine", LabelVersion: "edge"}
@@ -42,6 +43,7 @@ func TestOperatingSystemStore_ResolveOperatingSystem(t *testing.T) {
 		rhel8,
 		rhel81,
 		debian10,
+		debian13,
 		alpine318,
 		alpineEdge,
 		debianUnstable,
@@ -165,6 +167,15 @@ func TestOperatingSystemStore_ResolveOperatingSystem(t *testing.T) {
 				Name:         "debian",
 				MajorVersion: "13",
 				LabelVersion: "trixie",
+			},
+			expected: []OperatingSystem{*debian13},
+		},
+		{
+			name: "debian by codename for rolling alias",
+			os: OSSpecifier{
+				Name:         "debian",
+				MajorVersion: "14",
+				LabelVersion: "forky",
 			},
 			expected: []OperatingSystem{*debianUnstable},
 		},


### PR DESCRIPTION
Debian 13 has been released, so we need to update the operating system specifiers to reflect this