### PR TITLE
Keep nested loggers labeled

### DIFF
--- a/cmd/grype/cli/cli.go
+++ b/cmd/grype/cli/cli.go
@@ -71,8 +71,8 @@ func SetupConfig(id clio.Identification) *clio.SetupConfig {
 				redact.Set(state.RedactStore)
 
 				log.Set(state.Logger)
-				syft.SetLogger(state.Logger)
-				stereoscope.SetLogger(state.Logger)
+				syft.SetLogger(state.Logger.Nested("from", "syft"))
+				stereoscope.SetLogger(state.Logger.Nested("from", "stereoscope"))
 
 				return nil
 			},


### PR DESCRIPTION
This adds a simple `lib=name` label onto log entries that come from syft and stereoscope, just like what we do with syft.