### PR TITLE
ci(snapshots): update CLI tests to exercise existing snapshots

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -281,6 +281,9 @@ jobs:
 
       - name: Run CLI Tests (Linux)
         run: make cli
+        env:
+          GRYPE_SNAPSHOT_PREBUILT: "true"
+          GRYPE_BINARY_LOCATION: ${{ github.workspace }}/snapshot/linux-build_linux_amd64_v1/grype
 
   Cleanup-Cache:
     name: "Cleanup snapshot cache"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -221,12 +221,20 @@ tasks:
       # exercise most of the CLI with the data race detector enabled
       - "go run -race cmd/{{ .PROJECT }}/main.go alpine:latest"
 
+  _ensure-snapshot:
+    # Ensure the snapshot binary is available, building only if needed.
+    # In CI, set GRYPE_SNAPSHOT_PREBUILT=true to skip the rebuild when the binary was restored from cache.
+    # Locally, this falls through to the snapshot task which uses checksum-based staleness detection
+    # so that code changes always produce a fresh binary.
+    internal: true
+    status:
+      - test -n "$GRYPE_SNAPSHOT_PREBUILT" -a -f "{{ .SNAPSHOT_BIN }}"
+    cmds:
+      - task: snapshot
+
   cli:
     desc: Run CLI tests
-    # note: we don't want to regenerate the snapshot unless we have to. In CI it's probable
-    # that the cache being restored with the correct binary will be rebuilt since the timestamps
-    # and local checksums will not line up.
-    deps: [tools, snapshot]
+    deps: [tools, _ensure-snapshot]
     sources:
       - "{{ .SNAPSHOT_BIN }}"
       - ./test/cli/**


### PR DESCRIPTION
Previously, the CI validations workflow would make build the snapshots, then invoke a Taskfile target that would build the snapshot again, then invoke a go test that would `go build` the CLI again, and then exercise that CLI. Instead, update it so that the snapshot built by the snapshot CI job is used in tests and not rebuilt unnecessarily.