### PR TITLE
fix: disable version fallback in EOL query

### DIFF
--- a/grype/db/v6/operating_system_store.go
+++ b/grype/db/v6/operating_system_store.go
@@ -37,6 +37,11 @@ type OSSpecifier struct {
 
 	// DisableAliasing prevents OS aliasing when true (used for exact distro matching)
 	DisableAliasing bool
+
+	// DisableFallback prevents fallback to less specific version matching when true.
+	// When set, only exact version matches are returned (no major-only fallback).
+	// Used for EOL lookups where we don't want e.g. Alpine 3.24 to match Alpine 3.12.
+	DisableFallback bool
 }
 
 func (d *OSSpecifier) clean() {
@@ -379,6 +384,11 @@ func (s *operatingSystemStore) searchForOSExactVersions(query *gorm.DB, d OSSpec
 			if err != nil || len(result) > 0 {
 				return result, err
 			}
+		}
+
+		// when fallback is disabled, don't try less specific version matches
+		if d.DisableFallback {
+			return nil, nil
 		}
 
 		// fallback to major version only, requiring the minor version to be blank. Note: it is important that we don't

--- a/grype/db/v6/operating_system_store_test.go
+++ b/grype/db/v6/operating_system_store_test.go
@@ -314,6 +314,25 @@ func TestOperatingSystemStore_ResolveOperatingSystem(t *testing.T) {
 			},
 			expected: []OperatingSystem{*minimos},
 		},
+		{
+			name: "nonexistent minor version falls back to major by default",
+			os: OSSpecifier{
+				Name:         "alpine",
+				MajorVersion: "3",
+				MinorVersion: "99", // doesn't exist, should fall back to 3.18
+			},
+			expected: []OperatingSystem{*alpine318},
+		},
+		{
+			name: "nonexistent minor version with DisableFallback returns nothing",
+			os: OSSpecifier{
+				Name:            "alpine",
+				MajorVersion:    "3",
+				MinorVersion:    "99", // doesn't exist
+				DisableFallback: true, // should NOT fall back
+			},
+			expected: nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/grype/db/v6/vulnerability_provider.go
+++ b/grype/db/v6/vulnerability_provider.go
@@ -362,6 +362,7 @@ func (vp vulnerabilityProvider) GetOperatingSystemEOL(d *distro.Distro) (eolDate
 		RemainingVersion: d.RemainingVersion(),
 		LabelVersion:     d.Codename,
 		DisableAliasing:  true, // EOL lookups must use exact distro match
+		DisableFallback:  true, // don't fall back to major-only matching (e.g. Alpine 3.24 shouldn't match EOL'd 3.12)
 	}
 
 	results, err := vp.reader.GetOperatingSystems(spec)


### PR DESCRIPTION
Previously, searching alpine:edge would result in searching for
alpine:3.24, which doesn't exist yet (because it's a prerelease / edge
build), and so the code would fall back to only major version matching,
resulting in alpine:edge being reported as EOL because the query
returned Alpine 3.12, which is EOL.

Signed-off-by: Will Murphy <willmurphyscode@users.noreply.github.com>
