### PR TITLE
Respect rpmmod PURL qualifier

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4
 	github.com/anchore/packageurl-go v0.1.1-0.20250220190351-d62adb6e1115
 	github.com/anchore/stereoscope v0.1.11
-	github.com/anchore/syft v1.36.0
+	github.com/anchore/syft v1.36.1-0.20251028133511-0d9ea69a668d
 	github.com/aquasecurity/go-pep440-version v0.0.1
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/bitnami/go-version v0.0.0-20250505154626-452e8c5ee607

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/anchore/packageurl-go v0.1.1-0.20250220190351-d62adb6e1115 h1:ZyRCmiE
 github.com/anchore/packageurl-go v0.1.1-0.20250220190351-d62adb6e1115/go.mod h1:KoYIv7tdP5+CC9VGkeZV4/vGCKsY55VvoG+5dadg4YI=
 github.com/anchore/stereoscope v0.1.11 h1:YP/XUNcJyMbOOPAWPkeZNCVlKKTRO2cnBTEeUW6I40Y=
 github.com/anchore/stereoscope v0.1.11/go.mod h1:G3PZlzPbxFhylj9pQwtqfVPaahuWmy/UCtv5FTIIMvg=
-github.com/anchore/syft v1.36.0 h1:vmrQz/eCPEdniHi2XRqEXxpvO3Q3wHL9o+YcE45XtUI=
-github.com/anchore/syft v1.36.0/go.mod h1:DdJMDHhI2V7pOjC/5FL98BKbG2DkbIT5zYmig6AORdU=
+github.com/anchore/syft v1.36.1-0.20251028133511-0d9ea69a668d h1:AwhVbgiMNKquSldwZdML8W6kkrG5p+qFZn451hb5me4=
+github.com/anchore/syft v1.36.1-0.20251028133511-0d9ea69a668d/go.mod h1:DdJMDHhI2V7pOjC/5FL98BKbG2DkbIT5zYmig6AORdU=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=

--- a/grype/pkg/purl_provider_test.go
+++ b/grype/pkg/purl_provider_test.go
@@ -204,6 +204,30 @@ func Test_PurlProvider(t *testing.T) {
 			},
 		},
 		{
+			name:      "RPM with rpmmod",
+			userInput: "pkg:rpm/redhat/httpd@2.4.37-51?arch=x86_64&distro=rhel-8.7&rpmmod=httpd:2.4",
+			channels:  testFixChannels(),
+			wantContext: Context{
+				Source: &source.Description{
+					Metadata: PURLLiteralMetadata{
+						PURL: "pkg:rpm/redhat/httpd@2.4.37-51?arch=x86_64&distro=rhel-8.7&rpmmod=httpd:2.4",
+					},
+				},
+			},
+			wantPkgs: []Package{
+				{
+					Name:    "httpd",
+					Version: "2.4.37-51",
+					Type:    pkg.RpmPkg,
+					PURL:    "pkg:rpm/redhat/httpd@2.4.37-51?arch=x86_64&distro=rhel-8.7&rpmmod=httpd:2.4",
+					Distro:  &distro.Distro{Type: distro.RedHat, Version: "8.7", Codename: "", IDLike: []string{"redhat"}},
+					Metadata: RpmMetadata{
+						ModularityLabel: strRef("httpd:2.4"),
+					},
+				},
+			},
+		},
+		{
 			name:      "infer context when distro is present for single purl",
 			userInput: "pkg:apk/curl@7.61.1?arch=aarch64&distro=alpine-3.20.3",
 			channels:  testFixChannels(),


### PR DESCRIPTION
Pull in a Syft change and add unit test so that passing PURLs to grype with the "rpmmod" qualifier filters to RPMs with that modularity for matching.