### PR TITLE
Fix error message when database is missing

### DIFF
--- a/grype/db/v6/installation/curator.go
+++ b/grype/db/v6/installation/curator.go
@@ -85,6 +85,11 @@ func NewCurator(cfg Config, downloader distribution.Client) (db.Curator, error) 
 }
 
 func (c curator) Reader() (db.Reader, error) {
+	status := c.Status()
+	if err := status.Error; err != nil && errors.Is(err, db.ErrDBDoesNotExist) {
+		return nil, fmt.Errorf("vulnerability database error: %w. Try 'grype db update'", err)
+	}
+
 	s, err := db.NewReader(
 		db.Config{
 			DBDirPath: c.config.DBDirectoryPath(),


### PR DESCRIPTION
Added a check before connecting to the DB to see if the DB exists first and returns an appropriate error if not.

Would close: https://github.com/anchore/grype/issues/3049