### PR TITLE
docs: fix Cosign documentation URL in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -758,7 +758,7 @@ prep_signature_verification() {
   if is_command "${COSIGN_BINARY}"; then
     log_trace "${COSIGN_BINARY} binary is installed"
   else
-    log_err "signature verification is requested but ${COSIGN_BINARY} binary is not installed (see https://docs.sigstore.dev/system_config/installation/ to install it)"
+    log_err "signature verification is requested but ${COSIGN_BINARY} binary is not installed (see https://docs.sigstore.dev/cosign/system_config/installation/ to install it)"
     return 1
   fi
 }


### PR DESCRIPTION
Noticed that the URL in the installer message had gone out of date. Updated to a working one, matching the one in the README:

https://github.com/anchore/grype/blob/0b97898466a18d0fa5f52bb3997e46855d69085a/README.md?plain=1#L113