### PR TITLE
add `--stdout` flag for simultaneous file and console output (ALREADY EXISTS => `-o json=grype.json -o table=grype.table`)

### DIFF
--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -112,7 +112,7 @@ var ignoreLinuxKernelHeaders = []match.IgnoreRule{
 
 //nolint:funlen
 func runGrype(app clio.Application, opts *options.Grype, userInput string) (errs error) {
-	writer, err := format.MakeScanResultWriter(opts.Outputs, opts.File, format.PresentationConfig{
+	writer, err := format.MakeScanResultWriter(opts.Outputs, opts.File, opts.Stdout, format.PresentationConfig{
 		TemplateFilePath: opts.OutputTemplateFile,
 		ShowSuppressed:   opts.ShowSuppressed,
 		Pretty:           opts.Pretty,

--- a/cmd/grype/cli/options/grype.go
+++ b/cmd/grype/cli/options/grype.go
@@ -14,6 +14,7 @@ import (
 type Grype struct {
 	Outputs                    []string           `yaml:"output" json:"output" mapstructure:"output"` // -o, <presenter>=<file> the Presenter hint string to use for report formatting and the output file
 	File                       string             `yaml:"file" json:"file" mapstructure:"file"`       // --file, the file to write report output to
+	Stdout                     string             `yaml:"stdout" json:"stdout" mapstructure:"stdout"` // --stdout, explicit output format for stdout (use with --file to get both file and stdout output)
 	Pretty                     bool               `yaml:"pretty" json:"pretty" mapstructure:"pretty"`
 	Distro                     string             `yaml:"distro" json:"distro" mapstructure:"distro"`                                           // --distro, specify a distro to explicitly use
 	GenerateMissingCPEs        bool               `yaml:"add-cpes-if-none" json:"add-cpes-if-none" mapstructure:"add-cpes-if-none"`             // --add-cpes-if-none, automatically generate CPEs if they are not present in import (e.g. from a 3rd party SPDX document)
@@ -90,6 +91,11 @@ func (o *Grype) AddFlags(flags clio.FlagSet) {
 	flags.StringVarP(&o.File,
 		"file", "",
 		"file to write the default report output to (default is STDOUT)",
+	)
+
+	flags.StringVarP(&o.Stdout,
+		"stdout", "",
+		fmt.Sprintf("explicitly set the output format for stdout (useful with --file to get both file and stdout output), formats=%v", format.AvailableFormats),
 	)
 
 	flags.StringVarP(&o.Name,
@@ -171,6 +177,14 @@ func (o *Grype) PostLoad() error {
 			return fmt.Errorf("bad --fail-on severity value '%s'", o.FailOn)
 		}
 	}
+
+	if o.Stdout != "" {
+		stdoutFormat := format.Parse(o.Stdout)
+		if stdoutFormat == format.UnknownFormat {
+			return fmt.Errorf("bad --stdout format value '%s', supported formats are: %v", o.Stdout, format.AvailableFormats)
+		}
+	}
+
 	return nil
 }
 

--- a/cmd/grype/cli/options/grype_test.go
+++ b/cmd/grype/cli/options/grype_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_flatten(t *testing.T) {
@@ -43,6 +44,55 @@ func Test_flatten(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := flatten(tt.input)
 			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestGrype_PostLoad_StdoutValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		stdout  string
+		wantErr string
+	}{
+		{
+			name:    "valid stdout format table",
+			stdout:  "table",
+			wantErr: "",
+		},
+		{
+			name:    "valid stdout format json",
+			stdout:  "json",
+			wantErr: "",
+		},
+		{
+			name:    "valid stdout format sarif",
+			stdout:  "sarif",
+			wantErr: "",
+		},
+		{
+			name:    "empty stdout format is valid",
+			stdout:  "",
+			wantErr: "",
+		},
+		{
+			name:    "invalid stdout format",
+			stdout:  "invalid-format",
+			wantErr: "bad --stdout format value 'invalid-format'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &Grype{
+				Stdout: tt.stdout,
+			}
+			err := opts.PostLoad()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Background

This PR adds a new `--stdout` flag that allows users to specify an output format for stdout while also writing a different format to a file using the `--file` flag. 

> [!TIP]
> This enables workflows where users want both a human-readable table output in the console and a machine-readable format (like SARIF or JSON) saved to a file.

## Usage

```bash
# Write SARIF to a file while displaying table format in the terminal
grype <image> -o sarif --file grype-scan-results.sarif --stdout table

# Write JSON to a file while displaying table format in the terminal
grype <image> -o json --file results.json --stdout table

# Write CycloneDX to a file while displaying table format in the terminal
grype <image> -o cyclonedx-json --file sbom.json --stdout table
```

## Why?

Because I ended up having to run Grype twice to get the nice table output:

```bash
$GRYPE_CMD sbom:$GRYPE_SBOM_PATH $GRYPE_CLI_OVERRIDE_ARGS -o table > $SUMMARY_FILE
$GRYPE_CMD sbom:$GRYPE_SBOM_PATH $GRYPE_CLI_OVERRIDE_ARGS -o sarif --file grype-scan-results.sarif
```

Which I prefer to have for concise GH summaries.