### PR TITLE
fix: add UnmarshalJSON to fix availability blob

### DIFF
--- a/grype/db/v6/blobs.go
+++ b/grype/db/v6/blobs.go
@@ -215,6 +215,36 @@ func (f FixAvailability) MarshalJSON() ([]byte, error) {
 	return json.Marshal(aux)
 }
 
+func (f *FixAvailability) UnmarshalJSON(data []byte) error {
+	type Alias FixAvailability
+	aux := &struct {
+		Date *string `json:"date,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(f),
+	}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	if aux.Date != nil {
+		if t, err := time.Parse("2006-01-02", *aux.Date); err == nil {
+			f.Date = &t
+			return nil
+		}
+
+		if t, err := time.Parse(time.RFC3339, *aux.Date); err == nil {
+			f.Date = &t
+			return nil
+		}
+
+		return fmt.Errorf("unable to parse date %q: expected format YYYY-MM-DD or RFC3339", *aux.Date)
+	}
+
+	return nil
+}
+
 // AffectedVersion defines the versioning format and constraints.
 type AffectedVersion struct {
 	// Type specifies the versioning system used (e.g., "semver", "rpm").

--- a/grype/db/v6/blobs_test.go
+++ b/grype/db/v6/blobs_test.go
@@ -1,0 +1,125 @@
+package v6
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFixAvailability_MarshalJSON(t *testing.T) {
+	testTime := time.Date(2022, 4, 9, 15, 30, 45, 0, time.UTC)
+
+	fixAvail := FixAvailability{
+		Date: &testTime,
+		Kind: "advisory",
+	}
+
+	jsonData, err := json.Marshal(fixAvail)
+	require.NoError(t, err)
+
+	expected := `{"date":"2022-04-09","kind":"advisory"}`
+	assert.JSONEq(t, expected, string(jsonData))
+}
+
+func TestFixAvailability_UnmarshalJSON_SimpleDateFormat(t *testing.T) {
+	jsonData := `{"date":"2022-04-09","kind":"advisory"}`
+
+	var fixAvail FixAvailability
+	err := json.Unmarshal([]byte(jsonData), &fixAvail)
+	require.NoError(t, err)
+
+	expectedTime := time.Date(2022, 4, 9, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, &expectedTime, fixAvail.Date)
+	assert.Equal(t, "advisory", fixAvail.Kind)
+}
+
+func TestFixAvailability_UnmarshalJSON_RFC3339Format(t *testing.T) {
+	jsonData := `{"date":"2022-04-09T00:00:00Z","kind":"advisory"}`
+
+	var fixAvail FixAvailability
+	err := json.Unmarshal([]byte(jsonData), &fixAvail)
+	require.NoError(t, err)
+
+	expectedTime := time.Date(2022, 4, 9, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, &expectedTime, fixAvail.Date)
+	assert.Equal(t, "advisory", fixAvail.Kind)
+}
+
+func TestFixAvailability_RoundTripMarshalUnmarshal(t *testing.T) {
+	originalTime := time.Date(2022, 4, 9, 15, 30, 45, 0, time.UTC)
+
+	original := FixAvailability{
+		Date: &originalTime,
+		Kind: "advisory",
+	}
+
+	jsonData, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var unmarshaled FixAvailability
+	err = json.Unmarshal(jsonData, &unmarshaled)
+	require.NoError(t, err)
+
+	// Time precision is lost during marshaling - only date is preserved
+	expectedTime := time.Date(2022, 4, 9, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, &expectedTime, unmarshaled.Date)
+	assert.Equal(t, "advisory", unmarshaled.Kind)
+}
+
+func TestAffectedPackageBlob_WithFixAvailability(t *testing.T) {
+	testTime := time.Date(2022, 4, 9, 0, 0, 0, 0, time.UTC)
+
+	blob := AffectedPackageBlob{
+		CVEs: []string{"CVE-2021-3521"},
+		Ranges: []AffectedRange{
+			{
+				Version: AffectedVersion{
+					Type:       "rpm",
+					Constraint: "< 0:4.14.2-15.cm1",
+				},
+				Fix: &Fix{
+					Version: "0:4.14.2-15.cm1",
+					State:   FixedStatus,
+					Detail: &FixDetail{
+						Available: &FixAvailability{
+							Date: &testTime,
+							Kind: "advisory",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(blob)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(jsonData), `"date":"2022-04-09"`)
+	assert.NotContains(t, string(jsonData), `"date":"2022-04-09T`)
+
+	var unmarshaledBlob AffectedPackageBlob
+	err = json.Unmarshal(jsonData, &unmarshaledBlob)
+	require.NoError(t, err)
+
+	require.Len(t, unmarshaledBlob.Ranges, 1)
+	require.NotNil(t, unmarshaledBlob.Ranges[0].Fix)
+	require.NotNil(t, unmarshaledBlob.Ranges[0].Fix.Detail)
+	require.NotNil(t, unmarshaledBlob.Ranges[0].Fix.Detail.Available)
+
+	assert.Equal(t, &testTime, unmarshaledBlob.Ranges[0].Fix.Detail.Available.Date)
+	assert.Equal(t, "advisory", unmarshaledBlob.Ranges[0].Fix.Detail.Available.Kind)
+}
+
+func TestFixAvailability_UnmarshalJSON_InvalidDateFormat(t *testing.T) {
+	jsonData := `{"date":"invalid-date","kind":"advisory"}`
+
+	var fixAvail FixAvailability
+	err := json.Unmarshal([]byte(jsonData), &fixAvail)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unable to parse date "invalid-date"`)
+	assert.Contains(t, err.Error(), "expected format YYYY-MM-DD or RFC3339")
+}


### PR DESCRIPTION
When grype-db writes the fix availability date it truncates the datetime object to a simple date, since more granularity is not really available in fix availability timing. Add a corresponding unmarshal method that enables grype to parse these truncated dates.