### PR TITLE
fix(eol-warnings): fix fallback on major only distro

### DIFF
--- a/grype/db/v6/operating_system_store.go
+++ b/grype/db/v6/operating_system_store.go
@@ -384,6 +384,13 @@ func (s *operatingSystemStore) searchForOSExactVersions(query *gorm.DB, d OSSpec
 			if err != nil || len(result) > 0 {
 				return result, err
 			}
+		} else {
+			// empty minor version - exact match for major-only distros (e.g., Debian 8, 9, 10...)
+			majorExclusiveQuery := query.Session(&gorm.Session{}).Where("major_version = ? AND minor_version = ?", d.MajorVersion, "")
+			result, err = handleQuery(majorExclusiveQuery, "major version with empty minor")
+			if err != nil || len(result) > 0 {
+				return result, err
+			}
 		}
 
 		// when fallback is disabled, don't try less specific version matches

--- a/grype/db/v6/operating_system_store_test.go
+++ b/grype/db/v6/operating_system_store_test.go
@@ -333,6 +333,34 @@ func TestOperatingSystemStore_ResolveOperatingSystem(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			name: "major-only distro with DisableFallback finds exact match (Debian EOL lookup)",
+			os: OSSpecifier{
+				Name:            "debian",
+				MajorVersion:    "10",
+				MinorVersion:    "", // Debian uses major-only versions
+				DisableFallback: true,
+			},
+			expected: []OperatingSystem{*debian10},
+		},
+		{
+			name: "RHEL major-only lookup finds major-only record (vuln matching)",
+			os: OSSpecifier{
+				Name:         "rhel",
+				MajorVersion: "8",
+				MinorVersion: "", // empty minor should find rhel8 directly
+			},
+			expected: []OperatingSystem{*rhel8},
+		},
+		{
+			name: "RHEL nonexistent minor falls back to major-only record (vuln matching)",
+			os: OSSpecifier{
+				Name:         "rhel",
+				MajorVersion: "8",
+				MinorVersion: "5", // 8.5 doesn't exist, should fall back to 8
+			},
+			expected: []OperatingSystem{*rhel8},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION

Previously, there was a bug where rolling distros like alpine:edge would
incorrectly fallback to an EOLed version of alpine, resulting in
spurious EOL warnings. This was fixed by disabling the fallback in the
EOL query. However, this fix introduced a bug where major only distros,
like "Debian 8", would not fall back correctly. Therefore, when fallback
is disabled on the distro, and the minor version is missing, treat
"blank minor version" as part of the query, instead of unintentionally
excluding based on it.

Add a couple more unit tests to OS querying.
