### PR TITLE
fix(cli): fix autocompletion for zsh

### DIFF
--- a/cmd/grype/cli/commands/completion.go
+++ b/cmd/grype/cli/commands/completion.go
@@ -96,16 +96,13 @@ func listLocalDockerImages(prefix string) ([]string, error) {
 }
 
 func dockerImageValidArgsFunction(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	// Since we use ValidArgsFunction, Cobra will call this AFTER having parsed all flags and arguments provided
+	// Since we use ValidArgsFunction, Cobra will call this AFTER having parsed all flags and arguments provided.
+	// When the docker daemon is unavailable (or has no images), fall through to the shell's default behavior so
+	// that subcommand completions and filename completion still work — returning ShellCompDirectiveError here
+	// causes shells (notably zsh) to discard all completions, including the auto-generated subcommand list.
 	dockerImageRepoTags, err := listLocalDockerImages(toComplete)
-	if err != nil {
-		// Indicates that an error occurred and completions should be ignored
-		return []string{"completion failed"}, cobra.ShellCompDirectiveError
+	if err != nil || len(dockerImageRepoTags) == 0 {
+		return nil, cobra.ShellCompDirectiveDefault
 	}
-	if len(dockerImageRepoTags) == 0 {
-		return []string{"no docker images found"}, cobra.ShellCompDirectiveError
-	}
-	// ShellCompDirectiveDefault indicates that the shell will perform its default behavior after completions have
-	// been provided (without implying other possible directives)
 	return dockerImageRepoTags, cobra.ShellCompDirectiveDefault
 }


### PR DESCRIPTION
## Summary

`grype <TAB>` in zsh produces no completions on hosts where the Docker daemon isn't reachable from the Docker Go SDK. The root command's ValidArgsFunction (dockerImageValidArgsFunction) returned `cobra.ShellCompDirectiveError` whenever ImageList failed or yielded no matches. Zsh treats that directive as "discard everything," so it threw away not just the (empty) image list but also the subcommand completions Cobra auto-emits, leaving the user with nothing.

Both failure paths now return (nil, cobra.ShellCompDirectiveDefault) instead of an error directive with placeholder strings. Subcommand completion (db, config, explain, …) flows through cleanly, and the shell falls back to filename completion for non-image scan targets like dir:, sbom:, file:. 

The Docker happy path is unchanged: when ImageList returns tags matching the prefix, they're returned with ShellCompDirectiveDefault as before.

Fixes #2933

## Other

I noticed another subtle issue as well. The completer uses `client.NewClientWithOpts(client.FromEnv, ...)`, which only honors DOCKER_HOST and does not read Docker contexts from ~/.docker/config.json. On Colima, Docker Desktop, Rancher Desktop, Podman, and rootless Docker setups, the SDK falls back to unix:///var/run/docker.sock (which doesn't exist) and silently fails to find the daemon. So even with this PR, image suggestions won't appear for those users; they'll just get the subcommand list and shell file completion. That's an improvement over the current "completely silent" state. I'll open a separate issue for context-aware client construction.