### PR TITLE
fix: add Grype version and vulnerability DB info to HTML template

### DIFF
--- a/templates/html.tmpl
+++ b/templates/html.tmpl
@@ -730,6 +730,14 @@
                     {{- end -}}
                     {{- end -}}
 
+                    <dt>Grype Version:</dt>
+                    <dd>{{.Descriptor.Name}} {{.Descriptor.Version}}</dd>
+
+                    {{- if .Descriptor.DB -}}
+                    <dt>Vulnerability DB:</dt>
+                    <dd>{{ toJson .Descriptor.DB }}</dd>
+                    {{- end -}}
+
                     <dt>Date:</dt>
                     <dd>
                         <span id="dateElement">{{.Descriptor.Timestamp}}</span>


### PR DESCRIPTION
## Summary

The HTML vulnerability report template (`templates/html.tmpl`) currently does not display the Grype version or vulnerability database version/date in the report header. This makes it impossible to determine from the report output whether it was generated with a recent version of Grype and an up-to-date vulnerability database.

Fixes #2877

## Changes

- Added "Grype Version" row to the report header showing `{{.Descriptor.Name}} {{.Descriptor.Version}}`
- Added "Vulnerability DB" row (conditionally shown) displaying the DB metadata as JSON

## Testing

- Verified the template syntax is valid Go templating
- The Grype version and DB info are already available in the `.Descriptor` struct (`name`, `version`, `db` fields)
- No code changes required — only template modification
- Existing template functionality (date, source info, severity counts, table) is unchanged