### PR TITLE
fix: correct help text for return code for fail-on severity option

### DIFF
--- a/cmd/grype/cli/options/grype.go
+++ b/cmd/grype/cli/options/grype.go
@@ -113,7 +113,7 @@ func (o *Grype) AddFlags(flags clio.FlagSet) {
 
 	flags.StringVarP(&o.FailOn,
 		"fail-on", "f",
-		fmt.Sprintf("set the return code to 1 if a vulnerability is found with a severity >= the given severity, options=%v", vulnerability.AllSeverities()),
+		fmt.Sprintf("set the return code to 2 if a vulnerability is found with a severity >= the given severity, options=%v", vulnerability.AllSeverities()),
 	)
 
 	flags.BoolVarP(&o.OnlyFixed,


### PR DESCRIPTION
## Background

Minor correction, whilst using Grype CLI, I noticed the return status is 2 NOT 1 for `--fail-on` string as per: https://github.com/anchore/grype/pull/2575 . This small detail can cause unexpected behavior for new adopters 🙂  

## Further Details

Sample output during our CI run (private)

```log
[0000] ERROR discovered vulnerabilities at or above the severity threshold
Error: Grype scan command failed with exit code: 2
Error: Process completed with exit code 2.
```

Hope it helps.