### PR TITLE
Strip v prefix from apk versions

### DIFF
--- a/grype/version/apk_version.go
+++ b/grype/version/apk_version.go
@@ -11,7 +11,7 @@ type apkVersion struct {
 }
 
 func newApkVersion(raw string) (apkVersion, error) {
-	ver, err := apk.NewVersion(raw)
+	ver, err := apk.NewVersion(trimLeadingV(raw))
 	if err != nil {
 		return apkVersion{}, invalidFormatError(ApkFormat, raw, err)
 	}
@@ -19,6 +19,15 @@ func newApkVersion(raw string) (apkVersion, error) {
 	return apkVersion{
 		obj: ver,
 	}, nil
+}
+
+// trimLeadingV removes a single leading 'v' or 'V' prefix only if it's followed by a digit.
+// This allows versions like "v1.5.0" to be treated as "1.5.0" while preserving other strings as-is.
+func trimLeadingV(raw string) string {
+	if len(raw) >= 2 && (raw[0] == 'v' || raw[0] == 'V') && raw[1] >= '0' && raw[1] <= '9' {
+		return raw[1:]
+	}
+	return raw
 }
 
 func (v apkVersion) Compare(other *Version) (int, error) {


### PR DESCRIPTION
As far as I know there is no official APK version spec, only a [reference implementation](https://gitlab.alpinelinux.org/alpine/apk-tools/-/blob/master/src/version.c). Though the implementation does not allow for `v1.5.0 == 1.5.0`, it seems logical to include this case. I also have not been able to find a case where this would cause a problem with any existing packages / vuln data. For this reason, like we do with semver, this PR strips leading `v`/`V` prefixes from versions before they are processed.