### PR TITLE
Tighten workflow-level permissions and modernize release gate

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
       # these are checks that should be run on pull-request and merges to main.
       # we do NOT want to kick off a release if these have not been verified on main.
       # Please see the validations.yaml workflow for the names that should be used here.
-      checks: '["Acceptance tests", "Build snapshot artifacts", "CLI tests", "Cleanup snapshot cache", "Integration tests", "Quality tests", "Static analysis", "Unit tests", "Upload snapshot artifacts"]'
+      checks: '["Acceptance tests (Linux)", "Acceptance tests (Mac)", "Build snapshot artifacts", "CLI tests (Linux)", "Integration tests", "Quality tests", "Static analysis", "Unit tests"]'
 
   # only release core assets within the "release" job. Any other assets not already under the purview of the
   # goreleaser configuration should be added as separate jobs to allow for debugging separately from the release workflow

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,143 +1,42 @@
 name: "Release"
+
+permissions: {}
+
+# there should never be two releases in progress at the same time
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
     inputs:
       version:
         description: tag the latest commit on main with the given version (prefixed with v)
         required: true
-      skip_quality_gate:
-        description: skip quality gate and proceed directly to releasing (for emergency releases)
-        type: boolean
-        default: false
-
-permissions:
-  contents: read
 
 jobs:
-  quality-gate:
-    if: ${{ !inputs.skip_quality_gate }}
-    environment: release
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-        with:
-          persist-credentials: false
 
-      - name: Check if running on main
-        if: github.ref != 'refs/heads/main'
-        # we are using the following flag when running `cosign blob-verify` for checksum signature verification:
-        #   --certificate-identity-regexp "https://github.com/anchore/.github/workflows/release.yaml@refs/heads/main"
-        # if we are not on the main branch, the signature will not be verifiable since the suffix requires the main branch
-        # at the time of when the OIDC token was issued on the Github Actions runner.
-        run: echo "This can only be run on the main branch otherwise releases produced will not be verifiable with cosign" && exit 1
+  version-available:
+    uses: anchore/workflows/.github/workflows/check-version-available.yaml@8b2b1caf40e03933c6807e03b99e883e2ceb5ac8 # v0.4.0
+    with:
+      version: ${{ github.event.inputs.version }}
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Check if pinned syft is a release version
-        run: .github/scripts/check-syft-version-is-release.sh
-
-      - name: Check if tag already exists
-        # note: this will fail if the tag already exists
-        run: |
-          [[ "$VERSION" == v* ]] || (echo "version '$VERSION' does not have a 'v' prefix" && exit 1)
-          git tag "$VERSION"
-        env:
-          VERSION: ${{ github.event.inputs.version }}
-
-      - name: Check static analysis results
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
-        id: static-analysis
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
-          checkName: "Static analysis"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check unit test results
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
-        id: unit
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
-          checkName: "Unit tests"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check integration test results
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
-        id: integration
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
-          checkName: "Integration tests"
-          timeoutSeconds: 1200 # 20 minutes, it sometimes takes that long
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check integration test results
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
-        id: quality_tests
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
-          checkName: "Quality tests"
-          timeoutSeconds: 1200 # 20 minutes, it sometimes takes that long
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check acceptance test results (linux)
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
-        id: acceptance-linux
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
-          checkName: "Acceptance tests (Linux)"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check acceptance test results (mac)
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
-        id: acceptance-mac
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
-          checkName: "Acceptance tests (Mac)"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check cli test results (linux)
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
-        id: cli-linux
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
-          checkName: "CLI tests (Linux)"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Quality gate
-        if: steps.static-analysis.outputs.conclusion != 'success' || steps.unit.outputs.conclusion != 'success' || steps.integration.outputs.conclusion != 'success' || steps.quality_tests.outputs.conclusion != 'success' || steps.cli-linux.outputs.conclusion != 'success' || steps.acceptance-linux.outputs.conclusion != 'success' || steps.acceptance-mac.outputs.conclusion != 'success'
-        env:
-          STATIC_ANALYSIS_STATUS: ${{ steps.static-analysis.conclusion }}
-          UNIT_TEST_STATUS: ${{ steps.unit.outputs.conclusion }}
-          INTEGRATION_TEST_STATUS: ${{ steps.integration.outputs.conclusion }}
-          QUALITY_TEST_STATUS: ${{ steps.quality_tests.outputs.conclusion }}
-          ACCEPTANCE_LINUX_STATUS: ${{ steps.acceptance-linux.outputs.conclusion }}
-          ACCEPTANCE_MAC_STATUS: ${{ steps.acceptance-mac.outputs.conclusion }}
-          CLI_LINUX_STATUS: ${{ steps.cli-linux.outputs.conclusion }}
-        run: |
-          echo "Static Analysis Status: $STATIC_ANALYSIS_STATUS"
-          echo "Unit Test Status: $UNIT_TEST_STATUS"
-          echo "Integration Test Status: $INTEGRATION_TEST_STATUS"
-          echo "Quality Test Status: $QUALITY_TEST_STATUS"
-          echo "Acceptance Test (Linux) Status: $ACCEPTANCE_LINUX_STATUS"
-          echo "Acceptance Test (Mac) Status: $ACCEPTANCE_MAC_STATUS"
-          echo "CLI Test (Linux) Status: $CLI_LINUX_STATUS"
-          false
+  check-gate:
+    permissions:
+      checks: read   # required for getting the status of specific check names
+    uses: anchore/workflows/.github/workflows/check-gate.yaml@8b2b1caf40e03933c6807e03b99e883e2ceb5ac8 # v0.4.0
+    with:
+      # these are checks that should be run on pull-request and merges to main.
+      # we do NOT want to kick off a release if these have not been verified on main.
+      # Please see the validations.yaml workflow for the names that should be used here.
+      checks: '["Acceptance tests", "Build snapshot artifacts", "CLI tests", "Cleanup snapshot cache", "Integration tests", "Quality tests", "Static analysis", "Unit tests", "Upload snapshot artifacts"]'
 
   # only release core assets within the "release" job. Any other assets not already under the purview of the
   # goreleaser configuration should be added as separate jobs to allow for debugging separately from the release workflow
   # as well as not accidentally be re-run as a step multiple times (as could be done within the release workflow) as
   # not all actions are guaranteed to be idempotent.
   release:
-    needs: [quality-gate]
-    if: ${{ always() && (needs.quality-gate.result == 'success' || inputs.skip_quality_gate) }}
+    needs: [check-gate, version-available]
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -10,8 +10,7 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -7,14 +7,15 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   Static-Analysis:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Static analysis"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -30,6 +31,8 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Unit tests"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -47,6 +50,8 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Quality tests"
     runs-on: ubuntu-22.04-4core-16gb
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -105,6 +110,8 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Integration tests"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -127,6 +134,8 @@ jobs:
   Build-Snapshot-Artifacts:
     name: "Build snapshot artifacts"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -158,6 +167,8 @@ jobs:
     name: "Acceptance tests (Linux)"
     needs: [Build-Snapshot-Artifacts]
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
@@ -195,6 +206,8 @@ jobs:
     name: "Acceptance tests (Mac)"
     needs: [Build-Snapshot-Artifacts]
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
       - name: Install Cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 #v4.1.1
@@ -228,6 +241,8 @@ jobs:
     name: "CLI tests (Linux)"
     needs: [Build-Snapshot-Artifacts]
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:


### PR DESCRIPTION
Replaces the hand-rolled quality-gate job in release.yaml with the canonical check-version-available and check-gate reusable workflows from anchore/workflows. Also removes the skip_quality_gate bypass input and enforces permissions: {} at the workflow level across three files.

Changes:
- release.yaml: drop skip_quality_gate input; replace quality-gate job with version-available + check-gate reusable workflows; add concurrency group; set top-level permissions: {}
- validations.yaml: set top-level permissions: {}; add contents: read to each job
- validate-github-actions.yaml: set top-level permissions: {} (job already had its own permissions block)

Notes:
- release job body is unchanged; only the gate mechanism changed