### PR TITLE
fix: preserve local version segment in constraints for PEP 440 comparison

### DIFF
--- a/grype/version/pep440_version_test.go
+++ b/grype/version/pep440_version_test.go
@@ -234,6 +234,50 @@ func TestPep440Version_Constraint(t *testing.T) {
 			constraint: "<=6.4.0",
 			satisfied:  true,
 		},
+		// When constraint has a local version, require exact match (important for unaffected entries)
+		{
+			name:       "local version in constraint should not match version without local segment",
+			version:    "2.0.0",
+			constraint: "= 2.0.0+cgr.1",
+			satisfied:  false,
+		},
+		{
+			name:       "local version in constraint should match same local version",
+			version:    "2.0.0+cgr.1",
+			constraint: "= 2.0.0+cgr.1",
+			satisfied:  true,
+		},
+		{
+			name:       "version with local segment should match constraint without local segment",
+			version:    "2.0.0+cgr.1",
+			constraint: "= 2.0.0",
+			satisfied:  true,
+		},
+		{
+			name:       "version with local segment should satisfy less-than constraint",
+			version:    "2.0.0+cgr.1",
+			constraint: "< 2.0.1",
+			satisfied:  true,
+		},
+		{
+			name:       "different local versions should not match on equality",
+			version:    "2.0.0+other",
+			constraint: "= 2.0.0+cgr.1",
+			satisfied:  false,
+		},
+		// Local version segments compared per PEP 440 (numeric segments as integers)
+		{
+			name:       "local version segments compared numerically not lexicographically",
+			version:    "2.0.0+cgr.12",
+			constraint: "> 2.0.0+cgr.2",
+			satisfied:  true,
+		},
+		{
+			name:       "local version segment numeric comparison - less than",
+			version:    "2.0.0+cgr.2",
+			constraint: "< 2.0.0+cgr.12",
+			satisfied:  true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
PR #3121 fixed an issue where 6.4+cgr.1 wasn't matching <= 6.4.0 by stripping local version segments during comparison. However, this introduced a regression: constraints with local segments (like = 2.0.0+cgr.1) incorrectly matched versions without that local segment (like 2.0.0).

This caused false negatives where upstream packages were incorrectly marked as "unaffected" by downstream distributor patches. For example, flask==2.0.0 from PyPI was not flagged for GHSA-m2qf-hxjv-5gpq because Chainguard's unaffected entry for = 2.0.0+cgr.1 was incorrectly matching it.

The fix:
- Package versions: local segment is still ignored (preserving #3121 fix)
- Constraint versions: local segment is now preserved and compared using PEP 440 rules

This ensures:
- 6.4+cgr.1 matches <= 6.4.0 ✓ (original fix preserved)
- 2.0.0 does NOT match = 2.0.0+cgr.1 ✓ (regression fixed)
- 2.0.0+cgr.1 matches = 2.0.0+cgr.1 ✓ (exact match works)
- 2.0.0+cgr.12 > 2.0.0+cgr.2 ✓ (proper numeric comparison per PEP 440)