### PR TITLE
fix(db search vuln): missing EPSS/KEV should not be fatal error

### DIFF
--- a/cmd/grype/cli/commands/internal/dbsearch/affected_packages.go
+++ b/cmd/grype/cli/commands/internal/dbsearch/affected_packages.go
@@ -232,15 +232,11 @@ func findAffectedPackages(reader interface { //nolint:funlen,gocognit
 	// ensures that all paths are handled the same way.
 	defer func() {
 		for i := range allAffectedPkgs {
-			if err := decorateVulnerabilities(reader, &allAffectedPkgs[i]); err != nil {
-				log.WithFields("error", err).Debug("unable to decorate vulnerability on affected package")
-			}
+			decorateVulnerabilities(reader, &allAffectedPkgs[i])
 		}
 
 		for i := range allAffectedCPEs {
-			if err := decorateVulnerabilities(reader, &allAffectedCPEs[i]); err != nil {
-				log.WithFields("error", err).Debug("unable to decorate vulnerability on affected CPE")
-			}
+			decorateVulnerabilities(reader, &allAffectedCPEs[i])
 		}
 	}()
 

--- a/cmd/grype/cli/commands/internal/dbsearch/vulnerabilities.go
+++ b/cmd/grype/cli/commands/internal/dbsearch/vulnerabilities.go
@@ -272,9 +272,7 @@ func FindVulnerabilities(reader interface { //nolint:funlen
 	}
 
 	for i := range pairs {
-		if err := decorateVulnerabilities(reader, &pairs[i]); err != nil {
-			return nil, fmt.Errorf("unable to decorate vulnerability: %w", err)
-		}
+		decorateVulnerabilities(reader, &pairs[i])
 	}
 
 	var err error

--- a/cmd/grype/cli/commands/internal/dbsearch/vulnerabilities_test.go
+++ b/cmd/grype/cli/commands/internal/dbsearch/vulnerabilities_test.go
@@ -1,6 +1,7 @@
 package dbsearch
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -347,6 +348,66 @@ func TestVulnerabilities(t *testing.T) {
 
 	if diff := cmp.Diff(expected, results, cmpOpts()...); diff != "" {
 		t.Errorf("unexpected results (-want +got):\n%s", diff)
+	}
+}
+
+func TestFindVulnerabilities_DecorationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		kevErr  error
+		epssErr error
+	}{
+		{
+			name:    "EPSS error is not fatal",
+			epssErr: fmt.Errorf("unable to fetch EPSS metadata: record not found"),
+		},
+		{
+			name:   "KEV error is not fatal",
+			kevErr: fmt.Errorf("unable to fetch KEV records: record not found"),
+		},
+		{
+			name:    "both EPSS and KEV errors are not fatal",
+			kevErr:  fmt.Errorf("unable to fetch KEV records: record not found"),
+			epssErr: fmt.Errorf("unable to fetch EPSS metadata: record not found"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockReader := new(mockVulnReader)
+
+			mockReader.On("GetVulnerabilities", mock.Anything, mock.Anything).Return([]v6.VulnerabilityHandle{
+				{
+					ID:       1,
+					Name:     "CVE-2021-22947",
+					Status:   "active",
+					Provider: &v6.Provider{ID: "nvd"},
+					BlobValue: &v6.VulnerabilityBlob{
+						Description: "Test vuln",
+					},
+				},
+			}, nil)
+
+			mockReader.On("GetAffectedPackages", mock.Anything, mock.Anything).Return([]v6.AffectedPackageHandle{}, nil)
+
+			mockReader.On("GetKnownExploitedVulnerabilities", "CVE-2021-22947").Return(
+				[]v6.KnownExploitedVulnerabilityHandle{}, tt.kevErr,
+			)
+
+			mockReader.On("GetEpss", "CVE-2021-22947").Return(
+				[]v6.EpssHandle{}, tt.epssErr,
+			)
+
+			results, err := FindVulnerabilities(mockReader, VulnerabilitiesOptions{
+				Vulnerability: v6.VulnerabilitySpecifiers{{Name: "CVE-2021-22947"}},
+			})
+
+			require.NoError(t, err, "decoration errors should not propagate as fatal errors")
+			require.Len(t, results, 1)
+			require.Equal(t, "Test vuln", results[0].VulnerabilityBlob.Description)
+			require.Empty(t, results[0].KnownExploited)
+			require.Empty(t, results[0].EPSS)
+		})
 	}
 }
 

--- a/cmd/grype/cli/commands/internal/dbsearch/vulnerability_decorations.go
+++ b/cmd/grype/cli/commands/internal/dbsearch/vulnerability_decorations.go
@@ -1,7 +1,6 @@
 package dbsearch
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -9,6 +8,7 @@ import (
 	"github.com/scylladb/go-set/strset"
 
 	v6 "github.com/anchore/grype/grype/db/v6"
+	"github.com/anchore/grype/internal/log"
 )
 
 type canonicalVulnerability interface {
@@ -25,7 +25,7 @@ type vulnerabilityDecorations struct {
 	EPSS           []EPSS           `json:"epss,omitempty"`
 }
 
-func decorateVulnerabilities(reader v6.VulnerabilityDecoratorStoreReader, cvs ...canonicalVulnerability) error {
+func decorateVulnerabilities(reader v6.VulnerabilityDecoratorStoreReader, cvs ...canonicalVulnerability) {
 	for _, cv := range cvs {
 		cves := cv.getCVEs()
 		if len(cves) == 0 {
@@ -34,17 +34,16 @@ func decorateVulnerabilities(reader v6.VulnerabilityDecoratorStoreReader, cvs ..
 
 		knownExploited, err := fetchKnownExploited(reader, cves)
 		if err != nil {
-			return fmt.Errorf("unable to get known exploited vulnerabilities: %w", err)
+			log.WithFields("error", err).Debug("unable to get known exploited vulnerabilities")
 		}
 
 		epss, err := fetchEpss(reader, cves)
 		if err != nil {
-			return fmt.Errorf("unable to get EPSS scores: %w", err)
+			log.WithFields("error", err).Debug("unable to get EPSS scores")
 		}
 
 		cv.decorate(knownExploited, epss)
 	}
-	return nil
 }
 
 func (afj *vulnerabilityAffectedPackageJoin) getCVEs() []string {


### PR DESCRIPTION
Previously, when running 'grype db search vuln ...', especially in a dev environment with only a subset of the real database available, grype would treat missing EPSS or KEV for the vuln as a fatal error. However, this missing auxiliary information should not prevent grype from displaying the vuln at all.