### PR TITLE
feat(os transformer): unaffected package handles

### DIFF
--- a/grype/db/v6/build/transformers/os/testdata/rhel-8-not-affected.json
+++ b/grype/db/v6/build/transformers/os/testdata/rhel-8-not-affected.json
@@ -1,0 +1,52 @@
+[
+  {
+    "Vulnerability": {
+      "CVSS": [
+        {
+          "base_metrics": {
+            "base_score": 7.8,
+            "base_severity": "High",
+            "exploitability_score": 1.8,
+            "impact_score": 5.9
+          },
+          "status": "draft",
+          "vector_string": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+          "version": "3.1"
+        }
+      ],
+      "Description": "Test vulnerability with a not-affected package and an affected package.",
+      "FixedIn": [
+        {
+          "Name": "ghostscript",
+          "NamespaceName": "rhel:8",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "rpm"
+        },
+        {
+          "Name": "firefox",
+          "NamespaceName": "rhel:8",
+          "VendorAdvisory": {
+            "AdvisorySummary": [
+              {
+                "ID": "RHSA-2020:1341",
+                "Link": "https://access.redhat.com/errata/RHSA-2020:1341"
+              }
+            ],
+            "NoAdvisory": false
+          },
+          "Version": "0:68.6.1-1.el8_1",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2020-99999",
+      "Metadata": {},
+      "Name": "CVE-2020-99999",
+      "NamespaceName": "rhel:8",
+      "Severity": "Medium"
+    }
+  }
+]

--- a/grype/db/v6/build/transformers/os/transform.go
+++ b/grype/db/v6/build/transformers/os/transform.go
@@ -49,17 +49,56 @@ func Transform(vulnerability unmarshal.OSVulnerability, state provider.State) ([
 		},
 	}
 
-	for _, a := range getAffectedPackages(vulnerability) {
+	affected, unaffected := getPackages(vulnerability)
+	for _, a := range affected {
 		in = append(in, a)
+	}
+	for _, u := range unaffected {
+		in = append(in, u)
 	}
 
 	return transformers.NewEntries(in...), nil
 }
 
-func getAffectedPackages(vuln unmarshal.OSVulnerability) []db.AffectedPackageHandle {
+func isNotAffectedGroup(fixedIns []unmarshal.OSFixedIn) bool {
+	for _, f := range fixedIns {
+		if versionutil.CleanFixedInVersion(f.Version) != "0" {
+			return false
+		}
+	}
+	return true
+}
+
+func getPackages(vuln unmarshal.OSVulnerability) ([]db.AffectedPackageHandle, []db.UnaffectedPackageHandle) {
 	var afs []db.AffectedPackageHandle
+	var unafs []db.UnaffectedPackageHandle
 	groups := groupFixedIns(vuln)
 	for group, fixedIns := range groups {
+		// APK providers already handle not-affected signaling in their own matching layer,
+		// so skip emitting unaffected package handles for them.
+		pkgType := getPackageType(group.osName)
+		if pkgType != pkg.ApkPkg && isNotAffectedGroup(fixedIns) {
+			unafs = append(unafs, db.UnaffectedPackageHandle{
+				OperatingSystem: getOperatingSystem(group.osName, group.id, group.osVersion, group.osChannel),
+				Package:         getPackage(group),
+				BlobValue: &db.PackageBlob{
+					CVEs: getAliases(vuln),
+					Ranges: []db.Range{
+						{
+							Version: db.Version{
+								Type:       fixedIns[0].VersionFormat,
+								Constraint: "",
+							},
+							Fix: &db.Fix{
+								State: db.NotAffectedFixStatus,
+							},
+						},
+					},
+				},
+			})
+			continue
+		}
+
 		// we only care about a single qualifier: rpm modules. The important thing to note about this is that
 		// a package with no module vs a package with a module should be detectable in the DB.
 		var qualifiers *db.PackageQualifiers
@@ -99,8 +138,9 @@ func getAffectedPackages(vuln unmarshal.OSVulnerability) []db.AffectedPackageHan
 
 	// stable ordering
 	sort.Sort(internal.ByAffectedPackage(afs))
+	sort.Sort(internal.ByUnaffectedPackage(unafs))
 
-	return afs
+	return afs, unafs
 }
 
 func getFix(fixedInEntry unmarshal.OSFixedIn) *db.Fix {

--- a/grype/db/v6/build/transformers/os/transform_test.go
+++ b/grype/db/v6/build/transformers/os/transform_test.go
@@ -1249,6 +1249,85 @@ func TestTransform(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "testdata/rhel-8-not-affected.json",
+			provider: "rhel",
+			want: []transformers.RelatedEntries{
+				{
+					VulnerabilityHandle: &db.VulnerabilityHandle{
+						Name:       "CVE-2020-99999",
+						Status:     "active",
+						ProviderID: "rhel",
+						Provider:   expectedProvider("rhel"),
+						BlobValue: &db.VulnerabilityBlob{
+							ID:          "CVE-2020-99999",
+							Description: "Test vulnerability with a not-affected package and an affected package.",
+							References: []db.Reference{
+								{URL: "https://access.redhat.com/security/cve/CVE-2020-99999"},
+							},
+							Severities: []db.Severity{
+								{
+									Scheme: db.SeveritySchemeCHMLN,
+									Value:  "medium",
+									Rank:   1,
+								},
+								{
+									Scheme: db.SeveritySchemeCVSS,
+									Value: db.CVSSSeverity{
+										Vector:  "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+										Version: "3.1",
+									},
+									Rank: 2,
+								},
+							},
+						},
+					},
+					Related: append(
+						affectedPkgSlice(
+							db.AffectedPackageHandle{
+								OperatingSystem: rhel8OS,
+								Package:         &db.Package{Ecosystem: "rpm", Name: "firefox"},
+								BlobValue: &db.PackageBlob{
+									Qualifiers: &db.PackageQualifiers{RpmModularity: strRef("")},
+									Ranges: []db.Range{
+										{
+											Version: db.Version{Type: "rpm", Constraint: "< 0:68.6.1-1.el8_1"},
+											Fix: &db.Fix{
+												Version: "0:68.6.1-1.el8_1",
+												State:   db.FixedStatus,
+												Detail: &db.FixDetail{
+													References: []db.Reference{
+														{
+															ID:   "RHSA-2020:1341",
+															URL:  "https://access.redhat.com/errata/RHSA-2020:1341",
+															Tags: []string{db.AdvisoryReferenceTag},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						),
+						unaffectedPkgSlice(
+							db.UnaffectedPackageHandle{
+								OperatingSystem: rhel8OS,
+								Package:         &db.Package{Ecosystem: "rpm", Name: "ghostscript"},
+								BlobValue: &db.PackageBlob{
+									Ranges: []db.Range{
+										{
+											Version: db.Version{Type: "rpm"},
+											Fix:     &db.Fix{State: db.NotAffectedFixStatus},
+										},
+									},
+								},
+							},
+						)...,
+					),
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -1710,6 +1789,14 @@ func TestGetFixWithDetailFixtures(t *testing.T) {
 }
 
 func affectedPkgSlice(a ...db.AffectedPackageHandle) []any {
+	var r []any
+	for _, v := range a {
+		r = append(r, v)
+	}
+	return r
+}
+
+func unaffectedPkgSlice(a ...db.UnaffectedPackageHandle) []any {
 	var r []any
 	for _, v := range a {
 		r = append(r, v)


### PR DESCRIPTION
Previously, vunnel dropped records in OS schema providers when the record indicated a package was not affected, since that could not result in a match. However, in order to suppress false positives in the case where a distro has recorded a package is not affected, and that package brings in a language package (npm, PyPI, etc), these records are forwarded by vunnel as if fixed at "version 0". In Grype, take version 0 FixedIn records and transform them into Unaffected Packages in the database.

Notably, skip doing this for APKs, since Alpine already has a separate system of NAKs built around forwarding the APK "< 0" versions.

This is the database transform component of https://github.com/anchore/grype/issues/3368