### PR TITLE
fix: compare mismatched package / db versions

### DIFF
--- a/grype/db/v6/vulnerability_provider_mocks_test.go
+++ b/grype/db/v6/vulnerability_provider_mocks_test.go
@@ -65,7 +65,7 @@ func testVulnerabilityProvider(t *testing.T) vulnerability.Provider {
 		{
 			PackageName:       "neutron",
 			Namespace:         "debian:distro:debian:8",
-			VersionConstraint: "< 70.3.0-rc0", // intentionally bad value
+			VersionConstraint: "< fred70.3.0-rc0", // intentionally bad value
 			ID:                "CVE-2014-fake-3",
 			VersionFormat:     "apk",
 		},

--- a/grype/matcher/apk/matcher_test.go
+++ b/grype/matcher/apk/matcher_test.go
@@ -84,6 +84,41 @@ func TestSecDBOnlyMatch(t *testing.T) {
 	assertMatches(t, expected, actual)
 }
 
+func TestCPEConstraintVersionsOtherThanAPK(t *testing.T) {
+	nvdVuln := vulnerability.Vulnerability{
+		Reference: vulnerability.Reference{
+			ID:        "CVE-2020-1234",
+			Namespace: "nvd:cpe",
+		},
+		PackageName: "libvncserver",
+		Constraint:  version.MustGetConstraint("<= 0.9.11", version.GolangFormat),
+		CPEs: []cpe.CPE{
+			cpe.Must(`cpe:2.3:a:lib_vnc_project-\(server\):libvncserver:*:*:*:*:*:*:*:*`, ""),
+		},
+	}
+
+	vp := mock.VulnerabilityProvider(nvdVuln)
+
+	m := Matcher{}
+	d := distro.New(distro.Alpine, "3.12.0", "")
+
+	p := pkg.Package{
+		ID:      pkg.ID(uuid.NewString()),
+		Name:    "libvncserver",
+		Version: "0.9.9",
+		Type:    syftPkg.ApkPkg,
+		Distro:  d,
+		CPEs: []cpe.CPE{
+			cpe.Must("cpe:2.3:a:*:libvncserver:0.9.9:*:*:*:*:*:*:*", ""),
+		},
+	}
+
+	matches, _, err := m.Match(vp, p)
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	require.Equal(t, nvdVuln, matches[0].Vulnerability)
+}
+
 func TestBothSecdbAndNvdMatches(t *testing.T) {
 	// NVD and Alpine's secDB both have the same CVE ID for the package
 	nvdVuln := vulnerability.Vulnerability{

--- a/grype/version/generic_constraint.go
+++ b/grype/version/generic_constraint.go
@@ -53,10 +53,6 @@ func (g genericConstraint) Satisfied(version *Version) (bool, error) {
 		}
 		return true, nil
 	}
-	// we want to prevent against two known formats that are different from being compared.
-	// if the passed in version is unknown, we allow the comparison to proceed
-	if version.Format != g.Fmt && version.Format != UnknownFormat {
-		return false, newUnsupportedFormatError(g.Fmt, version)
-	}
+
 	return g.Expression.satisfied(g.Fmt, version)
 }

--- a/grype/version/generic_constraint_test.go
+++ b/grype/version/generic_constraint_test.go
@@ -211,10 +211,10 @@ func TestGenericConstraint_Satisfied_UnknownFormatComparison(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			name:           "different known formats should error",
+			name:           "unparseable versions should error",
 			constraintFmt:  SemanticFormat,
-			constraint:     "> 1.0.0",
-			versionStr:     "1.2.3-r1",
+			constraint:     "> george1.0.0",
+			versionStr:     "fred1.2.3-r1",
 			versionFmt:     ApkFormat,
 			expectedResult: false,
 			wantErr:        require.Error,

--- a/grype/version/portage_version_test.go
+++ b/grype/version/portage_version_test.go
@@ -146,19 +146,6 @@ func TestPortageConstraint_Constraint_NilVersion(t *testing.T) {
 	}
 }
 
-func TestPortageVersion_Constraint_UnsupportedFormat(t *testing.T) {
-	c, err := GetConstraint("> 1.0.0", PortageFormat)
-	assert.NoError(t, err)
-
-	// test with a semantic version (wrong format)
-	version := New("1.2.3", SemanticFormat)
-
-	satisfied, err := c.Satisfied(version)
-	require.Error(t, err)
-	assert.False(t, satisfied)
-	assert.Contains(t, err.Error(), "unsupported version comparison")
-}
-
 func TestPortageConstraint_String(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
This PR corrects an issue where explicitly set database constraint version types that did not match package version types were dropping matches, for example: an APK package and a Go version type in the db.

NOTE: the [version compare function](https://github.com/anchore/grype/blob/main/grype/version/version.go#L96-L126) already accounts for package and db version differences, this check must have been missed when the latest refactorings were made to the version package.