### PR TITLE
feat: support context cancellation while finding vuln matches

### DIFF
--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -81,12 +82,12 @@ You can also pipe in Syft JSON directly:
 		Args:          validateRootArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			userInput := ""
 			if len(args) > 0 {
 				userInput = args[0]
 			}
-			return runGrype(app, opts, userInput)
+			return runGrype(cmd.Context(), app, opts, userInput)
 		},
 		ValidArgsFunction: dockerImageValidArgsFunction,
 	}, opts)
@@ -114,7 +115,7 @@ var ignoreLinuxKernelHeaders = []match.IgnoreRule{
 }
 
 //nolint:funlen
-func runGrype(app clio.Application, opts *options.Grype, userInput string) (errs error) {
+func runGrype(ctx context.Context, app clio.Application, opts *options.Grype, userInput string) (errs error) {
 	writer, err := format.MakeScanResultWriter(opts.Outputs, opts.File, format.PresentationConfig{
 		TemplateFilePath: opts.OutputTemplateFile,
 		ShowSuppressed:   opts.ShowSuppressed,
@@ -228,7 +229,7 @@ func runGrype(app clio.Application, opts *options.Grype, userInput string) (errs
 		VexProcessor:          vexProcessor,
 	}
 
-	remainingMatches, ignoredMatches, err := vulnMatcher.FindMatches(packages, pkgContext)
+	remainingMatches, ignoredMatches, err := vulnMatcher.FindMatchesContext(ctx, packages, pkgContext)
 	if err != nil {
 		if !errors.Is(err, grypeerr.ErrAboveSeverityThreshold) {
 			return err

--- a/grype/vulnerability_matcher.go
+++ b/grype/vulnerability_matcher.go
@@ -1,6 +1,7 @@
 package grype
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"runtime/debug"
@@ -69,11 +70,27 @@ func (m *VulnerabilityMatcher) EOLDistroPackages() []pkg.Package {
 	return m.eolDistroPackages
 }
 
-func (m *VulnerabilityMatcher) FindMatches(pkgs []pkg.Package, context pkg.Context) (remainingMatches *match.Matches, ignoredMatches []match.IgnoredMatch, err error) {
+// FindMatches finds vulnerabilities for the given packages and package context.
+// FindMatches does not support context cancellation; for that, use
+// FindMatchesContext.
+func (m *VulnerabilityMatcher) FindMatches(
+	pkgs []pkg.Package,
+	pkgContext pkg.Context,
+) (remainingMatches *match.Matches, ignoredMatches []match.IgnoredMatch, err error) {
+	return m.FindMatchesContext(context.Background(), pkgs, pkgContext)
+}
+
+// FindMatchesContext finds vulnerabilities for the given packages and package
+// context, and supports context cancellation.
+func (m *VulnerabilityMatcher) FindMatchesContext(
+	ctx context.Context,
+	pkgs []pkg.Package,
+	pkgContext pkg.Context,
+) (remainingMatches *match.Matches, ignoredMatches []match.IgnoredMatch, err error) {
 	progressMonitor := trackMatcher(len(pkgs))
 
-	// capture distro detection failure from context for alerting
-	m.distroDetectionFailed = context.DistroDetectionFailed
+	// capture distro detection failure from pkgContext for alerting
+	m.distroDetectionFailed = pkgContext.DistroDetectionFailed
 	if m.distroDetectionFailed {
 		log.Warn("distro detection failed: linux release info was present but distro type could not be determined")
 	}
@@ -86,13 +103,13 @@ func (m *VulnerabilityMatcher) FindMatches(pkgs []pkg.Package, context pkg.Conte
 		}
 	}()
 
-	remainingMatches, ignoredMatches, err = m.findDBMatches(pkgs, progressMonitor)
+	remainingMatches, ignoredMatches, err = m.findDBMatches(ctx, pkgs, progressMonitor)
 	if err != nil {
 		err = fmt.Errorf("unable to find matches against vulnerability database: %w", err)
 		return remainingMatches, ignoredMatches, err
 	}
 
-	remainingMatches, ignoredMatches, err = m.findVEXMatches(context, remainingMatches, ignoredMatches, progressMonitor)
+	remainingMatches, ignoredMatches, err = m.findVEXMatches(pkgContext, remainingMatches, ignoredMatches, progressMonitor)
 	if err != nil {
 		err = fmt.Errorf("unable to find matches against VEX sources: %w", err)
 		return remainingMatches, ignoredMatches, err
@@ -110,11 +127,11 @@ func (m *VulnerabilityMatcher) FindMatches(pkgs []pkg.Package, context pkg.Conte
 	return remainingMatches, ignoredMatches, nil
 }
 
-func (m *VulnerabilityMatcher) findDBMatches(pkgs []pkg.Package, progressMonitor *monitorWriter) (*match.Matches, []match.IgnoredMatch, error) {
+func (m *VulnerabilityMatcher) findDBMatches(ctx context.Context, pkgs []pkg.Package, progressMonitor *monitorWriter) (*match.Matches, []match.IgnoredMatch, error) {
 	var ignoredMatches []match.IgnoredMatch
 
 	log.Trace("finding matches against DB")
-	matches, err := m.searchDBForMatches(pkgs, progressMonitor)
+	matches, err := m.searchDBForMatches(ctx, pkgs, progressMonitor)
 	if err != nil {
 		if match.IsFatalError(err) {
 			return nil, nil, err
@@ -160,6 +177,7 @@ func (m *VulnerabilityMatcher) mergeIgnoredMatches(allIgnoredMatches ...[]match.
 
 //nolint:funlen
 func (m *VulnerabilityMatcher) searchDBForMatches(
+	ctx context.Context,
 	packages []pkg.Package,
 	progressMonitor *monitorWriter,
 ) (match.Matches, error) {
@@ -213,6 +231,10 @@ func (m *VulnerabilityMatcher) searchDBForMatches(
 			matchAgainst = []match.Matcher{defaultMatcher}
 		}
 		for _, theMatcher := range matchAgainst {
+			if err := ctx.Err(); err != nil {
+				return match.Matches{}, err
+			}
+
 			matches, ignorers, err := callMatcherSafely(theMatcher, m.VulnerabilityProvider, p)
 			if err != nil {
 				if match.IsFatalError(err) {
@@ -265,14 +287,14 @@ func callMatcherSafely(m match.Matcher, vp vulnerability.Provider, p pkg.Package
 	return m.Match(vp, p)
 }
 
-func (m *VulnerabilityMatcher) findVEXMatches(context pkg.Context, remainingMatches *match.Matches, ignoredMatches []match.IgnoredMatch, progressMonitor *monitorWriter) (*match.Matches, []match.IgnoredMatch, error) {
+func (m *VulnerabilityMatcher) findVEXMatches(pkgContext pkg.Context, remainingMatches *match.Matches, ignoredMatches []match.IgnoredMatch, progressMonitor *monitorWriter) (*match.Matches, []match.IgnoredMatch, error) {
 	if m.VexProcessor == nil {
 		log.Trace("no VEX documents provided, skipping VEX matching")
 		return remainingMatches, ignoredMatches, nil
 	}
 
 	log.Trace("finding matches against available VEX documents")
-	matchesAfterVex, ignoredMatchesAfterVex, err := m.VexProcessor.ApplyVEX(&context, remainingMatches, ignoredMatches)
+	matchesAfterVex, ignoredMatchesAfterVex, err := m.VexProcessor.ApplyVEX(&pkgContext, remainingMatches, ignoredMatches)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to find matches against VEX documents: %w", err)
 	}


### PR DESCRIPTION
Today Grype's library entrypoint for vulnerability matching `FindMatches` doesn't accept a `context.Context`.

In idiomatic Go, function calls that either perform I/O or do nontrivial processing (`FindMatches` does both) accept a `ctx context.Context` as the first parameter and check for context cancellation at appropriate points during processing to allow the caller to stop long-running work early as needed.

This PR adds support for context cancellation in a non-breaking way:

- The implementation of `FindMatches` moves to a new variant, `FindMatchesContext`.
- `FindMatchesContext` checks for context errors (e.g. cancellation) at each iteration of the inner loop right before a specific matcher is called for a specific package. Non-nil context errors cause the function to return immediately.
- The signature of `FindMatches` doesn't change, and it's now a thin wrapper that passes `context.Background()` to `FindMatchesContext`.
- Cobra's command context is now able to be plumbed to `FindMatchesContext` (via `runGrype`).

**Note:** If there's other process cleanup or CLI UX changes needed as a result of this that aren't handled yet, just let me know!