### PR TITLE
Handle uppercase V prefix in semantic version comparison

### DIFF
--- a/grype/version/semantic_version.go
+++ b/grype/version/semantic_version.go
@@ -19,7 +19,7 @@ type semanticVersion struct {
 	obj *hashiVer.Version
 }
 
-var versionStartsWithV = regexp.MustCompile(`^v\d+`)
+var versionStartsWithV = regexp.MustCompile(`^[vV]\d+`)
 
 func newSemanticVersion(raw string, strict bool) (semanticVersion, error) {
 	clean := semverPrereleaseNormalizer.Replace(raw)
@@ -27,9 +27,9 @@ func newSemanticVersion(raw string, strict bool) (semanticVersion, error) {
 	var verObj *hashiVer.Version
 	var err error
 	if strict {
-		// we still want v-prefix processing
+		// we still want v-prefix processing for both lowercase and uppercase
 		if versionStartsWithV.MatchString(clean) {
-			clean = strings.TrimPrefix(clean, "v")
+			clean = clean[1:]  // remove leading v or V
 		}
 		verObj, err = hashiVer.NewSemver(clean)
 	} else {

--- a/grype/version/semantic_version_test.go
+++ b/grype/version/semantic_version_test.go
@@ -289,6 +289,22 @@ func TestSemanticVersion_Compare_EdgeCases(t *testing.T) {
 		errorSubstring string
 	}{
 		{
+			name: "uppercase V prefix comparison",
+			setupFunc: func(t testing.TB) (*Version, *Version) {
+				thisVer := New("1.5.0", SemanticFormat)
+				otherVer := New("V1.5.0", SemanticFormat)
+				return thisVer, otherVer
+			},
+		},
+		{
+			name: "uppercase V prefix on this version",
+			setupFunc: func(t testing.TB) (*Version, *Version) {
+				thisVer := New("V1.5.0", SemanticFormat)
+				otherVer := New("1.5.0", SemanticFormat)
+				return thisVer, otherVer
+			},
+		},
+		{
 			name: "nil version object",
 			setupFunc: func(t testing.TB) (*Version, *Version) {
 				thisVer := New("1.2.3", SemanticFormat)


### PR DESCRIPTION
## Summary

Treat both `v1.5.0` and `V1.5.0` equivalently for version matching.

## Fixes #3037

SBOM files with uppercase V prefix (e.g., `V1500-SP2`) were not being matched against CVE vulnerabilities because the version comparison logic only recognized lowercase `v` prefix.

## Changes

- Update regex from `^v\d+` to `^[vV]\d+` in `semantic_version.go`
- Use direct slice `[1:]` instead of `strings.TrimPrefix` for consistency

## Testing

Added test cases:
- `uppercase V prefix comparison`: `1.5.0` vs `V1.5.0`
- `uppercase V prefix on this version`: `V1.5.0` vs `1.5.0`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)