### PR TITLE
fix(archlinux): set alpm ecosystem for Arch Linux packages

### DIFF
--- a/grype/db/v6/build/transformers/os/testdata/archlinux.json
+++ b/grype/db/v6/build/transformers/os/testdata/archlinux.json
@@ -1,0 +1,44 @@
+{
+    "Vulnerability": {
+        "Name": "AVG-2780",
+        "NamespaceName": "arch:rolling",
+        "Description": "unknown",
+        "Severity": "Unknown",
+        "Link": "https://security.archlinux.org/AVG-2780",
+        "CVSS": [],
+        "FixedIn": [
+            {
+                "Name": "wpewebkit",
+                "NamespaceName": "arch:rolling",
+                "VersionFormat": "pacman",
+                "Version": "2.36.4-1",
+                "Module": "",
+                "VendorAdvisory": {
+                    "NoAdvisory": false,
+                    "AdvisorySummary": []
+                },
+                "VulnerableRange": null,
+                "Available": {
+                    "Date": "2026-01-27",
+                    "Kind": "first-observed"
+                }
+            }
+        ],
+        "Metadata": {
+            "CVE": [
+                {
+                    "Name": "CVE-2022-26710",
+                    "Link": "https://nvd.nist.gov/vuln/detail/CVE-2022-26710"
+                },
+                {
+                    "Name": "CVE-2022-22677",
+                    "Link": "https://nvd.nist.gov/vuln/detail/CVE-2022-22677"
+                },
+                {
+                    "Name": "CVE-2022-22662",
+                    "Link": "https://nvd.nist.gov/vuln/detail/CVE-2022-22662"
+                }
+            ]
+        }
+    }
+}

--- a/grype/db/v6/build/transformers/os/transform.go
+++ b/grype/db/v6/build/transformers/os/transform.go
@@ -240,6 +240,8 @@ func groupFixedIns(vuln unmarshal.OSVulnerability) map[groupIndex][]unmarshal.OS
 
 func getPackageType(osName string) pkg.Type {
 	switch osName {
+	case "arch", "archlinux":
+		return pkg.AlpmPkg
 	case "redhat", "amazonlinux", "oraclelinux", "sles", "mariner", "azurelinux", "photon", "fedora", "rocky", "rockylinux", "almalinux", "centos":
 		return pkg.RpmPkg
 	case "ubuntu", "debian", "echo":

--- a/grype/db/v6/build/transformers/os/transform_test.go
+++ b/grype/db/v6/build/transformers/os/transform_test.go
@@ -90,6 +90,11 @@ func TestTransform(t *testing.T) {
 		ReleaseID:    "fedora",
 		MajorVersion: "39",
 	}
+	archLinux := &db.OperatingSystem{
+		Name:         "archlinux",
+		ReleaseID:    "arch",
+		LabelVersion: "rolling",
+	}
 	tests := []struct {
 		name     string
 		provider string
@@ -1184,6 +1189,55 @@ func TestTransform(t *testing.T) {
 														URL:  "https://bodhi.fedoraproject.org/updates/FEDORA-2024-fd2569c4e9",
 														Tags: []string{db.AdvisoryReferenceTag},
 													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					),
+				},
+			},
+		},
+		{
+			name:     "testdata/archlinux.json",
+			provider: "arch",
+			want: []transformers.RelatedEntries{
+				{
+					VulnerabilityHandle: &db.VulnerabilityHandle{
+						Name:       "AVG-2780",
+						Status:     "active",
+						ProviderID: "arch",
+						Provider:   expectedProvider("arch"),
+						BlobValue: &db.VulnerabilityBlob{
+							ID:          "AVG-2780",
+							Description: "unknown",
+							Aliases:     []string{"CVE-2022-26710", "CVE-2022-22677", "CVE-2022-22662"},
+							References: []db.Reference{
+								{URL: "https://security.archlinux.org/AVG-2780"},
+								{URL: "https://nvd.nist.gov/vuln/detail/CVE-2022-26710"},
+								{URL: "https://nvd.nist.gov/vuln/detail/CVE-2022-22677"},
+								{URL: "https://nvd.nist.gov/vuln/detail/CVE-2022-22662"},
+							},
+						},
+					},
+					Related: affectedPkgSlice(
+						db.AffectedPackageHandle{
+							OperatingSystem: archLinux,
+							Package:         &db.Package{Ecosystem: "alpm", Name: "wpewebkit"},
+							BlobValue: &db.PackageBlob{
+								CVEs: []string{"CVE-2022-26710", "CVE-2022-22677", "CVE-2022-22662"},
+								Ranges: []db.Range{
+									{
+										Version: db.Version{Type: "pacman", Constraint: "< 2.36.4-1"},
+										Fix: &db.Fix{
+											Version: "2.36.4-1",
+											State:   db.FixedStatus,
+											Detail: &db.FixDetail{
+												Available: &db.FixAvailability{
+													Date: timeRef(time.Date(2026, 1, 27, 0, 0, 0, 0, time.UTC)),
+													Kind: "first-observed",
 												},
 											},
 										},

--- a/grype/db/v6/data.go
+++ b/grype/db/v6/data.go
@@ -132,6 +132,9 @@ func KnownPackageSpecifierOverrides() []PackageSpecifierOverride {
 		{Ecosystem: "kb", ReplacementEcosystem: ptr(string(pkg.KbPkg))},
 		{Ecosystem: "dpkg", ReplacementEcosystem: ptr(string(pkg.DebPkg))},
 		{Ecosystem: "apkg", ReplacementEcosystem: ptr(string(pkg.ApkPkg))},
+
+		// Common aliases
+		{Ecosystem: "pacman", ReplacementEcosystem: ptr(string(pkg.AlpmPkg))},
 	}
 
 	// remap package URL types to syft package types


### PR DESCRIPTION
Arch Linux packages were being inserted into the `packages` table in the database without an ecosystem type set