### PR TITLE
Use specifier matching rules when comparing python versions

### DIFF
--- a/grype/version/pep440_version.go
+++ b/grype/version/pep440_version.go
@@ -11,12 +11,26 @@ type pep440Version struct {
 }
 
 func newPep440Version(raw string) (pep440Version, error) {
+	// lets ensure this is a valid PEP 440 version
 	parsed, err := goPepVersion.Parse(raw)
 	if err != nil {
 		return pep440Version{}, invalidFormatError(SemanticFormat, raw, err)
 	}
+
+	// we want to use the "public" portion of the version for comparison purposes (for specifier matching, not local versions).
+	// Note per PEP 440:
+	//   <public version identifier>[+<local version label>]
+	// see:
+	// - https://peps.python.org/pep-0440/#public-version-identifiers
+	// - https://peps.python.org/pep-0440/#local-version-identifiers
+	//
+	// This means that for a version like "1.0.0+abc.1", we only want to consider "1.0.0" for comparison purposes.
+	public, err := goPepVersion.Parse(parsed.Public())
+	if err != nil {
+		return pep440Version{}, invalidFormatError(SemanticFormat, raw, err)
+	}
 	return pep440Version{
-		obj: parsed,
+		obj: public,
 	}, nil
 }
 

--- a/grype/version/pep440_version_test.go
+++ b/grype/version/pep440_version_test.go
@@ -207,6 +207,33 @@ func TestPep440Version_Constraint(t *testing.T) {
 			version:    "2022.12.7",
 			constraint: ">=2017.11.05,<2022.12.07",
 		},
+		// regression (partial version with metadata should be valid)
+		// this is a fun one! PEP 440 has two different use cases for ordering semantics: direct versions and version specifiers.
+		// Take this python code for example:
+		//
+		// ```python
+		// from packaging.version import Version
+		// from packaging.specifiers import SpecifierSet
+		//
+		// # direct ordering comparison
+		// Version('6.4+cgr.1') <= Version('6.4.0')  # False
+		//
+		// # specifier matching
+		// Version('6.4+cgr.1') in SpecifierSet('<=6.4.0')  # True
+		// ```
+		//
+		// The root cause of the regression is that we have been doing direct version comparisons instead of specifier matching.
+		// The fix is to treat constraint matching as specifier matching (only consider the public version segment for
+		// constraint matching, not the local version segment).
+		//
+		// We want specifier semantics (ignore local) since 6.4+cgr.1 should be considered "the same release" as
+		// 6.4 for vulnerability matching applicability.
+		{
+			name:       "partial version with metadata",
+			version:    "6.4+cgr.1",
+			constraint: "<=6.4.0",
+			satisfied:  true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Take the following matching differences:

```
$ grype -q pkg:pypi/tornado@6.4
NAME     INSTALLED  FIXED IN  TYPE    VULNERABILITY        SEVERITY  EPSS         RISK   
tornado  6.4        6.4.2     python  GHSA-8w49-h785-mj3c  High      0.7% (71st)  0.5    
tornado  6.4        6.5       python  GHSA-7cx3-6m66-7c5m  High      0.1% (33rd)  < 0.1  
tornado  6.4        6.4.1     python  GHSA-753j-mpmx-qq6g  Medium    N/A          N/A    
tornado  6.4        6.4.1     python  GHSA-w235-7p84-xx57  Medium    N/A          N/A
```

```
$ grype -q pkg:pypi/tornado@6.4+cgr.1
NAME     INSTALLED  FIXED IN  TYPE    VULNERABILITY        SEVERITY  EPSS         RISK  
tornado  6.4+cgr.1  6.4.2     python  GHSA-8w49-h785-mj3c  High      0.7% (71st)  0.5
```

The chainguard library vex data doesn't claim the removal of `GHSA-753j-mpmx-qq6g` and `GHSA-w235-7p84-xx57` (only `GHSA-7cx3-6m66-7c5m` should be removed)
<details>
<summary>(chainguard library vex data)</summary>

```json
{
  "@context": "https://openvex.dev/ns/v0.2.0",
  "@id": "https://openvex.dev/docs/public/vex-9d6955582789f3bae7e1ca3c720a6e754ed103c3070d6c28594ec1e7a5b14f5b",
  "author": "Chainguard Team",
  "version": 1,
  "supplier": "Chainguard",
  "statements": [
    {
      "vulnerability": {
        "name": "CGA-34h3-w64p-m39f",
        "aliases": [
          "CGA-4v5j-gvwc-mq34",
          "CVE-2025-47287",
          "GHSA-7cx3-6m66-7c5m"
        ]
      },
      "products": [
        {
          "identifiers": {
            "purl": "pkg:pypi/tornado@6.3.3%2Bcgr.1"
          }
        },
        {
          "identifiers": {
            "purl": "pkg:pypi/tornado@6.4%2Bcgr.1"
          }
        },
        {
          "identifiers": {
            "purl": "pkg:pypi/tornado@6.4.1%2Bcgr.1"
          }
        },
        {
          "identifiers": {
            "purl": "pkg:pypi/tornado@6.4.2%2Bcgr.1"
          }
        }
      ],
      "status": "fixed",
      "timestamp": "2025-10-23T06:01:33.317Z",
      "last_updated": "2025-12-13T06:01:48.583Z"
    }
  ],
  "timestamp": "2025-10-23T06:01:33Z",
  "last_updated": "2025-12-13T06:01:48Z"
}
```

</details>

What's happening is that Grype is comparing the version constraint `6.4+cgr.1 <= 6.4.0` and concluding this as `False`. This is not the behavior we want, however, strictly speaking, PEP 440 does intend for this behavior when performing direct version comparisons. Though there is another use case supported by PEP 440: specifier matching (as done for dependency resolution). In this way the "public" portion (without `+...`) is the only section that should be compared. See the PR code comments for more detail here.

This PR makes the adjustment to only compare the public portion of valid PEP440 formatted version strings.

With the fix, the new results for the given example are:
```
$ go run ./cmd/grype -q pkg:pypi/tornado@6.4                                
NAME     INSTALLED  FIXED IN  TYPE    VULNERABILITY        SEVERITY  EPSS         RISK  
tornado  6.4        6.4.2     python  GHSA-8w49-h785-mj3c  High      0.7% (71st)  0.5   
tornado  6.4        6.4.1     python  GHSA-753j-mpmx-qq6g  Medium    N/A          N/A   
tornado  6.4        6.4.1     python  GHSA-w235-7p84-xx57  Medium    N/A          N/A
```