### PR TITLE
Present fix available version in grype JSON output

### DIFF
--- a/grype/db/v6/vulnerability.go
+++ b/grype/db/v6/vulnerability.go
@@ -254,6 +254,7 @@ func toPackageQualifiers(qualifiers *AffectedPackageQualifiers) []qualifier.Qual
 func toFix(affectedRanges []AffectedRange) vulnerability.Fix {
 	var state vulnerability.FixState
 	var versions []string
+	var availables []vulnerability.FixAvailable
 	for _, r := range affectedRanges {
 		if r.Fix == nil {
 			continue
@@ -262,6 +263,16 @@ func toFix(affectedRanges []AffectedRange) vulnerability.Fix {
 		case FixedStatus:
 			state = vulnerability.FixStateFixed
 			versions = append(versions, r.Fix.Version)
+			if r.Fix.Detail != nil && r.Fix.Detail.Available != nil {
+				a := r.Fix.Detail.Available
+				if a.Date != nil {
+					availables = append(availables, vulnerability.FixAvailable{
+						Version: r.Fix.Version,
+						Date:    *a.Date,
+						Kind:    a.Kind,
+					})
+				}
+			}
 		case NotAffectedFixStatus:
 			// TODO: not handled yet
 		case WontFixStatus:
@@ -278,8 +289,9 @@ func toFix(affectedRanges []AffectedRange) vulnerability.Fix {
 		return vulnerability.Fix{}
 	}
 	return vulnerability.Fix{
-		Versions: versions,
-		State:    state,
+		Versions:  versions,
+		State:     state,
+		Available: availables,
 	}
 }
 

--- a/grype/db/v6/vulnerability_test.go
+++ b/grype/db/v6/vulnerability_test.go
@@ -3,6 +3,7 @@ package v6
 import (
 	"strings"
 	"testing"
+	"time"
 	"unicode"
 
 	"github.com/stretchr/testify/assert"
@@ -617,6 +618,371 @@ func Test_getRelatedVulnerabilities(t *testing.T) {
 				})
 			}
 			require.ElementsMatch(t, expected, got)
+		})
+	}
+}
+
+func TestToFix(t *testing.T) {
+	fixedDate := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	anotherDate := time.Date(2024, 2, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name           string
+		affectedRanges []AffectedRange
+		expectedFix    vulnerability.Fix
+	}{
+		{
+			name:           "empty affected ranges",
+			affectedRanges: []AffectedRange{},
+			expectedFix:    vulnerability.Fix{},
+		},
+		{
+			name: "all ranges have nil fix",
+			affectedRanges: []AffectedRange{
+				{Fix: nil},
+				{Fix: nil},
+			},
+			expectedFix: vulnerability.Fix{},
+		},
+		{
+			name: "single fixed version without available info",
+			affectedRanges: []AffectedRange{
+				{
+					Fix: &Fix{
+						Version: "1.2.3",
+						State:   FixedStatus,
+					},
+				},
+			},
+			expectedFix: vulnerability.Fix{
+				Versions:  []string{"1.2.3"},
+				State:     vulnerability.FixStateFixed,
+				Available: nil,
+			},
+		},
+		{
+			name: "single fixed version with complete available info",
+			affectedRanges: []AffectedRange{
+				{
+					Fix: &Fix{
+						Version: "1.2.3",
+						State:   FixedStatus,
+						Detail: &FixDetail{
+							Available: &FixAvailability{
+								Date: &fixedDate,
+								Kind: "first-observed",
+							},
+						},
+					},
+				},
+			},
+			expectedFix: vulnerability.Fix{
+				Versions: []string{"1.2.3"},
+				State:    vulnerability.FixStateFixed,
+				Available: []vulnerability.FixAvailable{
+					{
+						Version: "1.2.3",
+						Date:    fixedDate,
+						Kind:    "first-observed",
+					},
+				},
+			},
+		},
+		{
+			name: "fix detail is nil - no available info",
+			affectedRanges: []AffectedRange{
+				{
+					Fix: &Fix{
+						Version: "1.2.3",
+						State:   FixedStatus,
+						Detail:  nil,
+					},
+				},
+			},
+			expectedFix: vulnerability.Fix{
+				Versions:  []string{"1.2.3"},
+				State:     vulnerability.FixStateFixed,
+				Available: nil,
+			},
+		},
+		{
+			name: "fix detail available is nil - no available info",
+			affectedRanges: []AffectedRange{
+				{
+					Fix: &Fix{
+						Version: "1.2.3",
+						State:   FixedStatus,
+						Detail: &FixDetail{
+							Available: nil,
+						},
+					},
+				},
+			},
+			expectedFix: vulnerability.Fix{
+				Versions:  []string{"1.2.3"},
+				State:     vulnerability.FixStateFixed,
+				Available: nil,
+			},
+		},
+		{
+			name: "fix detail available date is nil - no available info",
+			affectedRanges: []AffectedRange{
+				{
+					Fix: &Fix{
+						Version: "1.2.3",
+						State:   FixedStatus,
+						Detail: &FixDetail{
+							Available: &FixAvailability{
+								Date: nil,
+								Kind: "first-observed",
+							},
+						},
+					},
+				},
+			},
+			expectedFix: vulnerability.Fix{
+				Versions:  []string{"1.2.3"},
+				State:     vulnerability.FixStateFixed,
+				Available: nil,
+			},
+		},
+		{
+			name: "multiple fixed versions with mixed available info",
+			affectedRanges: []AffectedRange{
+				{
+					Fix: &Fix{
+						Version: "1.2.3",
+						State:   FixedStatus,
+						Detail: &FixDetail{
+							Available: &FixAvailability{
+								Date: &fixedDate,
+								Kind: "first-observed",
+							},
+						},
+					},
+				},
+				{
+					Fix: &Fix{
+						Version: "1.3.0",
+						State:   FixedStatus,
+						Detail: &FixDetail{
+							Available: &FixAvailability{
+								Date: nil, // this should not create an available entry
+								Kind: "first-observed",
+							},
+						},
+					},
+				},
+				{
+					Fix: &Fix{
+						Version: "1.4.0",
+						State:   FixedStatus,
+						Detail: &FixDetail{
+							Available: &FixAvailability{
+								Date: &anotherDate,
+								Kind: "first-observed",
+							},
+						},
+					},
+				},
+			},
+			expectedFix: vulnerability.Fix{
+				Versions: []string{"1.2.3", "1.3.0", "1.4.0"},
+				State:    vulnerability.FixStateFixed,
+				Available: []vulnerability.FixAvailable{
+					{
+						Version: "1.2.3",
+						Date:    fixedDate,
+						Kind:    "first-observed",
+					},
+					{
+						Version: "1.4.0",
+						Date:    anotherDate,
+						Kind:    "first-observed",
+					},
+				},
+			},
+		},
+		{
+			name: "wont fix status only",
+			affectedRanges: []AffectedRange{
+				{
+					Fix: &Fix{
+						Version: "1.2.3",
+						State:   WontFixStatus,
+					},
+				},
+			},
+			expectedFix: vulnerability.Fix{
+				Versions:  nil,
+				State:     vulnerability.FixStateWontFix,
+				Available: nil,
+			},
+		},
+		{
+			name: "not fixed status only",
+			affectedRanges: []AffectedRange{
+				{
+					Fix: &Fix{
+						Version: "1.2.3",
+						State:   NotFixedStatus,
+					},
+				},
+			},
+			expectedFix: vulnerability.Fix{
+				Versions:  nil,
+				State:     vulnerability.FixStateNotFixed,
+				Available: nil,
+			},
+		},
+		{
+			name: "not affected status - not handled yet",
+			affectedRanges: []AffectedRange{
+				{
+					Fix: &Fix{
+						Version: "1.2.3",
+						State:   NotAffectedFixStatus,
+					},
+				},
+			},
+			expectedFix: vulnerability.Fix{},
+		},
+		{
+			name: "fixed status overrides wont fix",
+			affectedRanges: []AffectedRange{
+				{
+					Fix: &Fix{
+						Version: "1.2.3",
+						State:   WontFixStatus,
+					},
+				},
+				{
+					Fix: &Fix{
+						Version: "1.3.0",
+						State:   FixedStatus,
+					},
+				},
+			},
+			expectedFix: vulnerability.Fix{
+				Versions:  []string{"1.3.0"},
+				State:     vulnerability.FixStateFixed,
+				Available: nil,
+			},
+		},
+		{
+			name: "fixed status overrides not fixed",
+			affectedRanges: []AffectedRange{
+				{
+					Fix: &Fix{
+						Version: "1.2.3",
+						State:   NotFixedStatus,
+					},
+				},
+				{
+					Fix: &Fix{
+						Version: "1.3.0",
+						State:   FixedStatus,
+					},
+				},
+			},
+			expectedFix: vulnerability.Fix{
+				Versions:  []string{"1.3.0"},
+				State:     vulnerability.FixStateFixed,
+				Available: nil,
+			},
+		},
+		{
+			name: "wont fix overrides not fixed",
+			affectedRanges: []AffectedRange{
+				{
+					Fix: &Fix{
+						Version: "1.2.3",
+						State:   NotFixedStatus,
+					},
+				},
+				{
+					Fix: &Fix{
+						Version: "1.3.0",
+						State:   WontFixStatus,
+					},
+				},
+			},
+			expectedFix: vulnerability.Fix{
+				Versions:  nil,
+				State:     vulnerability.FixStateWontFix,
+				Available: nil,
+			},
+		},
+		{
+			name: "mix of nil fixes and various states",
+			affectedRanges: []AffectedRange{
+				{Fix: nil},
+				{
+					Fix: &Fix{
+						Version: "1.2.3",
+						State:   WontFixStatus,
+					},
+				},
+				{Fix: nil},
+				{
+					Fix: &Fix{
+						Version: "1.3.0",
+						State:   FixedStatus,
+						Detail: &FixDetail{
+							Available: &FixAvailability{
+								Date: &fixedDate,
+								Kind: "first-observed",
+							},
+						},
+					},
+				},
+			},
+			expectedFix: vulnerability.Fix{
+				Versions: []string{"1.3.0"},
+				State:    vulnerability.FixStateFixed,
+				Available: []vulnerability.FixAvailable{
+					{
+						Version: "1.3.0",
+						Date:    fixedDate,
+						Kind:    "first-observed",
+					},
+				},
+			},
+		},
+		{
+			name: "available with empty kind field",
+			affectedRanges: []AffectedRange{
+				{
+					Fix: &Fix{
+						Version: "1.2.3",
+						State:   FixedStatus,
+						Detail: &FixDetail{
+							Available: &FixAvailability{
+								Date: &fixedDate,
+								Kind: "", // empty kind should still work
+							},
+						},
+					},
+				},
+			},
+			expectedFix: vulnerability.Fix{
+				Versions: []string{"1.2.3"},
+				State:    vulnerability.FixStateFixed,
+				Available: []vulnerability.FixAvailable{
+					{
+						Version: "1.2.3",
+						Date:    fixedDate,
+						Kind:    "",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toFix(tt.affectedRanges)
+			require.Equal(t, tt.expectedFix, got)
 		})
 	}
 }

--- a/grype/presenter/models/vulnerability.go
+++ b/grype/presenter/models/vulnerability.go
@@ -16,14 +16,15 @@ type Vulnerability struct {
 }
 
 type Fix struct {
-	Versions  []string      `json:"versions"`
-	State     string        `json:"state"`
-	Available *FixAvailable `json:"available,omitempty"`
+	Versions  []string       `json:"versions"`
+	State     string         `json:"state"`
+	Available []FixAvailable `json:"available,omitempty"`
 }
 
 type FixAvailable struct {
-	Date string `json:"date"`
-	Kind string `json:"kind"`
+	Version string `json:"version"`
+	Date    string `json:"date"`
+	Kind    string `json:"kind,omitempty"`
 }
 
 type Advisory struct {
@@ -64,15 +65,25 @@ func NewVulnerability(vuln vulnerability.Vulnerability, metadata *vulnerability.
 	}
 }
 
-func getFixAvailable(fixAvailable *vulnerability.FixAvailable) *FixAvailable {
-	if fixAvailable == nil {
+func getFixAvailable(fixesAvailable []vulnerability.FixAvailable) []FixAvailable {
+	if len(fixesAvailable) == 0 {
 		return nil
 	}
 
-	return &FixAvailable{
-		Date: fixAvailable.Date.Format("2006-01-02"), // just extract the date
-		Kind: fixAvailable.Kind,
+	var results []FixAvailable
+	for _, fix := range fixesAvailable {
+		if fix.Date.IsZero() {
+			continue
+		}
+		f := FixAvailable{
+			Version: fix.Version,
+			Date:    fix.Date.Format("2006-01-02"), // just extract the
+			Kind:    fix.Kind,
+		}
+		results = append(results, f)
 	}
+
+	return results
 }
 
 func sortVersions(fixedVersions []string, format version.Format) []string {

--- a/grype/presenter/models/vulnerability_test.go
+++ b/grype/presenter/models/vulnerability_test.go
@@ -2,10 +2,12 @@ package models
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/anchore/grype/grype/version"
+	"github.com/anchore/grype/grype/vulnerability"
 )
 
 func Test_sortVersions(t *testing.T) {
@@ -72,6 +74,83 @@ func Test_sortVersions(t *testing.T) {
 
 			if d := cmp.Diff(tt.expected, result); d != "" {
 				t.Errorf("sortVersions() mismatch (-want +got):\n%s", d)
+			}
+		})
+	}
+}
+
+func Test_getFixAvailable(t *testing.T) {
+	validDate1 := time.Date(2023, 1, 15, 0, 0, 0, 0, time.UTC)
+	validDate2 := time.Date(2023, 3, 10, 0, 0, 0, 0, time.UTC)
+	zeroDate := time.Time{}
+
+	tests := []struct {
+		name     string
+		input    []vulnerability.FixAvailable
+		expected []FixAvailable
+	}{
+		{
+			name:     "empty input returns nil",
+			input:    []vulnerability.FixAvailable{},
+			expected: nil,
+		},
+		{
+			name: "single fix with valid date",
+			input: []vulnerability.FixAvailable{
+				{Version: "1.2.3", Date: validDate1, Kind: "first-observed"},
+			},
+			expected: []FixAvailable{
+				{Version: "1.2.3", Date: "2023-01-15", Kind: "first-observed"},
+			},
+		},
+		{
+			name: "multiple fixes with valid dates",
+			input: []vulnerability.FixAvailable{
+				{Version: "1.2.3", Date: validDate1, Kind: "first-observed"},
+				{Version: "2.0.0", Date: validDate2, Kind: "first-observed"},
+			},
+			expected: []FixAvailable{
+				{Version: "1.2.3", Date: "2023-01-15", Kind: "first-observed"},
+				{Version: "2.0.0", Date: "2023-03-10", Kind: "first-observed"},
+			},
+		},
+		{
+			name: "filters out fixes with zero dates",
+			input: []vulnerability.FixAvailable{
+				{Version: "1.2.3", Date: validDate1, Kind: "first-observed"},
+				{Version: "1.2.4", Date: zeroDate, Kind: "first-observed"},
+				{Version: "2.0.0", Date: validDate2, Kind: "first-observed"},
+			},
+			expected: []FixAvailable{
+				{Version: "1.2.3", Date: "2023-01-15", Kind: "first-observed"},
+				{Version: "2.0.0", Date: "2023-03-10", Kind: "first-observed"},
+			},
+		},
+		{
+			name: "all fixes with zero dates returns nil",
+			input: []vulnerability.FixAvailable{
+				{Version: "1.2.3", Date: zeroDate, Kind: "first-observed"},
+				{Version: "1.2.4", Date: zeroDate, Kind: "first-observed"},
+			},
+			expected: nil,
+		},
+		{
+			name: "empty kind is preserved",
+			input: []vulnerability.FixAvailable{
+				{Version: "1.0.0", Date: validDate1, Kind: ""},
+			},
+			expected: []FixAvailable{
+				{Version: "1.0.0", Date: "2023-01-15", Kind: ""},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getFixAvailable(tt.input)
+
+			if d := cmp.Diff(tt.expected, result); d != "" {
+				t.Errorf("getFixAvailable() mismatch (-want +got):\n%s", d)
 			}
 		})
 	}

--- a/grype/vulnerability/fix.go
+++ b/grype/vulnerability/fix.go
@@ -23,12 +23,13 @@ func AllFixStates() []FixState {
 type Fix struct {
 	Versions  []string
 	State     FixState
-	Available *FixAvailable
+	Available []FixAvailable
 }
 
 type FixAvailable struct {
-	Date time.Time
-	Kind string
+	Version string
+	Date    time.Time
+	Kind    string
 }
 
 func (f FixState) String() string {


### PR DESCRIPTION
Though the DB search commands and the DB schema all have fix available information, and the JSON model had a place for the information, they were not wired up. This PR fixes two things:
- wires up the available date information from the DB
- pairs up expressing which fix date corresponds with which version without breaking the current JSON output