### PR TITLE
fix: Add cyclonedx to RpmMetadata

### DIFF
--- a/grype/pkg/rpm_metadata.go
+++ b/grype/pkg/rpm_metadata.go
@@ -1,6 +1,6 @@
 package pkg
 
 type RpmMetadata struct {
-	Epoch           *int    `json:"epoch"`
-	ModularityLabel *string `json:"modularityLabel"`
+	Epoch           *int    `json:"epoch" cyclonedx:"epoch"`
+	ModularityLabel *string `json:"modularityLabel" cyclonedx:"modularityLabel"`
 }


### PR DESCRIPTION
Adding `cyclonedx` annotations for `RpmMetadata`. This allows for sboms in format `cyclonedx` to populate correctly the `RpmMetadata`.