### PR TITLE
fix: charmbracelet/bubbletea erases grype ui status line

### DIFF
--- a/cmd/grype/cli/ui/__snapshots__/handle_vulnerability_scanning_started_test.snap
+++ b/cmd/grype/cli/ui/__snapshots__/handle_vulnerability_scanning_started_test.snap
@@ -6,6 +6,7 @@
 [TestHandler_handleVulnerabilityScanningStarted/vulnerability_scanning_in_progress/tree - 1]
    ├── by severity: 1 critical, 2 high, 3 medium, 4 low, 5 negligible (6 unknown)
    └── by status:   30 fixed, 10 not-fixed, 4 ignored (2 dropped)
+
 ---
 
 [TestHandler_handleVulnerabilityScanningStarted/vulnerability_scanning_complete/task_line - 1]
@@ -15,4 +16,5 @@
 [TestHandler_handleVulnerabilityScanningStarted/vulnerability_scanning_complete/tree - 1]
    ├── by severity: 1 critical, 2 high, 3 medium, 4 low, 5 negligible (6 unknown)
    └── by status:   35 fixed, 10 not-fixed, 5 ignored (3 dropped)
+
 ---

--- a/cmd/grype/cli/ui/handle_vulnerability_scanning_started.go
+++ b/cmd/grype/cli/ui/handle_vulnerability_scanning_started.go
@@ -185,6 +185,7 @@ func (l vulnerabilityProgressTree) View() string {
 		),
 	)
 	sb.WriteString("\n" + fixedStr)
+	sb.WriteString("\n")
 
 	return sb.String()
 }


### PR DESCRIPTION
## Summary

When the UI model returns `tea.Quit` from its `Update()` bubbletea calls `standardRenderer.stop().` This fires `EraseEntireLine` on the last rendered line:
https://github.com/charmbracelet/bubbletea/blob/f9233d51192293dadda7184a4de347738606c328/standard_renderer.go#L103-L124

In grype the last line of the entire output before the table renders is
```
└── by status: 12 fixed, 235 not-fixed, 0 ignored
```

This PR adds a new line after this status. The new `\n`is then countered by `r.execute(ansi.EraseEntireLine)` rather than the status line being deleted.

#### Fixed (Has Status line)
<img width="872" height="282" alt="Screenshot 2026-02-09 at 12 04 07 AM" src="https://github.com/user-attachments/assets/81efc994-8c85-44c3-b05c-e7b3acf38378" />

#### Grype Main (Status cut off)
<img width="904" height="236" alt="Screenshot 2026-02-09 at 12 04 52 AM" src="https://github.com/user-attachments/assets/2aa8702b-dfb8-4898-b537-209e2fadba01" />