### PR TITLE
feat[raspbian]: support vulnerability matching for raspbian

### DIFF
--- a/grype/db/v6/data.go
+++ b/grype/db/v6/data.go
@@ -20,6 +20,9 @@ func KnownOperatingSystemSpecifierOverrides() []OperatingSystemSpecifierOverride
 		{Alias: "almalinux", ReplacementName: strRef("rhel")}, // non-standard, but common (dockerhub uses "almalinux")
 		{Alias: "gentoo", ReplacementName: strRef("rhel")},
 
+		// Alternaitve distros that should match against the debian vulnerability data
+		{Alias: "raspbian", ReplacementName: strRef("debian")},
+
 		// to remain backwards compatible, we need to keep old clients from ignoring EUS data.
 		// we do this by diverting any requests for a specific major.minor version of rhel to only
 		// use the major version. But, this only applies to clients before v6.0.3 DB schema version.

--- a/grype/distro/distro_test.go
+++ b/grype/distro/distro_test.go
@@ -456,6 +456,11 @@ func Test_NewDistroFromRelease_Coverage(t *testing.T) {
 			Type:    MinimOS,
 			Version: "20241031",
 		},
+		{
+			Name:    "test-fixtures/os/raspbian",
+			Type:    Raspbian,
+			Version: "9",
+		},
 	}
 
 	for _, tt := range tests {

--- a/grype/distro/test-fixtures/os/raspbian/etc/os-release
+++ b/grype/distro/test-fixtures/os/raspbian/etc/os-release
@@ -1,0 +1,9 @@
+PRETTY_NAME="Raspbian GNU/Linux 9 (stretch)"
+NAME="Raspbian GNU/Linux"
+VERSION_ID="9"
+VERSION="9 (stretch)"
+ID=raspbian
+ID_LIKE=debian
+HOME_URL="http://www.raspbian.org/"
+SUPPORT_URL="http://www.raspbian.org/RaspbianForums"
+BUG_REPORT_URL="http://www.raspbian.org/RaspbianBugs"

--- a/grype/distro/type.go
+++ b/grype/distro/type.go
@@ -33,6 +33,7 @@ const (
 	Wolfi        Type = "wolfi"
 	Chainguard   Type = "chainguard"
 	MinimOS      Type = "minimos"
+	Raspbian     Type = "raspbian"
 )
 
 // All contains all Linux distribution options
@@ -60,6 +61,7 @@ var All = []Type{
 	Wolfi,
 	Chainguard,
 	MinimOS,
+	Raspbian,
 }
 
 // IDMapping maps a distro ID from the /etc/os-release (e.g. like "ubuntu") to a Distro type.
@@ -86,6 +88,7 @@ var IDMapping = map[string]Type{
 	"wolfi":         Wolfi,
 	"chainguard":    Chainguard,
 	"minimos":       MinimOS,
+	"raspbian":      Raspbian,
 }
 
 // aliasTypes maps common aliases to their corresponding Type.


### PR DESCRIPTION
Support matching packages from raspbian against the debian vulnerability data provider.

This will require a new db to be published by grype-db before the matching will work since it needs a new operating_system_specifier_override record in the db