### PR TITLE
chore: stop redundant install in test fixture

### DIFF
--- a/test/integration/test-fixtures/image-alpine-match-coverage/Dockerfile
+++ b/test/integration/test-fixtures/image-alpine-match-coverage/Dockerfile
@@ -1,7 +1,4 @@
-FROM cgr.dev/chainguard/go as builder
-
-RUN go install github.com/google/ko@v0.15.1
+FROM cgr.dev/chainguard/go AS builder
 
 FROM scratch
 COPY . .
-COPY --from=builder /root/go/bin/ko /ko


### PR DESCRIPTION
This install command has stopped working. However, copying the the lib/apk/db/installed file in is what enables grype to find the packages, so just removing the go install command allows the image to build and the tests to pass.