### PR TITLE
Fix vulnerability ignore matching to be case-insensitive

### DIFF
--- a/grype/match/ignore.go
+++ b/grype/match/ignore.go
@@ -2,6 +2,7 @@ package match
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/bmatcuk/doublestar/v2"
 
@@ -193,12 +194,12 @@ func ifFixStateApplies(fs string) ignoreCondition {
 
 func ifVulnerabilityApplies(vulnerability string, includeAliases bool) ignoreCondition {
 	return func(match Match) bool {
-		if vulnerability == match.Vulnerability.ID {
+		if strings.EqualFold(vulnerability, match.Vulnerability.ID) {
 			return true
 		}
 		if includeAliases {
 			for _, related := range match.Vulnerability.RelatedVulnerabilities {
-				if vulnerability == related.ID {
+				if strings.EqualFold(vulnerability, related.ID) {
 					return true
 				}
 			}

--- a/grype/match/ignore_test.go
+++ b/grype/match/ignore_test.go
@@ -297,6 +297,24 @@ var (
 	}
 )
 
+func TestIgnoreRule_VulnerabilityID_IsCaseInsensitive(t *testing.T) {
+	rule := IgnoreRule{
+		Vulnerability:  "ghsa-jc7w-c686-c4v9",
+		IncludeAliases: true,
+	}
+
+	match := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			ID: "GHSA-JC7W-C686-C4V9",
+		},
+	}
+
+	ignored := rule.IgnoreMatch(match)
+	if len(ignored) == 0 {
+		t.Fatalf("expected vulnerability to be ignored regardless of casing")
+	}
+}
+
 func TestApplyIgnoreRules(t *testing.T) {
 	cases := []struct {
 		name                     string


### PR DESCRIPTION
### Summary
Vulnerability identifiers such as CVE and GHSA are case-insensitive, but ignore
rules were previously matched using exact string comparison. This caused ignore
rules to fail when casing differed between sources.

### Root Cause
Ignore rule evaluation compared vulnerability IDs using strict string equality,
while vulnerability sources (e.g., Grype data, GHSA) may report identifiers in
mixed or lowercase formats.

### Changes
- Make vulnerability ID matching case-insensitive when applying ignore rules
- Add a unit test validating that GHSA identifiers are ignored regardless of casing

### Impact
- Fixes ignore rules not applying to GHSA vulnerabilities with lowercase IDs
- Backward compatible; does not affect existing ignore behavior

### Notes
Local full test execution could not complete due to disk space constraints on the
development machine. The change is isolated to `grype/match`, and CI will validate
the full test suite.
