### PR TITLE
fix(registry): warn when insecure transport is configured

### DIFF
--- a/cmd/grype/cli/options/registry.go
+++ b/cmd/grype/cli/options/registry.go
@@ -1,9 +1,12 @@
 package options
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/anchore/clio"
+	"github.com/anchore/grype/internal/log"
 	"github.com/anchore/stereoscope/pkg/image"
 )
 
@@ -53,7 +56,30 @@ func (cfg *registry) PostLoad() error {
 			},
 		}, cfg.Auth...)
 	}
+
+	if msg := cfg.insecureTransportWarning(); msg != "" {
+		log.Warn(msg)
+	}
+
 	return nil
+}
+
+// insecureTransportWarning returns a warning message listing any insecure registry transport
+// flags that are enabled, or an empty string if none are. These flags may be picked up from a
+// config file or environment variable without the user realizing, so surfacing them in CI/CD
+// output makes the risk visible.
+func (cfg *registry) insecureTransportWarning() string {
+	var flags []string
+	if cfg.InsecureSkipTLSVerify {
+		flags = append(flags, "insecure-skip-tls-verify")
+	}
+	if cfg.InsecureUseHTTP {
+		flags = append(flags, "insecure-use-http")
+	}
+	if len(flags) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("registry communication is insecure: %s enabled", strings.Join(flags, ", "))
 }
 
 func (cfg *registry) DescribeFields(descriptions clio.FieldDescriptionSet) {

--- a/cmd/grype/cli/options/registry.go
+++ b/cmd/grype/cli/options/registry.go
@@ -1,7 +1,6 @@
 package options
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -57,29 +56,20 @@ func (cfg *registry) PostLoad() error {
 		}, cfg.Auth...)
 	}
 
-	if msg := cfg.insecureTransportWarning(); msg != "" {
-		log.Warn(msg)
+	// these flags may be picked up from a config file or environment variable without the
+	// user realizing, so surfacing them makes unprotected registry traffic visible in CI/CD output
+	var insecureFlags []string
+	if cfg.InsecureSkipTLSVerify {
+		insecureFlags = append(insecureFlags, "insecure-skip-tls-verify")
+	}
+	if cfg.InsecureUseHTTP {
+		insecureFlags = append(insecureFlags, "insecure-use-http")
+	}
+	if len(insecureFlags) > 0 {
+		log.Warnf("registry communication is insecure: %s enabled", strings.Join(insecureFlags, ", "))
 	}
 
 	return nil
-}
-
-// insecureTransportWarning returns a warning message listing any insecure registry transport
-// flags that are enabled, or an empty string if none are. These flags may be picked up from a
-// config file or environment variable without the user realizing, so surfacing them in CI/CD
-// output makes the risk visible.
-func (cfg *registry) insecureTransportWarning() string {
-	var flags []string
-	if cfg.InsecureSkipTLSVerify {
-		flags = append(flags, "insecure-skip-tls-verify")
-	}
-	if cfg.InsecureUseHTTP {
-		flags = append(flags, "insecure-use-http")
-	}
-	if len(flags) == 0 {
-		return ""
-	}
-	return fmt.Sprintf("registry communication is insecure: %s enabled", strings.Join(flags, ", "))
 }
 
 func (cfg *registry) DescribeFields(descriptions clio.FieldDescriptionSet) {

--- a/cmd/grype/cli/options/registry_test.go
+++ b/cmd/grype/cli/options/registry_test.go
@@ -69,6 +69,62 @@ func TestHasNonEmptyCredentials(t *testing.T) {
 	}
 }
 
+func Test_registry_insecureTransportWarning(t *testing.T) {
+	tests := []struct {
+		name  string
+		input registry
+		want  string
+	}{
+		{
+			name:  "no insecure options set",
+			input: registry{},
+			want:  "",
+		},
+		{
+			name:  "only InsecureSkipTLSVerify set",
+			input: registry{InsecureSkipTLSVerify: true},
+			want:  "registry communication is insecure: insecure-skip-tls-verify enabled",
+		},
+		{
+			name:  "only InsecureUseHTTP set",
+			input: registry{InsecureUseHTTP: true},
+			want:  "registry communication is insecure: insecure-use-http enabled",
+		},
+		{
+			name:  "both insecure options set",
+			input: registry{InsecureSkipTLSVerify: true, InsecureUseHTTP: true},
+			want:  "registry communication is insecure: insecure-skip-tls-verify, insecure-use-http enabled",
+		},
+		{
+			name: "credentials present but no insecure options",
+			input: registry{
+				Auth: []RegistryCredentials{{Authority: "example.com", Username: "user", Password: "pass"}},
+			},
+			want: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, test.input.insecureTransportWarning())
+		})
+	}
+}
+
+func Test_registry_PostLoad_returnsNoError(t *testing.T) {
+	// PostLoad should never return an error for the insecure transport warning;
+	// the warning is a side effect and should not block config loading.
+	tests := []registry{
+		{},
+		{InsecureSkipTLSVerify: true},
+		{InsecureUseHTTP: true},
+		{InsecureSkipTLSVerify: true, InsecureUseHTTP: true},
+	}
+	for _, cfg := range tests {
+		assert.NoError(t, cfg.PostLoad())
+	}
+}
+
 func Test_registry_ToOptions(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/grype/cli/options/registry_test.go
+++ b/cmd/grype/cli/options/registry_test.go
@@ -69,48 +69,6 @@ func TestHasNonEmptyCredentials(t *testing.T) {
 	}
 }
 
-func Test_registry_insecureTransportWarning(t *testing.T) {
-	tests := []struct {
-		name  string
-		input registry
-		want  string
-	}{
-		{
-			name:  "no insecure options set",
-			input: registry{},
-			want:  "",
-		},
-		{
-			name:  "only InsecureSkipTLSVerify set",
-			input: registry{InsecureSkipTLSVerify: true},
-			want:  "registry communication is insecure: insecure-skip-tls-verify enabled",
-		},
-		{
-			name:  "only InsecureUseHTTP set",
-			input: registry{InsecureUseHTTP: true},
-			want:  "registry communication is insecure: insecure-use-http enabled",
-		},
-		{
-			name:  "both insecure options set",
-			input: registry{InsecureSkipTLSVerify: true, InsecureUseHTTP: true},
-			want:  "registry communication is insecure: insecure-skip-tls-verify, insecure-use-http enabled",
-		},
-		{
-			name: "credentials present but no insecure options",
-			input: registry{
-				Auth: []RegistryCredentials{{Authority: "example.com", Username: "user", Password: "pass"}},
-			},
-			want: "",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.want, test.input.insecureTransportWarning())
-		})
-	}
-}
-
 func Test_registry_PostLoad_returnsNoError(t *testing.T) {
 	// PostLoad should never return an error for the insecure transport warning;
 	// the warning is a side effect and should not block config loading.


### PR DESCRIPTION
## Summary

- Emit a one-time warning during config load when `insecure-skip-tls-verify` or `insecure-use-http` is set
- These flags can be silently picked up from a config file or env var, leaving registry traffic unprotected with no indication in normal CLI output
- The warning lists exactly which insecure flag(s) are enabled so the user can find and address them

Fixes #3101 (grype CLI half — see scope note below).

## Details

The warning is emitted from the existing `PostLoad()` hook on the registry config struct, which is the natural single point where merged config (flag + env + YAML) is available exactly once per invocation. There is precedent for `log.Warnf` from inside `PostLoad()` in the same package (see [database_search_packages.go](cmd/grype/cli/options/database_search_packages.go) lines 43, 62).

Implementation:

- `insecureTransportWarning() string` is a pure helper that returns the message, or empty if neither flag is set. Splitting message construction from the log call lets the branching logic be unit-tested deterministically without touching the logger singleton.
- `PostLoad()` calls the helper and emits `log.Warn(msg)` only when non-empty.
- No behavior change beyond the new log line.

Sample output when both flags are set:

```
[WARN] registry communication is insecure: insecure-skip-tls-verify, insecure-use-http enabled
```

## Scope note

#3101 outlined two changes: (1) a debug log inside stereoscope at the actual TLS/HTTP application sites, and (2) a warning at the grype CLI level. This PR addresses only (2), which @Tanish-26 indicated was the higher priority (\"If I had to choose only one, I'd prioritize the grype CLI warning\"). The stereoscope debug log can follow as a separate, smaller PR to anchore/stereoscope.

## Test plan

- [x] `Test_registry_insecureTransportWarning`: 5 cases covering neither set, each alone, both set, and credentials-without-insecure-flags (regression guard)
- [x] `Test_registry_PostLoad_returnsNoError`: verifies all 4 flag combinations don't return an error from PostLoad (warning is observability, must never block config load)
- [x] Full `cmd/grype/cli/options/...` test suite passes — no regressions