### PR TITLE
Add CycloneDX v1.5 writing

### DIFF
--- a/grype/presenter/cyclonedx/presenter.go
+++ b/grype/presenter/cyclonedx/presenter.go
@@ -18,6 +18,7 @@ type Presenter struct {
 	document models.Document
 	src      source.Description
 	format   cyclonedx.BOMFileFormat
+	version  cyclonedx.SpecVersion
 	sbom     *sbom.SBOM
 }
 
@@ -28,6 +29,7 @@ func NewJSONPresenter(pb models.PresenterConfig) *Presenter {
 		document: pb.Document,
 		src:      pb.SBOM.Source,
 		sbom:     pb.SBOM,
+		version:  cyclonedx.SpecVersion1_6,
 		format:   cyclonedx.BOMFileFormatJSON,
 	}
 }
@@ -39,6 +41,31 @@ func NewXMLPresenter(pb models.PresenterConfig) *Presenter {
 		document: pb.Document,
 		src:      pb.SBOM.Source,
 		sbom:     pb.SBOM,
+		version:  cyclonedx.SpecVersion1_6,
+		format:   cyclonedx.BOMFileFormatXML,
+	}
+}
+
+// NewJSONPresenterv1_5 is a *Presenter constructor
+func NewJSONPresenterv1_5(pb models.PresenterConfig) *Presenter {
+	return &Presenter{
+		id:       pb.ID,
+		document: pb.Document,
+		src:      pb.SBOM.Source,
+		sbom:     pb.SBOM,
+		version:  cyclonedx.SpecVersion1_5,
+		format:   cyclonedx.BOMFileFormatJSON,
+	}
+}
+
+// NewXMLPresenterv1_5 is a *Presenter constructor
+func NewXMLPresenterv1_5(pb models.PresenterConfig) *Presenter {
+	return &Presenter{
+		id:       pb.ID,
+		document: pb.Document,
+		src:      pb.SBOM.Source,
+		sbom:     pb.SBOM,
+		version:  cyclonedx.SpecVersion1_5,
 		format:   cyclonedx.BOMFileFormatXML,
 	}
 }
@@ -74,5 +101,5 @@ func (p *Presenter) Present(output io.Writer) error {
 	enc.SetPretty(true)
 	enc.SetEscapeHTML(false)
 
-	return enc.EncodeVersion(cyclonedxBOM, cyclonedxBOM.SpecVersion)
+	return enc.EncodeVersion(cyclonedxBOM, p.version)
 }

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -4,54 +4,74 @@ import (
 	"strings"
 )
 
-const (
-	UnknownFormat   Format = "unknown"
-	JSONFormat      Format = "json"
-	TableFormat     Format = "table"
-	CycloneDXFormat Format = "cyclonedx"
-	CycloneDXJSON   Format = "cyclonedx-json"
-	CycloneDXXML    Format = "cyclonedx-xml"
-	SarifFormat     Format = "sarif"
-	TemplateFormat  Format = "template"
+var (
+	UnknownFormat       = Format{name: "unknown", version: ""}
+	JSONFormat          = Format{name: "json", version: ""}
+	TableFormat         = Format{name: "table", version: ""}
+	CycloneDXFormat     = Format{name: "cyclonedx", version: ""}
+	CycloneDXJSON       = Format{name: "cyclonedx-json", version: ""}
+	CycloneDXXML        = Format{name: "cyclonedx-xml", version: ""}
+	CycloneDXFormatv1_5 = Format{name: "cyclonedx", version: "1.5"}
+	CycloneDXJSONv1_5   = Format{name: "cyclonedx-json", version: "1.5"}
+	CycloneDXXMLv1_5    = Format{name: "cyclonedx-xml", version: "1.5"}
+	SarifFormat         = Format{name: "sarif", version: ""}
+	TemplateFormat      = Format{name: "template", version: ""}
 
 	// DEPRECATED <-- TODO: remove in v1.0
-	EmbeddedVEXJSON Format = "embedded-cyclonedx-vex-json"
-	EmbeddedVEXXML  Format = "embedded-cyclonedx-vex-xml"
+	EmbeddedVEXJSON = Format{name: "embedded-cyclonedx-vex-json", version: ""}
+	EmbeddedVEXXML  = Format{name: "embedded-cyclonedx-vex-xml", version: ""}
 )
 
 // Format is a dedicated type to represent a specific kind of presenter output format.
-type Format string
+type Format struct {
+	name    string
+	version string
+}
 
 func (f Format) String() string {
-	return string(f)
+	if f.version != "" {
+		return f.name + "@" + f.version
+	}
+	return f.name
 }
 
 // Parse returns the presenter.format specified by the given user input.
 func Parse(userInput string) Format {
-	switch strings.ToLower(userInput) {
-	case "":
-		return TableFormat
-	case strings.ToLower(JSONFormat.String()):
-		return JSONFormat
-	case strings.ToLower(TableFormat.String()):
-		return TableFormat
-	case strings.ToLower(SarifFormat.String()):
-		return SarifFormat
-	case strings.ToLower(TemplateFormat.String()):
-		return TemplateFormat
-	case strings.ToLower(CycloneDXFormat.String()):
-		return CycloneDXFormat
-	case strings.ToLower(CycloneDXJSON.String()):
-		return CycloneDXJSON
-	case strings.ToLower(CycloneDXXML.String()):
-		return CycloneDXXML
-	case strings.ToLower(EmbeddedVEXJSON.String()):
-		return CycloneDXJSON
-	case strings.ToLower(EmbeddedVEXXML.String()):
-		return CycloneDXFormat
-	default:
-		return UnknownFormat
+	parts := strings.SplitN(userInput, "@", 2)
+	version := ""
+
+	if len(parts) > 1 {
+		version = parts[1]
 	}
+
+	result := UnknownFormat
+	switch strings.ToLower(parts[0]) {
+	case "":
+		result = TableFormat
+	case strings.ToLower(JSONFormat.String()):
+		result = JSONFormat
+	case strings.ToLower(TableFormat.String()):
+		result = TableFormat
+	case strings.ToLower(SarifFormat.String()):
+		result = SarifFormat
+	case strings.ToLower(TemplateFormat.String()):
+		result = TemplateFormat
+	case strings.ToLower(CycloneDXFormat.String()):
+		result = CycloneDXFormat
+	case strings.ToLower(CycloneDXJSON.String()):
+		result = CycloneDXJSON
+	case strings.ToLower(CycloneDXXML.String()):
+		result = CycloneDXXML
+	case strings.ToLower(EmbeddedVEXJSON.String()):
+		result = CycloneDXJSON
+	case strings.ToLower(EmbeddedVEXXML.String()):
+		result = CycloneDXFormat
+	default:
+		result = UnknownFormat
+	}
+
+	result.version = version
+	return result
 }
 
 // AvailableFormats is a list of presenter format options available to users.
@@ -60,6 +80,8 @@ var AvailableFormats = []Format{
 	TableFormat,
 	CycloneDXFormat,
 	CycloneDXJSON,
+	CycloneDXFormatv1_5,
+	CycloneDXJSONv1_5,
 	SarifFormat,
 	TemplateFormat,
 }

--- a/internal/format/presenter.go
+++ b/internal/format/presenter.go
@@ -35,6 +35,12 @@ func GetPresenter(format Format, c PresentationConfig, pb models.PresenterConfig
 		return cyclonedx.NewJSONPresenter(pb)
 	case CycloneDXXML:
 		return cyclonedx.NewXMLPresenter(pb)
+	case CycloneDXFormatv1_5:
+		return cyclonedx.NewXMLPresenterv1_5(pb)
+	case CycloneDXJSONv1_5:
+		return cyclonedx.NewJSONPresenterv1_5(pb)
+	case CycloneDXXMLv1_5:
+		return cyclonedx.NewXMLPresenterv1_5(pb)
 	case SarifFormat:
 		return sarif.NewPresenter(pb)
 	case TemplateFormat:

--- a/internal/format/writer.go
+++ b/internal/format/writer.go
@@ -186,6 +186,9 @@ type scanResultStreamWriter struct {
 // Write the provided result to the data stream
 func (w *scanResultStreamWriter) Write(s models.PresenterConfig) error {
 	pres := GetPresenter(w.format, w.cfg, s)
+	if pres == nil {
+		return fmt.Errorf("invalid format: %s", w.format)
+	}
 	if err := pres.Present(w.out); err != nil {
 		return fmt.Errorf("unable to encode result: %w", err)
 	}

--- a/internal/format/writer_test.go
+++ b/internal/format/writer_test.go
@@ -47,7 +47,7 @@ func Test_newSBOMMultiWriter(t *testing.T) {
 	testName := func(options []scanResultWriterDescription, err bool) string {
 		var out []string
 		for _, opt := range options {
-			out = append(out, string(opt.Format)+"="+opt.Path)
+			out = append(out, opt.Format.String()+"="+opt.Path)
 		}
 		errs := ""
 		if err {
@@ -68,7 +68,7 @@ func Test_newSBOMMultiWriter(t *testing.T) {
 		{
 			outputs: []scanResultWriterDescription{
 				{
-					Format: "table",
+					Format: Format{name: "table", version: ""},
 					Path:   "",
 				},
 			},
@@ -81,7 +81,7 @@ func Test_newSBOMMultiWriter(t *testing.T) {
 		{
 			outputs: []scanResultWriterDescription{
 				{
-					Format: "json",
+					Format: Format{name: "json", version: ""},
 				},
 			},
 			expected: []writerConfig{
@@ -93,7 +93,7 @@ func Test_newSBOMMultiWriter(t *testing.T) {
 		{
 			outputs: []scanResultWriterDescription{
 				{
-					Format: "json",
+					Format: Format{name: "json", version: ""},
 					Path:   "test-2.json",
 				},
 			},
@@ -107,11 +107,11 @@ func Test_newSBOMMultiWriter(t *testing.T) {
 		{
 			outputs: []scanResultWriterDescription{
 				{
-					Format: "json",
+					Format: Format{name: "json", version: ""},
 					Path:   "test-3/1.json",
 				},
 				{
-					Format: "spdx-json",
+					Format: Format{name: "spdx-json", version: ""},
 					Path:   "test-3/2.json",
 				},
 			},
@@ -129,10 +129,10 @@ func Test_newSBOMMultiWriter(t *testing.T) {
 		{
 			outputs: []scanResultWriterDescription{
 				{
-					Format: "text",
+					Format: Format{name: "text", version: ""},
 				},
 				{
-					Format: "spdx-json",
+					Format: Format{name: "spdx-json", version: ""},
 					Path:   "test-4.json",
 				},
 			},
@@ -171,13 +171,13 @@ func Test_newSBOMMultiWriter(t *testing.T) {
 			for i, e := range test.expected {
 				switch w := mw.writers[i].(type) {
 				case *scanResultStreamWriter:
-					assert.Equal(t, string(w.format), e.format)
+					assert.Equal(t, w.format.String(), e.format)
 					assert.NotNil(t, w.out)
 					if e.file != "" {
 						assert.FileExists(t, tmp+e.file)
 					}
 				case *scanResultPublisher:
-					assert.Equal(t, string(w.format), e.format)
+					assert.Equal(t, w.format.String(), e.format)
 				default:
 					t.Fatalf("unknown writer type: %T", w)
 				}
@@ -211,7 +211,7 @@ func Test_newSBOMWriterDescription(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			o := newWriterDescription("table", tt.path, PresentationConfig{})
+			o := newWriterDescription(Format{name: "table", version: ""}, tt.path, PresentationConfig{})
 			assert.Equal(t, tt.expected, o.Path)
 		})
 	}


### PR DESCRIPTION
It is useful to be able to write CycloneDX v1.5 VEX since the CycloneDX Rust crate does not support v1.6 yet (ref: https://github.com/CycloneDX/cyclonedx-rust-cargo/issues/769). Rather than waiting for the crate to support that, or spending the time to implement it, it is simpler to just make Grype support it.