### PR TITLE
perf: compile CVSS regex once at package level

### DIFF
--- a/grype/db/v6/build/transformers/osv/helpers.go
+++ b/grype/db/v6/build/transformers/osv/helpers.go
@@ -240,9 +240,10 @@ func createUnaffectedRange(fixedVersion string, fixByVersion map[string]db.FixAv
 // Severity / CVSS
 // ============================================================================
 
+var cvssPattern = regexp.MustCompile(`^CVSS:(\d+\.\d+)/(.+)$`)
+
 func extractCVSSInfo(cvss string) (string, string, error) {
-	re := regexp.MustCompile(`^CVSS:(\d+\.\d+)/(.+)$`)
-	matches := re.FindStringSubmatch(cvss)
+	matches := cvssPattern.FindStringSubmatch(cvss)
 	if len(matches) != 3 {
 		return "", "", fmt.Errorf("invalid CVSS format")
 	}


### PR DESCRIPTION
Similar to #3305 

## Summary
- Hoist `regexp.MustCompile` in `extractCVSSInfo()` from a local variable to a package-level `var` so the pattern is compiled once rather than on every call
- `extractCVSSInfo` is invoked for every severity entry in every OSV vulnerability record during database builds, so the repeated compilation is unnecessary overhead