### PR TITLE
docs: Add multiple outputs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,12 @@ You can also find the template for the default "table" output format in the same
 
 Grype also includes a vast array of utility templating functions from [sprig](http://masterminds.github.io/sprig/) apart from the default golang [text/template](https://pkg.go.dev/text/template#hdr-Functions) to allow users to customize the output from Grype.
 
+### Multiple Outputs
+Grype can also output *multiple* files in differing formats by appending `=<file>` to the option. For example, to output Grype JSON, Table, and templated HTML Report:
+```
+grype image -o json=grype.json -o table=grype.table -o template=grype.html -t ./templates/html.tmpl
+```
+
 ### Gating on severity of vulnerabilities
 
 You can have Grype exit with an error if any vulnerabilities are reported at or above the specified severity level. This comes in handy when using Grype within a script or CI pipeline. To do this, use the `--fail-on <severity>` CLI flag.


### PR DESCRIPTION
Add documentation for multiple outputs functionality to match syft.

I had to google and find the Issue documenting this feature's existence in Grype. Issue #648 was closed as complete in July 2023.
https://github.com/anchore/grype/issues/648

Documentation was added using the Syft Wiki as a reference point:
https://github.com/anchore/syft/wiki/multiple-outputs