### PR TITLE
fix(version): accept uppercase V prefix in fuzzy version comparison

### DIFF
--- a/grype/version/fuzzy_constraint.go
+++ b/grype/version/fuzzy_constraint.go
@@ -12,8 +12,8 @@ import (
 
 // derived from https://semver.org/, but additionally matches:
 // - partial versions (e.g. "2.0")
-// - optional prefix "v" (e.g. "v1.0.0")
-var pseudoSemverPattern = regexp.MustCompile(`^v?(0|[1-9]\d*)(\.(0|[1-9]\d*))?(\.(0|[1-9]\d*))?(?:(-|alpha|beta|rc)((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+// - optional prefix "v" or "V" (e.g. "v1.0.0", "V1.0.0")
+var pseudoSemverPattern = regexp.MustCompile(`^[vV]?(0|[1-9]\d*)(\.(0|[1-9]\d*))?(\.(0|[1-9]\d*))?(?:(-|alpha|beta|rc)((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 
 type fuzzyConstraint struct {
 	RawPhrase          string
@@ -211,7 +211,10 @@ func leftPad(s string, n int) string {
 }
 
 func stripLeadingV(ver string) string {
-	return strings.TrimPrefix(ver, "v")
+	if len(ver) > 0 && (ver[0] == 'v' || ver[0] == 'V') {
+		return ver[1:]
+	}
+	return ver
 }
 
 // hasPatchNumber returns true if the version segment looks like it has a patch number

--- a/grype/version/fuzzy_constraint_test.go
+++ b/grype/version/fuzzy_constraint_test.go
@@ -68,6 +68,11 @@ func TestFuzzyVersionComparison(t *testing.T) {
 		{"1.0.2k", "1.0.2l", -1},
 		// 1.1.1w is a later patch on 1.1.1
 		{"1.1.1", "1.1.1w", -1},
+		// uppercase V prefix should be stripped the same as lowercase v
+		{"V1.2.3", "v1.2.3", 0},
+		{"V1.2.3", "1.2.3", 0},
+		{"V1.2.3", "V1.2.4", -1},
+		{"V2.0.0", "v1.9.9", 1},
 	}
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%q vs %q", c.v1, c.v2), func(t *testing.T) {
@@ -381,6 +386,24 @@ func TestFuzzyVersion_Constraint(t *testing.T) {
 			constraint: "<0.0.0-20230922105210-14b16010c2ee",
 			satisfied:  false,
 		},
+		{
+			name:       "uppercase V prefix on version matches constraint",
+			version:    "V1.5.0",
+			constraint: "> 1.0, < 2.0",
+			satisfied:  true,
+		},
+		{
+			name:       "uppercase V prefix on both version and constraint",
+			version:    "V1.5.0",
+			constraint: "> V1.0, < V2.0",
+			satisfied:  true,
+		},
+		{
+			name:       "uppercase V prefix on version out of range",
+			version:    "V3.0.0",
+			constraint: "> 1.0, < 2.0",
+			satisfied:  false,
+		},
 	}
 
 	for _, test := range tests {
@@ -401,6 +424,8 @@ func TestPseudoSemverPattern(t *testing.T) {
 	}{
 		{name: "rc candidates are valid semver", version: "1.2.3-rc1", valid: true},
 		{name: "rc candidates with no dash are valid semver", version: "1.2.3rc1", valid: true},
+		{name: "uppercase V prefix is valid semver", version: "V1.2.3", valid: true},
+		{name: "lowercase v prefix is valid semver", version: "v1.2.3", valid: true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

- Fuzzy version comparison had two hardcoded lowercase `v` prefix strippers — uppercase `V` versions like `V1.2.3` or `V1500-SP2` were not normalized and compared as unrelated strings against CVE ranges
- Result: silent false negatives when a CPE or SBOM package carried a `V`-prefixed version (e.g. the Bosch `V1500-SP2` case from the issue)
- Fix both locations to accept `[vV]`, matching the existing `trimLeadingV` helper in `apk_version.go`

Fixes #3037

## Details

`pseudoSemverPattern` at [fuzzy_constraint.go:16](grype/version/fuzzy_constraint.go#L16) used `^v?` — only lowercase. `V`-prefixed versions failed the gate and fell through to the fuzzy path where `stripLeadingV` at [fuzzy_constraint.go:213](grype/version/fuzzy_constraint.go#L213) then did `strings.TrimPrefix(ver, \"v\")` — also lowercase. Both paths left the `V` in place, producing wrong comparisons.

Changes:
1. Regex: `^v?` -> `^[vV]?` — strictly more permissive, no behavior change for existing `v`/no-prefix inputs
2. `stripLeadingV`: explicit `ver[0] == 'v' || ver[0] == 'V'` check, with empty-string guard to preserve `TrimPrefix`'s safety for empty inputs

## Scope note

There's a related third location at [semantic_version.go:22-32](grype/version/semantic_version.go#L22-L32) (`versionStartsWithV` regex and a lowercase-only `TrimPrefix`) that would also benefit from this change. I intentionally left it out of scope — @wagoodman's comment on #3037 named exactly the two locations in this PR, and `newSemanticVersion` has callers outside the fuzzy path that I haven't audited. Happy to file a follow-up if maintainers want it addressed.

## Test plan

- [x] `TestPseudoSemverPattern`: 2 new cases (V prefix accepted, v prefix as baseline)
- [x] `TestFuzzyVersionComparison`: 4 new cases exercising `stripLeadingV` through the comparator — V vs v equal, V vs no-prefix equal, V ordering correctness, mixed-case cross-version ordering
- [x] `TestFuzzyVersion_Constraint`: 3 end-to-end cases — V on version satisfies range, V on both sides, V out of range returns false (guard against false positives)
- [x] Full `grype/version/...` test suite passes with no regressions