### PR TITLE
feat: add Root.io unaffected vulnerability  filtering

### DIFF
--- a/grype/db/v6/vulnerability_provider.go
+++ b/grype/db/v6/vulnerability_provider.go
@@ -256,6 +256,66 @@ func (vp vulnerabilityProvider) FindVulnerabilities(criteria ...vulnerability.Cr
 	return out, nil
 }
 
+func (vp vulnerabilityProvider) FindUnaffectedPackages(p pkg.Package, criteria ...vulnerability.Criteria) ([]vulnerability.UnaffectedPackage, error) {
+	pkgSpec := &PackageSpecifier{
+		Name:      p.Name,
+		Ecosystem: string(p.Type),
+	}
+
+	var osSpecs []*OSSpecifier
+
+	for _, criterion := range criteria {
+		if osProvider, ok := criterion.(search.OSSpecifierProvider); ok {
+			name, major, minor, remaining := osProvider.GetOSSpecifier()
+			osSpec := &OSSpecifier{
+				Name:             name,
+				MajorVersion:     major,
+				MinorVersion:     minor,
+				RemainingVersion: remaining,
+			}
+			osSpecs = append(osSpecs, osSpec)
+		}
+	}
+
+	if len(osSpecs) == 0 {
+		return nil, nil
+	}
+
+	unaffectedHandles, err := vp.reader.GetUnaffectedPackages(pkgSpec, &GetPackageOptions{
+		OSs:         osSpecs,
+		PreloadBlob: true,
+	})
+	if err != nil {
+		if errors.Is(err, ErrOSNotPresent) {
+			log.WithFields("package", p.Name, "os", osSpecs).Trace("no unaffected package records found")
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var results []vulnerability.UnaffectedPackage
+	for _, handle := range unaffectedHandles {
+		if handle.BlobValue == nil {
+			continue
+		}
+
+		for _, cve := range handle.BlobValue.CVEs {
+			for _, rng := range handle.BlobValue.Ranges {
+				if rng.Version.Constraint != "" {
+					results = append(results, vulnerability.UnaffectedPackage{
+						CVE:        cve,
+						Package:    handle.Package.Name,
+						Constraint: rng.Version.Constraint,
+					})
+				}
+			}
+		}
+	}
+
+	log.WithFields("package", p.Name, "unaffected_count", len(results)).Trace("found unaffected package records")
+	return results, nil
+}
+
 // fetchAndProcessPackages fetches packages and returns vulnerabilities directly
 func (vp vulnerabilityProvider) fetchAndProcessPackages(query *searchQuery) ([]vulnerability.Vulnerability, error) {
 	// only fetch if we have package specifications or vulnerability specifications

--- a/grype/matcher/apk/matcher.go
+++ b/grype/matcher/apk/matcher.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/matcher/common"
 	"github.com/anchore/grype/grype/matcher/internal"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/search"
@@ -49,6 +50,9 @@ func (m *Matcher) Match(store vulnerability.Provider, p pkg.Package) ([]match.Ma
 		return nil, nil, err
 	}
 	matches = append(matches, indirectMatches...)
+
+	// Check if this is a Root.io package and filter unaffected vulnerabilities
+	matches = common.FilterRootIoUnaffectedMatches(store, p, matches)
 
 	// APK sources are also able to NAK vulnerabilities, so we want to return these as explicit ignores in order
 	// to allow rules later to use these to ignore "the same" vulnerability found in "the same" locations
@@ -269,3 +273,4 @@ func (m *Matcher) findNaksForPackage(provider vulnerability.Provider, p pkg.Pack
 
 	return ignores, nil
 }
+

--- a/grype/matcher/common/rootio.go
+++ b/grype/matcher/common/rootio.go
@@ -1,0 +1,67 @@
+package common
+
+import (
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/search"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/grype/internal/log"
+)
+
+func FilterRootIoUnaffectedMatches(store vulnerability.Provider, p pkg.Package, matches []match.Match) []match.Match {
+	if len(matches) == 0 || p.Distro == nil {
+		return matches
+	}
+
+	rootIOCriteria := search.RootIOCriteria{
+		DistroName:    p.Distro.Name(),
+		DistroVersion: p.Distro.VersionString(),
+	}
+
+	unaffectedPkgs, err := store.FindUnaffectedPackages(p, rootIOCriteria)
+	if err != nil {
+		log.WithFields("package", p.Name, "error", err).Debug("failed to query unaffected packages")
+		return matches
+	}
+
+	if len(unaffectedPkgs) == 0 {
+		return matches
+	}
+
+	unaffectedCVEs := make(map[string]vulnerability.UnaffectedPackage)
+	for _, up := range unaffectedPkgs {
+		unaffectedCVEs[up.CVE] = up
+	}
+
+	versionFormat := pkg.VersionFormat(p)
+
+	var filteredMatches []match.Match
+	for _, m := range matches {
+		up, isUnaffected := unaffectedCVEs[m.Vulnerability.ID]
+		if !isUnaffected {
+			filteredMatches = append(filteredMatches, m)
+			continue
+		}
+
+		matched, err := up.Matches(p.Version, versionFormat)
+		if err != nil {
+			log.WithFields("package", p.Name, "version", p.Version, "constraint", up.Constraint, "error", err).
+				Debug("failed to check unaffected constraint")
+			filteredMatches = append(filteredMatches, m)
+			continue
+		}
+
+		if matched {
+			log.WithFields("package", p.Name, "version", p.Version, "cve", m.Vulnerability.ID, "constraint", up.Constraint).
+				Debug("filtered Root.io unaffected vulnerability")
+		} else {
+			filteredMatches = append(filteredMatches, m)
+		}
+	}
+
+	return filteredMatches
+}
+
+func FilterRootIoUnaffectedMatchesForLanguage(store vulnerability.Provider, p pkg.Package, language string, matches []match.Match) []match.Match {
+	return FilterRootIoUnaffectedMatches(store, p, matches)
+}

--- a/grype/matcher/common/rootio_test.go
+++ b/grype/matcher/common/rootio_test.go
@@ -1,0 +1,337 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/grype/grype/distro"
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+func TestFilterRootIoUnaffectedMatches_NoMatches(t *testing.T) {
+	store := &mockStore{}
+	p := pkg.Package{
+		Name:    "test-package",
+		Version: "1.0.0.root.io.1",
+		Type:    syftPkg.ApkPkg,
+		Distro: &distro.Distro{
+			Type:    distro.Alpine,
+			Version: "3.17",
+		},
+	}
+
+	matches := []match.Match{}
+	result := FilterRootIoUnaffectedMatches(store, p, matches)
+	assert.Equal(t, matches, result)
+	assert.False(t, store.findUnaffectedCalled)
+}
+
+func TestFilterRootIoUnaffectedMatches_NoDistro(t *testing.T) {
+	store := &mockStore{}
+	p := pkg.Package{
+		Name:    "test-package",
+		Version: "1.0.0.root.io.1",
+		Type:    syftPkg.ApkPkg,
+		Distro:  nil,
+	}
+
+	matches := []match.Match{
+		{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{
+					ID: "CVE-2023-1234",
+				},
+			},
+		},
+	}
+
+	result := FilterRootIoUnaffectedMatches(store, p, matches)
+	assert.Equal(t, matches, result)
+	assert.False(t, store.findUnaffectedCalled)
+}
+
+func TestFilterRootIoUnaffectedMatches_NoUnaffectedInDB(t *testing.T) {
+	store := &mockStore{
+		unaffectedPackages: []vulnerability.UnaffectedPackage{},
+	}
+
+	p := pkg.Package{
+		Name:    "libssl3",
+		Version: "3.0.8-r4.root.io.1",
+		Type:    syftPkg.ApkPkg,
+	}
+	p.Distro = &distro.Distro{
+		Type:    distro.Alpine,
+		Version: "3.17",
+	}
+
+	matches := []match.Match{
+		{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{
+					ID: "CVE-2023-0464",
+				},
+			},
+		},
+		{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{
+					ID: "CVE-2023-0465",
+				},
+			},
+		},
+	}
+
+	result := FilterRootIoUnaffectedMatches(store, p, matches)
+	assert.Len(t, result, 2)
+	assert.True(t, store.findUnaffectedCalled)
+}
+
+func TestFilterRootIoUnaffectedMatches_FiltersCVEInDB(t *testing.T) {
+	store := &mockStore{
+		unaffectedPackages: []vulnerability.UnaffectedPackage{
+			{
+				CVE:        "CVE-2023-0464",
+				Package:    "libssl3",
+				Constraint: "version_contains .root.io",
+			},
+		},
+	}
+
+	p := pkg.Package{
+		Name:    "libssl3",
+		Version: "3.0.8-r4.root.io.1",
+		Type:    syftPkg.ApkPkg,
+	}
+	p.Distro = &distro.Distro{
+		Type:    distro.Alpine,
+		Version: "3.17",
+	}
+
+	matches := []match.Match{
+		{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{
+					ID: "CVE-2023-0464",
+				}, // Should be filtered
+			},
+		},
+		{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{
+					ID: "CVE-2023-0465",
+				}, // Should remain (not in unaffected list)
+			},
+		},
+	}
+
+	result := FilterRootIoUnaffectedMatches(store, p, matches)
+	require.Len(t, result, 1)
+	assert.Equal(t, "CVE-2023-0465", result[0].Vulnerability.ID)
+	assert.True(t, store.findUnaffectedCalled)
+}
+
+func TestFilterRootIoUnaffectedMatches_KeepsCVENotInDB(t *testing.T) {
+	store := &mockStore{
+		unaffectedPackages: []vulnerability.UnaffectedPackage{
+			{
+				CVE:        "CVE-2023-0464",
+				Package:    "libssl3",
+				Constraint: "version_contains .root.io",
+			},
+		},
+	}
+
+	p := pkg.Package{
+		Name:    "libssl3",
+		Version: "3.0.8-r4.root.io.1",
+		Type:    syftPkg.ApkPkg,
+	}
+	p.Distro = &distro.Distro{
+		Type:    distro.Alpine,
+		Version: "3.17",
+	}
+
+	matches := []match.Match{
+		{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{
+					ID: "CVE-2023-9999",
+				},
+			},
+		},
+	}
+
+	result := FilterRootIoUnaffectedMatches(store, p, matches)
+	require.Len(t, result, 1)
+	assert.Equal(t, "CVE-2023-9999", result[0].Vulnerability.ID)
+}
+
+func TestFilterRootIoUnaffectedMatches_KeepsCVEWhenVersionDoesntMatch(t *testing.T) {
+	store := &mockStore{
+		unaffectedPackages: []vulnerability.UnaffectedPackage{
+			{
+				CVE:        "CVE-2023-0464",
+				Package:    "libssl3",
+				Constraint: "version_contains .root.io",
+			},
+		},
+	}
+
+	p := pkg.Package{
+		Name:    "libssl3",
+		Version: "3.0.8-r4",
+		Type:    syftPkg.ApkPkg,
+	}
+	p.Distro = &distro.Distro{
+		Type:    distro.Alpine,
+		Version: "3.17",
+	}
+
+	matches := []match.Match{
+		{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{
+					ID: "CVE-2023-0464",
+				},
+			},
+		},
+	}
+
+	result := FilterRootIoUnaffectedMatches(store, p, matches)
+	require.Len(t, result, 1)
+	assert.Equal(t, "CVE-2023-0464", result[0].Vulnerability.ID)
+}
+
+func TestFilterRootIoUnaffectedMatches_MultipleCVEs(t *testing.T) {
+	store := &mockStore{
+		unaffectedPackages: []vulnerability.UnaffectedPackage{
+			{
+				CVE:        "CVE-2023-0464",
+				Package:    "libssl3",
+				Constraint: "version_contains .root.io",
+			},
+			{
+				CVE:        "CVE-2023-0465",
+				Package:    "libssl3",
+				Constraint: "version_contains .root.io",
+			},
+		},
+	}
+
+	p := pkg.Package{
+		Name:    "libssl3",
+		Version: "3.0.8-r4.root.io.1",
+		Type:    syftPkg.ApkPkg,
+	}
+	p.Distro = &distro.Distro{
+		Type:    distro.Alpine,
+		Version: "3.17",
+	}
+
+	matches := []match.Match{
+		{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{
+					ID: "CVE-2023-0464",
+				},
+			},
+		},
+		{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{
+					ID: "CVE-2023-0465",
+				},
+			},
+		},
+		{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{
+					ID: "CVE-2023-9999",
+				},
+			},
+		},
+	}
+
+	result := FilterRootIoUnaffectedMatches(store, p, matches)
+	require.Len(t, result, 1)
+	assert.Equal(t, "CVE-2023-9999", result[0].Vulnerability.ID)
+}
+
+func TestFilterRootIoUnaffectedMatchesForLanguage(t *testing.T) {
+	store := &mockStore{
+		unaffectedPackages: []vulnerability.UnaffectedPackage{
+			{
+				CVE:        "CVE-2023-1234",
+				Package:    "requests",
+				Constraint: "version_contains .root.io",
+			},
+		},
+	}
+
+	p := pkg.Package{
+		Name:    "requests",
+		Version: "2.28.0.root.io.1",
+		Type:    syftPkg.PythonPkg,
+	}
+	p.Distro = &distro.Distro{
+		Type:    distro.Debian,
+		Version: "11",
+	}
+
+	matches := []match.Match{
+		{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{
+					ID: "CVE-2023-1234",
+				},
+			},
+		},
+		{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{
+					ID: "CVE-2023-5678",
+				},
+			},
+		},
+	}
+
+	result := FilterRootIoUnaffectedMatchesForLanguage(store, p, "python", matches)
+	require.Len(t, result, 1)
+	assert.Equal(t, "CVE-2023-5678", result[0].Vulnerability.ID)
+}
+
+type mockStore struct {
+	unaffectedPackages   []vulnerability.UnaffectedPackage
+	findUnaffectedCalled bool
+	findUnaffectedError  error
+}
+
+func (m *mockStore) PackageSearchNames(_ pkg.Package) []string {
+	return nil
+}
+
+func (m *mockStore) FindVulnerabilities(criteria ...vulnerability.Criteria) ([]vulnerability.Vulnerability, error) {
+	return nil, nil
+}
+
+func (m *mockStore) FindUnaffectedPackages(_ pkg.Package, _ ...vulnerability.Criteria) ([]vulnerability.UnaffectedPackage, error) {
+	m.findUnaffectedCalled = true
+	if m.findUnaffectedError != nil {
+		return nil, m.findUnaffectedError
+	}
+	return m.unaffectedPackages, nil
+}
+
+func (m *mockStore) VulnerabilityMetadata(_ vulnerability.Reference) (*vulnerability.Metadata, error) {
+	return nil, nil
+}
+
+func (m *mockStore) Close() error {
+	return nil
+}

--- a/grype/matcher/dpkg/matcher.go
+++ b/grype/matcher/dpkg/matcher.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/matcher/common"
 	"github.com/anchore/grype/grype/matcher/internal"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
@@ -36,6 +37,9 @@ func (m *Matcher) Match(store vulnerability.Provider, p pkg.Package) ([]match.Ma
 	}
 	matches = append(matches, exactMatches...)
 
+	// Check if this is a Root.io package and filter unaffected vulnerabilities
+	matches = common.FilterRootIoUnaffectedMatches(store, p, matches)
+
 	return matches, nil, nil
 }
 
@@ -56,3 +60,4 @@ func (m *Matcher) matchUpstreamPackages(store vulnerability.Provider, p pkg.Pack
 
 	return matches, nil
 }
+

--- a/grype/matcher/python/matcher.go
+++ b/grype/matcher/python/matcher.go
@@ -2,6 +2,7 @@ package python
 
 import (
 	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/matcher/common"
 	"github.com/anchore/grype/grype/matcher/internal"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
@@ -31,5 +32,14 @@ func (m *Matcher) Type() match.MatcherType {
 }
 
 func (m *Matcher) Match(store vulnerability.Provider, p pkg.Package) ([]match.Match, []match.IgnoreFilter, error) {
-	return internal.MatchPackageByEcosystemAndCPEs(store, p, m.Type(), m.cfg.UseCPEs)
+	matches, ignores, err := internal.MatchPackageByEcosystemAndCPEs(store, p, m.Type(), m.cfg.UseCPEs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Check if this is a Root.io package and filter unaffected vulnerabilities
+	matches = common.FilterRootIoUnaffectedMatchesForLanguage(store, p, "python", matches)
+
+	return matches, ignores, nil
 }
+

--- a/grype/search/rootio_criteria.go
+++ b/grype/search/rootio_criteria.go
@@ -1,0 +1,31 @@
+package search
+
+import (
+	"strings"
+
+	"github.com/anchore/grype/grype/vulnerability"
+)
+
+type RootIOCriteria struct {
+	DistroName    string
+	DistroVersion string
+}
+
+func (r RootIOCriteria) MatchesVulnerability(_ vulnerability.Vulnerability) (bool, string, error) {
+	return true, "", nil
+}
+
+func (r RootIOCriteria) GetOSSpecifier() (name, major, minor, remaining string) {
+	parts := strings.Split(r.DistroVersion, ".")
+	name = "rootio-" + r.DistroName
+	if len(parts) > 0 {
+		major = parts[0]
+	}
+	if len(parts) > 1 {
+		minor = parts[1]
+	}
+	if len(parts) > 2 {
+		remaining = strings.Join(parts[2:], ".")
+	}
+	return
+}

--- a/grype/search/unaffected_criteria.go
+++ b/grype/search/unaffected_criteria.go
@@ -1,0 +1,8 @@
+package search
+
+import "github.com/anchore/grype/grype/vulnerability"
+
+type OSSpecifierProvider interface {
+	vulnerability.Criteria
+	GetOSSpecifier() (name, major, minor, remaining string)
+}

--- a/grype/vulnerability/mock/vulnerability_provider.go
+++ b/grype/vulnerability/mock/vulnerability_provider.go
@@ -72,6 +72,10 @@ func (s *mockProvider) FindVulnerabilities(criteria ...vulnerability.Criteria) (
 	})
 }
 
+func (s *mockProvider) FindUnaffectedPackages(_ grypePkg.Package, _ ...vulnerability.Criteria) ([]vulnerability.UnaffectedPackage, error) {
+	return nil, nil
+}
+
 func filterE[T any](out []T, keep func(v T) (bool, error)) ([]T, error) {
 	for i := 0; i < len(out); i++ {
 		ok, err := keep(out[i])

--- a/grype/vulnerability/provider.go
+++ b/grype/vulnerability/provider.go
@@ -25,8 +25,8 @@ type MetadataProvider interface {
 // Provider is the common interface for vulnerability sources to provide searching and metadata, such as a database
 type Provider interface {
 	PackageSearchNames(grypePkg.Package) []string
-	// FindVulnerabilities returns vulnerabilities matching all the provided criteria
 	FindVulnerabilities(criteria ...Criteria) ([]Vulnerability, error)
+	FindUnaffectedPackages(pkg grypePkg.Package, criteria ...Criteria) ([]UnaffectedPackage, error)
 
 	MetadataProvider
 

--- a/grype/vulnerability/unaffected_package.go
+++ b/grype/vulnerability/unaffected_package.go
@@ -1,0 +1,54 @@
+package vulnerability
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/anchore/grype/grype/version"
+)
+
+var (
+	// Alpine Root.io version pattern: -rXX007X (e.g., -r00071, -r10074)
+	alpineRootIOPattern = regexp.MustCompile(`-r\d{2}07\d+`)
+)
+
+type UnaffectedPackage struct {
+	CVE        string
+	Package    string
+	Constraint string
+}
+
+func (u UnaffectedPackage) Matches(pkgVersion string, format version.Format) (bool, error) {
+	if strings.HasPrefix(u.Constraint, "version_contains ") {
+		substring := strings.TrimPrefix(u.Constraint, "version_contains ")
+
+		// Check for the substring (e.g., ".root.io")
+		if strings.Contains(pkgVersion, substring) {
+			return true, nil
+		}
+
+		// For Alpine packages, also check for -rXX007X pattern
+		// This handles cases where Root.io uses the Alpine-specific pattern
+		if substring == ".root.io" && format == version.ApkFormat {
+			if alpineRootIOPattern.MatchString(pkgVersion) {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	}
+
+	constraint, err := version.GetConstraint(u.Constraint, format)
+	if err != nil {
+		return false, err
+	}
+
+	v := version.NewVersion(pkgVersion, format)
+
+	satisfied, err := constraint.Satisfied(v)
+	if err != nil {
+		return false, err
+	}
+
+	return satisfied, nil
+}

--- a/grype/vulnerability/unaffected_package_test.go
+++ b/grype/vulnerability/unaffected_package_test.go
@@ -1,0 +1,192 @@
+package vulnerability
+
+import (
+	"testing"
+
+	"github.com/anchore/grype/grype/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnaffectedPackage_Matches_VersionContains(t *testing.T) {
+	tests := []struct {
+		name           string
+		constraint     string
+		packageVersion string
+		versionFormat  version.Format
+		expectedMatch  bool
+		expectError    bool
+	}{
+		{
+			name:           "Debian with .root.io suffix - matches",
+			constraint:     "version_contains .root.io",
+			packageVersion: "1.5.2-6+deb12u1.root.io.4",
+			versionFormat:  version.DebFormat,
+			expectedMatch:  true,
+		},
+		{
+			name:           "Ubuntu with .root.io suffix - matches",
+			constraint:     "version_contains .root.io",
+			packageVersion: "2.3.4-1ubuntu1.root.io.2",
+			versionFormat:  version.DebFormat,
+			expectedMatch:  true,
+		},
+		{
+			name:           "Alpine with .root.io suffix - matches",
+			constraint:     "version_contains .root.io",
+			packageVersion: "3.0.8-r3.root.io.1",
+			versionFormat:  version.ApkFormat,
+			expectedMatch:  true,
+		},
+		{
+			name:           "Alpine with -rXX007X pattern - matches",
+			constraint:     "version_contains .root.io",
+			packageVersion: "3.0.8-r00071",
+			versionFormat:  version.ApkFormat,
+			expectedMatch:  true,
+		},
+		{
+			name:           "Alpine with -r10074 pattern - matches",
+			constraint:     "version_contains .root.io",
+			packageVersion: "1.6.17-r10074",
+			versionFormat:  version.ApkFormat,
+			expectedMatch:  true,
+		},
+		{
+			name:           "Alpine with -r20075 pattern - matches",
+			constraint:     "version_contains .root.io",
+			packageVersion: "2.1.0-r20075",
+			versionFormat:  version.ApkFormat,
+			expectedMatch:  true,
+		},
+		{
+			name:           "Alpine regular version - does not match",
+			constraint:     "version_contains .root.io",
+			packageVersion: "3.0.8-r3",
+			versionFormat:  version.ApkFormat,
+			expectedMatch:  false,
+		},
+		{
+			name:           "Alpine with -r3 (no 007) - does not match",
+			constraint:     "version_contains .root.io",
+			packageVersion: "3.0.8-r3",
+			versionFormat:  version.ApkFormat,
+			expectedMatch:  false,
+		},
+		{
+			name:           "Alpine with -r1234 (no 007) - does not match",
+			constraint:     "version_contains .root.io",
+			packageVersion: "3.0.8-r1234",
+			versionFormat:  version.ApkFormat,
+			expectedMatch:  false,
+		},
+		{
+			name:           "Debian regular version - does not match",
+			constraint:     "version_contains .root.io",
+			packageVersion: "1.5.2-6+deb12u1",
+			versionFormat:  version.DebFormat,
+			expectedMatch:  false,
+		},
+		{
+			name:           "Alpine pattern only applies to APK format",
+			constraint:     "version_contains .root.io",
+			packageVersion: "1.0.0-r00071",
+			versionFormat:  version.DebFormat,
+			expectedMatch:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			up := UnaffectedPackage{
+				CVE:        "CVE-2024-1234",
+				Package:    "test-package",
+				Constraint: tt.constraint,
+			}
+
+			matched, err := up.Matches(tt.packageVersion, tt.versionFormat)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedMatch, matched,
+					"Expected match=%v for version %s with constraint %s",
+					tt.expectedMatch, tt.packageVersion, tt.constraint)
+			}
+		})
+	}
+}
+
+func TestUnaffectedPackage_Matches_VersionConstraint(t *testing.T) {
+	tests := []struct {
+		name           string
+		constraint     string
+		packageVersion string
+		versionFormat  version.Format
+		expectedMatch  bool
+	}{
+		{
+			name:           "Greater than or equal - matches",
+			constraint:     ">= 3.0.8-r4",
+			packageVersion: "3.0.9-r1",
+			versionFormat:  version.ApkFormat,
+			expectedMatch:  true,
+		},
+		{
+			name:           "Greater than or equal - equal matches",
+			constraint:     ">= 3.0.8-r4",
+			packageVersion: "3.0.8-r4",
+			versionFormat:  version.ApkFormat,
+			expectedMatch:  true,
+		},
+		{
+			name:           "Greater than or equal - less than does not match",
+			constraint:     ">= 3.0.8-r4",
+			packageVersion: "3.0.8-r3",
+			versionFormat:  version.ApkFormat,
+			expectedMatch:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			up := UnaffectedPackage{
+				CVE:        "CVE-2024-1234",
+				Package:    "test-package",
+				Constraint: tt.constraint,
+			}
+
+			matched, err := up.Matches(tt.packageVersion, tt.versionFormat)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedMatch, matched)
+		})
+	}
+}
+
+func TestAlpineRootIOPattern(t *testing.T) {
+	tests := []struct {
+		version      string
+		shouldMatch  bool
+		description  string
+	}{
+		{"3.0.8-r00071", true, "Basic -r00071 pattern"},
+		{"1.6.17-r10074", true, "Pattern with higher first digit"},
+		{"2.1.0-r20075", true, "Pattern with 2 as first digit"},
+		{"3.0.8-r99079", true, "Pattern with 99 prefix"},
+		{"3.0.8-r3", false, "Regular release number"},
+		{"3.0.8-r1234", false, "No 007 in pattern"},
+		{"3.0.8-r007", false, "Too short"},
+		{"3.0.8-r0071", false, "Only 4 digits total (needs 5+)"},
+		{"3.0.8-r0007", false, "007 at wrong position"},
+		{"3.0.8-r12345", false, "No 007 anywhere"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			matched := alpineRootIOPattern.MatchString(tt.version)
+			assert.Equal(t, tt.shouldMatch, matched,
+				"Version %s should match=%v: %s", tt.version, tt.shouldMatch, tt.description)
+		})
+	}
+}


### PR DESCRIPTION
  - Add common helper functions to identify Root.io patched packages
  - Implement filtering logic to remove false positives for .root.io versions
  - Integrate filtering into APK, DPKG, and Python matchers
  - Add comprehensive unit tests for filtering logic

  Packages with .root.io in their version string are patched by Root.io
  and should not report vulnerabilities marked as ROOTIO_UNAFFECTED.

  Signed-off-by: Chai Tadmor <chai.tadmor@root.io>