### PR TITLE
fix(rpm): respect EUS limitation in --only-fixed

### DIFF
--- a/grype/matcher/rpm/rhel_eus.go
+++ b/grype/matcher/rpm/rhel_eus.go
@@ -2,6 +2,8 @@ package rpm
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/anchore/grype/grype/distro"
@@ -14,6 +16,105 @@ import (
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal/log"
 )
+
+// elVersionPattern matches patterns like "el9_5", "el8_10", "el7" in RPM release strings
+var elVersionPattern = regexp.MustCompile(`\.el(\d+)(?:_(\d+))?`)
+
+// extractRHELVersionFromRelease parses RHEL major/minor from release string.
+// Examples:
+//
+//	"503.11.1.el9_5" -> (9, 5, true)
+//	"82.el8_10.2" -> (8, 10, true)
+//	"1.el7" -> (7, 0, true)  // missing minor treated as 0
+//	"1.0.0" -> (0, 0, false)
+func extractRHELVersionFromRelease(release string) (major, minor int, found bool) {
+	matches := elVersionPattern.FindStringSubmatch(release)
+	if matches == nil {
+		return 0, 0, false
+	}
+
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, 0, false
+	}
+
+	// If no minor version captured, treat as 0 (base version)
+	if matches[2] == "" {
+		return major, 0, true
+	}
+
+	minor, err = strconv.Atoi(matches[2])
+	if err != nil {
+		return major, 0, true
+	}
+
+	return major, minor, true
+}
+
+// extractReleaseFromRPMVersion extracts release portion from full RPM version.
+// Examples:
+//
+//	"5.14.0-503.11.1.el9_5" -> "503.11.1.el9_5"
+//	"0:5.14.0-503.11.1.el9_5" -> "503.11.1.el9_5" (handles epoch)
+func extractReleaseFromRPMVersion(rpmVersion string) string {
+	// Strip epoch if present (e.g., "0:5.14.0-..." -> "5.14.0-...")
+	if idx := strings.Index(rpmVersion, ":"); idx != -1 {
+		rpmVersion = rpmVersion[idx+1:]
+	}
+
+	// Extract release portion after the hyphen
+	if idx := strings.LastIndex(rpmVersion, "-"); idx != -1 {
+		return rpmVersion[idx+1:]
+	}
+
+	return rpmVersion
+}
+
+// isFixReachableForEUS returns true if fix version is reachable for EUS distro.
+// A fix is reachable if:
+//  1. The fix's RHEL version cannot be determined (fail-open)
+//  2. The fix's major version matches AND minor version <= EUS minor version
+func isFixReachableForEUS(fixVersion string, eusDistro *distro.Distro) bool {
+	if eusDistro == nil {
+		return true
+	}
+
+	// Parse EUS distro version (e.g., "9.4" -> major=9, minor=4)
+	eusMajor, eusMinor := eusDistro.MajorVersion(), eusDistro.MinorVersion()
+
+	if eusMajor == "" {
+		// Cannot determine EUS version, fail-open
+		return true
+	}
+
+	eusMajorInt, err := strconv.Atoi(eusMajor)
+	if err != nil {
+		return true
+	}
+
+	// Treat missing minor version as 0 (e.g., "9+eus" means "9.0+eus")
+	eusMinorInt := 0
+	if eusMinor != "" {
+		eusMinorInt, _ = strconv.Atoi(eusMinor)
+	}
+
+	// Extract release from fix version and parse RHEL version from it
+	release := extractReleaseFromRPMVersion(fixVersion)
+	fixMajor, fixMinor, found := extractRHELVersionFromRelease(release)
+	if !found {
+		// Cannot determine fix's RHEL version, fail-open (assume reachable)
+		return true
+	}
+
+	// Different major version is not reachable
+	if fixMajor != eusMajorInt {
+		return false
+	}
+
+	// Fix is reachable only if fix's minor version <= EUS minor version
+	// (missing minor is treated as 0, so ".el9" is reachable by any EUS version)
+	return fixMinor <= eusMinorInt
+}
 
 func shouldUseRedhatEUSMatching(d *distro.Distro) bool {
 	if d == nil {
@@ -114,40 +215,22 @@ func redhatEUSMatches(provider result.Provider, searchPkg pkg.Package, missingEp
 	// b. disclosures that have EUS fixes that resolve the disclosure for future versions of the package (thus we're vulnerable) are kept.
 	// c. all fixes from the incoming resolutions are patched onto the disclosures in the returned collection, so the
 	//    final set of vulnerabilities is a fused set of disclosures and fixes together.
-	remaining = remaining.Merge(resolutions, mergeEUSAdvisoriesIntoMainDisclosures(pkgVersion, false))
+	// Note: we pass searchPkg.Distro (the EUS distro) to filter out fixes not reachable for this EUS version
+	remaining = remaining.Merge(resolutions, mergeEUSAdvisoriesIntoMainDisclosures(pkgVersion, searchPkg.Distro))
 
 	return remaining.ToMatches(), err
 }
 
 // mergeEUSAdvisoriesIntoMainDisclosures returns a function that will filter disclosures based on the provided advisory information (by fix version only).
 // Additionally, this will merge applicable fixes into one vulnerability record, so that the final result contains only one vulnerability record per disclosure.
-func mergeEUSAdvisoriesIntoMainDisclosures(v *version.Version, treatResolutionsAsDisclosures bool) func(disclosures, advisoryOverlays []result.Result) []result.Result {
+func mergeEUSAdvisoriesIntoMainDisclosures(v *version.Version, eusDistro *distro.Distro) func(disclosures, advisoryOverlays []result.Result) []result.Result {
 	return func(disclosures, advisoryOverlays []result.Result) []result.Result {
 		var out []result.Result
 
 		for _, ds := range disclosures {
-			processedResult := mergeEUSAdvisoryIntoMainDisclosure(v, ds, advisoryOverlays)
+			processedResult := mergeEUSAdvisoryIntoMainDisclosure(v, ds, advisoryOverlays, eusDistro)
 			if len(processedResult.Vulnerabilities) > 0 {
 				out = append(out, processedResult)
-			}
-		}
-
-		if treatResolutionsAsDisclosures {
-			// add any incoming results that don't have corresponding existing results
-			for _, advisory := range advisoryOverlays {
-				hasCorrespondingExisting := false
-				for _, e := range disclosures {
-					if e.ID == advisory.ID {
-						hasCorrespondingExisting = true
-						break
-					}
-				}
-				if !hasCorrespondingExisting {
-					// this advisory doesn't have a corresponding disclosure, include it as-is
-					// note: we are presuming that the original disclosure has already been verified to be vulnerable
-					// against the original package.
-					out = append(out, advisory)
-				}
 			}
 		}
 
@@ -156,7 +239,7 @@ func mergeEUSAdvisoriesIntoMainDisclosures(v *version.Version, treatResolutionsA
 }
 
 // mergeEUSAdvisoryIntoMainDisclosure processes a single disclosure Result against its corresponding advisory overlay Results
-func mergeEUSAdvisoryIntoMainDisclosure(v *version.Version, disclosures result.Result, advisoryOverlays []result.Result) result.Result {
+func mergeEUSAdvisoryIntoMainDisclosure(v *version.Version, disclosures result.Result, advisoryOverlays []result.Result, eusDistro *distro.Distro) result.Result {
 	processedResult := result.Result{
 		ID:      disclosures.ID,
 		Package: disclosures.Package,
@@ -164,7 +247,7 @@ func mergeEUSAdvisoryIntoMainDisclosure(v *version.Version, disclosures result.R
 
 	// process each disclosure vulnerability against advisory overlays
 	for _, disclosure := range disclosures.Vulnerabilities {
-		processedVuln, advisoryDetails := mergeEUSAdvisoryIntoSingleDisclosure(v, disclosure, advisoryOverlays)
+		processedVuln, advisoryDetails := mergeEUSAdvisoryIntoSingleDisclosure(v, disclosure, advisoryOverlays, eusDistro)
 		if processedVuln != nil {
 			processedResult.Vulnerabilities = append(processedResult.Vulnerabilities, *processedVuln)
 			processedResult.Details = append(processedResult.Details, advisoryDetails...)
@@ -176,7 +259,7 @@ func mergeEUSAdvisoryIntoMainDisclosure(v *version.Version, disclosures result.R
 }
 
 // mergeEUSAdvisoryIntoSingleDisclosure processes a single vulnerability against advisory overlays
-func mergeEUSAdvisoryIntoSingleDisclosure(v *version.Version, disclosure vulnerability.Vulnerability, advisoryOverlays []result.Result) (*vulnerability.Vulnerability, match.Details) {
+func mergeEUSAdvisoryIntoSingleDisclosure(v *version.Version, disclosure vulnerability.Vulnerability, advisoryOverlays []result.Result, eusDistro *distro.Distro) (*vulnerability.Vulnerability, match.Details) {
 	fixVersions := version.NewSet(true)
 	var constraints []version.Constraint
 	var state vulnerability.FixState
@@ -189,7 +272,7 @@ func mergeEUSAdvisoryIntoSingleDisclosure(v *version.Version, disclosure vulnera
 
 	// process advisory overlays, incorporating new fix versions and updating the version constraints
 	for _, advisoryOverlay := range advisoryOverlays {
-		collectMatchingConstraintsDetailsAndFixState(v, advisoryOverlay, fixVersions, &constraints, &state, &allAdvisoryDetails)
+		collectMatchingConstraintsDetailsAndFixState(v, advisoryOverlay, fixVersions, &constraints, &state, &allAdvisoryDetails, eusDistro)
 	}
 
 	if len(constraints) == 0 {
@@ -202,7 +285,7 @@ func mergeEUSAdvisoryIntoSingleDisclosure(v *version.Version, disclosure vulnera
 }
 
 // collectMatchingConstraintsDetailsAndFixState processes vulnerabilities from advisory overlays, applying any new fix versions and updating the given fix state / constraints.
-func collectMatchingConstraintsDetailsAndFixState(v *version.Version, advisoryResult result.Result, fixVersions *version.Set, constraints *[]version.Constraint, state *vulnerability.FixState, allAdvisoryDetails *match.Details) {
+func collectMatchingConstraintsDetailsAndFixState(v *version.Version, advisoryResult result.Result, fixVersions *version.Set, constraints *[]version.Constraint, state *vulnerability.FixState, allAdvisoryDetails *match.Details, eusDistro *distro.Distro) {
 	advisories := advisoryResult.Vulnerabilities
 	var keepDetails bool
 	for _, advisory := range advisories {
@@ -210,9 +293,21 @@ func collectMatchingConstraintsDetailsAndFixState(v *version.Version, advisoryRe
 			*state = advisory.Fix.State
 		}
 
-		applicableFixes := neededFixes(v, advisory.Fix.Versions, advisory.Constraint.Format(), advisory.ID)
+		// Get all fixes greater than current version (parses versions once)
+		allFixes := neededFixes(v, advisory.Fix.Versions, advisory.Constraint.Format(), advisory.ID)
+
+		// Filter to only those reachable for EUS (quick string-based check)
+		applicableFixes := filterFixesForEUS(allFixes, eusDistro, advisory.ID)
+
 		if len(applicableFixes) == 0 {
-			// none of the fixes on this advisory are greater than the current version, so we can skip this advisory
+			// If there were fixes but none are reachable for EUS, mark as NotFixed
+			if len(allFixes) > 0 && eusDistro != nil && *state != vulnerability.FixStateFixed {
+				*state = vulnerability.FixStateNotFixed
+				// Still add the constraint since the user is vulnerable
+				*constraints = append(*constraints, advisory.Constraint)
+				keepDetails = true
+			}
+			// none of the fixes on this advisory are greater than the current version (or reachable for EUS), so we can skip adding fixes
 			continue
 		}
 
@@ -317,6 +412,23 @@ func neededFixes(v *version.Version, fixVersions []string, format version.Format
 	}
 
 	return needed
+}
+
+// filterFixesForEUS filters a list of fix versions to only those reachable for the given EUS distro.
+func filterFixesForEUS(fixes []*version.Version, eusDistro *distro.Distro, id string) []*version.Version {
+	if eusDistro == nil {
+		return fixes
+	}
+
+	var reachable []*version.Version
+	for _, fix := range fixes {
+		if isFixReachableForEUS(fix.Raw, eusDistro) {
+			reachable = append(reachable, fix)
+		} else {
+			log.WithFields("vulnerability", id, "fixVersion", fix.Raw, "eusDistro", eusDistro.String()).Trace("skipping fix not reachable for EUS version")
+		}
+	}
+	return reachable
 }
 
 func finalizeFixState(record vulnerability.Vulnerability, state vulnerability.FixState) vulnerability.FixState {

--- a/grype/matcher/rpm/rhel_eus_test.go
+++ b/grype/matcher/rpm/rhel_eus_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/grype/grype/distro"
@@ -18,14 +19,206 @@ import (
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
+func TestExtractRHELVersionFromRelease(t *testing.T) {
+	tests := []struct {
+		name      string
+		release   string
+		wantMajor int
+		wantMinor int
+		wantFound bool
+	}{
+		{
+			name:      "el9_5 pattern",
+			release:   "503.11.1.el9_5",
+			wantMajor: 9,
+			wantMinor: 5,
+			wantFound: true,
+		},
+		{
+			name:      "el8_10 pattern (double digit minor)",
+			release:   "82.el8_10.2",
+			wantMajor: 8,
+			wantMinor: 10,
+			wantFound: true,
+		},
+		{
+			name:      "el7 pattern (no minor version treated as 0)",
+			release:   "1.el7",
+			wantMajor: 7,
+			wantMinor: 0,
+			wantFound: true,
+		},
+		{
+			name:      "el9 pattern (no minor version treated as 0)",
+			release:   "427.79.1.el9",
+			wantMajor: 9,
+			wantMinor: 0,
+			wantFound: true,
+		},
+		{
+			name:      "el9_4 pattern",
+			release:   "427.79.1.el9_4",
+			wantMajor: 9,
+			wantMinor: 4,
+			wantFound: true,
+		},
+		{
+			name:      "no el pattern",
+			release:   "1.0.0",
+			wantMajor: 0,
+			wantMinor: 0,
+			wantFound: false,
+		},
+		{
+			name:      "empty string",
+			release:   "",
+			wantMajor: 0,
+			wantMinor: 0,
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMajor, gotMinor, gotFound := extractRHELVersionFromRelease(tt.release)
+			assert.Equal(t, tt.wantMajor, gotMajor, "major version mismatch")
+			assert.Equal(t, tt.wantMinor, gotMinor, "minor version mismatch")
+			assert.Equal(t, tt.wantFound, gotFound, "found mismatch")
+		})
+	}
+}
+
+func TestExtractReleaseFromRPMVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		rpmVersion string
+		want       string
+	}{
+		{
+			name:       "version with hyphen",
+			rpmVersion: "5.14.0-503.11.1.el9_5",
+			want:       "503.11.1.el9_5",
+		},
+		{
+			name:       "version with epoch and hyphen",
+			rpmVersion: "0:5.14.0-503.11.1.el9_5",
+			want:       "503.11.1.el9_5",
+		},
+		{
+			name:       "version without hyphen",
+			rpmVersion: "1.0.0",
+			want:       "1.0.0",
+		},
+		{
+			name:       "version with epoch but no hyphen",
+			rpmVersion: "1:2.3.4",
+			want:       "2.3.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractReleaseFromRPMVersion(tt.rpmVersion)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsFixReachableForEUS(t *testing.T) {
+	tests := []struct {
+		name       string
+		fixVersion string
+		eusDistro  *distro.Distro
+		want       bool
+	}{
+		{
+			name:       "nil distro - always reachable",
+			fixVersion: "5.14.0-503.11.1.el9_5",
+			eusDistro:  nil,
+			want:       true,
+		},
+		{
+			name:       "el9_5 fix NOT reachable from 9.4 EUS",
+			fixVersion: "5.14.0-503.11.1.el9_5",
+			eusDistro:  newEUSDistro("9.4"),
+			want:       false,
+		},
+		{
+			name:       "el9_4 fix IS reachable from 9.4 EUS (same minor)",
+			fixVersion: "5.14.0-427.80.1.el9_4",
+			eusDistro:  newEUSDistro("9.4"),
+			want:       true,
+		},
+		{
+			// This is the key test case: mainline 9.2 fixes ARE reachable from 9.4 EUS
+			// because EUS 9.4 includes all mainline fixes up to 9.4
+			name:       "el9_2 mainline fix IS reachable from 9.4 EUS (lower minor version)",
+			fixVersion: "5.14.0-100.el9_2",
+			eusDistro:  newEUSDistro("9.4"),
+			want:       true,
+		},
+		{
+			name:       "el9 base fix IS reachable from 9.4 EUS (no minor version in fix)",
+			fixVersion: "5.14.0-100.el9",
+			eusDistro:  newEUSDistro("9.4"),
+			want:       true,
+		},
+		{
+			name:       "el8 fix NOT reachable from el9 (different major)",
+			fixVersion: "4.18.0-100.el8_10",
+			eusDistro:  newEUSDistro("9.4"),
+			want:       false,
+		},
+		{
+			name:       "no el pattern - fail open (assume reachable)",
+			fixVersion: "1.0.0-1",
+			eusDistro:  newEUSDistro("9.4"),
+			want:       true,
+		},
+		{
+			name:       "distro without version - fail open",
+			fixVersion: "5.14.0-503.11.1.el9_5",
+			eusDistro:  newEUSDistro(""),
+			want:       true,
+		},
+		{
+			// "9+eus" (no minor) is treated as "9.0+eus", so el9_1 fixes are NOT reachable
+			name:       "distro with major only treated as .0 - el9_1 fix NOT reachable from 9+eus",
+			fixVersion: "5.14.0-100.el9_1",
+			eusDistro:  distro.New(distro.RedHat, "9+eus", ""),
+			want:       false,
+		},
+		{
+			// "9+eus" (no minor) is treated as "9.0+eus", so el9_0 fixes ARE reachable
+			name:       "distro with major only treated as .0 - el9_0 fix IS reachable from 9+eus",
+			fixVersion: "5.14.0-100.el9_0",
+			eusDistro:  distro.New(distro.RedHat, "9+eus", ""),
+			want:       true,
+		},
+		{
+			// "9+eus" (no minor) is treated as "9.0+eus", so base el9 fixes ARE reachable
+			name:       "distro with major only treated as .0 - el9 base fix IS reachable from 9+eus",
+			fixVersion: "5.14.0-100.el9",
+			eusDistro:  distro.New(distro.RedHat, "9+eus", ""),
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isFixReachableForEUS(tt.fixVersion, tt.eusDistro)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestResolveEUSDisclosures(t *testing.T) {
 	tests := []struct {
-		name                     string
-		packageVersion           string
-		resolutionsAsDisclosures bool
-		disclosures              []result.Result
-		advisoryOverlay          []result.Result
-		want                     []result.Result
+		name            string
+		packageVersion  string
+		disclosures     []result.Result
+		advisoryOverlay []result.Result
+		want            []result.Result
 	}{
 		{
 			name:           "disclosure with fix version - package version is vulnerable",
@@ -559,7 +752,7 @@ func TestResolveEUSDisclosures(t *testing.T) {
 				v = nil
 			}
 
-			resolver := mergeEUSAdvisoriesIntoMainDisclosures(v, tt.resolutionsAsDisclosures)
+			resolver := mergeEUSAdvisoriesIntoMainDisclosures(v, nil)
 
 			got := resolver(tt.disclosures, tt.advisoryOverlay)
 
@@ -581,11 +774,7 @@ func TestRedhatEUSMatches(t *testing.T) {
 		Name:    "test-pkg",
 		Version: "1.0.0",
 		Type:    syftPkg.RpmPkg,
-		Distro: &distro.Distro{
-			Type:     distro.RedHat,
-			Version:  "9.4",
-			Channels: channels("eus"),
-		},
+		Distro:  newEUSDistro("9.4"),
 	}
 
 	tests := []struct {
@@ -655,11 +844,7 @@ func TestRedhatEUSMatches(t *testing.T) {
 						Name:    "test-pkg",
 						Version: "1.0.0",
 						Type:    syftPkg.RpmPkg,
-						Distro: &distro.Distro{
-							Type:     distro.RedHat,
-							Version:  "9.4",
-							Channels: channels("eus"),
-						},
+						Distro:  newEUSDistro("9.4"),
 					},
 					Details: []match.Detail{
 						{
@@ -714,11 +899,7 @@ func TestRedhatEUSMatches(t *testing.T) {
 				Name:    "indirect-test-pkg", // important! this will be detected as an indirect match
 				Version: "1.0.0",
 				Type:    syftPkg.RpmPkg,
-				Distro: &distro.Distro{
-					Type:     distro.RedHat,
-					Version:  "9.4",
-					Channels: channels("eus"),
-				},
+				Distro:  newEUSDistro("9.4"),
 			},
 			disclosureVulns: []vulnerability.Vulnerability{
 				{
@@ -766,11 +947,7 @@ func TestRedhatEUSMatches(t *testing.T) {
 						Name:    "test-pkg",
 						Version: "1.0.0",
 						Type:    syftPkg.RpmPkg,
-						Distro: &distro.Distro{
-							Type:     distro.RedHat,
-							Version:  "9.4",
-							Channels: channels("eus"),
-						},
+						Distro:  newEUSDistro("9.4"),
 					},
 					Details: []match.Detail{
 						{
@@ -854,11 +1031,7 @@ func TestRedhatEUSMatches(t *testing.T) {
 						Name:    "test-pkg",
 						Version: "1.0.0",
 						Type:    syftPkg.RpmPkg,
-						Distro: &distro.Distro{
-							Type:     distro.RedHat,
-							Version:  "9.4",
-							Channels: channels("eus"),
-						},
+						Distro:  newEUSDistro("9.4"),
 					},
 					Details: []match.Detail{
 						{
@@ -892,11 +1065,7 @@ func TestRedhatEUSMatches(t *testing.T) {
 				Name:    "test-pkg",
 				Version: "2.0.0", // version higher than fix, so resolved
 				Type:    syftPkg.RpmPkg,
-				Distro: &distro.Distro{
-					Type:     distro.RedHat,
-					Version:  "9.4",
-					Channels: channels("eus"),
-				},
+				Distro:  newEUSDistro("9.4"),
 			},
 			disclosureVulns: []vulnerability.Vulnerability{
 				{
@@ -1000,11 +1169,7 @@ func TestRedhatEUSMatches(t *testing.T) {
 						Name:    "test-pkg",
 						Version: "1.0.0",
 						Type:    syftPkg.RpmPkg,
-						Distro: &distro.Distro{
-							Type:     distro.RedHat,
-							Version:  "9.4",
-							Channels: channels("eus"),
-						},
+						Distro:  newEUSDistro("9.4"),
 					},
 					Details: []match.Detail{
 						{
@@ -1086,11 +1251,7 @@ func TestRedhatEUSMatches(t *testing.T) {
 						Name:    "test-pkg",
 						Version: "1.0.0",
 						Type:    syftPkg.RpmPkg,
-						Distro: &distro.Distro{
-							Type:     distro.RedHat,
-							Version:  "9.4",
-							Channels: channels("eus"),
-						},
+						Distro:  newEUSDistro("9.4"),
 					},
 					Details: []match.Detail{
 						{
@@ -1170,6 +1331,117 @@ func TestRedhatEUSMatches(t *testing.T) {
 			disclosureError: errors.New("disclosure error"),
 			want:            nil,
 			wantErr:         require.Error,
+		},
+		{
+			// This test case demonstrates issue #2847: when a user is on RHEL 9.4+eus and
+			// the only available fix is for RHEL 9.5 (indicated by el9_5 in the fix version),
+			// the vulnerability should NOT be reported as "Fixed" when using --only-fixed,
+			// because the EUS user cannot upgrade to RHEL 9.5.
+			name: "fix version for higher minor version should not be considered fixed for EUS - issue 2847",
+			catalogPkg: pkg.Package{
+				ID:      pkg.ID("kernel-id"),
+				Name:    "kernel",
+				Version: "5.14.0-427.79.1.el9_4", // user's current version on RHEL 9.4 EUS
+				Type:    syftPkg.RpmPkg,
+				Distro:  newEUSDistro("9.4"),
+			},
+			disclosureVulns: []vulnerability.Vulnerability{
+				{
+					Reference: vulnerability.Reference{
+						ID:        "CVE-2020-10135",
+						Namespace: "redhat:distro:redhat:9",
+					},
+					PackageName: "kernel",
+					Constraint:  version.MustGetConstraint("< 5.14.0-503.11.1.el9_5", version.RpmFormat),
+					Fix: vulnerability.Fix{
+						State:    vulnerability.FixStateUnknown,
+						Versions: []string{},
+					},
+				},
+			},
+			resolutionVulns: []vulnerability.Vulnerability{
+				{
+					// This fix is for RHEL 9.5 (indicated by el9_5 in the version),
+					// which is NOT available to RHEL 9.4 EUS users
+					Reference: vulnerability.Reference{
+						ID:        "CVE-2020-10135",
+						Namespace: "redhat:distro:redhat:9",
+					},
+					PackageName: "kernel",
+					Constraint:  version.MustGetConstraint("< 5.14.0-503.11.1.el9_5", version.RpmFormat),
+					Fix: vulnerability.Fix{
+						State:    vulnerability.FixStateFixed,
+						Versions: []string{"5.14.0-503.11.1.el9_5"}, // note: el9_5 indicates RHEL 9.5
+					},
+				},
+			},
+			// Expected behavior: since the fix requires upgrading to RHEL 9.5 and the user
+			// is on RHEL 9.4 EUS (can't upgrade to 9.5), the fix should NOT be considered
+			// valid and the FixState should be NotFixed (not Fixed).
+			want: []match.Match{
+				{
+					Vulnerability: vulnerability.Vulnerability{
+						Reference: vulnerability.Reference{
+							ID:        "CVE-2020-10135",
+							Namespace: "redhat:distro:redhat:9",
+						},
+						PackageName: "kernel",
+						Fix: vulnerability.Fix{
+							State:    vulnerability.FixStateNotFixed, // fix exists but not reachable for EUS 9.4
+							Versions: []string{},                     // no valid fixes for EUS 9.4
+						},
+					},
+					Package: pkg.Package{
+						ID:      pkg.ID("kernel-id"),
+						Name:    "kernel",
+						Version: "5.14.0-427.79.1.el9_4",
+						Type:    syftPkg.RpmPkg,
+						Distro:  newEUSDistro("9.4"),
+					},
+					Details: []match.Detail{
+						{
+							Type: match.ExactDirectMatch,
+							SearchedBy: match.DistroParameters{
+								Distro: match.DistroIdentification{
+									Type:    "redhat",
+									Version: "9.4",
+								},
+								Package: match.PackageParameter{
+									Name:    "kernel",
+									Version: "5.14.0-427.79.1.el9_4",
+								},
+								Namespace: "redhat:distro:redhat:9",
+							},
+							Found: match.DistroResult{
+								VulnerabilityID:   "CVE-2020-10135",
+								VersionConstraint: "< 5.14.0-503.11.1.el9_5 (rpm)",
+							},
+							Matcher:    match.RpmMatcher,
+							Confidence: 1,
+						},
+						{
+							Type: match.ExactDirectMatch,
+							SearchedBy: match.DistroParameters{
+								Distro: match.DistroIdentification{
+									Type:    "redhat",
+									Version: "9.4+eus",
+								},
+								Package: match.PackageParameter{
+									Name:    "kernel",
+									Version: "5.14.0-427.79.1.el9_4",
+								},
+								Namespace: "redhat:distro:redhat:9",
+							},
+							Found: match.DistroResult{
+								VulnerabilityID:   "CVE-2020-10135",
+								VersionConstraint: "< 5.14.0-503.11.1.el9_5 (rpm)",
+							},
+							Matcher:    match.RpmMatcher,
+							Confidence: 1,
+						},
+					},
+				},
+			},
 		},
 		{
 			name:       "error fetching resolutions",
@@ -1295,4 +1567,19 @@ func (m *mockVulnProvider) FindVulnerabilities(criteria ...vulnerability.Criteri
 
 func channels(s ...string) []string {
 	return s
+}
+
+// newEUSDistro creates a properly initialized RHEL EUS distro using distro.New().
+// This ensures MajorVersion()/MinorVersion() work correctly.
+// Pass version like "9.4" (the "+eus" channel suffix is added automatically).
+// Pass empty string for a distro without a version.
+func newEUSDistro(version string) *distro.Distro {
+	if version == "" {
+		// For empty version, we need to set channels manually since "+eus" alone
+		// doesn't parse well
+		d := distro.New(distro.RedHat, "", "")
+		d.Channels = []string{"eus"}
+		return d
+	}
+	return distro.New(distro.RedHat, version+"+eus", "")
 }


### PR DESCRIPTION
When using --only-fixed with RHEL EUS, fixes targeting a higher minor version (e.g., el9_5) were incorrectly shown as "fixed" for users on lower EUS versions (e.g., 9.4 EUS). EUS users cannot upgrade to a higher minor version, so these fixes are not actually reachable.

Now grype parses the elX_Y suffix from fix versions and compares against the user's EUS minor version. Fixes for higher minor versions are marked as "not-fixed" instead of "fixed".

- Add isFixReachableForEUS to check fix version against EUS distro
- Mark unreachable fixes as NotFixed instead of Fixed
- Treat missing minor version as 0 (e.g., "9+eus" = "9.0+eus")
- Remove unused treatResolutionsAsDisclosures parameter

Fixes [#2847](https://github.com/anchore/grype/issues/2847)