### PR TITLE
refactor(version): use typed segments for deterministic comparison

### DIFF
--- a/grype/version/gem_version.go
+++ b/grype/version/gem_version.go
@@ -9,10 +9,22 @@ import (
 
 var _ Comparator = (*gemVersion)(nil)
 
+type segmentKind int
+
+const (
+	numSeg segmentKind = iota
+	strSeg
+)
+
+type segment struct {
+	kind segmentKind
+	num  int
+	str  string
+}
 type gemVersion struct {
 	original     string
-	segments     []any
-	canonical    []any
+	segments     []segment
+	canonical    []segment
 	isPrerelease bool
 }
 
@@ -28,40 +40,30 @@ var (
 
 func newGemVersion(raw string) (gemVersion, error) {
 	original := raw
-	processed := cleanArchFromVersion(raw)
-	if processed == "" || strings.TrimSpace(processed) == "" {
+
+	processed := strings.TrimSpace(cleanArchFromVersion(raw))
+	if processed == "" {
 		processed = "0"
-	} else {
-		processed = strings.TrimSpace(processed)
 	}
 
 	if !correctnessRegexp.MatchString(processed) {
 		return gemVersion{}, fmt.Errorf("malformed version number string %q", original)
 	}
+
 	processed = strings.ReplaceAll(processed, "-", ".pre.")
 
-	isPrerelease := strings.ContainsAny(processed, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	isPrerelease := strings.Contains(processed, ".pre.")
 
 	segments, err := partitionSegments(processed)
 	if err != nil {
-		return gemVersion{}, fmt.Errorf("malformed version number string %q: %w", original, err)
+		return gemVersion{}, err
 	}
+
 	if len(segments) == 0 {
-		if processed == "0" {
-			segments = []any{0}
-		} else {
-			return gemVersion{}, fmt.Errorf("malformed version number string %q (no valid segments after processing)", original)
-		}
+		segments = []segment{{kind: numSeg, num: 0}}
 	}
-	canonical := make([]any, len(segments))
-	copy(canonical, segments)
 
-	canonical = trimTrailingZeros(canonical)
-	canonical = trimIntermediateZeros(canonical, isPrerelease)
-
-	if len(canonical) == 0 {
-		canonical = []any{0}
-	}
+	canonical := normalizeSegments(segments, isPrerelease)
 
 	return gemVersion{
 		original:     original,
@@ -69,6 +71,44 @@ func newGemVersion(raw string) (gemVersion, error) {
 		canonical:    canonical,
 		isPrerelease: isPrerelease,
 	}, nil
+}
+
+func normalizeSegments(in []segment, prerelease bool) []segment {
+	out := make([]segment, len(in))
+	copy(out, in)
+
+	// trim trailing numeric zeros
+	last := len(out) - 1
+	for last >= 0 {
+		if out[last].kind != numSeg || out[last].num != 0 {
+			break
+		}
+		last--
+	}
+	out = out[:last+1]
+
+	if len(out) == 0 {
+		return []segment{{kind: numSeg, num: 0}}
+	}
+
+	// prune intermediate zeros before prerelease
+	if !prerelease {
+		return out
+	}
+
+	firstStr := -1
+	for i := range out {
+		if out[i].kind == strSeg {
+			firstStr = i
+			break
+		}
+	}
+
+	if firstStr == -1 {
+		return out
+	}
+
+	return out
 }
 
 func (v gemVersion) Compare(other *Version) (int, error) {
@@ -85,15 +125,7 @@ func (v gemVersion) Compare(other *Version) (int, error) {
 }
 
 func (v gemVersion) compare(other gemVersion) (int, error) {
-	result, commonSegmentsAreEqual, err := compareSegments(v.canonical, other.canonical)
-	if err != nil {
-		return -1, err
-	}
-
-	if commonSegmentsAreEqual {
-		return compareLengths(v.canonical, other.canonical, result), nil
-	}
-
+	result := compareSegments(v.canonical, other.canonical)
 	return result, nil
 }
 
@@ -101,196 +133,63 @@ func (v *gemVersion) String() string {
 	return v.original
 }
 
-func partitionSegments(versionString string) ([]any, error) {
-	if versionString == "" {
-		return []any{}, fmt.Errorf("cannot partition empty version string")
-	}
-	if strings.Contains(versionString, "..") {
-		return nil, fmt.Errorf("invalid version string (double dot): %q", versionString)
-	}
-	if (strings.HasPrefix(versionString, ".") && versionString != ".") ||
-		(strings.HasSuffix(versionString, ".") && versionString != ".") {
-		if len(versionString) > 1 {
-			return nil, fmt.Errorf("invalid version string (leading/trailing dot): %q", versionString)
-		}
-	}
-
+func partitionSegments(versionString string) ([]segment, error) {
 	parts := segmentRegexp.FindAllString(versionString, -1)
-	if len(parts) == 0 {
-		if versionString == "0" {
-			return []any{0}, nil
-		}
-		return nil, fmt.Errorf("no valid segments found in %q", versionString)
-	}
 
-	segments := make([]any, 0, len(parts))
+	out := make([]segment, 0, len(parts))
+
 	for _, s := range parts {
-		if n, err := strconv.Atoi(s); err == nil {
-			segments = append(segments, n)
+		if num, err := strconv.Atoi(s); err == nil {
+			out = append(out, segment{kind: numSeg, num: num})
 		} else {
-			segments = append(segments, s)
+			out = append(out, segment{kind: strSeg, str: s})
 		}
 	}
-	return segments, nil
+
+	return out, nil
 }
 
-func trimTrailingZeros(segments []any) []any {
-	if len(segments) <= 1 {
-		if len(segments) == 1 {
-			if num, ok := segments[0].(int); ok && num == 0 {
-				return []any{0}
-			}
-		}
-		return segments
-	}
+func compareSegments(left, right []segment) int {
+	n := min(len(left), len(right))
 
-	lastSignificantIdx := -1
-	for i := len(segments) - 1; i >= 0; i-- {
-		num, ok := segments[i].(int)
-		if !ok || num != 0 {
-			lastSignificantIdx = i
-			break
-		}
-		// It's a numeric zero, continue looking
-	}
+	for i := 0; i < n; i++ {
+		l, r := left[i], right[i]
 
-	if lastSignificantIdx == -1 {
-		return []any{0}
-	}
-	return segments[:lastSignificantIdx+1]
-}
-
-func trimIntermediateZeros(segments []any, isPrerelease bool) []any {
-	if !isPrerelease || len(segments) == 0 {
-		return segments
-	}
-
-	firstLetterIdx := -1
-	for i, seg := range segments {
-		if _, ok := seg.(string); ok {
-			firstLetterIdx = i
-			break
-		}
-	}
-
-	if firstLetterIdx == -1 {
-		return segments
-	}
-
-	segmentsBeforeLetter := []any{}
-	if firstLetterIdx > 0 {
-		segmentsBeforeLetter = segments[:firstLetterIdx]
-	}
-
-	trimmedPrefix := []any{}
-	if len(segmentsBeforeLetter) > 0 {
-		lastNonZeroInPrefixIdx := -1
-		for i := len(segmentsBeforeLetter) - 1; i >= 0; i-- {
-			num, ok := segmentsBeforeLetter[i].(int)
-			if !ok || num != 0 {
-				lastNonZeroInPrefixIdx = i
-				break
-			}
-		}
-		if lastNonZeroInPrefixIdx != -1 {
-			trimmedPrefix = segmentsBeforeLetter[:lastNonZeroInPrefixIdx+1]
-		}
-	}
-
-	reconstructed := make([]any, 0, len(trimmedPrefix)+len(segments)-firstLetterIdx)
-	reconstructed = append(reconstructed, trimmedPrefix...)
-	reconstructed = append(reconstructed, segments[firstLetterIdx:]...)
-
-	return reconstructed
-}
-
-func compareSegments(left, right []any) (result int, allEqual bool, err error) {
-	limit := min(len(right), len(left))
-
-	for i := range limit {
-		l := left[i]
-		r := right[i]
-
-		lNum, lIsNum := l.(int)
-		lStr, lIsStr := l.(string)
-		rNum, rIsNum := r.(int)
-		rStr, rIsStr := r.(string)
-
-		if lIsNum && rIsNum {
-			if lNum != rNum {
-				if lNum < rNum {
-					return -1, false, nil
+		switch {
+		case l.kind == numSeg && r.kind == numSeg:
+			if l.num != r.num {
+				if l.num < r.num {
+					return -1
 				}
-				return 1, false, nil
-			}
-			continue
-		}
-
-		if lIsStr && rIsStr {
-			if cmp := strings.Compare(lStr, rStr); cmp != 0 {
-				return cmp, false, nil
-			}
-			continue
-		}
-
-		if lIsNum && rIsStr {
-			return 1, false, nil
-		}
-		if lIsStr && rIsNum {
-			return -1, false, nil
-		}
-
-		return 0, false, fmt.Errorf("internal comparison error: unexpected types %T vs %T", l, r)
-	}
-	return 0, true, nil
-}
-
-func compareLengths(left, right []any, commonResult int) int {
-	if commonResult != 0 {
-		return commonResult
-	}
-
-	lLen := len(left)
-	rLen := len(right)
-
-	if lLen == rLen {
-		return 0
-	}
-
-	if lLen > rLen {
-		for i := rLen; i < lLen; i++ {
-			seg := left[i]
-			if _, isStr := seg.(string); isStr {
-				return -1
-			}
-			if num, isNum := seg.(int); isNum && num != 0 {
 				return 1
 			}
-		}
-		return 0
-	}
 
-	for i := lLen; i < rLen; i++ {
-		seg := right[i]
-		if _, isStr := seg.(string); isStr {
+		case l.kind == strSeg && r.kind == strSeg:
+			if l.str != r.str {
+				if l.str < r.str {
+					return -1
+				}
+				return 1
+			}
+
+		case l.kind == numSeg && r.kind == strSeg:
 			return 1
-		}
-		if num, isNum := seg.(int); isNum && num != 0 {
+
+		case l.kind == strSeg && r.kind == numSeg:
 			return -1
 		}
+	}
+
+	if len(left) < len(right) {
+		return -1
+	}
+	if len(left) > len(right) {
+		return 1
 	}
 	return 0
 }
 
 func cleanArchFromVersion(raw string) string {
-	platforms := []string{"x86", "universal", "arm", "java", "dalvik", "x64", "powerpc", "sparc", "mswin"}
-	dash := "-"
-	for _, p := range platforms {
-		vals := strings.SplitN(raw, dash+p, 2)
-		if len(vals) == 2 {
-			return vals[0]
-		}
-	}
-
-	return raw
+	archSuffixRegex := regexp.MustCompile(`-(x86|universal|arm64|aarch64|x64|powerpc|sparc|mswin|java|dalvik|arm)$`)
+	return archSuffixRegex.ReplaceAllString(raw, "")
 }

--- a/grype/version/gem_version_test.go
+++ b/grype/version/gem_version_test.go
@@ -310,3 +310,28 @@ func TestGemVersion_canonical(t *testing.T) {
 		})
 	}
 }
+
+func Test_cleanArchFromVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"correct case", "1.2.3-aarch64", "1.2.3"},
+		{"correct case", "2.0.0-arm64", "2.0.0"},
+		{"correct case", "1.2.4-aarch64", "1.2.4"},
+		{"x64 suffix", "3.4.5-x64", "3.4.5"},
+		{"mswin suffix", "1.0.0-mswin", "1.0.0"},
+		{"multiple dashes", "1.2.3-alpha-aarch64", "1.2.3-alpha"},
+		{"no match", "1.2.3-beta1", "1.2.3-beta1"},
+		{"empty string", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cleanArchFromVersion(tt.raw)
+			if got != tt.want {
+				t.Errorf("cleanArchFromVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Replace  based version logic with a strongly typed segment model. Remove runtime type assertions and legacy comparison helpers.

Ensures stable, transitive ordering for SBOM/version matching and fixes inconsistencies in prior comparison logic.

Resolves #3442 