### PR TITLE
fix: unaffected package ignore rules

### DIFF
--- a/grype/vulnerability_matcher.go
+++ b/grype/vulnerability_matcher.go
@@ -302,16 +302,24 @@ func (m *VulnerabilityMatcher) normalizeByCVE(match match.Match) match.Match {
 	return match
 }
 
-// ignoreRulesByLocation implements match.IgnoreFilter to filter each matching
+// ignoreRulesByIndex implements match.IgnoreFilter to filter each matching
 // package that overlaps by location and have the same vulnerability ID (CVE)
-type ignoreRulesByLocation struct {
-	remainingFilters      []match.IgnoreFilter
-	locationToIgnoreRules map[string][]match.IgnoreRule
+type ignoreRulesByIndex struct {
+	remainingFilters       []match.IgnoreFilter
+	locationIgnoreRules    map[string][]match.IgnoreRule
+	packageNameIgnoreRules map[string][]match.IgnoreRule
 }
 
-func (i ignoreRulesByLocation) IgnoreMatch(m match.Match) []match.IgnoreRule {
+func (i ignoreRulesByIndex) IgnoreMatch(m match.Match) []match.IgnoreRule {
+	if nameRules := i.packageNameIgnoreRules[m.Package.Name]; nameRules != nil {
+		for _, rule := range nameRules {
+			if matched := rule.IgnoreMatch(m); matched != nil {
+				return matched
+			}
+		}
+	}
 	for _, l := range m.Package.Locations.ToSlice() {
-		for _, rule := range i.locationToIgnoreRules[l.RealPath] {
+		for _, rule := range i.locationIgnoreRules[l.RealPath] {
 			if matched := rule.IgnoreMatch(m); matched != nil {
 				return matched
 			}
@@ -328,14 +336,23 @@ func (i ignoreRulesByLocation) IgnoreMatch(m match.Match) []match.IgnoreRule {
 // ignoredMatchFilter creates an ignore filter based on location-based IgnoredMatches to filter out "the same"
 // vulnerabilities reported by other matchers based on overlapping file locations
 func ignoredMatchFilter(ignores []match.IgnoreFilter) match.IgnoreFilter {
-	out := ignoreRulesByLocation{locationToIgnoreRules: map[string][]match.IgnoreRule{}}
+	out := ignoreRulesByIndex{
+		locationIgnoreRules:    map[string][]match.IgnoreRule{},
+		packageNameIgnoreRules: map[string][]match.IgnoreRule{},
+	}
 	// the returned slice of remaining rules are not location-based rules
 	out.remainingFilters = slices.DeleteFunc(ignores, func(ignore match.IgnoreFilter) bool {
-		rule, ok := ignore.(match.IgnoreRule)
-		if ok && rule.Package.Location != "" && !strings.ContainsRune(rule.Package.Location, '*') {
-			// this rule is handled with location lookups, remove it from the remaining filter list
-			out.locationToIgnoreRules[rule.Package.Location] = append(out.locationToIgnoreRules[rule.Package.Location], rule)
-			return true
+		if rule, ok := ignore.(match.IgnoreRule); ok {
+			// return true to remove rules handled with index lookups from the remaining filter list
+			if rule.Package.Location != "" && !strings.ContainsRune(rule.Package.Location, '*') {
+				out.locationIgnoreRules[rule.Package.Location] = append(out.locationIgnoreRules[rule.Package.Location], rule)
+				return true
+			}
+			if rule.Package.Name != "" {
+				// this rule is handled with location lookups, remove it from the remaining filter list
+				out.packageNameIgnoreRules[rule.Package.Name] = append(out.packageNameIgnoreRules[rule.Package.Name], rule)
+				return true
+			}
 		}
 		return false
 	})

--- a/grype/vulnerability_matcher_test.go
+++ b/grype/vulnerability_matcher_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/anchore/grype/grype/grypeerr"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/matcher"
-	"github.com/anchore/grype/grype/matcher/apk"
 	matcherMock "github.com/anchore/grype/grype/matcher/mock"
 	"github.com/anchore/grype/grype/matcher/ruby"
 	"github.com/anchore/grype/grype/pkg"
@@ -1062,292 +1061,233 @@ func Test_fatalErrors(t *testing.T) {
 	}
 }
 
-func Test_indexFalsePositivesByLocation(t *testing.T) {
-	cases := []struct {
-		name           string
-		pkgs           []pkg.Package
-		vulns          []vulnerability.Vulnerability
-		expectedResult map[string][]string
-		errAssertion   assert.ErrorAssertionFunc
-	}{
-		{
-			name: "false positive in wolfi package adds index entry",
-			pkgs: []pkg.Package{
-				{
-					Name:   "foo",
-					Distro: &distro.Distro{Type: distro.Wolfi},
-					Metadata: pkg.ApkMetadata{Files: []pkg.ApkFileRecord{
-						{
-							Path: "/bin/foo-binary",
-						},
-					}},
-				},
-			},
-			vulns: []vulnerability.Vulnerability{
-				{
-					Reference: vulnerability.Reference{
-						ID:        "GHSA-2014-fake-3",
-						Namespace: "wolfi:distro:wolfi:rolling",
+func Test_matchIgnoreFiltering(t *testing.T) {
+	// one commonly used filter uses APK NAK data to exclude false positives on language packages at the same locations
+	// based on packages in the APK DB. for example:
+	//   APK package pkg1 is not vulnerable, but another python package is found with a slightly different name
+	//   by the python cataloger when it scans the same files at the same locations that were associated with
+	//   the APK package. the python package is checked by a separate matcher, so we surface ignore rules
+	//   based on location and vuln id to exclude these false positives
+	ignoreByLocationAndVuln := func(locationToVulnIDs map[string][]string) []match.IgnoreFilter {
+		var out []match.IgnoreFilter
+		for path, vulnIDs := range locationToVulnIDs {
+			for _, vulnID := range vulnIDs {
+				out = append(out, match.IgnoreRule{
+					Vulnerability:  vulnID,
+					IncludeAliases: true,
+					Package: match.IgnoreRulePackage{
+						Location: path,
 					},
-					PackageName: "foo",
-					Constraint:  version.MustGetConstraint("< 0", version.ApkFormat),
-				},
-			},
-			expectedResult: map[string][]string{
-				"/bin/foo-binary": {"GHSA-2014-fake-3"},
-			},
-			errAssertion: assert.NoError,
-		},
-		{
-			name: "false positive in wolfi subpackage adds index entry",
-			pkgs: []pkg.Package{
-				{
-					Name:   "subpackage-foo",
-					Distro: &distro.Distro{Type: distro.Wolfi},
-					Metadata: pkg.ApkMetadata{Files: []pkg.ApkFileRecord{
-						{
-							Path: "/bin/foo-subpackage-binary",
-						},
-					}},
-					Upstreams: []pkg.UpstreamPackage{
-						{
-							Name: "origin-foo",
-						},
-					},
-				},
-			},
-			vulns: []vulnerability.Vulnerability{
-				{
-					Reference: vulnerability.Reference{
-						ID:        "GHSA-2014-fake-3",
-						Namespace: "wolfi:distro:wolfi:rolling",
-					},
-					PackageName: "origin-foo",
-					Constraint:  version.MustGetConstraint("< 0", version.ApkFormat),
-				},
-			},
-			expectedResult: map[string][]string{
-				"/bin/foo-subpackage-binary": {"GHSA-2014-fake-3"},
-			},
-			errAssertion: assert.NoError,
-		},
-		{
-			name: "fixed vuln (not a false positive) in wolfi package",
-			pkgs: []pkg.Package{
-				{
-					Name:   "foo",
-					Distro: &distro.Distro{Type: distro.Wolfi},
-					Metadata: pkg.ApkMetadata{Files: []pkg.ApkFileRecord{
-						{
-							Path: "/bin/foo-binary",
-						},
-					}},
-				},
-			},
-			vulns: []vulnerability.Vulnerability{
-				{
-					Reference: vulnerability.Reference{
-						ID:        "GHSA-2014-fake-3",
-						Namespace: "wolfi:distro:wolfi:rolling",
-					},
-					PackageName: "foo",
-					Constraint:  version.MustGetConstraint("< 1.2.3-r4", version.ApkFormat),
-				},
-			},
-			expectedResult: map[string][]string{},
-			errAssertion:   assert.NoError,
-		},
-		{
-			name: "no vuln data for wolfi package",
-			pkgs: []pkg.Package{
-				{
-					Name:   "foo",
-					Distro: &distro.Distro{Type: distro.Wolfi},
-					Metadata: pkg.ApkMetadata{Files: []pkg.ApkFileRecord{
-						{
-							Path: "/bin/foo-binary",
-						},
-					}},
-				},
-			},
-			vulns:          []vulnerability.Vulnerability{},
-			expectedResult: map[string][]string{},
-			errAssertion:   assert.NoError,
-		},
-		{
-			name: "no files listed for a wolfi package",
-			pkgs: []pkg.Package{
-				{
-					Name:     "foo",
-					Distro:   &distro.Distro{Type: distro.Wolfi},
-					Metadata: pkg.ApkMetadata{Files: nil},
-				},
-			},
-			vulns: []vulnerability.Vulnerability{
-				{
-					Reference: vulnerability.Reference{
-						ID:        "GHSA-2014-fake-3",
-						Namespace: "wolfi:distro:wolfi:rolling",
-					},
-					PackageName: "foo",
-					Constraint:  version.MustGetConstraint("< 0", version.ApkFormat),
-				},
-			},
-			expectedResult: map[string][]string{},
-			errAssertion:   assert.NoError,
-		},
+				})
+			}
+		}
+		return out
 	}
 
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			// create mock vulnerability provider
-			vp := mock.VulnerabilityProvider(tt.vulns...)
-			apkMatcher := &apk.Matcher{}
-
-			var allMatches []match.Match
-			var allIgnores []match.IgnoreFilter
-			for _, p := range tt.pkgs {
-				matches, ignores, err := apkMatcher.Match(vp, p)
-				require.NoError(t, err)
-				allMatches = append(allMatches, matches...)
-				allIgnores = append(allIgnores, ignores...)
+	// with the addition of unaffected packages, ignore rules are returned by package language searches to account for
+	// searches for subsequent CPE searches based on the specific package
+	ignoreByPackageNameAndVuln := func(pkgNameToVulnIDs map[string][]string) []match.IgnoreFilter {
+		var out []match.IgnoreFilter
+		for packageName, vulnIDs := range pkgNameToVulnIDs {
+			for _, vulnID := range vulnIDs {
+				out = append(out, match.IgnoreRule{
+					Vulnerability:  vulnID,
+					IncludeAliases: true,
+					Package: match.IgnoreRulePackage{
+						Name: packageName,
+					},
+				})
 			}
-
-			actualResult := map[string][]string{}
-			for _, ignore := range allIgnores {
-				rule, ok := ignore.(match.IgnoreRule)
-				if !ok {
-					continue
-				}
-				if rule.Package.Location == "" {
-					continue
-				}
-				actualResult[rule.Package.Location] = append(actualResult[rule.Package.Location], rule.Vulnerability)
-			}
-			assert.Equal(t, tt.expectedResult, actualResult)
-		})
+		}
+		return out
 	}
-}
 
-func Test_filterMatchesUsingDistroFalsePositives(t *testing.T) {
+	// construct matches here so we can make test cases more readable
+
+	loc1 := "/usr/bin/pkg1"
+	loc2 := "/other/pkg1"
+
+	vuln1 := "vuln1"
+	vuln2 := "vuln2"
+
+	pkg1_vuln1_loc1 := match.Match{
+		Package: pkg.Package{
+			Type:      syftPkg.PythonPkg,
+			Name:      "pkg1",
+			Locations: file.NewLocationSet(file.NewLocation(loc1)),
+		},
+		Vulnerability: vulnerability.Vulnerability{Reference: vulnerability.Reference{ID: vuln1}},
+	}
+	pkg1_vuln2_loc1 := match.Match{
+		Package: pkg.Package{
+			Name:      "pkg1",
+			Locations: file.NewLocationSet(file.NewLocation(loc1)),
+		},
+		Vulnerability: vulnerability.Vulnerability{Reference: vulnerability.Reference{ID: vuln2}},
+	}
+	pkg1_vuln1_loc2 := match.Match{
+		Package: pkg.Package{
+			Name:      "pkg1",
+			Locations: file.NewLocationSet(file.NewLocation(loc2)),
+		},
+		Vulnerability: vulnerability.Vulnerability{Reference: vulnerability.Reference{ID: vuln1}},
+	}
+	pkg2_vuln1_loc1 := match.Match{
+		Package: pkg.Package{
+			Type:      syftPkg.PythonPkg,
+			Name:      "pkg2",
+			Locations: file.NewLocationSet(file.NewLocation(loc1)),
+		},
+		Vulnerability: vulnerability.Vulnerability{Reference: vulnerability.Reference{ID: vuln1}},
+	}
+	pkg2_vuln2_loc1 := match.Match{
+		Package: pkg.Package{
+			Name:      "pkg2",
+			Locations: file.NewLocationSet(file.NewLocation(loc1)),
+		},
+		Vulnerability: vulnerability.Vulnerability{Reference: vulnerability.Reference{ID: vuln2}},
+	}
+
 	cases := []struct {
-		name         string
-		inputMatches []match.Match
-		fpIndex      map[string][]string
-		expected     []match.Match
+		name          string
+		inputMatches  []match.Match
+		ignoreFilters []match.IgnoreFilter
+		expected      []match.Match
 	}{
 		{
 			name:         "no input matches",
 			inputMatches: nil,
-			fpIndex: map[string][]string{
-				"/usr/bin/crane": {"CVE-2014-fake-3"},
-			},
+			ignoreFilters: ignoreByLocationAndVuln(map[string][]string{
+				loc1: {vuln1},
+			}),
 			expected: nil,
+		},
+		{
+			name: "no ignore rules",
+			inputMatches: []match.Match{
+				pkg1_vuln1_loc1,
+				pkg1_vuln1_loc2,
+			},
+			ignoreFilters: nil,
+			expected: []match.Match{
+				pkg1_vuln1_loc1,
+				pkg1_vuln1_loc2,
+			},
 		},
 		{
 			name: "happy path filtering",
 			inputMatches: []match.Match{
-				{
-					Package: pkg.Package{
-						Name:      "crane",
-						Locations: file.NewLocationSet(file.NewLocation("/usr/bin/crane")),
-					},
-					Vulnerability: vulnerability.Vulnerability{Reference: vulnerability.Reference{ID: "CVE-2014-fake-3"}},
-				},
+				pkg1_vuln1_loc1,
 			},
-			fpIndex: map[string][]string{
-				"/usr/bin/crane": {"CVE-2014-fake-3"},
-			},
+			ignoreFilters: ignoreByLocationAndVuln(map[string][]string{
+				loc1: {vuln1},
+			}),
 			expected: nil,
 		},
 		{
-			name: "location match but no vulns in FP index",
+			name: "location match different vuln",
 			inputMatches: []match.Match{
-				{
-					Package: pkg.Package{
-						Name:      "crane",
-						Locations: file.NewLocationSet(file.NewLocation("/usr/bin/crane")),
-					},
-					Vulnerability: vulnerability.Vulnerability{Reference: vulnerability.Reference{ID: "CVE-2014-fake-3"}},
-				},
+				pkg1_vuln1_loc1,
 			},
-			fpIndex: map[string][]string{
-				"/usr/bin/crane": {},
-			},
+			ignoreFilters: ignoreByLocationAndVuln(map[string][]string{
+				loc1: {vuln2},
+			}),
 			expected: []match.Match{
-				{
-					Package: pkg.Package{
-						Name:      "crane",
-						Locations: file.NewLocationSet(file.NewLocation("/usr/bin/crane")),
-					},
-					Vulnerability: vulnerability.Vulnerability{Reference: vulnerability.Reference{ID: "CVE-2014-fake-3"}},
-				},
+				pkg1_vuln1_loc1,
 			},
 		},
 		{
-			name: "location match but matched vuln not in FP index",
+			name: "location across packages",
 			inputMatches: []match.Match{
-				{
-					Package: pkg.Package{
-						Name:      "crane",
-						Locations: file.NewLocationSet(file.NewLocation("/usr/bin/crane")),
-					},
-					Vulnerability: vulnerability.Vulnerability{Reference: vulnerability.Reference{ID: "CVE-2014-fake-3"}},
-				},
+				pkg1_vuln1_loc1,
+				pkg1_vuln2_loc1,
+				pkg2_vuln1_loc1,
+				pkg2_vuln2_loc1,
 			},
-			fpIndex: map[string][]string{
-				"/usr/bin/crane": {"CVE-2016-fake-3"},
-			},
+			ignoreFilters: ignoreByLocationAndVuln(map[string][]string{
+				loc1: {vuln1},
+			}),
 			expected: []match.Match{
-				{
-					Package: pkg.Package{
-						Name:      "crane",
-						Locations: file.NewLocationSet(file.NewLocation("/usr/bin/crane")),
-					},
-					Vulnerability: vulnerability.Vulnerability{Reference: vulnerability.Reference{ID: "CVE-2014-fake-3"}},
-				},
+				pkg1_vuln2_loc1,
+				pkg2_vuln2_loc1,
 			},
 		},
 		{
-			name: "empty FP index",
+			name: "package name",
 			inputMatches: []match.Match{
-				{
-					Package: pkg.Package{
-						Name:      "crane",
-						Locations: file.NewLocationSet(file.NewLocation("/usr/bin/crane")),
+				pkg1_vuln1_loc1,
+				pkg1_vuln2_loc1,
+				pkg2_vuln1_loc1,
+			},
+			ignoreFilters: ignoreByPackageNameAndVuln(map[string][]string{
+				pkg1_vuln1_loc1.Package.Name: {vuln1},
+			}),
+			expected: []match.Match{
+				pkg1_vuln2_loc1,
+				pkg2_vuln1_loc1,
+			},
+		},
+		{
+			name: "not indexed rule",
+			inputMatches: []match.Match{
+				pkg1_vuln1_loc1,
+				pkg1_vuln2_loc1, // not python package
+				pkg2_vuln1_loc1,
+			},
+			ignoreFilters: []match.IgnoreFilter{
+				match.IgnoreRule{
+					Package: match.IgnoreRulePackage{
+						Type: string(syftPkg.PythonPkg), // no indexed properties
 					},
-					Vulnerability: vulnerability.Vulnerability{Reference: vulnerability.Reference{ID: "CVE-2014-fake-3"}},
 				},
 			},
-			fpIndex: map[string][]string{},
 			expected: []match.Match{
-				{
-					Package: pkg.Package{
-						Name:      "crane",
-						Locations: file.NewLocationSet(file.NewLocation("/usr/bin/crane")),
-					},
-					Vulnerability: vulnerability.Vulnerability{Reference: vulnerability.Reference{ID: "CVE-2014-fake-3"}},
-				},
+				pkg1_vuln2_loc1,
+			},
+		},
+		{
+			name: "not indexed filter",
+			inputMatches: []match.Match{
+				pkg1_vuln1_loc1,
+				pkg1_vuln1_loc2,
+				pkg2_vuln1_loc1,
+				pkg1_vuln2_loc1,
+			},
+			ignoreFilters: []match.IgnoreFilter{
+				testIgnoreFilter{func(m match.Match) bool {
+					return m.Vulnerability.ID == vuln1
+				}},
+			},
+			expected: []match.Match{
+				pkg1_vuln2_loc1,
+			},
+		},
+		{
+			name: "multiple rules mixed",
+			inputMatches: []match.Match{
+				pkg1_vuln1_loc1, // removed by custom filter
+				pkg1_vuln1_loc2,
+				pkg2_vuln1_loc1, // removed by name + vuln
+				pkg1_vuln2_loc1, // removed by location + vuln
+			},
+			ignoreFilters: append(append([]match.IgnoreFilter{
+				testIgnoreFilter{func(m match.Match) bool {
+					return m.Vulnerability.ID == vuln1
+				}},
+			}, ignoreByLocationAndVuln(map[string][]string{
+				loc2: {vuln2},
+			})...), ignoreByPackageNameAndVuln(map[string][]string{
+				pkg2_vuln1_loc1.Package.Name: {vuln1},
+			})...),
+			expected: []match.Match{
+				pkg1_vuln2_loc1,
 			},
 		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			var allIgnores []match.IgnoreFilter
-			for path, cves := range tt.fpIndex {
-				for _, cve := range cves {
-					allIgnores = append(allIgnores, match.IgnoreRule{
-						Vulnerability:  cve,
-						IncludeAliases: true,
-						Package: match.IgnoreRulePackage{
-							Location: path,
-						},
-					})
-				}
-			}
-
-			filter := ignoredMatchFilter(allIgnores)
+			filter := ignoredMatchFilter(tt.ignoreFilters)
 
 			actual, _ := match.ApplyIgnoreFilters(tt.inputMatches, filter)
 
@@ -1356,7 +1296,7 @@ func Test_filterMatchesUsingDistroFalsePositives(t *testing.T) {
 	}
 }
 
-func Test_ignoredMatchFilter(t *testing.T) {
+func Test_ignoredMatchFilterReasons(t *testing.T) {
 	matches := []match.Match{
 		{
 			Vulnerability: vulnerability.Vulnerability{


### PR DESCRIPTION
This PR fixes an issue where _unaffected_ records for vulnerabilities found for language matches did not apply to the same package when an identical CPE match was also found.

Fixes #3056