### PR TITLE
feat: enhanced OSV transformer

### DIFF
--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/anchore/grype/grype/matcher/java"
 	"github.com/anchore/grype/grype/matcher/javascript"
 	"github.com/anchore/grype/grype/matcher/python"
+	"github.com/anchore/grype/grype/matcher/r"
 	"github.com/anchore/grype/grype/matcher/rpm"
 	"github.com/anchore/grype/grype/matcher/ruby"
 	"github.com/anchore/grype/grype/matcher/stock"
@@ -378,6 +379,7 @@ func getMatcherConfig(opts *options.Grype) matcher.Config {
 			AlwaysUseCPEForStdlib:                  opts.Match.Golang.AlwaysUseCPEForStdlib,
 			AllowMainModulePseudoVersionComparison: opts.Match.Golang.AllowMainModulePseudoVersionComparison,
 		},
+		R:     r.MatcherConfig(opts.Match.R),
 		Hex:   hex.MatcherConfig(opts.Match.Hex),
 		Stock: stock.MatcherConfig(opts.Match.Stock),
 		Dpkg: dpkg.MatcherConfig{

--- a/cmd/grype/cli/options/match.go
+++ b/cmd/grype/cli/options/match.go
@@ -15,6 +15,7 @@ type matchConfig struct {
 	Golang     golangConfig  `yaml:"golang" json:"golang" mapstructure:"golang"`             // settings for the golang matcher
 	Javascript matcherConfig `yaml:"javascript" json:"javascript" mapstructure:"javascript"` // settings for the javascript matcher
 	Python     matcherConfig `yaml:"python" json:"python" mapstructure:"python"`             // settings for the python matcher
+	R          matcherConfig `yaml:"r" json:"r" mapstructure:"r"`                            // settings for the r matcher (R language)
 	Ruby       matcherConfig `yaml:"ruby" json:"ruby" mapstructure:"ruby"`                   // settings for the ruby matcher
 	Rust       matcherConfig `yaml:"rust" json:"rust" mapstructure:"rust"`                   // settings for the rust matcher
 	Hex        matcherConfig `yaml:"hex" json:"hex" mapstructure:"hex"`                      // settings for the hex matcher (Elixir/Erlang)
@@ -124,6 +125,7 @@ func defaultMatchConfig() matchConfig {
 		Golang:     defaultGolangConfig(),
 		Javascript: dontUseCpe,
 		Python:     dontUseCpe,
+		R:          dontUseCpe,
 		Ruby:       dontUseCpe,
 		Rust:       dontUseCpe,
 		Hex:        dontUseCpe,
@@ -170,6 +172,7 @@ func (cfg *matchConfig) DescribeFields(descriptions clio.FieldDescriptionSet) {
 	descriptions.Add(&cfg.Golang.AllowMainModulePseudoVersionComparison, `allow comparison between main module pseudo-versions (e.g. v0.0.0-20240413-2b432cf643...)`)
 	descriptions.Add(&cfg.Javascript.UseCPEs, usingCpeDescription)
 	descriptions.Add(&cfg.Python.UseCPEs, usingCpeDescription)
+	descriptions.Add(&cfg.R.UseCPEs, usingCpeDescription)
 	descriptions.Add(&cfg.Ruby.UseCPEs, usingCpeDescription)
 	descriptions.Add(&cfg.Rust.UseCPEs, usingCpeDescription)
 	descriptions.Add(&cfg.Hex.UseCPEs, usingCpeDescription)

--- a/grype/db/internal/provider/unmarshal/osv_vulnerability.go
+++ b/grype/db/internal/provider/unmarshal/osv_vulnerability.go
@@ -1,12 +1,40 @@
 package unmarshal
 
 import (
+	"encoding/json"
 	"io"
 
 	"github.com/google/osv-scanner/pkg/models"
 )
 
-type OSVVulnerability = models.Vulnerability
+// OSVVulnerability extends the osv-scanner Vulnerability model to support
+// the "upstream" field used by some OSV databases (e.g. openEuler, BellSoft,
+// R Sec) as an alternative to the standard "aliases" field for referencing CVEs.
+type OSVVulnerability struct {
+	models.Vulnerability
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling that captures the "upstream"
+// field and merges it into Aliases.
+func (v *OSVVulnerability) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &v.Vulnerability); err != nil {
+		return err
+	}
+
+	// Some OSV databases use "upstream" instead of "aliases" to reference CVEs
+	var extra struct {
+		Upstream []string `json:"upstream"`
+	}
+	if err := json.Unmarshal(data, &extra); err != nil {
+		return err
+	}
+
+	if len(extra.Upstream) > 0 {
+		v.Aliases = append(v.Aliases, extra.Upstream...)
+	}
+
+	return nil
+}
 
 func OSVVulnerabilityEntries(reader io.Reader) ([]OSVVulnerability, error) {
 	return unmarshalSingleOrMulti[OSVVulnerability](reader)

--- a/grype/db/v6/build/transformers/osv/test-fixtures/BELL-CVE-2024-0232.json
+++ b/grype/db/v6/build/transformers/osv/test-fixtures/BELL-CVE-2024-0232.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "1.7.3",
+  "id": "BELL-CVE-2024-0232",
+  "published": "2024-01-12T06:00:31.487567Z",
+  "modified": "2026-01-26T09:34:44.321485Z",
+  "upstream": [
+    "CVE-2024-0232"
+  ],
+  "affected": [
+    {
+      "package": {
+        "name": "sqlite",
+        "ecosystem": "Alpaquita:stream",
+        "purl": "pkg:apk/alpaquita/sqlite?arch=source&distro=stream"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.43.0-r0"
+            },
+            {
+              "fixed": "3.43.2-r0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "source": "https://github.com/bell-sw/osv-database/blob/master/BELL-CVE/BELL-CVE-2024-0232.json"
+      }
+    },
+    {
+      "package": {
+        "name": "sqlite",
+        "ecosystem": "BellSoft Hardened Containers:stream",
+        "purl": "pkg:apk/bellsoft-hardened-containers/sqlite?arch=source&distro=stream"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.43.0-r0"
+            },
+            {
+              "fixed": "3.43.2-r0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "source": "https://github.com/bell-sw/osv-database/blob/master/BELL-CVE/BELL-CVE-2024-0232.json"
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://docs.bell-sw.com/security/cves/CVE-2024-0232"
+    }
+  ],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+    }
+  ]
+}

--- a/grype/db/v6/build/transformers/osv/test-fixtures/GO-2024-2611.json
+++ b/grype/db/v6/build/transformers/osv/test-fixtures/GO-2024-2611.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1.7.3",
+  "id": "GO-2024-2611",
+  "published": "2024-03-05T20:24:05Z",
+  "modified": "2026-01-28T03:41:22.146319Z",
+  "aliases": [
+    "CVE-2024-24786",
+    "GHSA-8r3f-844c-mc37"
+  ],
+  "related": [
+    "CGA-p6mq-m46f-v73f",
+    "RHSA-2024:0043",
+    "RHSA-2024:2548"
+  ],
+  "summary": "Infinite loop in JSON unmarshaling in google.golang.org/protobuf",
+  "details": "The protojson.Unmarshal function can enter an infinite loop when unmarshaling certain forms of invalid JSON. This condition can occur when unmarshaling into a message which contains a google.protobuf.Any value, or when the UnmarshalOptions.DiscardUnknown option is set.",
+  "affected": [
+    {
+      "package": {
+        "name": "google.golang.org/protobuf",
+        "ecosystem": "Go",
+        "purl": "pkg:golang/google.golang.org/protobuf"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.33.0"
+            }
+          ]
+        }
+      ],
+      "ecosystem_specific": {
+        "imports": [
+          {
+            "path": "google.golang.org/protobuf/encoding/protojson",
+            "symbols": [
+              "Unmarshal",
+              "UnmarshalOptions.Unmarshal"
+            ]
+          }
+        ]
+      },
+      "database_specific": {
+        "source": "https://vuln.go.dev/ID/GO-2024-2611.json"
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "FIX",
+      "url": "https://go.dev/cl/569356"
+    }
+  ],
+  "database_specific": {
+    "review_status": "REVIEWED",
+    "url": "https://pkg.go.dev/vuln/GO-2024-2611"
+  }
+}

--- a/grype/db/v6/build/transformers/osv/test-fixtures/OESA-2024-2048.json
+++ b/grype/db/v6/build/transformers/osv/test-fixtures/OESA-2024-2048.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.7.3",
+  "id": "OESA-2024-2048",
+  "published": "2024-08-23T11:08:56Z",
+  "modified": "2025-09-03T06:20:13.702698Z",
+  "upstream": [
+    "CVE-2024-3049"
+  ],
+  "summary": "booth security update",
+  "details": "Booth manages tickets which authorize cluster sites located in geographically dispersed locations to run resources. It facilitates support of geographically distributed clustering in Pacemaker.\r\n\r\nSecurity Fix(es):\r\n\r\nA flaw was found in Booth, a cluster ticket manager. If a specially-crafted hash is passed to gcry_md_get_algo_dlen(), it may allow an invalid HMAC to be accepted by the Booth server.(CVE-2024-3049)",
+  "affected": [
+    {
+      "package": {
+        "name": "booth",
+        "ecosystem": "openEuler:22.03-LTS-SP3",
+        "purl": "pkg:rpm/openEuler/booth&distro=openEuler-22.03-LTS-SP3"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.0-7.oe2203sp3"
+            }
+          ]
+        }
+      ],
+      "ecosystem_specific": {
+        "aarch64": [
+          "booth-1.0-7.oe2203sp3.aarch64.rpm",
+          "booth-core-1.0-7.oe2203sp3.aarch64.rpm"
+        ],
+        "src": [
+          "booth-1.0-7.oe2203sp3.src.rpm"
+        ],
+        "x86_64": [
+          "booth-1.0-7.oe2203sp3.x86_64.rpm",
+          "booth-core-1.0-7.oe2203sp3.x86_64.rpm"
+        ]
+      },
+      "database_specific": {
+        "source": "https://repo.openeuler.org/security/data/osv/OESA-2024-2048.json"
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://www.openeuler.org/zh/security/security-bulletins/detail/?id=openEuler-SA-2024-2048"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-3049"
+    }
+  ],
+  "database_specific": {
+    "severity": "High"
+  }
+}

--- a/grype/db/v6/build/transformers/osv/test-fixtures/RSEC-2023-6.json
+++ b/grype/db/v6/build/transformers/osv/test-fixtures/RSEC-2023-6.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "1.7.3",
+  "id": "RSEC-2023-6",
+  "published": "2023-10-06T05:00:00.600Z",
+  "modified": "2025-05-19T19:43:47.903227Z",
+  "upstream": [
+    "CVE-2020-5238"
+  ],
+  "summary": "Denial of Service (DoS) vulnerability",
+  "details": "The commonmark package, specifically in its dependency on GitHub Flavored Markdown before version 0.29.0.gfm.1, has a vulnerability related to time complexity. Parsing certain crafted markdown tables can take O(n * n) time, leading to potential Denial of Service attacks. This issue does not affect the upstream cmark project and has been fixed in version 0.29.0.gfm.1.",
+  "affected": [
+    {
+      "package": {
+        "name": "commonmark",
+        "ecosystem": "CRAN",
+        "purl": "pkg:cran/commonmark"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.2"
+            },
+            {
+              "fixed": "1.8"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "0.2",
+        "0.4",
+        "0.5",
+        "0.6",
+        "0.7",
+        "0.8",
+        "0.9",
+        "1.0",
+        "1.1",
+        "1.2",
+        "1.4",
+        "1.5",
+        "1.6",
+        "1.7"
+      ],
+      "database_specific": {
+        "source": "https://github.com/RConsortium/r-advisory-database/blob/main/vulns/commonmark/RSEC-2023-6.yaml"
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://security-tracker.debian.org/tracker/CVE-2020-5238"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/r-lib/commonmark/issues/13"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/r-lib/commonmark/pull/18"
+    }
+  ]
+}

--- a/grype/db/v6/build/transformers/osv/transform.go
+++ b/grype/db/v6/build/transformers/osv/transform.go
@@ -476,6 +476,9 @@ func getOperatingSystemFromEcosystem(ecosystem string) *db.OperatingSystem {
 		return nil
 	}
 
+	// Normalize OS name to match /etc/os-release ID format (hyphens, not spaces)
+	releaseID := strings.ReplaceAll(osName, " ", "-")
+
 	osVersion := parts[1]
 
 	// Separate any label suffix from the version (e.g. "20.03-LTS-SP4" → version="20.03", label="LTS-SP4")
@@ -497,10 +500,10 @@ func getOperatingSystemFromEcosystem(ecosystem string) *db.OperatingSystem {
 				majorVersion = majorVersion + "-" + labelVersion
 			}
 			return &db.OperatingSystem{
-				Name:         osName,
-				ReleaseID:    osName,
+				Name:         releaseID,
+				ReleaseID:    releaseID,
 				LabelVersion: majorVersion,
-				Codename:     codename.LookupOS(osName, "", ""),
+				Codename:     codename.LookupOS(releaseID, "", ""),
 			}
 		}
 		if len(versionFields) > 1 {
@@ -509,12 +512,12 @@ func getOperatingSystemFromEcosystem(ecosystem string) *db.OperatingSystem {
 	}
 
 	return &db.OperatingSystem{
-		Name:         osName,
-		ReleaseID:    osName,
+		Name:         releaseID,
+		ReleaseID:    releaseID,
 		MajorVersion: majorVersion,
 		MinorVersion: minorVersion,
 		LabelVersion: labelVersion,
-		Codename:     codename.LookupOS(osName, majorVersion, minorVersion),
+		Codename:     codename.LookupOS(releaseID, majorVersion, minorVersion),
 	}
 }
 

--- a/grype/db/v6/build/transformers/osv/transform.go
+++ b/grype/db/v6/build/transformers/osv/transform.go
@@ -350,8 +350,7 @@ func getPackageTypeFromEcosystem(ecosystem string) pkg.Type {
 		return pt
 	}
 
-	switch osName {
-	case "cran":
+	if osName == "cran" {
 		return pkg.Rpkg
 	}
 

--- a/grype/db/v6/build/transformers/osv/transform_test.go
+++ b/grype/db/v6/build/transformers/osv/transform_test.go
@@ -517,8 +517,8 @@ func TestTransform(t *testing.T) {
 							Ecosystem: "apk",
 						},
 						OperatingSystem: &db.OperatingSystem{
-							Name:         "bellsoft hardened containers",
-							ReleaseID:    "bellsoft hardened containers",
+							Name:         "bellsoft-hardened-containers",
+							ReleaseID:    "bellsoft-hardened-containers",
 							LabelVersion: "stream",
 						},
 						BlobValue: &db.PackageBlob{
@@ -1222,6 +1222,15 @@ func Test_getOperatingSystemFromEcosystem(t *testing.T) {
 			want: &db.OperatingSystem{
 				Name:         "alpaquita",
 				ReleaseID:    "alpaquita",
+				LabelVersion: "stream",
+			},
+		},
+		{
+			name:      "BellSoft Hardened Containers stream",
+			ecosystem: "BellSoft Hardened Containers:stream",
+			want: &db.OperatingSystem{
+				Name:         "bellsoft-hardened-containers",
+				ReleaseID:    "bellsoft-hardened-containers",
 				LabelVersion: "stream",
 			},
 		},

--- a/grype/db/v6/build/transformers/osv/transform_test.go
+++ b/grype/db/v6/build/transformers/osv/transform_test.go
@@ -723,6 +723,109 @@ func Test_getPackageQualifiers(t *testing.T) {
 	}
 }
 
+func Test_getOperatingSystemFromEcosystem(t *testing.T) {
+	tests := []struct {
+		name      string
+		ecosystem string
+		want      *db.OperatingSystem
+	}{
+		{
+			name:      "openEuler base LTS",
+			ecosystem: "openEuler:20.03-LTS",
+			want: &db.OperatingSystem{
+				Name:         "openeuler",
+				ReleaseID:    "openeuler",
+				MajorVersion: "20",
+				MinorVersion: "03",
+				LabelVersion: "LTS",
+			},
+		},
+		{
+			name:      "openEuler LTS service pack",
+			ecosystem: "openEuler:20.03-LTS-SP4",
+			want: &db.OperatingSystem{
+				Name:         "openeuler",
+				ReleaseID:    "openeuler",
+				MajorVersion: "20",
+				MinorVersion: "03",
+				LabelVersion: "LTS-SP4",
+			},
+		},
+		{
+			name:      "openEuler 24.03 LTS service pack",
+			ecosystem: "openEuler:24.03-LTS-SP1",
+			want: &db.OperatingSystem{
+				Name:         "openeuler",
+				ReleaseID:    "openeuler",
+				MajorVersion: "24",
+				MinorVersion: "03",
+				LabelVersion: "LTS-SP1",
+			},
+		},
+		{
+			name:      "AlmaLinux major only",
+			ecosystem: "AlmaLinux:8",
+			want: &db.OperatingSystem{
+				Name:         "almalinux",
+				ReleaseID:    "almalinux",
+				MajorVersion: "8",
+			},
+		},
+		{
+			name:      "AlmaLinux major and minor",
+			ecosystem: "AlmaLinux:10",
+			want: &db.OperatingSystem{
+				Name:         "almalinux",
+				ReleaseID:    "almalinux",
+				MajorVersion: "10",
+			},
+		},
+		{
+			name:      "Rocky with minor version",
+			ecosystem: "Rocky:9.2",
+			want: &db.OperatingSystem{
+				Name:         "rocky",
+				ReleaseID:    "rocky",
+				MajorVersion: "9",
+				MinorVersion: "2",
+			},
+		},
+		{
+			name:      "Alpaquita stream (non-numeric label)",
+			ecosystem: "Alpaquita:stream",
+			want: &db.OperatingSystem{
+				Name:         "alpaquita",
+				ReleaseID:    "alpaquita",
+				LabelVersion: "stream",
+			},
+		},
+		{
+			name:      "unknown ecosystem returns nil",
+			ecosystem: "Bitnami:something",
+			want:      nil,
+		},
+		{
+			name:      "no version component returns nil",
+			ecosystem: "openEuler",
+			want:      nil,
+		},
+		{
+			name:      "empty string returns nil",
+			ecosystem: "",
+			want:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getOperatingSystemFromEcosystem(tt.ecosystem)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("getOperatingSystemFromEcosystem() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func stringRef(s string) *string {
 	return &s
 }

--- a/grype/db/v6/build/writer_test.go
+++ b/grype/db/v6/build/writer_test.go
@@ -1,6 +1,7 @@
 package v6
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -831,23 +832,24 @@ func createTestEntries(count int) []data.Entry {
 	entries := make([]data.Entry, count)
 
 	for i := 0; i < count; i++ {
+		name := fmt.Sprintf("CVE-2023-TEST-%04d", i)
 		entries[i] = data.Entry{
 			DBSchemaVersion: db.ModelVersion,
 			Data: transformers.RelatedEntries{
 				VulnerabilityHandle: &db.VulnerabilityHandle{
-					Name:       "CVE-2023-TEST",
+					Name:       name,
 					ProviderID: "test-provider",
 					Provider: &db.Provider{
 						ID:      "test-provider",
 						Version: "1.0.0",
 					},
 					BlobValue: &db.VulnerabilityBlob{
-						ID: "CVE-2023-TEST",
+						ID: name,
 					},
 				},
 				Related: []any{
 					db.CWEHandle{
-						CVE: "CVE-2023-TEST",
+						CVE: name,
 						CWE: "CWE-79",
 					},
 				},

--- a/grype/db/v6/data.go
+++ b/grype/db/v6/data.go
@@ -44,7 +44,7 @@ func KnownOperatingSystemSpecifierOverrides() []OperatingSystemSpecifierOverride
 
 		// BellSoft family
 		{Alias: "alpaquita", Rolling: true},
-		{Alias: "bellsoft-hardened-containers", ReplacementName: strRef("alpaquita"), Rolling: true},
+		{Alias: "bellsoft-hardened-containers", Rolling: true},
 
 		// others
 		{Alias: "archlinux", Rolling: true},

--- a/grype/db/v6/data.go
+++ b/grype/db/v6/data.go
@@ -42,6 +42,10 @@ func KnownOperatingSystemSpecifierOverrides() []OperatingSystemSpecifierOverride
 		{Alias: "chainguard", Rolling: true},
 		{Alias: "secureos", Rolling: true},
 
+		// BellSoft family
+		{Alias: "alpaquita", Rolling: true},
+		{Alias: "bellsoft-hardened-containers", ReplacementName: strRef("alpaquita"), Rolling: true},
+
 		// others
 		{Alias: "archlinux", Rolling: true},
 		{Alias: "minimos", Rolling: true},

--- a/grype/db/v6/models.go
+++ b/grype/db/v6/models.go
@@ -581,13 +581,17 @@ func (o *OperatingSystem) Version() string {
 		return ""
 	}
 
-	if o.LabelVersion != "" {
+	// If only a label is set (no numeric version), return just the label (e.g. Alpaquita "stream")
+	if o.LabelVersion != "" && o.MajorVersion == "" {
 		return o.LabelVersion
 	}
 
 	var suffix string
+	if o.LabelVersion != "" {
+		suffix = "-" + o.LabelVersion
+	}
 	if o.Channel != "" {
-		suffix = fmt.Sprintf("+%s", o.Channel)
+		suffix += "+" + o.Channel
 	}
 
 	if o.MajorVersion != "" {

--- a/grype/db/v6/models_test.go
+++ b/grype/db/v6/models_test.go
@@ -124,6 +124,21 @@ func TestOperatingSystem_Version(t *testing.T) {
 			os:             &OperatingSystem{MajorVersion: "10", MinorVersion: "1", Channel: "stable"},
 			expectedResult: "10.1+stable",
 		},
+		{
+			name:           "major minor and label version",
+			os:             &OperatingSystem{MajorVersion: "24", MinorVersion: "3", LabelVersion: "LTS-SP1"},
+			expectedResult: "24.3-LTS-SP1",
+		},
+		{
+			name:           "major and label version without minor",
+			os:             &OperatingSystem{MajorVersion: "8", LabelVersion: "LTS"},
+			expectedResult: "8-LTS",
+		},
+		{
+			name:           "major minor label and channel",
+			os:             &OperatingSystem{MajorVersion: "24", MinorVersion: "3", LabelVersion: "LTS-SP1", Channel: "eus"},
+			expectedResult: "24.3-LTS-SP1+eus",
+		},
 	}
 
 	for _, tt := range tests {

--- a/grype/db/v6/vulnerability.go
+++ b/grype/db/v6/vulnerability.go
@@ -294,6 +294,8 @@ func mimicV5GithubNamespace(provider, language string) string {
 		language = "python"
 	case "rubygems", string(pkg.GemPkg):
 		language = "ruby"
+	case "cran", "r-package":
+		language = string(pkg.R)
 	}
 	return fmt.Sprintf("%s:language:%s", provider, language)
 }

--- a/grype/distro/distro_test.go
+++ b/grype/distro/distro_test.go
@@ -513,6 +513,17 @@ func Test_NewDistroFromRelease_Coverage(t *testing.T) {
 			Version:      "edge",
 			LabelVersion: "edge",
 		},
+		{
+			Name:    "test-fixtures/os/openeuler",
+			Type:    OpenEuler,
+			Version: "20.03",
+		},
+		{
+			Name:         "test-fixtures/os/alpaquita",
+			Type:         Alpaquita,
+			Version:      "stream",
+			LabelVersion: "stream",
+		},
 	}
 
 	for _, tt := range tests {

--- a/grype/distro/distro_test.go
+++ b/grype/distro/distro_test.go
@@ -271,6 +271,69 @@ func Test_NewDistroFromRelease(t *testing.T) {
 			minor: "4",
 		},
 		{
+			name: "openEuler base LTS extracts label from VERSION",
+			release: linux.Release{
+				ID:        "openEuler",
+				VersionID: "20.03",
+				Version:   "20.03 (LTS)",
+			},
+			channels: testFixChannels(),
+			expected: &Distro{
+				Type:     OpenEuler,
+				Version:  "20.03",
+				Codename: "LTS",
+			},
+			major: "20",
+			minor: "03",
+		},
+		{
+			name: "openEuler LTS-SP extracts label from VERSION",
+			release: linux.Release{
+				ID:        "openEuler",
+				VersionID: "20.03",
+				Version:   "20.03 (LTS-SP4)",
+			},
+			channels: testFixChannels(),
+			expected: &Distro{
+				Type:     OpenEuler,
+				Version:  "20.03",
+				Codename: "LTS-SP4",
+			},
+			major: "20",
+			minor: "03",
+		},
+		{
+			name: "openEuler LTS without parens extracts label from VERSION",
+			release: linux.Release{
+				ID:        "openEuler",
+				VersionID: "22.03",
+				Version:   "22.03 LTS",
+			},
+			channels: testFixChannels(),
+			expected: &Distro{
+				Type:     OpenEuler,
+				Version:  "22.03",
+				Codename: "LTS",
+			},
+			major: "22",
+			minor: "03",
+		},
+		{
+			name: "openEuler innovation release has no label",
+			release: linux.Release{
+				ID:        "openEuler",
+				VersionID: "23.03",
+				Version:   "23.03",
+			},
+			channels: testFixChannels(),
+			expected: &Distro{
+				Type:    OpenEuler,
+				Version: "23.03",
+			},
+			major: "23",
+			minor: "03",
+		},
+		{
 			name: "v versionID prefix postmarketos",
 			release: linux.Release{
 				ID:        "postmarketos",
@@ -514,9 +577,10 @@ func Test_NewDistroFromRelease_Coverage(t *testing.T) {
 			LabelVersion: "edge",
 		},
 		{
-			Name:    "test-fixtures/os/openeuler",
-			Type:    OpenEuler,
-			Version: "20.03",
+			Name:         "test-fixtures/os/openeuler",
+			Type:         OpenEuler,
+			Version:      "20.03",
+			LabelVersion: "LTS-SP4",
 		},
 		{
 			Name:         "test-fixtures/os/alpaquita",

--- a/grype/distro/test-fixtures/os/alpaquita/etc/os-release
+++ b/grype/distro/test-fixtures/os/alpaquita/etc/os-release
@@ -1,0 +1,5 @@
+NAME="BellSoft Alpaquita Linux"
+ID=alpaquita
+VERSION_ID=stream
+PRETTY_NAME="BellSoft Alpaquita Linux (stream)"
+HOME_URL="https://bell-sw.com/alpaquita-linux/"

--- a/grype/distro/test-fixtures/os/openeuler/etc/os-release
+++ b/grype/distro/test-fixtures/os/openeuler/etc/os-release
@@ -1,0 +1,6 @@
+NAME="openEuler"
+VERSION="20.03 (LTS-SP4)"
+ID="openEuler"
+VERSION_ID="20.03"
+PRETTY_NAME="openEuler 20.03 (LTS-SP4)"
+ANSI_COLOR="0;31"

--- a/grype/distro/type.go
+++ b/grype/distro/type.go
@@ -38,6 +38,7 @@ const (
 	Scientific   Type = "scientific"
 	SecureOS     Type = "secureos"
 	PostmarketOS Type = "postmarketos"
+	OpenEuler    Type = "openeuler"
 )
 
 // All contains all Linux distribution options
@@ -70,6 +71,7 @@ var All = []Type{
 	Scientific,
 	SecureOS,
 	PostmarketOS,
+	OpenEuler,
 }
 
 // IDMapping maps a distro ID from the /etc/os-release (e.g. like "ubuntu") to a Distro type.
@@ -102,6 +104,7 @@ var IDMapping = map[string]Type{
 	"scientific":    Scientific,
 	"secureos":      SecureOS,
 	"postmarketos":  PostmarketOS,
+	"openEuler":     OpenEuler,
 }
 
 // aliasTypes maps common aliases to their corresponding Type.

--- a/grype/distro/type.go
+++ b/grype/distro/type.go
@@ -83,7 +83,6 @@ var IDMapping = map[string]Type{
 	"fedora":        Fedora,
 	"alpine":        Alpine,
 	"alpaquita":     Alpaquita,
-	//"bellsoft-hardened-containers": Alpaquita,
 	"busybox":       Busybox,
 	"amzn":          AmazonLinux,
 	"ol":            OracleLinux,
@@ -109,7 +108,7 @@ var IDMapping = map[string]Type{
 
 // aliasTypes maps common aliases to their corresponding Type.
 var aliasTypes = map[string]Type{
-	"Alpine Linux":                 Alpine,    // needed for CPE matching (see #2039)
+	"Alpine Linux":                 Alpine, // needed for CPE matching (see #2039)
 	"BellSoft Hardened Containers": Alpaquita,
 	"openeuler":                    OpenEuler, // safety net for the mixed-case IDMapping key; TypeFromRelease is case-sensitive
 	"windows":                      Windows,

--- a/grype/distro/type.go
+++ b/grype/distro/type.go
@@ -104,15 +104,16 @@ var IDMapping = map[string]Type{
 	"scientific":    Scientific,
 	"secureos":      SecureOS,
 	"postmarketos":  PostmarketOS,
-	"openEuler":     OpenEuler,
+	"openEuler":     OpenEuler, // NOTE: mixed case is intentional — openEuler's /etc/os-release violates the freedesktop spec by using ID="openEuler" instead of lowercase
 }
 
 // aliasTypes maps common aliases to their corresponding Type.
 var aliasTypes = map[string]Type{
-	"Alpine Linux":     Alpine, // needed for CPE matching (see #2039)
+	"Alpine Linux":                 Alpine,    // needed for CPE matching (see #2039)
 	"BellSoft Hardened Containers": Alpaquita,
-	"windows":          Windows,
-	"scientific linux": Scientific, // Scientific linux prior to v7 didn't have an os-release file and syft raises up "scientific linux" as the release id as parsed from /etc/redhat-release
+	"openeuler":                    OpenEuler, // safety net for the mixed-case IDMapping key; TypeFromRelease is case-sensitive
+	"windows":                      Windows,
+	"scientific linux":             Scientific, // Scientific linux prior to v7 didn't have an os-release file and syft raises up "scientific linux" as the release id as parsed from /etc/redhat-release
 }
 
 var typeToIDMapping = map[Type]string{}

--- a/grype/distro/type.go
+++ b/grype/distro/type.go
@@ -16,6 +16,7 @@ const (
 	CentOS       Type = "centos"
 	Fedora       Type = "fedora"
 	Alpine       Type = "alpine"
+	Alpaquita    Type = "alpaquita"
 	Busybox      Type = "busybox"
 	AmazonLinux  Type = "amazonlinux"
 	OracleLinux  Type = "oraclelinux"
@@ -47,6 +48,7 @@ var All = []Type{
 	CentOS,
 	Fedora,
 	Alpine,
+	Alpaquita,
 	Busybox,
 	AmazonLinux,
 	OracleLinux,
@@ -78,6 +80,8 @@ var IDMapping = map[string]Type{
 	"centos":        CentOS,
 	"fedora":        Fedora,
 	"alpine":        Alpine,
+	"alpaquita":     Alpaquita,
+	//"bellsoft-hardened-containers": Alpaquita,
 	"busybox":       Busybox,
 	"amzn":          AmazonLinux,
 	"ol":            OracleLinux,
@@ -103,6 +107,7 @@ var IDMapping = map[string]Type{
 // aliasTypes maps common aliases to their corresponding Type.
 var aliasTypes = map[string]Type{
 	"Alpine Linux":     Alpine, // needed for CPE matching (see #2039)
+	"BellSoft Hardened Containers": Alpaquita,
 	"windows":          Windows,
 	"scientific linux": Scientific, // Scientific linux prior to v7 didn't have an os-release file and syft raises up "scientific linux" as the release id as parsed from /etc/redhat-release
 }

--- a/grype/match/matcher_type.go
+++ b/grype/match/matcher_type.go
@@ -7,6 +7,7 @@ const (
 	RubyGemMatcher     MatcherType = "ruby-gem-matcher"
 	DpkgMatcher        MatcherType = "dpkg-matcher"
 	RpmMatcher         MatcherType = "rpm-matcher"
+	RMatcher           MatcherType = "r-matcher"
 	JavaMatcher        MatcherType = "java-matcher"
 	PythonMatcher      MatcherType = "python-matcher"
 	DotnetMatcher      MatcherType = "dotnet-matcher"
@@ -27,6 +28,7 @@ var AllMatcherTypes = []MatcherType{
 	RubyGemMatcher,
 	DpkgMatcher,
 	RpmMatcher,
+	RMatcher,
 	JavaMatcher,
 	PythonMatcher,
 	DotnetMatcher,

--- a/grype/matcher/matchers.go
+++ b/grype/matcher/matchers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/anchore/grype/grype/matcher/pacman"
 	"github.com/anchore/grype/grype/matcher/portage"
 	"github.com/anchore/grype/grype/matcher/python"
+	"github.com/anchore/grype/grype/matcher/r"
 	"github.com/anchore/grype/grype/matcher/rpm"
 	"github.com/anchore/grype/grype/matcher/ruby"
 	"github.com/anchore/grype/grype/matcher/rust"
@@ -33,6 +34,7 @@ type Config struct {
 	Stock      stock.MatcherConfig
 	Dpkg       dpkg.MatcherConfig
 	Rpm        rpm.MatcherConfig
+	R          r.MatcherConfig
 }
 
 func NewDefaultMatchers(mc Config) []match.Matcher {
@@ -50,6 +52,7 @@ func NewDefaultMatchers(mc Config) []match.Matcher {
 		&portage.Matcher{},
 		rust.NewRustMatcher(mc.Rust),
 		hex.NewHexMatcher(mc.Hex),
+		r.NewRMatcher(mc.R),
 		stock.NewStockMatcher(mc.Stock),
 		&bitnami.Matcher{},
 		&pacman.Matcher{},

--- a/grype/matcher/r/matcher.go
+++ b/grype/matcher/r/matcher.go
@@ -1,0 +1,35 @@
+package r
+
+import (
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/matcher/internal"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+type Matcher struct {
+	cfg MatcherConfig
+}
+
+type MatcherConfig struct {
+	UseCPEs bool
+}
+
+func NewRMatcher(cfg MatcherConfig) *Matcher {
+	return &Matcher{
+		cfg: cfg,
+	}
+}
+
+func (m *Matcher) PackageTypes() []syftPkg.Type {
+	return []syftPkg.Type{syftPkg.Rpkg}
+}
+
+func (m *Matcher) Type() match.MatcherType {
+	return match.RMatcher
+}
+
+func (m *Matcher) Match(store vulnerability.Provider, p pkg.Package) ([]match.Match, []match.IgnoreFilter, error) {
+	return internal.MatchPackageByEcosystemAndCPEs(store, p, m.Type(), m.cfg.UseCPEs)
+}

--- a/grype/matcher/r/matcher_test.go
+++ b/grype/matcher/r/matcher_test.go
@@ -1,0 +1,232 @@
+package r
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/version"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/grype/grype/vulnerability/mock"
+	"github.com/anchore/grype/internal/stringutil"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+func TestMatcherType(t *testing.T) {
+	m := NewRMatcher(MatcherConfig{})
+	assert.Equal(t, match.RMatcher, m.Type())
+}
+
+func TestMatcherPackageTypes(t *testing.T) {
+	m := NewRMatcher(MatcherConfig{})
+	assert.Equal(t, []syftPkg.Type{syftPkg.Rpkg}, m.PackageTypes())
+}
+
+func newMockProvider() vulnerability.Provider {
+	return mock.VulnerabilityProvider([]vulnerability.Vulnerability{
+		{
+			Reference: vulnerability.Reference{
+				ID:        "RSEC-2023-1",
+				Namespace: "rsec:language:R",
+			},
+			PackageName: "jsonlite",
+			Constraint:  version.MustGetConstraint(">=0.9.12,<1.8.8", version.UnknownFormat),
+		},
+		{
+			Reference: vulnerability.Reference{
+				ID:        "RSEC-2023-2",
+				Namespace: "rsec:language:R",
+			},
+			PackageName: "commonmark",
+			Constraint:  version.MustGetConstraint(">=0.2,<1.9.2", version.UnknownFormat),
+		},
+		{
+			Reference: vulnerability.Reference{
+				ID:        "RSEC-2023-3",
+				Namespace: "rsec:language:R",
+			},
+			PackageName: "commonmark",
+			Constraint:  version.MustGetConstraint(">=0.2,<1.8", version.UnknownFormat),
+		},
+		{
+			Reference: vulnerability.Reference{
+				ID:        "RSEC-2023-4",
+				Namespace: "rsec:language:R",
+			},
+			PackageName: "gdata",
+			Constraint:  version.MustGetConstraint(">=2.16.1,<3.0.0", version.UnknownFormat),
+		},
+	}...)
+}
+
+func TestMatch(t *testing.T) {
+	tests := []struct {
+		name         string
+		pkg          pkg.Package
+		expectedCVEs []string
+	}{
+		{
+			name: "vulnerable jsonlite version",
+			pkg: pkg.Package{
+				ID:       pkg.ID(uuid.NewString()),
+				Name:     "jsonlite",
+				Version:  "1.7.0",
+				Language: syftPkg.R,
+				Type:     syftPkg.Rpkg,
+			},
+			expectedCVEs: []string{"RSEC-2023-1"},
+		},
+		{
+			name: "fixed jsonlite version - no match",
+			pkg: pkg.Package{
+				ID:       pkg.ID(uuid.NewString()),
+				Name:     "jsonlite",
+				Version:  "2.0.0",
+				Language: syftPkg.R,
+				Type:     syftPkg.Rpkg,
+			},
+			expectedCVEs: []string{},
+		},
+		{
+			name: "commonmark matches multiple vulnerabilities",
+			pkg: pkg.Package{
+				ID:       pkg.ID(uuid.NewString()),
+				Name:     "commonmark",
+				Version:  "1.7.0",
+				Language: syftPkg.R,
+				Type:     syftPkg.Rpkg,
+			},
+			expectedCVEs: []string{"RSEC-2023-2", "RSEC-2023-3"},
+		},
+		{
+			name: "commonmark fixed for one CVE but not another",
+			pkg: pkg.Package{
+				ID:       pkg.ID(uuid.NewString()),
+				Name:     "commonmark",
+				Version:  "1.8.1",
+				Language: syftPkg.R,
+				Type:     syftPkg.Rpkg,
+			},
+			expectedCVEs: []string{"RSEC-2023-2"},
+		},
+		{
+			name: "gdata at fixed version - no match",
+			pkg: pkg.Package{
+				ID:       pkg.ID(uuid.NewString()),
+				Name:     "gdata",
+				Version:  "3.0.0",
+				Language: syftPkg.R,
+				Type:     syftPkg.Rpkg,
+			},
+			expectedCVEs: []string{},
+		},
+		{
+			name: "gdata vulnerable version",
+			pkg: pkg.Package{
+				ID:       pkg.ID(uuid.NewString()),
+				Name:     "gdata",
+				Version:  "2.18.0",
+				Language: syftPkg.R,
+				Type:     syftPkg.Rpkg,
+			},
+			expectedCVEs: []string{"RSEC-2023-4"},
+		},
+		{
+			name: "unknown version - no match",
+			pkg: pkg.Package{
+				ID:       pkg.ID(uuid.NewString()),
+				Name:     "jsonlite",
+				Version:  "unknown",
+				Language: syftPkg.R,
+				Type:     syftPkg.Rpkg,
+			},
+			expectedCVEs: []string{},
+		},
+		{
+			name: "package not in database - no match",
+			pkg: pkg.Package{
+				ID:       pkg.ID(uuid.NewString()),
+				Name:     "ggplot2",
+				Version:  "3.4.0",
+				Language: syftPkg.R,
+				Type:     syftPkg.Rpkg,
+			},
+			expectedCVEs: []string{},
+		},
+	}
+
+	store := newMockProvider()
+	matcher := NewRMatcher(MatcherConfig{})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches, _, err := matcher.Match(store, tt.pkg)
+			require.NoError(t, err)
+
+			foundCVEs := stringutil.NewStringSet()
+			for _, m := range matches {
+				foundCVEs.Add(m.Vulnerability.ID)
+
+				require.NotEmpty(t, m.Details)
+				assert.Equal(t, tt.pkg.Name, m.Package.Name)
+				for _, detail := range m.Details {
+					assert.Equal(t, matcher.Type(), detail.Matcher)
+				}
+			}
+
+			assert.Equal(t, len(tt.expectedCVEs), len(matches), "unexpected match count")
+			for _, expectedCVE := range tt.expectedCVEs {
+				assert.True(t, foundCVEs.Contains(expectedCVE), "missing expected CVE: %s", expectedCVE)
+			}
+		})
+	}
+}
+
+func TestMatchWithConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  MatcherConfig
+		wantErr bool
+	}{
+		{
+			name:    "default config",
+			config:  MatcherConfig{},
+			wantErr: false,
+		},
+		{
+			name:    "with CPEs enabled",
+			config:  MatcherConfig{UseCPEs: true},
+			wantErr: false,
+		},
+		{
+			name:    "with CPEs disabled",
+			config:  MatcherConfig{UseCPEs: false},
+			wantErr: false,
+		},
+	}
+
+	store := newMockProvider()
+	pkg := pkg.Package{
+		ID:       pkg.ID(uuid.NewString()),
+		Name:     "jsonlite",
+		Version:  "1.7.0",
+		Language: syftPkg.R,
+		Type:     syftPkg.Rpkg,
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := NewRMatcher(tt.config)
+			_, _, err := matcher.Match(store, pkg)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/test/integration/match_by_image_test.go
+++ b/test/integration/match_by_image_test.go
@@ -948,6 +948,7 @@ func TestMatchByImage(t *testing.T) {
 	definedMatchers.Remove(string(match.MsrcMatcher))
 	definedMatchers.Remove(string(match.PortageMatcher)) // TODO: add this back in when #744 is complete
 	definedMatchers.Remove(string(match.BitnamiMatcher)) // bitnami will be tested via quality gate
+	definedMatchers.Remove(string(match.RMatcher))       // R will be tested via quality gate
 
 	if len(observedMatchers) != len(definedMatchers) {
 		t.Errorf("matcher coverage incomplete (matchers=%d, coverage=%d)", len(definedMatchers), len(observedMatchers))


### PR DESCRIPTION
There have been a couple of vunnel PRs that are held up by the lack of generality in the OSV schema (which was originally written to handle Bitnami data specifically and then lightly patched to handle AlmaLinux data.)

Generalize the transformer so that the following PRs can be tested and merged:

- https://github.com/anchore/vunnel/pull/1043 (CRAN)
- https://github.com/anchore/vunnel/pull/924 (BellSoft / Alpaquita Linux)
- https://github.com/anchore/vunnel/pull/839 (openEuler - requires port to OSV data over CSAF due to poor performance on their CSAF server)

The plan here is to get all of those PRs green and having quality gates (aside from the static analysis failing because they depend on a grype branch) and then merge this, and then merge them.