### PR TITLE
feat(matcher/java): add per-request timeout for Maven SHA1 lookups (#1624)

### DIFF
--- a/cmd/grype/cli/options/datasources.go
+++ b/cmd/grype/cli/options/datasources.go
@@ -24,6 +24,7 @@ type maven struct {
 	SearchUpstreamBySha1 bool          `yaml:"search-upstream" json:"searchUpstreamBySha1" mapstructure:"search-maven-upstream"`
 	BaseURL              string        `yaml:"base-url" json:"baseUrl" mapstructure:"base-url"`
 	RateLimit            time.Duration `yaml:"rate-limit" json:"rateLimit" mapstructure:"rate-limit"`
+	Timeout              time.Duration `yaml:"timeout" json:"timeout" mapstructure:"timeout"`
 }
 
 func defaultExternalSources() externalSources {
@@ -32,6 +33,7 @@ func defaultExternalSources() externalSources {
 			SearchUpstreamBySha1: true,
 			BaseURL:              defaultMavenBaseURL,
 			RateLimit:            300 * time.Millisecond,
+			Timeout:              10 * time.Second,
 		},
 	}
 }
@@ -46,6 +48,7 @@ func (cfg externalSources) ToJavaMatcherConfig() java.ExternalSearchConfig {
 		SearchMavenUpstream: smu,
 		MavenBaseURL:        cfg.Maven.BaseURL,
 		MavenRateLimit:      cfg.Maven.RateLimit,
+		MavenTimeout:        cfg.Maven.Timeout,
 	}
 }
 
@@ -53,4 +56,5 @@ func (cfg *externalSources) DescribeFields(descriptions clio.FieldDescriptionSet
 	descriptions.Add(&cfg.Enable, `enable Grype searching network source for additional information`)
 	descriptions.Add(&cfg.Maven.SearchUpstreamBySha1, `search for Maven artifacts by SHA1`)
 	descriptions.Add(&cfg.Maven.BaseURL, `base URL of the Maven repository to search`)
+	descriptions.Add(&cfg.Maven.Timeout, `per-request timeout for Maven SHA1 lookups; 0 disables the timeout`)
 }

--- a/grype/matcher/java/matcher.go
+++ b/grype/matcher/java/matcher.go
@@ -28,6 +28,7 @@ type ExternalSearchConfig struct {
 	SearchMavenUpstream bool
 	MavenBaseURL        string
 	MavenRateLimit      time.Duration
+	MavenTimeout        time.Duration
 }
 
 type MatcherConfig struct {
@@ -36,9 +37,14 @@ type MatcherConfig struct {
 }
 
 func NewJavaMatcher(cfg MatcherConfig) *Matcher {
+	client := http.DefaultClient
+	if cfg.MavenTimeout > 0 {
+		// dedicated client so a configured per-request timeout does not bleed onto unrelated callers
+		client = &http.Client{Timeout: cfg.MavenTimeout}
+	}
 	return &Matcher{
 		cfg:           cfg,
-		MavenSearcher: newMavenSearch(http.DefaultClient, cfg.MavenBaseURL, cfg.MavenRateLimit),
+		MavenSearcher: newMavenSearch(client, cfg.MavenBaseURL, cfg.MavenRateLimit),
 	}
 }
 

--- a/grype/matcher/java/matcher.go
+++ b/grype/matcher/java/matcher.go
@@ -39,8 +39,11 @@ type MatcherConfig struct {
 func NewJavaMatcher(cfg MatcherConfig) *Matcher {
 	client := http.DefaultClient
 	if cfg.MavenTimeout > 0 {
-		// dedicated client so a configured per-request timeout does not bleed onto unrelated callers
-		client = &http.Client{Timeout: cfg.MavenTimeout}
+		// shallow-copy the default client so the configured per-request timeout does not
+		// bleed onto unrelated callers, while preserving any Transport, CheckRedirect, or Jar
+		clientCopy := *http.DefaultClient
+		clientCopy.Timeout = cfg.MavenTimeout
+		client = &clientCopy
 	}
 	return &Matcher{
 		cfg:           cfg,

--- a/grype/matcher/java/maven_test.go
+++ b/grype/matcher/java/maven_test.go
@@ -98,3 +98,58 @@ func withinDelta(got, want, delta time.Duration) bool {
 	}
 	return diff <= delta
 }
+
+func TestNewJavaMatcherTimeout(t *testing.T) {
+	// stand up a server that hangs forever so any successful response would only happen
+	// because the configured timeout failed to abort the request. The hang channel must be
+	// closed before ts.Close() so any in-flight handlers unblock cleanly during shutdown.
+	hang := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-hang
+	}))
+	t.Cleanup(func() {
+		close(hang)
+		ts.Close()
+	})
+
+	t.Run("timeout aborts hanging upstream", func(t *testing.T) {
+		m := NewJavaMatcher(MatcherConfig{
+			ExternalSearchConfig: ExternalSearchConfig{
+				MavenBaseURL:   ts.URL,
+				MavenRateLimit: time.Nanosecond,
+				MavenTimeout:   100 * time.Millisecond,
+			},
+		})
+
+		start := time.Now()
+		_, err := m.GetMavenPackageBySha(context.Background(), "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+		elapsed := time.Since(start)
+
+		if err == nil {
+			t.Fatal("expected timeout error, got nil")
+		}
+		// give the runtime a generous ceiling so this test stays stable on slow CI
+		if elapsed > 2*time.Second {
+			t.Errorf("timeout did not fire promptly: elapsed = %v", elapsed)
+		}
+	})
+
+	t.Run("zero timeout disables the per-request limit", func(t *testing.T) {
+		m := NewJavaMatcher(MatcherConfig{
+			ExternalSearchConfig: ExternalSearchConfig{
+				MavenBaseURL: ts.URL,
+				// MavenTimeout intentionally unset (zero value)
+			},
+		})
+
+		// the underlying Matcher's MavenSearcher should be using http.DefaultClient,
+		// which has no Timeout set
+		ms, ok := m.MavenSearcher.(*mavenSearch)
+		if !ok {
+			t.Fatalf("MavenSearcher is not *mavenSearch, got %T", m.MavenSearcher)
+		}
+		if ms.client.Timeout != 0 {
+			t.Errorf("expected zero timeout on default client, got %v", ms.client.Timeout)
+		}
+	})
+}


### PR DESCRIPTION
## Description
Closes #1624.

Adds a new `external-sources.maven.timeout` config field that is wired through to the HTTP client used by the Java matcher's Maven SHA1 upstream search.

```yaml
external-sources:
  enable: true
  maven:
    search-upstream: true
    timeout: 5s   # new — per-request limit for the SHA1 lookup
```

The default is `10s`, and a value of `0` disables the limit (preserving the previous behavior of `http.DefaultClient` with no timeout).

## Why this fixes the reported pain
The issue describes the scenario where Maven Central (or any configured `base-url`) is unresponsive: grype falls back to a SHA1 lookup, the request hangs indefinitely, and the user sees a stuck scan with no console signal until they enable `--debug`. With this change, a per-request timeout fires, the lookup returns an error, and the scan continues with the remaining matchers.

## Per-request vs cumulative time
@tgerla suggested in the issue that "total time would be a good starting point" with cascading global + per-source overrides. This PR ships the smallest correct unit first — a per-request timeout — because a single hung request was the actual failure mode in the report. A cumulative time budget can build on top of this once a second external source lands; right now there is only one (Maven), so a global `abort-after` would be functionally identical to the per-source one.

If the project would prefer a different shape (cumulative-only, or `abort-after` instead of `timeout`), happy to revise — small enough patch.

## Implementation notes
- New `Timeout time.Duration` field on the `maven` struct in `cmd/grype/cli/options/datasources.go`, default `10s`, mapped through `ToJavaMatcherConfig()` as `MavenTimeout`.
- New `MavenTimeout time.Duration` field on `java.ExternalSearchConfig`.
- `NewJavaMatcher` constructs a dedicated `*http.Client` with the configured timeout when it is non-zero, so the timeout does not leak onto unrelated callers of `http.DefaultClient`. When the timeout is zero, the existing `http.DefaultClient` is used unchanged.

## Tests
Two new sub-tests in `TestNewJavaMatcherTimeout`:
- `timeout aborts hanging upstream` — boots an `httptest.Server` whose handler blocks on a never-closed channel, configures a `MavenTimeout` of 100ms, and asserts that `GetMavenPackageBySha` returns an error within ~2s.
- `zero timeout disables the per-request limit` — asserts the underlying `http.Client.Timeout` is `0` when no `MavenTimeout` is configured (so default behavior is preserved).

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./grype/matcher/java/ -run TestNewJavaMatcherTimeout` passes
- [x] `go test ./grype/matcher/java/ ./cmd/grype/cli/options/` — no regressions
- [x] `grype --help` and YAML config still load with the new field set, default value populated