### PR TITLE
Update Dependency: Replace Unmaintained gopkg.in/yaml.v3 with Officia…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,10 +66,10 @@ require (
 	github.com/wagoodman/go-presenter v0.0.0-20211015174752-f9c01afc824b
 	github.com/wagoodman/go-progress v0.0.0-20230925121702-07e42b3cdba0
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/exp v0.0.0-20250711185948-6ae5c78190dc
 	golang.org/x/time v0.14.0
 	golang.org/x/tools v0.40.0
-	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/gorm v1.31.1
 )
 
@@ -318,7 +318,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.37.0 // indirect
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/mod v0.31.0 // indirect
@@ -337,6 +336,7 @@ require (
 	google.golang.org/grpc v1.74.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.66.10 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/test/cli/config_test.go
+++ b/test/cli/config_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func Test_configLoading(t *testing.T) {


### PR DESCRIPTION
The current dependency gopkg.in/yaml.v3 was [marked as unmaintained in April 2025](https://github.com/go-yaml/yaml). This poses potential security and maintenance risks for our project as we will no longer receive updates, bug fixes, or security patches from the original repository.

Migrate from Unmaintained gopkg.in/yaml.v3 to Official go.yaml.in/yaml/v3