### PR TITLE
fix: add amazon_linux as alias for Amazon Linux distro

### DIFF
--- a/grype/distro/type.go
+++ b/grype/distro/type.go
@@ -108,6 +108,7 @@ var aliasTypes = map[string]Type{
 	"Alpine Linux":     Alpine, // needed for CPE matching (see #2039)
 	"windows":          Windows,
 	"scientific linux": Scientific, // Scientific linux prior to v7 didn't have an os-release file and syft raises up "scientific linux" as the release id as parsed from /etc/redhat-release
+	"amazon_linux":     AmazonLinux,
 }
 
 var typeToIDMapping = map[Type]string{}

--- a/grype/distro/type_test.go
+++ b/grype/distro/type_test.go
@@ -127,6 +127,14 @@ func TestTypeFromRelease(t *testing.T) {
 			},
 			want: Scientific,
 		},
+		{
+			name: "amazon_linux alias",
+			release: linux.Release{
+				ID:        "amazon_linux",
+				VersionID: "2",
+			},
+			want: AmazonLinux,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Amazon Linux's CPE uses `amazon_linux` as the product identifier (e.g., `cpe:2.3:o:amazon:amazon_linux:2:*:*:*:*:*:*:*`), but grype only mapped the `/etc/os-release` ID `amzn` to the `AmazonLinux` type. This caused "unknown distro" warnings and missed OS vulnerability matching when users supply distro info derived from CPE data or PURL `?distro=` qualifiers using `amazon_linux`.

## Change

Added `"amazon_linux"` to the `aliasTypes` map in `grype/distro/type.go`, resolving it to `AmazonLinux` (same as `"amzn"`).

Also added a test case to verify the alias mapping works via `TypeFromRelease`.

## Examples

- `amazon_linux-2` → now treated as `amzn-2`
- `amazon_linux-2023` → now treated as `amzn-2023`

Closes #3229