### PR TITLE
Allow hyphen in version string

### DIFF
--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -401,7 +401,8 @@ func applyDistroHint(hint string) *distro.Distro {
 		return nil
 	}
 
-	return distro.NewFromNameVersion(stringutil.SplitOnFirstString(hint, ":", "@"))
+	name, version := distro.ParseDistroString(hint)
+	return distro.NewFromNameVersion(name, version)
 }
 
 func validateDBLoad(loadErr error, status *vulnerability.ProviderStatus) error {

--- a/cmd/grype/cli/options/database_search_os.go
+++ b/cmd/grype/cli/options/database_search_os.go
@@ -1,13 +1,13 @@
 package options
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"unicode"
 
 	"github.com/anchore/clio"
 	v6 "github.com/anchore/grype/grype/db/v6"
+	"github.com/anchore/grype/grype/distro"
 )
 
 type DBSearchOSs struct {
@@ -17,7 +17,7 @@ type DBSearchOSs struct {
 
 func (o *DBSearchOSs) AddFlags(flags clio.FlagSet) {
 	// consistent with grype --distro flag today
-	flags.StringArrayVarP(&o.OSs, "distro", "", "refine to results with the given operating system (format: 'name', 'name@version', 'name@maj.min', 'name@codename')")
+	flags.StringArrayVarP(&o.OSs, "distro", "", "refine to results with the given operating system (format: 'name', 'name[-:@]version', 'name[-:@]maj.min', 'name[-:@]codename')")
 }
 
 func (o *DBSearchOSs) PostLoad() error {
@@ -40,56 +40,53 @@ func (o *DBSearchOSs) PostLoad() error {
 }
 
 func parseOSString(osValue string) (*v6.OSSpecifier, error) {
-	// parse name@version from the distro string
-	// version could be a codename, major version, major.minor version, or major.minior.patch version
-	switch strings.Count(osValue, ":") {
-	case 0:
-		// no-op
-	case 1:
-		// be nice to folks that are close...
-		osValue = strings.ReplaceAll(osValue, ":", "@")
-	default:
-		// this is pretty unexpected
+	// Check for multiple @ separators in the original input (not allowed)
+	if strings.Count(osValue, "@") > 1 {
+		return nil, fmt.Errorf("invalid distro name@version: %q", osValue)
+	}
+
+	// Use the shared parsing logic from grype/distro package
+	name, version := distro.ParseDistroString(osValue)
+
+	if name == "" {
 		return nil, fmt.Errorf("invalid distro input provided: %q", osValue)
 	}
 
-	parts := strings.Split(osValue, "@")
-	switch len(parts) {
-	case 1:
-		name := strings.TrimSpace(parts[0])
-		return &v6.OSSpecifier{Name: name}, nil
-	case 2:
-		version := strings.TrimSpace(parts[1])
-		name := strings.TrimSpace(parts[0])
-		if len(version) == 0 {
-			return nil, errors.New("invalid distro version provided")
+	// Check if there was a separator but no version (e.g., "ubuntu@")
+	// This can be detected by checking if the original string ends with a separator
+	originalTrimmed := strings.TrimSpace(osValue)
+	if len(originalTrimmed) > 0 && version == "" {
+		lastChar := originalTrimmed[len(originalTrimmed)-1]
+		if lastChar == '-' || lastChar == ':' || lastChar == '@' {
+			return nil, fmt.Errorf("invalid distro version provided")
 		}
-
-		// parse the version (major.minor.patch, major.minor, major, codename)
-
-		// if starts with a number, then it is a version
-		if unicode.IsDigit(rune(version[0])) {
-			versionParts := strings.Split(parts[1], ".")
-			var major, minor string
-			switch len(versionParts) {
-			case 1:
-				major = versionParts[0]
-			case 2:
-				major = versionParts[0]
-				minor = versionParts[1]
-			case 3:
-				return nil, fmt.Errorf("invalid distro version provided: patch version ignored: %q", version)
-			default:
-				return nil, fmt.Errorf("invalid distro version provided: %q", version)
-			}
-
-			return &v6.OSSpecifier{Name: name, MajorVersion: major, MinorVersion: minor}, nil
-		}
-
-		// is codename / label
-		return &v6.OSSpecifier{Name: name, LabelVersion: version}, nil
-
-	default:
-		return nil, fmt.Errorf("invalid distro name@version: %q", osValue)
 	}
+
+	// No version specified
+	if version == "" {
+		return &v6.OSSpecifier{Name: name}, nil
+	}
+
+	// parse the version (major.minor, major, or codename)
+	// if starts with a number, then it is a version
+	if unicode.IsDigit(rune(version[0])) {
+		versionParts := strings.Split(version, ".")
+		var major, minor string
+		switch len(versionParts) {
+		case 1:
+			major = versionParts[0]
+		case 2:
+			major = versionParts[0]
+			minor = versionParts[1]
+		case 3:
+			return nil, fmt.Errorf("invalid distro version provided: patch version ignored: %q", version)
+		default:
+			return nil, fmt.Errorf("invalid distro version provided: %q", version)
+		}
+
+		return &v6.OSSpecifier{Name: name, MajorVersion: major, MinorVersion: minor}, nil
+	}
+
+	// is codename / label
+	return &v6.OSSpecifier{Name: name, LabelVersion: version}, nil
 }

--- a/cmd/grype/cli/options/grype.go
+++ b/cmd/grype/cli/options/grype.go
@@ -97,7 +97,7 @@ func (o *Grype) AddFlags(flags clio.FlagSet) {
 
 	flags.StringVarP(&o.Distro,
 		"distro", "",
-		"distro to match against in the format: <distro>:<version>",
+		"distro to match against in the format: <distro>[-:@]<version>",
 	)
 
 	flags.BoolVarP(&o.GenerateMissingCPEs,

--- a/grype/distro/distro_test.go
+++ b/grype/distro/distro_test.go
@@ -577,3 +577,129 @@ func TestDistro_MajorVersion(t *testing.T) {
 func names(ns ...string) []string {
 	return ns
 }
+
+func TestParseDistroString(t *testing.T) {
+	tests := []struct {
+		name            string
+		input           string
+		expectedName    string
+		expectedVersion string
+	}{
+		{
+			name:            "hyphen separator",
+			input:           "debian-11",
+			expectedName:    "debian",
+			expectedVersion: "11",
+		},
+		{
+			name:            "colon separator",
+			input:           "debian:11",
+			expectedName:    "debian",
+			expectedVersion: "11",
+		},
+		{
+			name:            "at separator",
+			input:           "debian@11",
+			expectedName:    "debian",
+			expectedVersion: "11",
+		},
+		{
+			name:            "no separator",
+			input:           "debian",
+			expectedName:    "debian",
+			expectedVersion: "",
+		},
+		{
+			name:            "with major.minor version",
+			input:           "ubuntu-20.04",
+			expectedName:    "ubuntu",
+			expectedVersion: "20.04",
+		},
+		{
+			name:            "with codename",
+			input:           "ubuntu@focal",
+			expectedName:    "ubuntu",
+			expectedVersion: "focal",
+		},
+		{
+			name:            "with channels",
+			input:           "rhel:9.4+eus",
+			expectedName:    "rhel",
+			expectedVersion: "9.4+eus",
+		},
+		{
+			name:            "opensuse-leap with hyphen separator",
+			input:           "opensuse-leap-15.2",
+			expectedName:    "opensuse-leap",
+			expectedVersion: "15.2",
+		},
+		{
+			name:            "opensuse-leap with colon separator",
+			input:           "opensuse-leap:15.2",
+			expectedName:    "opensuse-leap",
+			expectedVersion: "15.2",
+		},
+		{
+			name:            "opensuse-leap with at separator",
+			input:           "opensuse-leap@15.2",
+			expectedName:    "opensuse-leap",
+			expectedVersion: "15.2",
+		},
+		{
+			name:            "opensuse-leap without version",
+			input:           "opensuse-leap",
+			expectedName:    "opensuse-leap",
+			expectedVersion: "",
+		},
+		{
+			name:            "opensuse-leap with mixed case",
+			input:           "OpenSUSE-Leap-15.2",
+			expectedName:    "opensuse-leap",
+			expectedVersion: "15.2",
+		},
+		{
+			name:            "empty string",
+			input:           "",
+			expectedName:    "",
+			expectedVersion: "",
+		},
+		{
+			name:            "with whitespace",
+			input:           "  debian : 11  ",
+			expectedName:    "debian",
+			expectedVersion: "11",
+		},
+		{
+			name:            "multiple separators uses first",
+			input:           "debian-11:test",
+			expectedName:    "debian",
+			expectedVersion: "11:test",
+		},
+		{
+			name:            "rhel with hyphen",
+			input:           "rhel-8",
+			expectedName:    "rhel",
+			expectedVersion: "8",
+		},
+		{
+			name:            "centos with colon",
+			input:           "centos:7",
+			expectedName:    "centos",
+			expectedVersion: "7",
+		},
+		{
+			name:            "alpine with at",
+			input:           "alpine@3.11",
+			expectedName:    "alpine",
+			expectedVersion: "3.11",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, version := ParseDistroString(tt.input)
+			assert.Equal(t, tt.expectedName, name, "unexpected name")
+			assert.Equal(t, tt.expectedVersion, version, "unexpected version")
+		})
+	}
+}

--- a/grype/pkg/purl_provider.go
+++ b/grype/pkg/purl_provider.go
@@ -89,11 +89,8 @@ func distroFromPURL(purl packageurl.PackageURL) (d *distro.Distro) {
 
 	for _, qualifier := range purl.Qualifiers {
 		if qualifier.Key == syftPkg.PURLQualifierDistro {
-			fields := strings.SplitN(qualifier.Value, "-", 2)
-			distroName = fields[0]
-			if len(fields) > 1 {
-				distroVersion = fields[1]
-			}
+			// Use shared parsing logic to support -, :, and @ separators
+			distroName, distroVersion = distro.ParseDistroString(qualifier.Value)
 		}
 	}
 


### PR DESCRIPTION
Previously, @ and : were allowed between the id and the version on --distro, but not '-'. However, - is in the PURLs in the distro parameter, and it surprises people when they cannot pass it to --distro. Also, consolidate and unit test the function that parses distro hint strings.

before:
```
❯ grype db search --pkg curl --distro debian-11
[0000] ERROR unable to get affected packages for any: OS not present
❯ grype "pkg:deb/openssl@1.1.1" --distro debian-11
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
No vulnerabilities found
```

after:
```
❯ go run ./cmd/grype db search --pkg curl --distro debian-11
VULNERABILITY     PACKAGE  ECOSYSTEM  NAMESPACE                VERSION CONSTRAINT
CVE-2003-1605     curl     deb        debian:distro:debian:11  < 7.10.7-1
CVE-2005-0490     curl     deb        debian:distro:debian:11  < 7.13.0-2
CVE-2005-3185     curl     deb        debian:distro:debian:11  < 7.15.0-1
... snip
❯ go run ./cmd/grype "pkg:deb/openssl@1.1.1" --distro debian-11
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 2 critical, 13 high, 20 medium, 4 low, 1 negligible
NAME     INSTALLED  FIXED IN          TYPE  VULNERABILITY   SEVERITY    EPSS           RISK
openssl  1.1.1      1.1.1n-0+deb11u4  deb   CVE-2023-0286   High        88.8% (99th)   66.1
openssl  1.1.1      1.1.1n-0+deb11u5  deb   CVE-2023-2650   Medium      88.2% (99th)   50.7
... snip ...
```