### PR TITLE
fix: apply overlap by ownership removal to dynamically created relationships

### DIFF
--- a/grype/pkg/cpe_provider.go
+++ b/grype/pkg/cpe_provider.go
@@ -17,7 +17,7 @@ type CPELiteralMetadata struct {
 	CPE string
 }
 
-func cpeProvider(userInput string, config ProviderConfig) ([]Package, Context, *sbom.SBOM, error) {
+func cpeProvider(userInput string, config ProviderConfig) ([]*Package, Context, *sbom.SBOM, error) {
 	reader, ctx, err := getCPEReader(userInput)
 	if err != nil {
 		return nil, Context{}, nil, err

--- a/grype/pkg/cpe_provider_test.go
+++ b/grype/pkg/cpe_provider_test.go
@@ -19,7 +19,7 @@ func Test_CPEProvider(t *testing.T) {
 		name      string
 		userInput string
 		context   Context
-		pkgs      []Package
+		pkgs      []*Package
 		sbom      *sbom.SBOM
 		wantErr   require.ErrorAssertionFunc
 	}{
@@ -33,7 +33,7 @@ func Test_CPEProvider(t *testing.T) {
 					},
 				},
 			},
-			pkgs: []Package{
+			pkgs: []*Package{
 				{
 					Name:    "log4j",
 					Version: "2.14.1",
@@ -64,7 +64,7 @@ func Test_CPEProvider(t *testing.T) {
 					},
 				},
 			},
-			pkgs: []Package{
+			pkgs: []*Package{
 				{
 					Name: "log4j",
 					CPEs: []cpe.CPE{
@@ -93,7 +93,7 @@ func Test_CPEProvider(t *testing.T) {
 					},
 				},
 			},
-			pkgs: []Package{
+			pkgs: []*Package{
 				{
 					Name:    "log4j",
 					Version: "2.14.1",
@@ -126,7 +126,7 @@ func Test_CPEProvider(t *testing.T) {
 					},
 				},
 			},
-			pkgs: []Package{
+			pkgs: []*Package{
 				{
 					Name:    "log4j",
 					Version: "2.14.1",

--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -174,8 +174,6 @@ func FromPackages(syftPkgs []syftPkg.Package, relationships []artifact.Relations
 		}
 	}
 
-	pkgs = removePackagesByOverlap(pkgs)
-
 	return pkgs
 }
 

--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/anchore/grype/grype/distro"
@@ -97,17 +98,13 @@ func FromCollection(catalog *syftPkg.Collection, relationships []artifact.Relati
 //
 //nolint:gocognit,funlen
 func FromPackages(syftPkgs []syftPkg.Package, relationships []artifact.Relationship, config SynthesisConfig, enhancers ...Enhancer) []Package {
-	var pkgs []Package
+	pkgs := make([]*Package, 0, len(syftPkgs))
 
 	// if the user provided a distro explicitly, then use that over any distro that may be inferred from a package url
 	enhancers = append([]Enhancer{applyDistroOverride(config.Distro.Override)}, enhancers...)
 
-	// we track ID to index rather than pointer, since the package may be copied during append operations
-	pkgIdx := make(map[ID]int)
-
-	// use metadata FileOwner to synthesize missing ownership-by-file-overlap relationships in cases
-	// these are not included in the SBOM
-	ownedLocations := map[string][]int{}
+	pkgByID := make(map[ID]*Package)
+	ownedLocations := map[string][]*Package{}
 
 	for _, p := range syftPkgs {
 		if len(p.CPEs) == 0 {
@@ -120,14 +117,14 @@ func FromPackages(syftPkgs []syftPkg.Package, relationships []artifact.Relations
 		}
 
 		grypePkg := New(p, enhancers...)
-		idx := len(pkgs)
-		pkgIdx[grypePkg.ID] = idx
-		pkgs = append(pkgs, grypePkg)
+
+		pkgByID[grypePkg.ID] = &grypePkg
+		pkgs = append(pkgs, &grypePkg)
 
 		// track all owned locations
 		if owner, ok := p.Metadata.(FileOwner); ok {
 			for _, loc := range owner.OwnedFiles() {
-				ownedLocations[loc] = append(ownedLocations[loc], idx)
+				ownedLocations[loc] = append(ownedLocations[loc], &grypePkg)
 			}
 		}
 	}
@@ -137,8 +134,8 @@ func FromPackages(syftPkgs []syftPkg.Package, relationships []artifact.Relations
 		if !retainRelationshipType(r.Type) {
 			continue
 		}
-		fromPkg, fromOK := pkgIdx[grypeID(r.From)]
-		toPkg, toOK := pkgIdx[grypeID(r.To)]
+		fromPkg, fromOK := pkgByID[grypeID(r.From)]
+		toPkg, toOK := pkgByID[grypeID(r.To)]
 		if !fromOK || !toOK {
 			continue
 		}
@@ -147,37 +144,53 @@ func FromPackages(syftPkgs []syftPkg.Package, relationships []artifact.Relations
 			fromPkg, toPkg = toPkg, fromPkg
 		}
 
-		if pkgs[fromPkg].RelatedPackages == nil {
-			pkgs[fromPkg].RelatedPackages = map[artifact.RelationshipType][]*Package{}
+		if fromPkg.RelatedPackages == nil {
+			fromPkg.RelatedPackages = map[artifact.RelationshipType][]*Package{}
 		}
 
 		// not all SBOMs include this relationship, we want to recreate this if it's missing
 		if r.Type == artifact.OwnershipByFileOverlapRelationship {
 			hasOverlapRelationships = true
 		}
-		pkgs[fromPkg].RelatedPackages[r.Type] = append(pkgs[fromPkg].RelatedPackages[r.Type], &pkgs[toPkg])
+		fromPkg.RelatedPackages[r.Type] = append(fromPkg.RelatedPackages[r.Type], toPkg)
 	}
 
 	// recreate overlap-by-file-ownership based on owned files for SBOMs without these relationships
 	if !hasOverlapRelationships && len(ownedLocations) > 0 {
-		for i := range pkgs {
-			for _, loc := range pkgs[i].Locations.ToUnorderedSlice() {
+		for _, p := range pkgs {
+			for _, loc := range p.Locations.ToUnorderedSlice() {
 				if contained, ok := ownedLocations[loc.RealPath]; ok {
-					for _, ownerPackageIndex := range contained {
-						if ownerPackageIndex == i {
+					for _, ownerPackage := range contained {
+						if ownerPackage == p {
 							continue
 						}
-						if pkgs[i].RelatedPackages == nil {
-							pkgs[i].RelatedPackages = map[artifact.RelationshipType][]*Package{}
+						if p.RelatedPackages == nil {
+							p.RelatedPackages = map[artifact.RelationshipType][]*Package{}
 						}
-						pkgs[i].RelatedPackages[artifact.OwnershipByFileOverlapRelationship] = append(pkgs[i].RelatedPackages[artifact.OwnershipByFileOverlapRelationship], &pkgs[ownerPackageIndex])
+						p.RelatedPackages[artifact.OwnershipByFileOverlapRelationship] = append(p.RelatedPackages[artifact.OwnershipByFileOverlapRelationship], ownerPackage)
 					}
 				}
 			}
 		}
 	}
 
-	return pkgs
+	pkgs = removePackagesByOverlap(pkgs)
+
+	// return non-pointer structs; update pointers to point to the packages in the slice
+	out := make([]Package, len(pkgs))
+	pkgIdx := map[*Package]int{}
+	for i := range pkgs {
+		out[i] = *pkgs[i]
+		pkgIdx[pkgs[i]] = i
+	}
+	for i := range out {
+		for r := range out[i].RelatedPackages {
+			for j := range out[i].RelatedPackages[r] {
+				out[i].RelatedPackages[r][j] = &out[pkgIdx[out[i].RelatedPackages[r][j]]]
+			}
+		}
+	}
+	return out
 }
 
 func (p Package) String() string {
@@ -192,31 +205,29 @@ func (p Package) String() string {
 	return fmt.Sprintf("Pkg(type=%s, name=%s, version=%s%s%s)", p.Type, p.Name, p.Version, u, d)
 }
 
-func removePackagesByOverlap(catalog *syftPkg.Collection, relationships []artifact.Relationship, distro *distro.Distro) *syftPkg.Collection {
-	byOverlap := map[artifact.ID]artifact.Relationship{}
-	for _, r := range relationships {
-		if r.Type == artifact.OwnershipByFileOverlapRelationship {
-			byOverlap[r.To.ID()] = r
+func removePackagesByOverlap(pkgs []*Package) []*Package {
+	return slices.DeleteFunc(pkgs, func(p *Package) bool {
+		if p.RelatedPackages == nil {
+			return false // don't delete
 		}
-	}
-
-	out := syftPkg.NewCollection()
-	comprehensiveDistroFeed := distroFeedIsComprehensive(distro)
-	for p := range catalog.Enumerate() {
-		r, ok := byOverlap[p.ID()]
-		if ok {
-			from := catalog.Package(r.From.ID())
-			if from != nil && excludePackage(comprehensiveDistroFeed, p, *from) {
-				continue
+		overlapping := p.RelatedPackages[artifact.OwnershipByFileOverlapRelationship]
+		if len(overlapping) == 0 {
+			return false
+		}
+		for _, from := range overlapping {
+			if excludePackage(p, from) {
+				return true
 			}
 		}
-		out.Add(p)
-	}
-
-	return out
+		return false
+	})
 }
 
-func excludePackage(comprehensiveDistroFeed bool, p syftPkg.Package, parent syftPkg.Package) bool {
+func excludePackage(p *Package, parent *Package) bool {
+	if p == nil || parent == nil || parent.Distro == nil {
+		return false
+	}
+
 	// NOTE: we are not checking the name because we have mismatches like:
 	// python      3.9.2      binary
 	// python3.9   3.9.2-1    deb
@@ -230,7 +241,7 @@ func excludePackage(comprehensiveDistroFeed bool, p syftPkg.Package, parent syft
 	// for distros that have a comprehensive feed. That is, distros that list
 	// vulnerabilities that aren't fixed. Otherwise, the child package might
 	// be needed for matching.
-	if comprehensiveDistroFeed && isOSPackage(parent) && !isOSPackage(p) {
+	if distroFeedIsComprehensive(parent.Distro) && isOSPackage(parent) && !isOSPackage(p) {
 		return true
 	}
 
@@ -281,7 +292,7 @@ var comprehensiveDistros = []distro.Type{
 	distro.Ubuntu,
 }
 
-func isOSPackage(p syftPkg.Package) bool {
+func isOSPackage(p *Package) bool {
 	switch p.Type {
 	case syftPkg.DebPkg, syftPkg.RpmPkg, syftPkg.PortagePkg, syftPkg.AlpmPkg, syftPkg.ApkPkg:
 		return true

--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -90,14 +90,14 @@ func New(p syftPkg.Package, enhancers ...Enhancer) Package {
 	return out
 }
 
-func FromCollection(catalog *syftPkg.Collection, relationships []artifact.Relationship, config SynthesisConfig, enhancers ...Enhancer) []Package {
+func FromCollection(catalog *syftPkg.Collection, relationships []artifact.Relationship, config SynthesisConfig, enhancers ...Enhancer) []*Package {
 	return FromPackages(catalog.Sorted(), relationships, config, enhancers...)
 }
 
 // FromPackages creates grype packages from syft packages, including relevant relationship mappings
 //
 //nolint:gocognit,funlen
-func FromPackages(syftPkgs []syftPkg.Package, relationships []artifact.Relationship, config SynthesisConfig, enhancers ...Enhancer) []Package {
+func FromPackages(syftPkgs []syftPkg.Package, relationships []artifact.Relationship, config SynthesisConfig, enhancers ...Enhancer) []*Package {
 	pkgs := make([]*Package, 0, len(syftPkgs))
 
 	// if the user provided a distro explicitly, then use that over any distro that may be inferred from a package url
@@ -176,21 +176,7 @@ func FromPackages(syftPkgs []syftPkg.Package, relationships []artifact.Relations
 
 	pkgs = removePackagesByOverlap(pkgs)
 
-	// return non-pointer structs; update pointers to point to the packages in the slice
-	out := make([]Package, len(pkgs))
-	pkgIdx := map[*Package]int{}
-	for i := range pkgs {
-		out[i] = *pkgs[i]
-		pkgIdx[pkgs[i]] = i
-	}
-	for i := range out {
-		for r := range out[i].RelatedPackages {
-			for j := range out[i].RelatedPackages[r] {
-				out[i].RelatedPackages[r][j] = &out[pkgIdx[out[i].RelatedPackages[r][j]]]
-			}
-		}
-	}
-	return out
+	return pkgs
 }
 
 func (p Package) String() string {

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/anchore/packageurl-go"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/anchore/grype/grype/distro"
@@ -1351,9 +1352,9 @@ func Test_RemovePackagesByOverlap(t *testing.T) {
 		},
 		{
 			name: "excludes single package by overlap",
-			sbom: catalogWithOverlaps(
+			sbom: withLinuxRelease(catalogWithOverlaps(
 				[]string{"apk:go@1.18", "apk:node@19.2-r1", "binary:node@19.2"},
-				[]string{"apk:node@19.2-r1 -> binary:node@19.2"}),
+				[]string{"apk:node@19.2-r1 -> binary:node@19.2"}), "rhel"),
 			expectedPackages: []string{"apk:go@1.18", "apk:node@19.2-r1"},
 		},
 		{
@@ -1365,16 +1366,16 @@ func Test_RemovePackagesByOverlap(t *testing.T) {
 		},
 		{
 			name: "does not exclude if owning package is non-OS",
-			sbom: catalogWithOverlaps(
+			sbom: withLinuxRelease(catalogWithOverlaps(
 				[]string{"python:urllib3@1.2.3", "python:otherlib@1.2.3"},
-				[]string{"python:urllib3@1.2.3 -> python:otherlib@1.2.3"}),
+				[]string{"python:urllib3@1.2.3 -> python:otherlib@1.2.3"}), "rhel"),
 			expectedPackages: []string{"python:otherlib@1.2.3", "python:urllib3@1.2.3"},
 		},
 		{
 			name: "excludes multiple package by overlap",
-			sbom: catalogWithOverlaps(
+			sbom: withLinuxRelease(catalogWithOverlaps(
 				[]string{"apk:go@1.18", "apk:node@19.2-r1", "binary:node@19.2", "apk:python@3.9-r9", "binary:python@3.9"},
-				[]string{"apk:node@19.2-r1 -> binary:node@19.2", "apk:python@3.9-r9 -> binary:python@3.9"}),
+				[]string{"apk:node@19.2-r1 -> binary:node@19.2", "apk:python@3.9-r9 -> binary:python@3.9"}), "rhel"),
 			expectedPackages: []string{"apk:go@1.18", "apk:node@19.2-r1", "apk:python@3.9-r9"},
 		},
 		{
@@ -1437,8 +1438,9 @@ func Test_RemovePackagesByOverlap(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			d := distro.FromRelease(test.sbom.Artifacts.LinuxDistribution, distro.DefaultFixChannels())
-			catalog := removePackagesByOverlap(test.sbom.Artifacts.Packages, test.sbom.Relationships, d)
-			pkgs := FromCollection(catalog, test.sbom.Relationships, SynthesisConfig{})
+			pkgs := FromCollection(test.sbom.Artifacts.Packages, test.sbom.Relationships, SynthesisConfig{}, func(out *Package, purl packageurl.PackageURL, pkg syftPkg.Package) {
+				out.Distro = d
+			})
 			var pkgNames []string
 			for _, p := range pkgs {
 				pkgNames = append(pkgNames, fmt.Sprintf("%s:%s@%s", p.Type, p.Name, p.Version))

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -1469,6 +1469,24 @@ func Test_ExcludeRetainsCorrectRelationships(t *testing.T) {
 	}
 	pythonPkg.SetID()
 
+	// Create an rpm package that owns a npm package via file overlap
+	rpmPkg := syftPkg.Package{
+		Type:      syftPkg.RpmPkg,
+		Name:      "npm",
+		Version:   "3.0.",
+		PURL:      "pkg:rpm/npm@3.0.5-r0?distro=rhel:9",
+		Locations: file.NewLocationSet(file.NewLocation("/lib/rpmdb")),
+	}
+	rpmPkg.SetID()
+
+	npmPkg := syftPkg.Package{
+		Type:      syftPkg.NpmPkg,
+		Name:      "npm",
+		Version:   "3.0.5",
+		Locations: file.NewLocationSet(file.NewLocation("/usr/lib/npm")),
+	}
+	npmPkg.SetID()
+
 	// Additional packages at locations that will be excluded
 	excludedPkg1 := syftPkg.Package{
 		Type:      syftPkg.PythonPkg,
@@ -1486,12 +1504,17 @@ func Test_ExcludeRetainsCorrectRelationships(t *testing.T) {
 	}
 	excludedPkg2.SetID()
 
-	catalog := syftPkg.NewCollection(apkPkg, pythonPkg, excludedPkg1, excludedPkg2)
+	catalog := syftPkg.NewCollection(excludedPkg1, excludedPkg2, rpmPkg, npmPkg, apkPkg, pythonPkg)
 
 	relationships := []artifact.Relationship{
 		{
 			From: apkPkg,
 			To:   pythonPkg,
+			Type: artifact.OwnershipByFileOverlapRelationship,
+		},
+		{
+			From: rpmPkg,
+			To:   npmPkg,
 			Type: artifact.OwnershipByFileOverlapRelationship,
 		},
 	}
@@ -1505,38 +1528,49 @@ func Test_ExcludeRetainsCorrectRelationships(t *testing.T) {
 	}
 
 	d := distro.FromRelease(s.Artifacts.LinuxDistribution, nil)
-	pkgs := FromCollection(s.Artifacts.Packages, s.Relationships, SynthesisConfig{}, func(out *Package, _ packageurl.PackageURL, _ syftPkg.Package) {
-		out.Distro = d
-	})
+	pkgs := FromCollection(s.Artifacts.Packages, s.Relationships, SynthesisConfig{},
+		setDistroFromPURL(func(d *distro.Distro) bool { return true }),
+		func(out *Package, _ packageurl.PackageURL, _ syftPkg.Package) {
+			if out.Type == syftPkg.ApkPkg {
+				out.Distro = d
+			}
+		})
+
+	assert.Len(t, pkgs, 6)
 
 	// alpine is not a comprehensive distro and python is not a binary package,
-	// so all packages should survive overlap removal
+	// rpm is a comprehensive that should remove the overlapping npm package
 	pkgs = removePackagesByOverlap(pkgs)
-	assert.Len(t, pkgs, 4)
+	assert.Len(t, pkgs, 5)
 
 	// apply exclusions to filter out packages at /excluded/**
 	filtered, err := filterPackageExclusions(pkgs, []string{"/excluded/**"})
 	assert.NoError(t, err)
-	assert.Len(t, filtered, 2)
+	assert.Len(t, filtered, 3)
 
-	// verify only the apk and python pip packages remain
-	var apkGrypePkg, pythonGrypePkg *Package
+	// verify only the apk and python pip language packages remain
+	var apkGrypePkg, pythonGrypePkg, npmGrypePkg *Package
 	for _, p := range filtered {
 		switch p.Name {
 		case "py3-pip":
 			apkGrypePkg = p
 		case "pip":
 			pythonGrypePkg = p
+		case "npm":
+			npmGrypePkg = p
 		}
 	}
 	assert.NotNil(t, apkGrypePkg)
 	assert.NotNil(t, pythonGrypePkg)
+	assert.NotNil(t, npmGrypePkg)
 
 	// the python package should have the apk package as its overlap owner
 	// (OwnershipByFileOverlapRelationship is inverted in FromPackages: child -> parent)
 	overlapping := pythonGrypePkg.RelatedPackages[artifact.OwnershipByFileOverlapRelationship]
 	assert.Len(t, overlapping, 1)
 	assert.Equal(t, "py3-pip", overlapping[0].Name)
+	assert.NotEmpty(t, overlapping[0].ID)
+	assert.Equal(t, apkGrypePkg.ID, overlapping[0].ID)
 }
 
 func catalogWithOverlaps(packages []string, overlaps []string) *sbom.SBOM {

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/anchore/packageurl-go"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/anchore/grype/grype/distro"
+	"github.com/anchore/packageurl-go"
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/cpe"
 	"github.com/anchore/syft/syft/file"
@@ -1302,7 +1302,7 @@ func TestFromPackages_OwnershipByFileOverlap(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			pkgs := FromPackages(tt.syftPkgs, tt.relationships, SynthesisConfig{})
 
-			pkgByName := map[string]Package{}
+			pkgByName := map[string]*Package{}
 			for _, p := range pkgs {
 				pkgByName[p.Name] = p
 			}

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -1441,6 +1441,7 @@ func Test_RemovePackagesByOverlap(t *testing.T) {
 			pkgs := FromCollection(test.sbom.Artifacts.Packages, test.sbom.Relationships, SynthesisConfig{}, func(out *Package, purl packageurl.PackageURL, pkg syftPkg.Package) {
 				out.Distro = d
 			})
+			pkgs = removePackagesByOverlap(pkgs)
 			var pkgNames []string
 			for _, p := range pkgs {
 				pkgNames = append(pkgNames, fmt.Sprintf("%s:%s@%s", p.Type, p.Name, p.Version))
@@ -1448,6 +1449,94 @@ func Test_RemovePackagesByOverlap(t *testing.T) {
 			assert.EqualValues(t, test.expectedPackages, pkgNames)
 		})
 	}
+}
+
+func Test_ExcludeRetainsCorrectRelationships(t *testing.T) {
+	// Create an apk package that owns a python package via file overlap
+	apkPkg := syftPkg.Package{
+		Type:      syftPkg.ApkPkg,
+		Name:      "py3-pip",
+		Version:   "23.0-r0",
+		Locations: file.NewLocationSet(file.NewLocation("/lib/apk/db/installed")),
+	}
+	apkPkg.SetID()
+
+	pythonPkg := syftPkg.Package{
+		Type:      syftPkg.PythonPkg,
+		Name:      "pip",
+		Version:   "23.0",
+		Locations: file.NewLocationSet(file.NewLocation("/usr/lib/python3.11/site-packages/pip")),
+	}
+	pythonPkg.SetID()
+
+	// Additional packages at locations that will be excluded
+	excludedPkg1 := syftPkg.Package{
+		Type:      syftPkg.PythonPkg,
+		Name:      "requests",
+		Version:   "2.28.0",
+		Locations: file.NewLocationSet(file.NewLocation("/excluded/lib/python3.11/site-packages/requests")),
+	}
+	excludedPkg1.SetID()
+
+	excludedPkg2 := syftPkg.Package{
+		Type:      syftPkg.PythonPkg,
+		Name:      "urllib3",
+		Version:   "1.26.0",
+		Locations: file.NewLocationSet(file.NewLocation("/excluded/lib/python3.11/site-packages/urllib3")),
+	}
+	excludedPkg2.SetID()
+
+	catalog := syftPkg.NewCollection(apkPkg, pythonPkg, excludedPkg1, excludedPkg2)
+
+	relationships := []artifact.Relationship{
+		{
+			From: apkPkg,
+			To:   pythonPkg,
+			Type: artifact.OwnershipByFileOverlapRelationship,
+		},
+	}
+
+	s := &sbom.SBOM{
+		Artifacts: sbom.Artifacts{
+			Packages:          catalog,
+			LinuxDistribution: &linux.Release{ID: "alpine"},
+		},
+		Relationships: relationships,
+	}
+
+	d := distro.FromRelease(s.Artifacts.LinuxDistribution, nil)
+	pkgs := FromCollection(s.Artifacts.Packages, s.Relationships, SynthesisConfig{}, func(out *Package, _ packageurl.PackageURL, _ syftPkg.Package) {
+		out.Distro = d
+	})
+
+	// alpine is not a comprehensive distro and python is not a binary package,
+	// so all packages should survive overlap removal
+	pkgs = removePackagesByOverlap(pkgs)
+	assert.Len(t, pkgs, 4)
+
+	// apply exclusions to filter out packages at /excluded/**
+	filtered, err := filterPackageExclusions(pkgs, []string{"/excluded/**"})
+	assert.NoError(t, err)
+	assert.Len(t, filtered, 2)
+
+	// verify only the apk and python pip packages remain
+	var apkGrypePkg, pythonGrypePkg *Package
+	for _, p := range filtered {
+		switch p.Name {
+		case "py3-pip":
+			apkGrypePkg = p
+		case "pip":
+			pythonGrypePkg = p
+		}
+	}
+	assert.NotNil(t, apkGrypePkg)
+	assert.NotNil(t, pythonGrypePkg)
+
+	// the python package should have the apk package as its overlap owner
+	// (OwnershipByFileOverlapRelationship is inverted in FromPackages: child -> parent)
+	overlapping := pythonGrypePkg.RelatedPackages[artifact.OwnershipByFileOverlapRelationship]
+	assert.Len(t, overlapping, 1)
+	assert.Equal(t, "py3-pip", overlapping[0].Name)
 }
 
 func catalogWithOverlaps(packages []string, overlaps []string) *sbom.SBOM {

--- a/grype/pkg/provider.go
+++ b/grype/pkg/provider.go
@@ -45,7 +45,7 @@ func Provide(userInput string, config ProviderConfig) ([]Package, Context, *sbom
 		}
 	}
 
-	return packages, ctx, s, nil
+	return FromPtrs(packages), ctx, s, nil
 }
 
 // ProvideFromReader is like Provide but reads an SBOM directly from the given reader
@@ -83,7 +83,31 @@ func ProvideFromReader(reader io.ReadSeeker, config ProviderConfig) ([]Package, 
 		}
 	}
 
-	return packages, ctx, s, nil
+	return FromPtrs(packages), ctx, s, nil
+}
+
+// FromPtrs converts a slice of Package pointers to a slice of Package structs,
+// including re-pointing related package pointers to the corresponding struct within the slice
+func FromPtrs(packages []*Package) []Package {
+	if len(packages) == 0 {
+		return nil
+	}
+	out := make([]Package, len(packages))
+	pkgIdx := make(map[*Package]int, len(packages))
+	for i, p := range packages {
+		pkgIdx[p] = i
+		out[i] = *p
+	}
+	for i := range out {
+		for m := range out[i].RelatedPackages {
+			for relatedIdx, p := range out[i].RelatedPackages[m] {
+				if idx, ok := pkgIdx[p]; ok {
+					out[i].RelatedPackages[m][relatedIdx] = &out[idx]
+				}
+			}
+		}
+	}
+	return out
 }
 
 // buildChannelIndex creates a map of distro IDs to their applicable fix channels
@@ -173,7 +197,7 @@ func applyChannelsToDistro(d *distro.Distro, channels distro.FixChannels) bool {
 }
 
 // Provide a set of packages and context metadata describing where they were sourced from.
-func provide(userInput string, config ProviderConfig, applyChannel func(d *distro.Distro) bool) ([]Package, Context, *sbom.SBOM, error) {
+func provide(userInput string, config ProviderConfig, applyChannel func(d *distro.Distro) bool) ([]*Package, Context, *sbom.SBOM, error) {
 	packages, ctx, s, err := purlProvider(userInput, config, applyChannel)
 	if !errors.Is(err, errDoesNotProvide) {
 		log.WithFields("input", userInput).Trace("interpreting input as one or more PURLs")
@@ -206,8 +230,8 @@ func provide(userInput string, config ProviderConfig, applyChannel func(d *distr
 // This will filter the provided packages list based on a set of exclusion expressions. Globs
 // are allowed for the exclusions. A package will be *excluded* only if *all locations* match
 // one of the provided exclusions.
-func filterPackageExclusions(packages []Package, exclusions []string) ([]Package, error) {
-	var out []Package
+func filterPackageExclusions(packages []*Package, exclusions []string) ([]*Package, error) {
+	var out []*Package
 	for _, pkg := range packages {
 		includePackage := true
 		locations := pkg.Locations.ToSlice()
@@ -252,7 +276,7 @@ func locationMatches(location file.Location, exclusion string) (bool, error) {
 	return matchesRealPath || matchesVirtualPath, nil
 }
 
-func setContextDistro(packages []Package, ctx *Context) {
+func setContextDistro(packages []*Package, ctx *Context) {
 	if ctx.Distro != nil {
 		return
 	}

--- a/grype/pkg/provider.go
+++ b/grype/pkg/provider.go
@@ -45,6 +45,8 @@ func Provide(userInput string, config ProviderConfig) ([]Package, Context, *sbom
 		}
 	}
 
+	packages = removePackagesByOverlap(packages)
+
 	return FromPtrs(packages), ctx, s, nil
 }
 
@@ -74,6 +76,8 @@ func ProvideFromReader(reader io.ReadSeeker, config ProviderConfig) ([]Package, 
 			log.Infof("using distro: %s", ctx.Distro.String())
 		}
 	}
+
+	packages = removePackagesByOverlap(packages)
 
 	if len(config.Exclusions) > 0 {
 		var exclusionsErr error

--- a/grype/pkg/provider_test.go
+++ b/grype/pkg/provider_test.go
@@ -228,7 +228,7 @@ func Test_filterPackageExclusions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			var packages []Package
+			var packages []*Package
 			for _, pkg := range test.locations {
 				locations := file.NewLocationSet()
 				for _, l := range pkg {
@@ -236,7 +236,7 @@ func Test_filterPackageExclusions(t *testing.T) {
 						file.NewVirtualLocation(l, l),
 					)
 				}
-				packages = append(packages, Package{Locations: locations})
+				packages = append(packages, &Package{Locations: locations})
 			}
 			filtered, err := filterPackageExclusions(packages, test.exclusions)
 

--- a/grype/pkg/purl_provider.go
+++ b/grype/pkg/purl_provider.go
@@ -27,7 +27,7 @@ func purlEnhancers(applyChannel func(*distro.Distro) bool) []Enhancer {
 	return []Enhancer{setUpstreamsFromPURL, setDistroFromPURL(applyChannel)}
 }
 
-func purlProvider(userInput string, config ProviderConfig, applyChannel func(*distro.Distro) bool) ([]Package, Context, *sbom.SBOM, error) {
+func purlProvider(userInput string, config ProviderConfig, applyChannel func(*distro.Distro) bool) ([]*Package, Context, *sbom.SBOM, error) {
 	reader, ctx, err := getPurlReader(userInput)
 	if err != nil {
 		return nil, Context{}, nil, err

--- a/grype/pkg/purl_provider_test.go
+++ b/grype/pkg/purl_provider_test.go
@@ -25,7 +25,7 @@ func Test_PurlProvider(t *testing.T) {
 		userInput   string
 		channels    []distro.FixChannel
 		wantContext Context
-		wantPkgs    []Package
+		wantPkgs    []*Package
 		wantErr     require.ErrorAssertionFunc
 	}{
 		{
@@ -39,7 +39,7 @@ func Test_PurlProvider(t *testing.T) {
 					},
 				},
 			},
-			wantPkgs: []Package{
+			wantPkgs: []*Package{
 				{
 					Name:    "curl",
 					Version: "7.61.1",
@@ -59,7 +59,7 @@ func Test_PurlProvider(t *testing.T) {
 					},
 				},
 			},
-			wantPkgs: []Package{
+			wantPkgs: []*Package{
 				{
 					Name:    "commons-lang3",
 					Version: "3.12.0",
@@ -83,7 +83,7 @@ func Test_PurlProvider(t *testing.T) {
 					},
 				},
 			},
-			wantPkgs: []Package{
+			wantPkgs: []*Package{
 				{
 					Name:    "sysv-rc",
 					Version: "2.88dsf-59",
@@ -109,7 +109,7 @@ func Test_PurlProvider(t *testing.T) {
 					},
 				},
 			},
-			wantPkgs: []Package{
+			wantPkgs: []*Package{
 				{
 					Name:    "libcrypto3",
 					Version: "3.3.2",
@@ -134,7 +134,7 @@ func Test_PurlProvider(t *testing.T) {
 					},
 				},
 			},
-			wantPkgs: []Package{
+			wantPkgs: []*Package{
 				{
 					Name:    "libcrypto3",
 					Version: "3.3.2",
@@ -160,7 +160,7 @@ func Test_PurlProvider(t *testing.T) {
 					},
 				},
 			},
-			wantPkgs: []Package{
+			wantPkgs: []*Package{
 				{
 					Name:    "systemd-x",
 					Version: "239-82.el8_10.2",
@@ -187,7 +187,7 @@ func Test_PurlProvider(t *testing.T) {
 					},
 				},
 			},
-			wantPkgs: []Package{
+			wantPkgs: []*Package{
 				{
 					Name:    "dbus-common",
 					Version: "1:1.12.8-26.el8",
@@ -214,7 +214,7 @@ func Test_PurlProvider(t *testing.T) {
 					},
 				},
 			},
-			wantPkgs: []Package{
+			wantPkgs: []*Package{
 				{
 					Name:    "httpd",
 					Version: "2.4.37-51",
@@ -238,7 +238,7 @@ func Test_PurlProvider(t *testing.T) {
 					},
 				},
 			},
-			wantPkgs: []Package{
+			wantPkgs: []*Package{
 				{
 					Name:    "curl",
 					Version: "7.61.1",
@@ -257,7 +257,7 @@ func Test_PurlProvider(t *testing.T) {
 					Metadata: PURLLiteralMetadata{PURL: "pkg:golang/k8s.io/ingress-nginx@v1.11.2"},
 				},
 			},
-			wantPkgs: []Package{
+			wantPkgs: []*Package{
 				{
 					Name:    "k8s.io/ingress-nginx",
 					Version: "v1.11.2",
@@ -275,7 +275,7 @@ func Test_PurlProvider(t *testing.T) {
 					Metadata: PURLLiteralMetadata{PURL: "pkg:golang/github.com/wazuh/wazuh@v4.5.0"},
 				},
 			},
-			wantPkgs: []Package{
+			wantPkgs: []*Package{
 				{
 					Name:    "github.com/wazuh/wazuh",
 					Version: "v4.5.0",
@@ -293,7 +293,7 @@ func Test_PurlProvider(t *testing.T) {
 					Metadata: PURLLiteralMetadata{PURL: "pkg:golang/wazuh@v4.5.0"},
 				},
 			},
-			wantPkgs: []Package{
+			wantPkgs: []*Package{
 				{
 					Name:    "wazuh",
 					Version: "v4.5.0",
@@ -313,7 +313,7 @@ func Test_PurlProvider(t *testing.T) {
 					},
 				},
 			},
-			wantPkgs: []Package{
+			wantPkgs: []*Package{
 				{
 					Name:    "systemd-x",
 					Version: "239-82.el8_10.2",
@@ -340,7 +340,7 @@ func Test_PurlProvider(t *testing.T) {
 					},
 				},
 			},
-			wantPkgs: []Package{
+			wantPkgs: []*Package{
 				{
 					Name:    "systemd-x",
 					Version: "239-82.el8_10.2",
@@ -367,7 +367,7 @@ func Test_PurlProvider(t *testing.T) {
 					},
 				},
 			},
-			wantPkgs: []Package{
+			wantPkgs: []*Package{
 				{
 					Name:    "systemd-x",
 					Version: "239-82.el8_10.2",
@@ -395,7 +395,7 @@ func Test_PurlProvider(t *testing.T) {
 					},
 				},
 			},
-			wantPkgs: []Package{
+			wantPkgs: []*Package{
 				{
 					Name:    "systemd-x",
 					Version: "239-82.el8_10.2",

--- a/grype/pkg/syft_provider.go
+++ b/grype/pkg/syft_provider.go
@@ -35,9 +35,7 @@ func syftProvider(userInput string, config ProviderConfig, applyChannel func(*di
 
 	d, distroDetectionFailed := distroFromSBOM(s, config, applyChannel)
 
-	pkgCatalog := removePackagesByOverlap(s.Artifacts.Packages, s.Relationships, d)
-
-	packages := FromCollection(pkgCatalog, s.Relationships, config.SynthesisConfig)
+	packages := FromCollection(s.Artifacts.Packages, s.Relationships, config.SynthesisConfig)
 	pkgCtx := Context{
 		Source:                &srcDescription,
 		Distro:                d,

--- a/grype/pkg/syft_provider.go
+++ b/grype/pkg/syft_provider.go
@@ -15,7 +15,7 @@ import (
 	"github.com/anchore/syft/syft/source/sourceproviders"
 )
 
-func syftProvider(userInput string, config ProviderConfig, applyChannel func(*distro.Distro) bool) ([]Package, Context, *sbom.SBOM, error) {
+func syftProvider(userInput string, config ProviderConfig, applyChannel func(*distro.Distro) bool) ([]*Package, Context, *sbom.SBOM, error) {
 	src, err := getSource(userInput, config)
 	if err != nil {
 		return nil, Context{}, nil, err

--- a/grype/pkg/syft_sbom_provider.go
+++ b/grype/pkg/syft_sbom_provider.go
@@ -38,14 +38,12 @@ func syftSBOMProvider(userInput string, config ProviderConfig, applyChannel func
 
 	d, distroDetectionFailed := distroFromSBOM(s, config, applyChannel)
 
-	catalog := removePackagesByOverlap(s.Artifacts.Packages, s.Relationships, d)
-
 	var enhancers []Enhancer
 	if fmtID != syftjson.ID {
 		enhancers = purlEnhancers(applyChannel)
 	}
 
-	return FromCollection(catalog, s.Relationships, config.SynthesisConfig, enhancers...), Context{
+	return FromCollection(s.Artifacts.Packages, s.Relationships, config.SynthesisConfig, enhancers...), Context{
 		Source:                &src,
 		Distro:                d,
 		DistroDetectionFailed: distroDetectionFailed,
@@ -60,8 +58,6 @@ func syftSBOMProviderFromReader(reader io.ReadSeeker, config ProviderConfig, app
 
 	d, distroDetectionFailed := distroFromSBOM(s, config, applyChannel)
 
-	catalog := removePackagesByOverlap(s.Artifacts.Packages, s.Relationships, d)
-
 	var enhancers []Enhancer
 	if fmtID != syftjson.ID {
 		enhancers = purlEnhancers(applyChannel)
@@ -69,7 +65,7 @@ func syftSBOMProviderFromReader(reader io.ReadSeeker, config ProviderConfig, app
 
 	src := s.Source
 
-	return FromCollection(catalog, s.Relationships, config.SynthesisConfig, enhancers...), Context{
+	return FromCollection(s.Artifacts.Packages, s.Relationships, config.SynthesisConfig, enhancers...), Context{
 		Source:                &src,
 		Distro:                d,
 		DistroDetectionFailed: distroDetectionFailed,

--- a/grype/pkg/syft_sbom_provider.go
+++ b/grype/pkg/syft_sbom_provider.go
@@ -23,7 +23,7 @@ type SBOMFileMetadata struct {
 	Path string
 }
 
-func syftSBOMProvider(userInput string, config ProviderConfig, applyChannel func(*distro.Distro) bool) ([]Package, Context, *sbom.SBOM, error) {
+func syftSBOMProvider(userInput string, config ProviderConfig, applyChannel func(*distro.Distro) bool) ([]*Package, Context, *sbom.SBOM, error) {
 	s, fmtID, path, err := getSBOM(userInput)
 	if err != nil {
 		return nil, Context{}, nil, err
@@ -50,7 +50,7 @@ func syftSBOMProvider(userInput string, config ProviderConfig, applyChannel func
 	}, s, nil
 }
 
-func syftSBOMProviderFromReader(reader io.ReadSeeker, config ProviderConfig, applyChannel func(*distro.Distro) bool) ([]Package, Context, *sbom.SBOM, error) {
+func syftSBOMProviderFromReader(reader io.ReadSeeker, config ProviderConfig, applyChannel func(*distro.Distro) bool) ([]*Package, Context, *sbom.SBOM, error) {
 	s, fmtID, err := readSBOM(reader)
 	if err != nil {
 		return nil, Context{}, nil, err

--- a/grype/pkg/syft_sbom_provider_test.go
+++ b/grype/pkg/syft_sbom_provider_test.go
@@ -22,12 +22,12 @@ func TestParseSyftJSON(t *testing.T) {
 
 	tests := []struct {
 		Fixture  string
-		Packages []Package
+		Packages []*Package
 		Context  Context
 	}{
 		{
 			Fixture: "testdata/syft-multiple-ecosystems.json",
-			Packages: []Package{
+			Packages: []*Package{
 				{
 					Name:    "alpine-baselayout",
 					Version: "3.2.0-r6",
@@ -279,11 +279,11 @@ func TestParseSyftJSON_BadCPEs(t *testing.T) {
 // and package IDs are removed so that the test case variable isn't unwieldingly huge.
 var springImageTestCase = struct {
 	Fixture  string
-	Packages []Package
+	Packages []*Package
 	Context  Context
 }{
 	Fixture: "testdata/syft-spring.json",
-	Packages: []Package{
+	Packages: []*Package{
 		{
 			Name:    "charsets",
 			Version: "",

--- a/grype/presenter/internal/test_helpers.go
+++ b/grype/presenter/internal/test_helpers.go
@@ -54,7 +54,7 @@ func GenerateAnalysis(t *testing.T, scheme SyftSource) (*sbom.SBOM, models.Docum
 		Source: *context.Source,
 	}
 
-	grypePackages := pkg.FromCollection(s.Artifacts.Packages, s.Relationships, pkg.SynthesisConfig{})
+	grypePackages := pkg.FromPtrs(pkg.FromCollection(s.Artifacts.Packages, s.Relationships, pkg.SynthesisConfig{}))
 
 	matches := generateMatches(t, grypePackages[0], grypePackages[1])
 
@@ -73,7 +73,7 @@ func GenerateAnalysisWithIgnoredMatches(t *testing.T, scheme SyftSource) models.
 		},
 	}
 
-	grypePackages := pkg.FromCollection(s.Artifacts.Packages, s.Relationships, pkg.SynthesisConfig{})
+	grypePackages := pkg.FromPtrs(pkg.FromCollection(s.Artifacts.Packages, s.Relationships, pkg.SynthesisConfig{}))
 
 	matches := generateMatches(t, grypePackages[0], grypePackages[1])
 	ignoredMatches := generateIgnoredMatches(t, grypePackages[1])

--- a/test/integration/match_by_image_test.go
+++ b/test/integration/match_by_image_test.go
@@ -874,11 +874,11 @@ func TestMatchByImage(t *testing.T) {
 				},
 			})
 
-			actualResults := grype.FindVulnerabilitiesForPackage(theProvider, matchers, pkg.FromCollection(s.Artifacts.Packages, s.Relationships, pkg.SynthesisConfig{
+			actualResults := grype.FindVulnerabilitiesForPackage(theProvider, matchers, pkg.FromPtrs(pkg.FromCollection(s.Artifacts.Packages, s.Relationships, pkg.SynthesisConfig{
 				Distro: pkg.DistroConfig{
 					Override: distro.FromRelease(s.Artifacts.LinuxDistribution, distro.DefaultFixChannels()),
 				},
-			}))
+			})))
 			for _, m := range actualResults.Sorted() {
 				for _, d := range m.Details {
 					observedMatchers.Add(string(d.Matcher))


### PR DESCRIPTION
This PR is a follow-on to a change made to dynamically create `ownership-by-file-overlap` relationships based on file locations. These dynamic relationships were added _after_ a set of packages were dropped, so the same logic was not applying to them. In particular, this corrects a deficiency in Syft-generated CycloneDX documents, since these _should_ have the correct metadata but do not have the relationships since CycloneDX cannot express that.

Related to at least #3329 and https://github.com/anchore/syft/issues/4760

This PR also seems to reduce memory usage slightly beyond https://github.com/anchore/grype/pull/3355 to the range of ~75-80 MB for the same SBOM.