### PR TITLE
openvex: normalize Docker Hub aliases for repository_url matching

### DIFF
--- a/grype/vex/openvex/implementation.go
+++ b/grype/vex/openvex/implementation.go
@@ -92,7 +92,7 @@ func normalizeDockerHubRepositoryURL(repoURL string) string {
 	repoURL = strings.TrimPrefix(repoURL, "https://")
 	repoURL = strings.TrimPrefix(repoURL, "http://")
 
-	repoURL = strings.TrimSuffix(repoURL, "/") // <-- add here
+	repoURL = strings.TrimSuffix(repoURL, "/")
 
 	host, rest, hasSlash := strings.Cut(repoURL, "/")
 

--- a/grype/vex/openvex/implementation_test.go
+++ b/grype/vex/openvex/implementation_test.go
@@ -440,3 +440,28 @@ func TestIdentifiersFromDigests_NormalizesDockerHubRepositoryURL(t *testing.T) {
 	require.NotEmpty(t, repoURL, "expected to find alpine purl in identifiers: %#v", ids)
 	require.Equal(t, "index.docker.io/library", repoURL)
 }
+
+func TestNormalizeDockerHubRepositoryURL(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"docker.io/library", "index.docker.io/library"},
+		{"index.docker.io/library", "index.docker.io/library"},
+		{"registry-1.docker.io/library", "index.docker.io/library"},
+		{"https://docker.io/library", "index.docker.io/library"},
+		{"http://docker.io/library", "index.docker.io/library"},
+		{"gcr.io/myorg", "gcr.io/myorg"},
+		{"", ""},
+		{"DOCKER.IO/Library", "index.docker.io/Library"},
+		{"docker.io", "index.docker.io"},
+		{"docker.io/", "index.docker.io"},
+		{"  docker.io/library  ", "index.docker.io/library"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := normalizeDockerHubRepositoryURL(tc.input)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
What
Some OpenVEX documents reference Docker Hub using "docker.io" (or "registry-1.docker.io") in the "repository_url” qualifier, but Grype-generated OCI PURLs can end up using a different Docker Hub hostname. That mismatch prevents VEX product matching from applying as expected.

Change
- Normalize Docker Hub registry aliases so “docker.io” / “registry-1.docker.io” (and existing “index.docker.io”) are treated consistently as “index.docker.io” for “repository_url”.
- Trim scheme + trailing slash defensively before normalization.
- Add a unit test verifying “docker.io/...” digests produce a package url with “repository_url=index.docker.io/.”.

Testing
- “go test -count=1 -v ./grype/vex/openvex”

Fixes #2818 
