### PR TITLE
fix: preserve VEX justification in applied ignore rules

### DIFF
--- a/grype/presenter/models/ignore_test.go
+++ b/grype/presenter/models/ignore_test.go
@@ -98,6 +98,19 @@ func TestNewIgnoreRule(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "vex fields",
+			input: match.IgnoreRule{
+				Namespace:        "vex",
+				VexStatus:        "not_affected",
+				VexJustification: "vulnerable_code_not_present",
+			},
+			expected: IgnoreRule{
+				Namespace:        "vex",
+				VexStatus:        "not_affected",
+				VexJustification: "vulnerable_code_not_present",
+			},
+		},
 	}
 
 	for _, testCase := range cases {

--- a/grype/vex/csaf/implementation.go
+++ b/grype/vex/csaf/implementation.go
@@ -203,7 +203,7 @@ func matchingRule(ignoreRules []match.IgnoreRule, m match.Match, advMatch *advis
 		// any status with any vulnerability. Alternatively, if the vulnerability
 		// is set, the rule applies if it is the same in the advisory match and the rule.
 		if rule.Vulnerability == "" || advMatch.cve() == rule.Vulnerability {
-			return &rule
+			return enrichRuleWithCSAFStatement(rule, advMatch)
 		}
 
 		// If the rule applies to a VEX justification it needs to match the
@@ -219,4 +219,13 @@ func matchingRule(ignoreRules []match.IgnoreRule, m match.Match, advMatch *advis
 	}
 
 	return nil
+}
+
+func enrichRuleWithCSAFStatement(rule match.IgnoreRule, advMatch *advisoryMatch) *match.IgnoreRule {
+	if !matchesVexStatus(advMatch.Status, vexStatus.NotAffected) || rule.VexJustification != "" {
+		return &rule
+	}
+
+	rule.VexJustification = advMatch.statement()
+	return &rule
 }

--- a/grype/vex/openvex/implementation.go
+++ b/grype/vex/openvex/implementation.go
@@ -300,16 +300,25 @@ func matchingRule(ignoreRules []match.IgnoreRule, m match.Match, statement *open
 		// If the vulnerability is blank in the rule it means we will honor
 		// any status with any vulnerability.
 		if rule.Vulnerability == "" {
-			return &rule
+			return enrichRuleWithOpenVEXStatement(rule, statement)
 		}
 
 		// If the vulnerability is set, the rule applies if it is the same
 		// in the statement and the rule.
 		if statement.Vulnerability.Matches(rule.Vulnerability) {
-			return &rule
+			return enrichRuleWithOpenVEXStatement(rule, statement)
 		}
 	}
 	return nil
+}
+
+func enrichRuleWithOpenVEXStatement(rule match.IgnoreRule, statement *openvex.Statement) *match.IgnoreRule {
+	if statement.Status != openvex.StatusNotAffected || rule.VexJustification != "" {
+		return &rule
+	}
+
+	rule.VexJustification = string(statement.Justification)
+	return &rule
 }
 
 // AugmentMatches adds results to the match.Matches array when matching data

--- a/grype/vex/processor_test.go
+++ b/grype/vex/processor_test.go
@@ -165,6 +165,30 @@ func TestProcessor_ApplyVEX(t *testing.T) {
 			}},
 		},
 		{
+			name: "csaf-demo2 - ignore by not_affected status backfills vulnerable_code_not_present justification",
+			options: ProcessorOptions{
+				Documents: []string{
+					"testdata/vex-docs/csaf-demo2.json",
+				},
+				IgnoreRules: []match.IgnoreRule{{
+					VexStatus: string(status.NotAffected),
+				}},
+			},
+			args: args{
+				pkgContext: pkgContext,
+				matches:    getSubject(),
+			},
+			wantMatches: matchesRef(libCryptoCVE_2023_1255, libCryptoCVE_2023_2975),
+			wantIgnoredMatches: []match.IgnoredMatch{{
+				Match: libCryptoCVE_2023_3817,
+				AppliedIgnoreRules: []match.IgnoreRule{{
+					Namespace:        "vex",
+					VexStatus:        string(status.NotAffected),
+					VexJustification: "vulnerable_code_not_present",
+				}},
+			}},
+		},
+		{
 			name: "csaf-demo2 - ignore by not_affected status and vulnerable_code_not_present justification",
 			options: ProcessorOptions{
 				Documents: []string{
@@ -288,6 +312,30 @@ func TestProcessor_ApplyVEX(t *testing.T) {
 					Namespace:     "vex",
 					Vulnerability: "CVE-2023-1255", // note: this is the difference between this test and the last test
 					VexStatus:     string(status.Fixed),
+				}},
+			}},
+		},
+		{
+			name: "openvex-demo2 - ignore by not_affected status backfills vulnerable_code_not_present justification",
+			options: ProcessorOptions{
+				Documents: []string{
+					"testdata/vex-docs/openvex-demo2.json",
+				},
+				IgnoreRules: []match.IgnoreRule{{
+					VexStatus: "not_affected",
+				}},
+			},
+			args: args{
+				pkgContext: pkgContext,
+				matches:    getSubject(),
+			},
+			wantMatches: matchesRef(libCryptoCVE_2023_2975, libCryptoCVE_2023_1255),
+			wantIgnoredMatches: []match.IgnoredMatch{{
+				Match: libCryptoCVE_2023_3817,
+				AppliedIgnoreRules: []match.IgnoreRule{{
+					Namespace:        "vex",
+					VexStatus:        "not_affected",
+					VexJustification: "vulnerable_code_not_present",
 				}},
 			}},
 		},


### PR DESCRIPTION
Fixes #2828

When a VEX `not_affected` statement matches a status-only ignore rule, the ignored match keeps the rule status but drops the statement justification from `appliedIgnoreRules`.

This preserves the matched VEX justification when Grype builds the applied ignore rule for both OpenVEX and CSAF documents, and adds focused regression tests for the processor plus presenter ignore-rule mapping.

Validation:
- `GOCACHE=/tmp/grype-gocache go test ./grype/vex ./grype/vex/openvex ./grype/vex/csaf ./grype/presenter/models -count=1`
