### PR TITLE
chore: update yardstick and pin dataclass-wizard to latest working ver

### DIFF
--- a/test/quality/requirements.txt
+++ b/test/quality/requirements.txt
@@ -1,3 +1,4 @@
-yardstick==v0.12.2
+yardstick==v0.15.0
 # ../../../yardstick
 tabulate==0.9.0
+dataclass-wizard==0.36.2


### PR DESCRIPTION
Quality gate has been failing since `dataclass-wizard @ 0.36.3` was released. This pins to the latest working version, and updates yardstick.