### PR TITLE
fix: redact during file output

### DIFF
--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -236,6 +236,9 @@ func runGrype(app clio.Application, opts *options.Grype, userInput string) (errs
 	log.WithFields("time", time.Since(startTime)).Info("found vulnerability matches")
 	startTime = time.Now()
 
+	// clear out the registry auth information to avoid including possibly sensitive information in the report
+	opts.Registry.Auth = nil
+
 	model, err := models.NewDocument(app.ID(), packages, pkgContext, *remainingMatches, ignoredMatches, vp, opts, dbInfo(status, vp), models.SortStrategy(opts.SortBy.Criteria), opts.Timestamp)
 	if err != nil {
 		return fmt.Errorf("failed to create document: %w", err)

--- a/cmd/grype/cli/options/registry.go
+++ b/cmd/grype/cli/options/registry.go
@@ -21,7 +21,7 @@ type RegistryCredentials struct {
 type registry struct {
 	InsecureSkipTLSVerify bool                  `yaml:"insecure-skip-tls-verify" json:"insecure-skip-tls-verify" mapstructure:"insecure-skip-tls-verify"`
 	InsecureUseHTTP       bool                  `yaml:"insecure-use-http" json:"insecure-use-http" mapstructure:"insecure-use-http"`
-	Auth                  []RegistryCredentials `yaml:"auth" json:"auth" mapstructure:"auth"`
+	Auth                  []RegistryCredentials `yaml:"auth" json:"auth,omitempty" mapstructure:"auth"`
 	CACert                string                `yaml:"ca-cert" json:"ca-cert" mapstructure:"ca-cert"`
 }
 
@@ -82,9 +82,9 @@ func (cfg *registry) ToOptions() *image.RegistryOptions {
 	for i, a := range cfg.Auth {
 		auth[i] = image.RegistryCredentials{
 			Authority:  a.Authority,
-			Username:   a.Username.String(),
-			Password:   a.Password.String(),
-			Token:      a.Token.String(),
+			Username:   string(a.Username),
+			Password:   string(a.Password),
+			Token:      string(a.Token),
 			ClientCert: a.TLSCert,
 			ClientKey:  a.TLSKey,
 		}

--- a/cmd/grype/cli/options/secret.go
+++ b/cmd/grype/cli/options/secret.go
@@ -21,5 +21,13 @@ func (r *secret) PostLoad() error {
 }
 
 func (r secret) String() string {
-	return string(r)
+	if r == "" {
+		return ""
+	}
+	// match the redactor's behavior, replacing with 7 asterisks
+	return "*******"
+}
+
+func (r secret) MarshalText() ([]byte, error) {
+	return []byte(r.String()), nil
 }


### PR DESCRIPTION
This PR corrects an issue that when using `--file` output, the same redactions were not applied to all fields as when outputting to console.