### PR TITLE
fix: normalise version constraint types in v6 db

### DIFF
--- a/grype/db/v6/build/transformers/openvex/transform.go
+++ b/grype/db/v6/build/transformers/openvex/transform.go
@@ -3,6 +3,7 @@ package openvex
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	govex "github.com/openvex/go-vex/pkg/vex"
 
@@ -210,7 +211,7 @@ func getPackageBlob(aliases []string, ver string, ty string, fixState db.FixStat
 		Ranges: []db.Range{
 			{
 				Version: db.Version{
-					Type:       version.ParseFormat(ty).String(),
+					Type:       strings.ToLower(version.ParseFormat(ty).String()),
 					Constraint: fmt.Sprintf("= %s", ver),
 				},
 				Fix: fix,

--- a/grype/db/v6/build/transformers/openvex/transform_test.go
+++ b/grype/db/v6/build/transformers/openvex/transform_test.go
@@ -13,7 +13,6 @@ import (
 	db "github.com/anchore/grype/grype/db/v6"
 	"github.com/anchore/grype/grype/db/v6/build/transformers"
 	"github.com/anchore/grype/grype/db/v6/build/transformers/internal"
-	"github.com/anchore/grype/grype/version"
 )
 
 var timeVal = time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -97,7 +96,7 @@ func TestOpenVEXTransform(t *testing.T) {
 							Ranges: []db.Range{
 								{
 									Version: db.Version{
-										Type:       version.PythonFormat.String(),
+										Type:       "python",
 										Constraint: "= 1.26.16",
 									},
 								},
@@ -169,7 +168,7 @@ func TestOpenVEXTransform(t *testing.T) {
 							Ranges: []db.Range{
 								{
 									Version: db.Version{
-										Type:       version.SemanticFormat.String(),
+										Type:       "semantic",
 										Constraint: "= 4.18.2",
 									},
 									Fix: &db.Fix{
@@ -190,7 +189,7 @@ func TestOpenVEXTransform(t *testing.T) {
 							Ranges: []db.Range{
 								{
 									Version: db.Version{
-										Type:       version.PythonFormat.String(),
+										Type:       "python",
 										Constraint: "= 1.26.16",
 									},
 									Fix: &db.Fix{
@@ -347,7 +346,7 @@ func Test_GetPackageHandles(t *testing.T) {
 						Ranges: []db.Range{
 							{
 								Version: db.Version{
-									Type:       version.PythonFormat.String(),
+									Type:       "python",
 									Constraint: "= 1.26.16",
 								},
 							},
@@ -397,7 +396,7 @@ func Test_GetPackageHandles(t *testing.T) {
 						Ranges: []db.Range{
 							{
 								Version: db.Version{
-									Type:       version.PythonFormat.String(),
+									Type:       "python",
 									Constraint: "= 1.26.16",
 								},
 								Fix: &db.Fix{
@@ -457,7 +456,7 @@ func Test_GetPackageHandles(t *testing.T) {
 						Ranges: []db.Range{
 							{
 								Version: db.Version{
-									Type:       version.PythonFormat.String(),
+									Type:       "python",
 									Constraint: "= 1.26.16",
 								},
 								Fix: &db.Fix{
@@ -509,7 +508,7 @@ func Test_GetPackageHandles(t *testing.T) {
 						Ranges: []db.Range{
 							{
 								Version: db.Version{
-									Type:       version.SemanticFormat.String(),
+									Type:       "semantic",
 									Constraint: "= 4.18.2",
 								},
 								Fix: &db.Fix{
@@ -530,7 +529,7 @@ func Test_GetPackageHandles(t *testing.T) {
 						Ranges: []db.Range{
 							{
 								Version: db.Version{
-									Type:       version.PythonFormat.String(),
+									Type:       "python",
 									Constraint: "= 1.26.16",
 								},
 								Fix: &db.Fix{
@@ -574,7 +573,7 @@ func Test_GetPackageHandles(t *testing.T) {
 						Ranges: []db.Range{
 							{
 								Version: db.Version{
-									Type:       version.PythonFormat.String(),
+									Type:       "python",
 									Constraint: "= 2.0.7",
 								},
 								Fix: &db.Fix{

--- a/grype/db/v6/build/transformers/osv/transform.go
+++ b/grype/db/v6/build/transformers/osv/transform.go
@@ -326,6 +326,11 @@ func normalizeRangeType(t models.RangeType, ecosystem string) string {
 		return "bitnami"
 	}
 
+	pkgType := getPackageTypeFromEcosystem(ecosystem)
+	if pkgType == pkg.RpmPkg && t == models.RangeEcosystem {
+		return pkgType.String()
+	}
+
 	switch t {
 	case models.RangeSemVer, models.RangeEcosystem, models.RangeGit:
 		return strings.ToLower(string(t))

--- a/grype/db/v6/build/transformers/osv/transform_test.go
+++ b/grype/db/v6/build/transformers/osv/transform_test.go
@@ -245,7 +245,7 @@ func TestTransform(t *testing.T) {
 							CVEs: []string{"CVE-2025-27144"},
 							Ranges: []db.Range{{
 								Version: db.Version{
-									Type:       "ecosystem",
+									Type:       "rpm",
 									Constraint: ">= 2:1.18.1-1.el10_0",
 								},
 								Fix: &db.Fix{
@@ -268,7 +268,7 @@ func TestTransform(t *testing.T) {
 							CVEs: []string{"CVE-2025-27144"},
 							Ranges: []db.Range{{
 								Version: db.Version{
-									Type:       "ecosystem",
+									Type:       "rpm",
 									Constraint: ">= 2:1.18.1-1.el10_0",
 								},
 								Fix: &db.Fix{


### PR DESCRIPTION
Previously the version range type for Alma vulnerability data was being set to `ecosystem` as it was using the OSV value, but prefer `rpm` here since we know that Alma packages use rpm versioning

Also, for OpenVex the version range type was not being normalised to lowercase.