### PR TITLE
fix: update build flag to use provenance=false

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -106,6 +106,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -119,6 +120,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -132,6 +134,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/ppc64le"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -145,6 +148,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/s390x"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -159,6 +163,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -172,6 +177,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -185,6 +191,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/ppc64le"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -198,6 +205,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/s390x"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -212,6 +220,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -225,6 +234,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -238,6 +248,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/ppc64le"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -251,6 +262,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/s390x"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"


### PR DESCRIPTION
GitHub Actions runner image ubuntu22/20260209.31 bumped Docker from 28.0.4 to 29.1.5.
https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20260209.31

Docker 29 defaults to the containerd image store on fresh installs, which causes docker buildx build to attach provenance attestations.

This turns single-platform images into manifest lists.

The current goreleaser configuration expects application/vnd.docker.distribution.manifest.v2+json and cannot work when the images are manifest lists with media type application/vnd.oci.image.index.v1+json

Adding this flag reverts the builds to be application/vnd.docker.distribution.manifest.v2+json by removing the attestation.