### PR TITLE
version: accept uppercase V prefix the same as lowercase v

### DIFF
--- a/grype/version/fuzzy_constraint.go
+++ b/grype/version/fuzzy_constraint.go
@@ -12,8 +12,8 @@ import (
 
 // derived from https://semver.org/, but additionally matches:
 // - partial versions (e.g. "2.0")
-// - optional prefix "v" (e.g. "v1.0.0")
-var pseudoSemverPattern = regexp.MustCompile(`^v?(0|[1-9]\d*)(\.(0|[1-9]\d*))?(\.(0|[1-9]\d*))?(?:(-|alpha|beta|rc)((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+// - optional prefix "v" or "V" (e.g. "v1.0.0", "V1500-SP2") — see issue #3037
+var pseudoSemverPattern = regexp.MustCompile(`^[vV]?(0|[1-9]\d*)(\.(0|[1-9]\d*))?(\.(0|[1-9]\d*))?(?:(-|alpha|beta|rc)((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 
 type fuzzyConstraint struct {
 	RawPhrase          string
@@ -211,7 +211,10 @@ func leftPad(s string, n int) string {
 }
 
 func stripLeadingV(ver string) string {
-	return strings.TrimPrefix(ver, "v")
+	if len(ver) > 0 && (ver[0] == 'v' || ver[0] == 'V') {
+		return ver[1:]
+	}
+	return ver
 }
 
 // hasPatchNumber returns true if the version segment looks like it has a patch number

--- a/grype/version/fuzzy_constraint_test.go
+++ b/grype/version/fuzzy_constraint_test.go
@@ -68,6 +68,11 @@ func TestFuzzyVersionComparison(t *testing.T) {
 		{"1.0.2k", "1.0.2l", -1},
 		// 1.1.1w is a later patch on 1.1.1
 		{"1.1.1", "1.1.1w", -1},
+		// Issue #3037: an uppercase 'V' prefix should be stripped just like 'v'
+		// (e.g. NEXO-OS V1500-SP2 vs 1500-SP2 should compare equal).
+		{"V1500-SP2", "1500-SP2", 0},
+		{"V1500-SP2", "v1500-SP2", 0},
+		{"V1500-SP1", "V1500-SP2", -1},
 	}
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%q vs %q", c.v1, c.v2), func(t *testing.T) {
@@ -401,6 +406,9 @@ func TestPseudoSemverPattern(t *testing.T) {
 	}{
 		{name: "rc candidates are valid semver", version: "1.2.3-rc1", valid: true},
 		{name: "rc candidates with no dash are valid semver", version: "1.2.3rc1", valid: true},
+		// Issue #3037: uppercase V prefix should be accepted just like lowercase v.
+		{name: "lowercase v prefix is valid", version: "v1.2.3", valid: true},
+		{name: "uppercase V prefix is valid", version: "V1.2.3", valid: true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Closes #3037.

Both `pseudoSemverPattern` (`^v?…`) and `stripLeadingV` only treated a lowercase `v` prefix as significant, so a Bosch industrial-firmware version like `V1500-SP2` (NEXO-OS) never matched a CPE without the prefix, silently dropping vulnerability hits like BOSCH-SA-711465.

@kzantow and @wagoodman both confirmed the bug and pointed at the exact spots to fix:
> the semver check is only looking for lowercase v within the [fuzzy version constraint](https://github.com/anchore/grype/blob/ee4941541a39a35c2bddf533927341b135456b65/grype/version/fuzzy_constraint.go#L16) , this could probably be relaxed to look for both upper and lower
> when we fallthrough to comparing non-semver cases, we should also allow for uppercase Vs as well

### Changes
- `grype/version/fuzzy_constraint.go`:
  - `pseudoSemverPattern` regex: `^v?…` → `^[vV]?…`
  - `stripLeadingV`: trim either `v` or `V`
- `grype/version/fuzzy_constraint_test.go`: extend `TestPseudoSemverPattern` with explicit `v1.2.3` and `V1.2.3` cases; add `TestFuzzyVersionComparison` cases for `V1500-SP2` vs `1500-SP2` (equal), `V1500-SP2` vs `v1500-SP2` (equal), and `V1500-SP1` vs `V1500-SP2` (`-1`).

### Verification
```
$ go test -count=1 ./grype/version/...
ok  	github.com/anchore/grype/grype/version	0.041s
```