### PR TITLE
fix: junit template use CDATA block to prevent XML parse errors

### DIFF
--- a/templates/junit.tmpl
+++ b/templates/junit.tmpl
@@ -11,10 +11,14 @@
 <![CDATA[
 {{ html .Vulnerability.Description }}
 
-{{ .Artifact.CPEs }}
+CPEs:
+{{- range .Artifact.CPEs }}
+{{ . }}
+{{- end }}
 
+DataSource:
 {{ html .Vulnerability.DataSource }}
-            
+
 ]]></failure>
         </testcase>
         {{- end }}


### PR DESCRIPTION
Sometimes CVE descriptions contain chars that end up in being an error in XML parser, for example `<` and `>`.
Adding description in CDATA block prevents processing of such content and thus no more errors.

ref https://en.wikipedia.org/wiki/CDATA