### PR TITLE
feat: include channel in grype db search output

### DIFF
--- a/cmd/grype/cli/commands/db_search.go
+++ b/cmd/grype/cli/commands/db_search.go
@@ -251,5 +251,11 @@ func renderDBSearchPackagesTableRows(structuredRows []dbsearch.AffectedPackage) 
 }
 
 func mimicV5Namespace(row dbsearch.AffectedPackage) string {
-	return v6.MimicV5Namespace(&row.Vulnerability.Model, row.Model)
+	namespace := v6.MimicV5Namespace(&row.Vulnerability.Model, row.Model)
+
+	if row.Model != nil && row.Model.OperatingSystem != nil && row.Model.OperatingSystem.Channel != "" {
+		return namespace + ":" + row.Model.OperatingSystem.Channel
+	}
+
+	return namespace
 }

--- a/cmd/grype/cli/commands/internal/dbsearch/affected_packages.go
+++ b/cmd/grype/cli/commands/internal/dbsearch/affected_packages.go
@@ -43,7 +43,6 @@ type AffectedPackageInfo struct {
 
 // Package represents a package name within a known ecosystem, such as "python" or "golang".
 type Package struct {
-
 	// Name is the name of the package within the ecosystem
 	Name string `json:"name"`
 
@@ -167,14 +166,10 @@ func toOS(os *v6.OperatingSystem) *OperatingSystem {
 	if os == nil {
 		return nil
 	}
-	version := os.VersionNumber()
-	if version == "" {
-		version = os.Version()
-	}
 
 	return &OperatingSystem{
 		Name:    os.Name,
-		Version: version,
+		Version: os.Version(),
 	}
 }
 
@@ -182,7 +177,8 @@ func FindAffectedPackages(reader interface {
 	v6.AffectedPackageStoreReader
 	v6.AffectedCPEStoreReader
 	v6.VulnerabilityDecoratorStoreReader
-}, criteria AffectedPackagesOptions) ([]AffectedPackage, error) {
+}, criteria AffectedPackagesOptions,
+) ([]AffectedPackage, error) {
 	allAffectedPkgs, allAffectedCPEs, err := findAffectedPackages(reader, criteria)
 	if err != nil {
 		return nil, err
@@ -195,7 +191,8 @@ func findAffectedPackages(reader interface { //nolint:funlen,gocognit
 	v6.AffectedPackageStoreReader
 	v6.AffectedCPEStoreReader
 	v6.VulnerabilityDecoratorStoreReader
-}, config AffectedPackagesOptions) ([]affectedPackageWithDecorations, []affectedCPEWithDecorations, error) {
+}, config AffectedPackagesOptions,
+) ([]affectedPackageWithDecorations, []affectedCPEWithDecorations, error) {
 	var allAffectedPkgs []affectedPackageWithDecorations
 	var allAffectedCPEs []affectedCPEWithDecorations
 

--- a/cmd/grype/cli/commands/internal/dbsearch/vulnerabilities.go
+++ b/cmd/grype/cli/commands/internal/dbsearch/vulnerabilities.go
@@ -185,7 +185,8 @@ func FindVulnerabilities(reader interface { //nolint:funlen
 	v6.VulnerabilityStoreReader
 	v6.AffectedPackageStoreReader
 	v6.VulnerabilityDecoratorStoreReader
-}, config VulnerabilitiesOptions) ([]Vulnerability, error) {
+}, config VulnerabilitiesOptions,
+) ([]Vulnerability, error) {
 	log.WithFields("vulnSpecs", len(config.Vulnerability)).Debug("fetching vulnerabilities")
 
 	if config.RecordLimit == 0 {


### PR DESCRIPTION
Otherwise, there will be rows that are apparently identical besides the fixed version, which makes the output hard to interpret. Include the channel at the end of the namespace looking string in the table output and on the OS object in the JSON output.