### PR TITLE
chore: replace os.Chdir with t.Chdir in test code

### DIFF
--- a/test/cli/config_test.go
+++ b/test/cli/config_test.go
@@ -13,7 +13,6 @@ import (
 func Test_configLoading(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
-	defer func() { require.NoError(t, os.Chdir(cwd)) }()
 
 	configsDir := filepath.Join(cwd, "test-fixtures", "configs")
 	path := func(path string) string {
@@ -149,8 +148,7 @@ func Test_configLoading(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			require.NoError(t, os.Chdir(test.cwd))
-			defer func() { require.NoError(t, os.Chdir(cwd)) }()
+			t.Chdir(test.cwd)
 			env := map[string]string{
 				"HOME":            test.home,
 				"XDG_CONFIG_HOME": test.home,

--- a/test/cli/utils_test.go
+++ b/test/cli/utils_test.go
@@ -83,12 +83,7 @@ func getGrypeBinaryLocationByOS(t testing.TB, goOS string) string {
 }
 
 func buildBinary(t testing.TB, loc string) {
-	wd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(repoRoot(t)))
-	defer func() {
-		require.NoError(t, os.Chdir(wd))
-	}()
+	t.Chdir(repoRoot(t))
 	t.Log("Building grype...")
 	c := exec.Command("go", "build", "-o", loc, "./cmd/grype")
 	c.Stdout = os.Stdout


### PR DESCRIPTION
Go 1.24 added [`t.Chdir`](https://pkg.go.dev/testing#T.Chdir) to simplify things, so this change moves the test code over to using it.