### PR TITLE
feat(build): enable fedora OS transformer

### DIFF
--- a/grype/db/v6/build/transformers/os/test-fixtures/fedora-39.json
+++ b/grype/db/v6/build/transformers/os/test-fixtures/fedora-39.json
@@ -1,0 +1,33 @@
+[
+  {
+    "Vulnerability": {
+      "CVSS": [],
+      "Description": "Security update for glib2 to fix CVE-2024-34397",
+      "FixedIn": [
+        {
+          "Name": "glib2",
+          "NamespaceName": "fedora:39",
+          "VendorAdvisory": {
+            "AdvisorySummary": [
+              {
+                "ID": "FEDORA-2024-fd2569c4e9",
+                "Link": "https://bodhi.fedoraproject.org/updates/FEDORA-2024-fd2569c4e9"
+              }
+            ],
+            "NoAdvisory": false
+          },
+          "Version": "0:2.78.6-1.fc39",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://bodhi.fedoraproject.org/updates/FEDORA-2024-fd2569c4e9",
+      "Metadata": {
+        "Issued": "2024-05-09T02:43:30Z",
+        "Updated": "2024-05-14T03:27:20Z"
+      },
+      "Name": "CVE-2024-34397",
+      "NamespaceName": "fedora:39",
+      "Severity": "High"
+    }
+  }
+]

--- a/grype/db/v6/build/transformers/os/transform.go
+++ b/grype/db/v6/build/transformers/os/transform.go
@@ -240,7 +240,7 @@ func groupFixedIns(vuln unmarshal.OSVulnerability) map[groupIndex][]unmarshal.OS
 
 func getPackageType(osName string) pkg.Type {
 	switch osName {
-	case "redhat", "amazonlinux", "oraclelinux", "sles", "mariner", "azurelinux", "photon":
+	case "redhat", "amazonlinux", "oraclelinux", "sles", "mariner", "azurelinux", "photon", "fedora", "rocky", "rockylinux", "almalinux", "centos":
 		return pkg.RpmPkg
 	case "ubuntu", "debian", "echo":
 		return pkg.DebPkg

--- a/grype/db/v6/build/transformers/os/transform_test.go
+++ b/grype/db/v6/build/transformers/os/transform_test.go
@@ -85,6 +85,11 @@ func TestTransform(t *testing.T) {
 		ReleaseID:    "rhel",
 		MajorVersion: "8",
 	}
+	fedora39OS := &db.OperatingSystem{
+		Name:         "fedora",
+		ReleaseID:    "fedora",
+		MajorVersion: "39",
+	}
 	tests := []struct {
 		name     string
 		provider string
@@ -1115,6 +1120,68 @@ func TestTransform(t *testing.T) {
 													{
 														ID:   "RHSA-2020:5619",
 														URL:  "https://access.redhat.com/errata/RHSA-2020:5619",
+														Tags: []string{db.AdvisoryReferenceTag},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					),
+				},
+			},
+		},
+		{
+			name:     "test-fixtures/fedora-39.json",
+			provider: "fedora",
+			want: []transformers.RelatedEntries{
+				{
+					VulnerabilityHandle: &db.VulnerabilityHandle{
+						Name:          "CVE-2024-34397",
+						ProviderID:    "fedora",
+						Provider:      expectedProvider("fedora"),
+						Status:        "active",
+						PublishedDate: timeRef(time.Date(2024, 5, 9, 2, 43, 30, 0, time.UTC)),
+						ModifiedDate:  timeRef(time.Date(2024, 5, 14, 3, 27, 20, 0, time.UTC)),
+						BlobValue: &db.VulnerabilityBlob{
+							ID:          "CVE-2024-34397",
+							Description: "Security update for glib2 to fix CVE-2024-34397",
+							References: []db.Reference{
+								{
+									URL: "https://bodhi.fedoraproject.org/updates/FEDORA-2024-fd2569c4e9",
+								},
+							},
+							Severities: []db.Severity{
+								{
+									Scheme: db.SeveritySchemeCHMLN,
+									Value:  "high",
+									Rank:   1,
+								},
+							},
+						},
+					},
+					Related: affectedPkgSlice(
+						db.AffectedPackageHandle{
+							OperatingSystem: fedora39OS,
+							Package:         &db.Package{Ecosystem: "rpm", Name: "glib2"},
+							BlobValue: &db.PackageBlob{
+								Qualifiers: &db.PackageQualifiers{RpmModularity: strRef("")},
+								Ranges: []db.Range{
+									{
+										Version: db.Version{
+											Type:       "rpm",
+											Constraint: "< 0:2.78.6-1.fc39",
+										},
+										Fix: &db.Fix{
+											Version: "0:2.78.6-1.fc39",
+											State:   db.FixedStatus,
+											Detail: &db.FixDetail{
+												References: []db.Reference{
+													{
+														ID:   "FEDORA-2024-fd2569c4e9",
+														URL:  "https://bodhi.fedoraproject.org/updates/FEDORA-2024-fd2569c4e9",
 														Tags: []string{db.AdvisoryReferenceTag},
 													},
 												},


### PR DESCRIPTION

Update OS transformer to account for fedora as a source of RPM vulns. Adds a couple of other distros that use RPMs which might prevent needing this PR again later (or might just be noise).
