### PR TITLE
docs: remove brew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ choco install grype -y
 ### Homebrew
 
 ```bash
-brew install anchore/grype/grype --cask
+brew install grype
 ```
 
 ### MacPorts


### PR DESCRIPTION
Add `--cask` since grype moved from Homebrew Formula to Cask.

Also, put install on oneliner since Homebrew can auto tap repositories during install.

EDIT: Remove `brew tap` from install command, to install from Homebrew's official repo.