### PR TITLE
Add OSV transformer for Ubuntu records

### DIFF
--- a/grype/db/internal/provider/unmarshal/osvmodel/anchore.go
+++ b/grype/db/internal/provider/unmarshal/osvmodel/anchore.go
@@ -1,0 +1,81 @@
+package osvmodel
+
+import "encoding/json"
+
+// AnchoreAffected is the grype-owned overlay stamped onto an OSV
+// affected[].database_specific by vunnel before grype-db consumes the record.
+// Anything outside this namespace is vendor-defined and read by per-provider
+// extension types in the transformer package.
+type AnchoreAffected struct {
+	// Status carries a normalized disposition that the upstream OSV record
+	// does not express directly. Currently observed: "wont-fix" (the provider
+	// explicitly will not patch this on this release).
+	Status string `json:"status,omitempty"`
+}
+
+// AnchoreRange is the grype-owned overlay on an
+// affected[].ranges[].database_specific. Today it only carries
+// fix-availability metadata sourced from vunnel's fix-date tracking.
+type AnchoreRange struct {
+	Fixes []AnchoreFix `json:"fixes,omitempty"`
+}
+
+// AnchoreFix is one entry in AnchoreRange.Fixes. Date is a string rather than
+// time.Time so callers control the parse (some emit RFC3339, some date-only).
+type AnchoreFix struct {
+	Version string `json:"version"`
+	Kind    string `json:"kind"`
+	Date    string `json:"date"`
+}
+
+// AffectedExtension returns the "anchore" key from an Affected's
+// database_specific map as a typed view. Missing key or decode failure yields
+// the zero value — both are treated as "no overlay" by the transformers.
+func AffectedExtension(databaseSpecific map[string]any) AnchoreAffected {
+	var ext AnchoreAffected
+	DecodeNamespace(databaseSpecific, "anchore", &ext)
+	return ext
+}
+
+// RangeExtension returns the "anchore" key from a Range's database_specific
+// map as a typed view. Missing key or decode failure yields the zero value.
+func RangeExtension(databaseSpecific map[string]any) AnchoreRange {
+	var ext AnchoreRange
+	DecodeNamespace(databaseSpecific, "anchore", &ext)
+	return ext
+}
+
+// DecodeNamespace pulls a single key out of an extension-point map and
+// decodes its JSON shape into the target. Errors are swallowed: the caller
+// either gets a populated target or the zero value, with no way to tell the
+// difference. That matches the transformers' "absence == no overlay" posture
+// and avoids re-flagging vunnel write-side bugs at read time.
+//
+// Use this when the vendor namespaces their extension under a single key
+// (the dominant shape, e.g. "anchore" or future "vendorname").
+func DecodeNamespace(m map[string]any, key string, into any) {
+	raw, ok := m[key]
+	if !ok {
+		return
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return
+	}
+	_ = json.Unmarshal(b, into)
+}
+
+// DecodeAll decodes an entire extension-point map into the target. Use this
+// when a vendor sticks fields at the top level of database_specific or
+// ecosystem_specific (e.g. alma's affected[].ecosystem_specific.rpm_modularity)
+// rather than under a namespacing key.
+func DecodeAll(m map[string]any, into any) {
+	if len(m) == 0 {
+		return
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return
+	}
+	_ = json.Unmarshal(b, into)
+}

--- a/grype/db/internal/provider/unmarshal/osvmodel/anchore_test.go
+++ b/grype/db/internal/provider/unmarshal/osvmodel/anchore_test.go
@@ -1,0 +1,283 @@
+package osvmodel
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestAffectedExtension covers the AnchoreAffected typed view over
+// affected[].database_specific["anchore"].
+//
+// Every OSV strategy reads through this helper to decide fix disposition.
+// The dominant shape today is the vunnel-stamped {"status": "wont-fix"}
+// from the VEX overlay; missing-key and malformed cases must both yield
+// the zero value so strategies stay tolerant of vunnel write-side bugs.
+func TestAffectedExtension(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]any
+		want AnchoreAffected
+	}{
+		{
+			name: "wont-fix status",
+			in: map[string]any{
+				"anchore": map[string]any{"status": "wont-fix"},
+			},
+			want: AnchoreAffected{Status: "wont-fix"},
+		},
+		{
+			name: "empty anchore object",
+			in: map[string]any{
+				"anchore": map[string]any{},
+			},
+			want: AnchoreAffected{},
+		},
+		{
+			name: "missing anchore key",
+			in: map[string]any{
+				"vendor": map[string]any{"status": "wont-fix"},
+			},
+			want: AnchoreAffected{},
+		},
+		{
+			name: "nil map",
+			in:   nil,
+			want: AnchoreAffected{},
+		},
+		{
+			// future-compatible: vunnel might emit other status values; the
+			// decode succeeds, and downstream strategies decide what to do
+			// with unknown values via their own switch (see ubuntu).
+			name: "unknown status passes through",
+			in: map[string]any{
+				"anchore": map[string]any{"status": "some-future-value"},
+			},
+			want: AnchoreAffected{Status: "some-future-value"},
+		},
+		{
+			// type mismatch (status is an int, not a string) → swallowed
+			// silently per the helper contract. The transformer falls back
+			// to the default branch.
+			name: "type mismatch yields zero value",
+			in: map[string]any{
+				"anchore": map[string]any{"status": 42},
+			},
+			want: AnchoreAffected{},
+		},
+		{
+			// anchore key is the wrong shape entirely (string instead of object).
+			// Decode fails silently.
+			name: "anchore key with non-object value",
+			in: map[string]any{
+				"anchore": "not an object",
+			},
+			want: AnchoreAffected{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AffectedExtension(tt.in)
+			if got != tt.want {
+				t.Errorf("AffectedExtension() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRangeExtension covers the AnchoreRange typed view over
+// ranges[].database_specific["anchore"]. This is the fix-availability
+// channel: vunnel stamps {"fixes": [{"version", "kind", "date"}]} per
+// range, and grype's extractFixAvailability reads it through here.
+func TestRangeExtension(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]any
+		want AnchoreRange
+	}{
+		{
+			name: "single fix entry",
+			in: map[string]any{
+				"anchore": map[string]any{
+					"fixes": []any{
+						map[string]any{"version": "1.2.3", "kind": "advisory", "date": "2024-01-01"},
+					},
+				},
+			},
+			want: AnchoreRange{
+				Fixes: []AnchoreFix{{Version: "1.2.3", Kind: "advisory", Date: "2024-01-01"}},
+			},
+		},
+		{
+			name: "multiple fix entries preserved in order",
+			in: map[string]any{
+				"anchore": map[string]any{
+					"fixes": []any{
+						map[string]any{"version": "1.0", "kind": "first-observed", "date": "2024-01-01"},
+						map[string]any{"version": "1.1", "kind": "advisory", "date": "2024-02-01"},
+					},
+				},
+			},
+			want: AnchoreRange{
+				Fixes: []AnchoreFix{
+					{Version: "1.0", Kind: "first-observed", Date: "2024-01-01"},
+					{Version: "1.1", Kind: "advisory", Date: "2024-02-01"},
+				},
+			},
+		},
+		{
+			name: "missing anchore key",
+			in:   map[string]any{"other": "data"},
+			want: AnchoreRange{},
+		},
+		{
+			name: "anchore present but no fixes key",
+			in: map[string]any{
+				"anchore": map[string]any{"status": "wont-fix"},
+			},
+			want: AnchoreRange{},
+		},
+		{
+			name: "empty fixes array",
+			in: map[string]any{
+				"anchore": map[string]any{"fixes": []any{}},
+			},
+			want: AnchoreRange{Fixes: []AnchoreFix{}},
+		},
+		{
+			name: "nil map",
+			in:   nil,
+			want: AnchoreRange{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RangeExtension(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RangeExtension() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDecodeNamespace exercises the namespaced-decode entry point directly.
+// Used by AffectedExtension/RangeExtension and by per-vendor extension
+// helpers that namespace under their own key.
+func TestDecodeNamespace(t *testing.T) {
+	type sample struct {
+		Name string `json:"name"`
+		Age  int    `json:"age,omitempty"`
+	}
+
+	tests := []struct {
+		name string
+		m    map[string]any
+		key  string
+		want sample
+	}{
+		{
+			name: "namespaced value decodes",
+			m:    map[string]any{"vendor": map[string]any{"name": "alice", "age": 30}},
+			key:  "vendor",
+			want: sample{Name: "alice", Age: 30},
+		},
+		{
+			name: "missing key yields zero value",
+			m:    map[string]any{"other": map[string]any{"name": "alice"}},
+			key:  "vendor",
+			want: sample{},
+		},
+		{
+			name: "empty map yields zero value",
+			m:    map[string]any{},
+			key:  "vendor",
+			want: sample{},
+		},
+		{
+			name: "nil map yields zero value",
+			m:    nil,
+			key:  "vendor",
+			want: sample{},
+		},
+		{
+			// unrelated keys present alongside the target — only the target is decoded.
+			name: "ignores sibling keys",
+			m: map[string]any{
+				"vendor": map[string]any{"name": "alice"},
+				"other":  map[string]any{"name": "bob"},
+			},
+			key:  "vendor",
+			want: sample{Name: "alice"},
+		},
+		{
+			// JSON-incompatible value at the key → decode fails silently,
+			// caller gets zero value.
+			name: "type mismatch yields zero value",
+			m:    map[string]any{"vendor": "not an object"},
+			key:  "vendor",
+			want: sample{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got sample
+			DecodeNamespace(tt.m, tt.key, &got)
+			if got != tt.want {
+				t.Errorf("DecodeNamespace() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDecodeAll exercises the top-level-decode entry point. Used when a
+// vendor sticks their fields directly at the root of database_specific or
+// ecosystem_specific (alma's rpm_modularity is the dominant example).
+func TestDecodeAll(t *testing.T) {
+	type rpm struct {
+		RpmModularity string `json:"rpm_modularity,omitempty"`
+	}
+
+	tests := []struct {
+		name string
+		m    map[string]any
+		want rpm
+	}{
+		{
+			name: "top-level field decodes",
+			m:    map[string]any{"rpm_modularity": "nodejs:18"},
+			want: rpm{RpmModularity: "nodejs:18"},
+		},
+		{
+			name: "absent field yields zero value",
+			m:    map[string]any{"other_field": "x"},
+			want: rpm{},
+		},
+		{
+			name: "empty map is a no-op (early return)",
+			m:    map[string]any{},
+			want: rpm{},
+		},
+		{
+			name: "nil map is a no-op (early return)",
+			m:    nil,
+			want: rpm{},
+		},
+		{
+			// extra keys are ignored at the json decode boundary
+			name: "extra keys ignored",
+			m: map[string]any{
+				"rpm_modularity": "nodejs:18",
+				"future_field":   42,
+			},
+			want: rpm{RpmModularity: "nodejs:18"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got rpm
+			DecodeAll(tt.m, &got)
+			if got != tt.want {
+				t.Errorf("DecodeAll() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/grype/db/internal/provider/unmarshal/osvmodel/osvmodel_test.go
+++ b/grype/db/internal/provider/unmarshal/osvmodel/osvmodel_test.go
@@ -1,0 +1,162 @@
+package osvmodel
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestVulnerabilityUnmarshal pins the JSON-tag wiring on the top-level OSV
+// record fields the transformers read. The fields here are exactly the set
+// strategies in grype/db/v6/build/transformers/osv depend on — anything
+// downstream that pulls another field needs to be added to the struct first
+// and to this test second.
+//
+// The fixture mirrors a real Canonical UBUNTU-CVE record shape: top-level
+// Upstream is the load-bearing extension (osv-scanner@v1.9.2 lacked it,
+// which is why we own the model now). Withdrawn is the "this CVE was
+// retracted" timestamp the ubuntu strategy skips on.
+func TestVulnerabilityUnmarshal(t *testing.T) {
+	raw := `{
+		"schema_version": "1.7.0",
+		"id": "UBUNTU-CVE-2023-38545",
+		"modified": "2026-04-22T07:45:24Z",
+		"published": "2023-10-11T06:00:00Z",
+		"withdrawn": "2025-06-23T15:53:49Z",
+		"aliases": [],
+		"related": [],
+		"upstream": ["CVE-2023-38545"],
+		"summary": "curl SOCKS5 heap overflow",
+		"details": "long description",
+		"severity": [
+			{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
+			{"type": "Ubuntu", "score": "high"}
+		],
+		"references": [
+			{"type": "REPORT", "url": "https://ubuntu.com/security/CVE-2023-38545"},
+			{"type": "ADVISORY", "url": "https://ubuntu.com/security/notices/USN-6429-1"}
+		],
+		"affected": [
+			{
+				"package": {"ecosystem": "Ubuntu:22.04:LTS", "name": "curl", "purl": "pkg:deb/ubuntu/curl@7.81?arch=source&distro=jammy"},
+				"ranges": [
+					{
+						"type": "ECOSYSTEM",
+						"events": [{"introduced": "0"}, {"fixed": "7.81.0-1ubuntu1.14"}],
+						"database_specific": {
+							"anchore": {
+								"fixes": [{"version": "7.81.0-1ubuntu1.14", "kind": "advisory", "date": "2023-10-11"}]
+							}
+						}
+					}
+				],
+				"versions": ["7.81.0-1ubuntu1.13"],
+				"ecosystem_specific": {"availability": "No subscription required"},
+				"database_specific": {"anchore": {"status": "wont-fix"}}
+			}
+		],
+		"database_specific": {"top_level_extension": "value"}
+	}`
+
+	var v Vulnerability
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if v.SchemaVersion != "1.7.0" {
+		t.Errorf("SchemaVersion = %q, want 1.7.0", v.SchemaVersion)
+	}
+	if v.ID != "UBUNTU-CVE-2023-38545" {
+		t.Errorf("ID = %q, want UBUNTU-CVE-2023-38545", v.ID)
+	}
+	if !v.Modified.Equal(time.Date(2026, time.April, 22, 7, 45, 24, 0, time.UTC)) {
+		t.Errorf("Modified = %v, unexpected", v.Modified)
+	}
+	if v.Withdrawn.IsZero() {
+		t.Errorf("Withdrawn should have parsed, got zero — withdrawn-skip logic depends on this")
+	}
+	if got, want := v.Upstream, []string{"CVE-2023-38545"}; !equalStrings(got, want) {
+		t.Errorf("Upstream = %v, want %v (this is the field osv-scanner@v1.9.2 lacked)", got, want)
+	}
+	if v.Summary != "curl SOCKS5 heap overflow" {
+		t.Errorf("Summary unexpected: %q", v.Summary)
+	}
+	if len(v.Severity) != 2 || v.Severity[0].Type != SeverityCVSSV3 {
+		t.Errorf("Severity wiring broke: %+v", v.Severity)
+	}
+	if len(v.References) != 2 || v.References[1].Type != ReferenceAdvisory {
+		t.Errorf("References wiring broke: %+v", v.References)
+	}
+
+	if len(v.Affected) != 1 {
+		t.Fatalf("Affected len = %d, want 1", len(v.Affected))
+	}
+	a := v.Affected[0]
+	if a.Package.Ecosystem != "Ubuntu:22.04:LTS" {
+		t.Errorf("Package.Ecosystem = %q, want Ubuntu:22.04:LTS", a.Package.Ecosystem)
+	}
+	if a.Package.Name != "curl" {
+		t.Errorf("Package.Name = %q, want curl", a.Package.Name)
+	}
+	if a.Package.Purl == "" {
+		t.Error("Package.Purl missing — the vunnel/vex distro-label join depends on this")
+	}
+	if len(a.Ranges) != 1 || a.Ranges[0].Type != RangeEcosystem {
+		t.Errorf("Range wiring broke: %+v", a.Ranges)
+	}
+	if AffectedExtension(a.DatabaseSpecific).Status != "wont-fix" {
+		t.Errorf("AffectedExtension.Status = %q, want wont-fix (round-trip through database_specific failed)",
+			AffectedExtension(a.DatabaseSpecific).Status)
+	}
+	if got := RangeExtension(a.Ranges[0].DatabaseSpecific).Fixes; len(got) != 1 || got[0].Version != "7.81.0-1ubuntu1.14" {
+		t.Errorf("RangeExtension.Fixes wiring broke: %+v", got)
+	}
+	// EcosystemSpecific is a free-form map by design — strategies own decoding.
+	if a.EcosystemSpecific["availability"] != "No subscription required" {
+		t.Errorf("EcosystemSpecific.availability did not round-trip: %v", a.EcosystemSpecific)
+	}
+	// Top-level database_specific stays as-is too.
+	if v.DatabaseSpecific["top_level_extension"] != "value" {
+		t.Errorf("top-level database_specific did not round-trip: %v", v.DatabaseSpecific)
+	}
+}
+
+// TestRangeTypeRoundTrip locks in the unknown-value passthrough behavior.
+// OSV admits new range types at the upstream's discretion; we want unknown
+// values to round-trip as their string form so the defaultRangeType fallback
+// can emit "unknown" rather than coercing into a known type.
+func TestRangeTypeRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want RangeType
+	}{
+		{"semver", `"SEMVER"`, RangeSemVer},
+		{"ecosystem", `"ECOSYSTEM"`, RangeEcosystem},
+		{"git", `"GIT"`, RangeGit},
+		{"unknown future value", `"SOMETHING_NEW"`, RangeType("SOMETHING_NEW")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got RangeType
+			if err := json.Unmarshal([]byte(tt.raw), &got); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("RangeType = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/grype/db/v6/build/transformers/osv/testdata/UBUNTU-CVE-2001-1593.json
+++ b/grype/db/v6/build/transformers/osv/testdata/UBUNTU-CVE-2001-1593.json
@@ -1,0 +1,74 @@
+{
+  "affected": [
+    {
+      "ecosystem_specific": {
+        "availability": "No subscription required",
+        "binaries": [
+          {
+            "binary_name": "a2ps",
+            "binary_version": "1:4.14-1.2"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:14.04:LTS",
+        "name": "a2ps",
+        "purl": "pkg:deb/ubuntu/a2ps@1:4.14-1.2?arch=source&distro=trusty"
+      },
+      "ranges": [
+        {
+          "database_specific": {
+            "anchore": {
+              "fixes": [
+                {
+                  "date": "2014-04-05",
+                  "kind": "advisory",
+                  "version": "1:4.14-1.2"
+                }
+              ]
+            }
+          },
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1:4.14-1.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "1:4.14-1.1"
+      ]
+    }
+  ],
+  "aliases": [],
+  "details": "Jakub Wilk found that a2ps, a tool to convert text and other types of files to PostScript, insecurely used a temporary file in spy_user(). A local attacker could use this flaw to perform a symbolic link attack to modify an arbitrary file accessible to the user running a2ps.",
+  "id": "UBUNTU-CVE-2001-1593",
+  "modified": "2025-07-16T04:49:52Z",
+  "published": "2014-04-05T21:55:00Z",
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://ubuntu.com/security/CVE-2001-1593"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://www.cve.org/CVERecord?id=CVE-2001-1593"
+    }
+  ],
+  "related": [],
+  "schema_version": "1.7.0",
+  "severity": [
+    {
+      "score": "low",
+      "type": "Ubuntu"
+    }
+  ],
+  "upstream": [
+    "CVE-2001-1593"
+  ],
+  "withdrawn": "2025-07-18T16:42:37Z"
+}

--- a/grype/db/v6/build/transformers/osv/testdata/UBUNTU-CVE-2002-2439.json
+++ b/grype/db/v6/build/transformers/osv/testdata/UBUNTU-CVE-2002-2439.json
@@ -1,0 +1,2366 @@
+{
+  "affected": [
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "cpp-4.7",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "g++-4.7",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "g++-4.7-multilib",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "gcc-4.7",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "gcc-4.7-base",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "gcc-4.7-locales",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "gcc-4.7-multilib",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "gcc-4.7-source",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "gccgo-4.7",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "gccgo-4.7-multilib",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "gfortran-4.7",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "gfortran-4.7-multilib",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "gobjc++-4.7",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "gobjc++-4.7-multilib",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "gobjc-4.7",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "gobjc-4.7-multilib",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "lib32go0",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "lib64go0",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "libgo0",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "libstdc++6-4.7-pic",
+            "binary_version": "4.7.3-12ubuntu1"
+          },
+          {
+            "binary_name": "libx32go0",
+            "binary_version": "4.7.3-12ubuntu1"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:14.04:LTS",
+        "name": "gcc-4.7",
+        "purl": "pkg:deb/ubuntu/gcc-4.7@4.7.3-12ubuntu1?arch=source&distro=trusty"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "4.7.3-7ubuntu3",
+        "4.7.3-8ubuntu1",
+        "4.7.3-9ubuntu1",
+        "4.7.3-9ubuntu2",
+        "4.7.3-10ubuntu1",
+        "4.7.3-11ubuntu1",
+        "4.7.3-12ubuntu1"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "g++-mingw-w64",
+            "binary_version": "4.8.2-10ubuntu2+12"
+          },
+          {
+            "binary_name": "g++-mingw-w64-i686",
+            "binary_version": "4.8.2-10ubuntu2+12"
+          },
+          {
+            "binary_name": "g++-mingw-w64-x86-64",
+            "binary_version": "4.8.2-10ubuntu2+12"
+          },
+          {
+            "binary_name": "gcc-mingw-w64",
+            "binary_version": "4.8.2-10ubuntu2+12"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-base",
+            "binary_version": "4.8.2-10ubuntu2+12"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686",
+            "binary_version": "4.8.2-10ubuntu2+12"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64",
+            "binary_version": "4.8.2-10ubuntu2+12"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64",
+            "binary_version": "4.8.2-10ubuntu2+12"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-i686",
+            "binary_version": "4.8.2-10ubuntu2+12"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-x86-64",
+            "binary_version": "4.8.2-10ubuntu2+12"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64",
+            "binary_version": "4.8.2-10ubuntu2+12"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-i686",
+            "binary_version": "4.8.2-10ubuntu2+12"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-x86-64",
+            "binary_version": "4.8.2-10ubuntu2+12"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64",
+            "binary_version": "4.8.2-10ubuntu2+12"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-i686",
+            "binary_version": "4.8.2-10ubuntu2+12"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-x86-64",
+            "binary_version": "4.8.2-10ubuntu2+12"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:14.04:LTS",
+        "name": "gcc-mingw-w64",
+        "purl": "pkg:deb/ubuntu/gcc-mingw-w64@12?arch=source&distro=trusty"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "8",
+        "9",
+        "11",
+        "12"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "cpp-4.7",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "g++-4.7",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "g++-4.7-multilib",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "gcc-4.7",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "gcc-4.7-base",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "gcc-4.7-locales",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "gcc-4.7-multilib",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "gcc-4.7-source",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "gccgo-4.7",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "gccgo-4.7-multilib",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "gfortran-4.7",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "gfortran-4.7-multilib",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "gobjc++-4.7",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "gobjc++-4.7-multilib",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "gobjc-4.7",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "gobjc-4.7-multilib",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "lib32go0",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "lib64go0",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "libgo0",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "libstdc++6-4.7-pic",
+            "binary_version": "4.7.4-3ubuntu12"
+          },
+          {
+            "binary_name": "libx32go0",
+            "binary_version": "4.7.4-3ubuntu12"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:16.04:LTS",
+        "name": "gcc-4.7",
+        "purl": "pkg:deb/ubuntu/gcc-4.7@4.7.4-3ubuntu12?arch=source&distro=xenial"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "4.7.4-3ubuntu3",
+        "4.7.4-3ubuntu7",
+        "4.7.4-3ubuntu9",
+        "4.7.4-3ubuntu10",
+        "4.7.4-3ubuntu11",
+        "4.7.4-3ubuntu12"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "cpp-4.7-arm-linux-gnueabi",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "g++-4.7-arm-linux-gnueabi",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "g++-4.7-multilib-arm-linux-gnueabi",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gcc-4.7-arm-linux-gnueabi",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gcc-4.7-arm-linux-gnueabi-base",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gcc-4.7-multilib-arm-linux-gnueabi",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gccgo-4.7-arm-linux-gnueabi",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gfortran-4.7-arm-linux-gnueabi",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gfortran-4.7-multilib-arm-linux-gnueabi",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gobjc++-4.7-arm-linux-gnueabi",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gobjc++-4.7-multilib-arm-linux-gnueabi",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gobjc-4.7-arm-linux-gnueabi",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gobjc-4.7-multilib-arm-linux-gnueabi",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libgcc-4.7-dev-armel-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libgfortran-4.7-dev-armel-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libgo0-armel-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libgo0-dbg-armel-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libhfgcc-4.7-dev-armel-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libhfgfortran-4.7-dev-armel-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libhfobjc-4.7-dev-armel-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libhfstdc++6-4.7-dbg-armel-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libhfstdc++6-4.7-dev-armel-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libobjc-4.7-dev-armel-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libstdc++6-4.7-dbg-armel-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libstdc++6-4.7-dev-armel-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libstdc++6-4.7-pic-armel-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:16.04:LTS",
+        "name": "gcc-4.7-armel-cross",
+        "purl": "pkg:deb/ubuntu/gcc-4.7-armel-cross@3?arch=source&distro=xenial"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "1.86",
+        "1.90",
+        "3"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "cpp-4.7-arm-linux-gnueabihf",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "g++-4.7-arm-linux-gnueabihf",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "g++-4.7-multilib-arm-linux-gnueabihf",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gcc-4.7-arm-linux-gnueabihf",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gcc-4.7-arm-linux-gnueabihf-base",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gcc-4.7-multilib-arm-linux-gnueabihf",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gccgo-4.7-arm-linux-gnueabihf",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gfortran-4.7-arm-linux-gnueabihf",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gfortran-4.7-multilib-arm-linux-gnueabihf",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gobjc++-4.7-arm-linux-gnueabihf",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gobjc++-4.7-multilib-arm-linux-gnueabihf",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gobjc-4.7-arm-linux-gnueabihf",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "gobjc-4.7-multilib-arm-linux-gnueabihf",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libgcc-4.7-dev-armhf-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libgfortran-4.7-dev-armhf-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libgo0-armhf-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libgo0-dbg-armhf-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libobjc-4.7-dev-armhf-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libsfgcc-4.7-dev-armhf-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libsfgfortran-4.7-dev-armhf-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libsfobjc-4.7-dev-armhf-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libsfstdc++6-4.7-dbg-armhf-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libsfstdc++6-4.7-dev-armhf-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libstdc++6-4.7-dbg-armhf-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libstdc++6-4.7-dev-armhf-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          },
+          {
+            "binary_name": "libstdc++6-4.7-pic-armhf-cross",
+            "binary_version": "4.7.4-3ubuntu12cross3"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:16.04:LTS",
+        "name": "gcc-4.7-armhf-cross",
+        "purl": "pkg:deb/ubuntu/gcc-4.7-armhf-cross@3?arch=source&distro=xenial"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "1.86",
+        "1.87",
+        "3"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-arm-linux-androideabi",
+            "binary_version": "0.20130705.1-0ubuntu9"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:16.04:LTS",
+        "name": "gcc-arm-linux-androideabi",
+        "purl": "pkg:deb/ubuntu/gcc-arm-linux-androideabi@0.20130705.1-0ubuntu9?arch=source&distro=xenial"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "0.20130705.1-0ubuntu8",
+        "0.20130705.1-0ubuntu9"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-arm-none-eabi",
+            "binary_version": "15:4.9.3+svn231177-1"
+          },
+          {
+            "binary_name": "gcc-arm-none-eabi-source",
+            "binary_version": "15:4.9.3+svn231177-1"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:16.04:LTS",
+        "name": "gcc-arm-none-eabi",
+        "purl": "pkg:deb/ubuntu/gcc-arm-none-eabi@15:4.9.3+svn231177-1?arch=source&distro=xenial"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "15:4.9.3+svn227297-1",
+        "15:4.9.3+svn227297-1build1",
+        "15:4.9.3+svn231177-1"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-h8300-hms",
+            "binary_version": "1:3.4.6+dfsg2-4ubuntu1"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:16.04:LTS",
+        "name": "gcc-h8300-hms",
+        "purl": "pkg:deb/ubuntu/gcc-h8300-hms@1:3.4.6+dfsg2-4ubuntu1?arch=source&distro=xenial"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "1:3.4.6+dfsg2-4ubuntu1"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-i686-linux-android",
+            "binary_version": "9"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:16.04:LTS",
+        "name": "gcc-i686-linux-android",
+        "purl": "pkg:deb/ubuntu/gcc-i686-linux-android@9?arch=source&distro=xenial"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "7",
+        "9"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "g++-mingw-w64",
+            "binary_version": "5.3.1-8ubuntu3+17"
+          },
+          {
+            "binary_name": "g++-mingw-w64-i686",
+            "binary_version": "5.3.1-8ubuntu3+17"
+          },
+          {
+            "binary_name": "g++-mingw-w64-x86-64",
+            "binary_version": "5.3.1-8ubuntu3+17"
+          },
+          {
+            "binary_name": "gcc-mingw-w64",
+            "binary_version": "5.3.1-8ubuntu3+17"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-base",
+            "binary_version": "5.3.1-8ubuntu3+17"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686",
+            "binary_version": "5.3.1-8ubuntu3+17"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64",
+            "binary_version": "5.3.1-8ubuntu3+17"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64",
+            "binary_version": "5.3.1-8ubuntu3+17"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-i686",
+            "binary_version": "5.3.1-8ubuntu3+17"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-x86-64",
+            "binary_version": "5.3.1-8ubuntu3+17"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64",
+            "binary_version": "5.3.1-8ubuntu3+17"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-i686",
+            "binary_version": "5.3.1-8ubuntu3+17"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-x86-64",
+            "binary_version": "5.3.1-8ubuntu3+17"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64",
+            "binary_version": "5.3.1-8ubuntu3+17"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-i686",
+            "binary_version": "5.3.1-8ubuntu3+17"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-x86-64",
+            "binary_version": "5.3.1-8ubuntu3+17"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:16.04:LTS",
+        "name": "gcc-mingw-w64",
+        "purl": "pkg:deb/ubuntu/gcc-mingw-w64@17?arch=source&distro=xenial"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "15.4",
+        "15.7",
+        "15.7build1",
+        "16build1",
+        "17"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-msp430",
+            "binary_version": "4.6.3~mspgcc-20120406-7ubuntu3"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:16.04:LTS",
+        "name": "gcc-msp430",
+        "purl": "pkg:deb/ubuntu/gcc-msp430@4.6.3~mspgcc-20120406-7ubuntu3?arch=source&distro=xenial"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "4.6.3~mspgcc-20120406-7ubuntu3"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-arm-none-eabi",
+            "binary_version": "15:6.3.1+svn253039-1build1"
+          },
+          {
+            "binary_name": "gcc-arm-none-eabi-source",
+            "binary_version": "15:6.3.1+svn253039-1build1"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:18.04:LTS",
+        "name": "gcc-arm-none-eabi",
+        "purl": "pkg:deb/ubuntu/gcc-arm-none-eabi@15:6.3.1+svn253039-1build1?arch=source&distro=bionic"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "15:5.4.1+svn241155-1",
+        "15:6.3.1+svn253039-1",
+        "15:6.3.1+svn253039-1build1"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-h8300-hms",
+            "binary_version": "1:3.4.6+dfsg2-4ubuntu3"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:18.04:LTS",
+        "name": "gcc-h8300-hms",
+        "purl": "pkg:deb/ubuntu/gcc-h8300-hms@1:3.4.6+dfsg2-4ubuntu3?arch=source&distro=bionic"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "1:3.4.6+dfsg2-4ubuntu1",
+        "1:3.4.6+dfsg2-4ubuntu3"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "g++-mingw-w64",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-i686",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-x86-64",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-base",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-i686",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-x86-64",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-i686",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-x86-64",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-i686",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-x86-64",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-i686",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-x86-64",
+            "binary_version": "7.3.0-11ubuntu1+20.2build1"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:18.04:LTS",
+        "name": "gcc-mingw-w64",
+        "purl": "pkg:deb/ubuntu/gcc-mingw-w64@20.2build1?arch=source&distro=bionic"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "19.3",
+        "20",
+        "20.1",
+        "20.2",
+        "20.2build1"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-msp430",
+            "binary_version": "4.6.3~mspgcc-20120406-7ubuntu5"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:18.04:LTS",
+        "name": "gcc-msp430",
+        "purl": "pkg:deb/ubuntu/gcc-msp430@4.6.3~mspgcc-20120406-7ubuntu5?arch=source&distro=bionic"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "4.6.3~mspgcc-20120406-7ubuntu4",
+        "4.6.3~mspgcc-20120406-7ubuntu5"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-arm-none-eabi",
+            "binary_version": "15:9-2019-q4-0ubuntu1"
+          },
+          {
+            "binary_name": "gcc-arm-none-eabi-source",
+            "binary_version": "15:9-2019-q4-0ubuntu1"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:20.04:LTS",
+        "name": "gcc-arm-none-eabi",
+        "purl": "pkg:deb/ubuntu/gcc-arm-none-eabi@15:9-2019-q4-0ubuntu1?arch=source&distro=focal"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "15:7-2018-q2-6",
+        "15:8-2019-q3-1",
+        "15:9-2019-q4-0ubuntu1"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-h8300-hms",
+            "binary_version": "1:3.4.6+dfsg2-4.1"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:20.04:LTS",
+        "name": "gcc-h8300-hms",
+        "purl": "pkg:deb/ubuntu/gcc-h8300-hms@1:3.4.6+dfsg2-4.1?arch=source&distro=focal"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "1:3.4.6+dfsg2-4ubuntu3",
+        "1:3.4.6+dfsg2-4.1"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "g++-mingw-w64",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "g++-mingw-w64-i686",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "g++-mingw-w64-x86-64",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "gcc-mingw-w64",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-base",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-i686",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-x86-64",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "gnat-mingw-w64",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-i686",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-x86-64",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-i686",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-x86-64",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-i686",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-x86-64",
+            "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:20.04:LTS",
+        "name": "gcc-mingw-w64",
+        "purl": "pkg:deb/ubuntu/gcc-mingw-w64@22~exp1ubuntu4?arch=source&distro=focal"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "22~exp1ubuntu2",
+        "22~exp1ubuntu3",
+        "22~exp1ubuntu4"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-msp430",
+            "binary_version": "4.6.3~mspgcc-20120406-7.1ubuntu3"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:20.04:LTS",
+        "name": "gcc-msp430",
+        "purl": "pkg:deb/ubuntu/gcc-msp430@4.6.3~mspgcc-20120406-7.1ubuntu3?arch=source&distro=focal"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "4.6.3~mspgcc-20120406-7.1ubuntu3"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-arm-none-eabi",
+            "binary_version": "15:10.3-2021.07-4"
+          },
+          {
+            "binary_name": "gcc-arm-none-eabi-source",
+            "binary_version": "15:10.3-2021.07-4"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:22.04:LTS",
+        "name": "gcc-arm-none-eabi",
+        "purl": "pkg:deb/ubuntu/gcc-arm-none-eabi@15:10.3-2021.07-4?arch=source&distro=jammy"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "15:9-2019-q4-0ubuntu2",
+        "15:10.3-2021.07-1",
+        "15:10.3-2021.07-2",
+        "15:10.3-2021.07-3",
+        "15:10.3-2021.07-4"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-h8300-hms",
+            "binary_version": "1:3.4.6+dfsg2-4.2"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:22.04:LTS",
+        "name": "gcc-h8300-hms",
+        "purl": "pkg:deb/ubuntu/gcc-h8300-hms@1:3.4.6+dfsg2-4.2?arch=source&distro=jammy"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "1:3.4.6+dfsg2-4.1",
+        "1:3.4.6+dfsg2-4.2"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "g++-mingw-w64",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "g++-mingw-w64-i686",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "g++-mingw-w64-i686-posix",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "g++-mingw-w64-i686-win32",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "g++-mingw-w64-x86-64",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "g++-mingw-w64-x86-64-posix",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "g++-mingw-w64-x86-64-win32",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gcc-mingw-w64",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-base",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686-posix",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686-posix-runtime",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686-win32",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686-win32-runtime",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64-posix",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64-posix-runtime",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64-win32",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64-win32-runtime",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-i686",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-i686-posix",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-i686-win32",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-x86-64",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-x86-64-posix",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-x86-64-win32",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gnat-mingw-w64",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-i686",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-i686-posix",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-i686-win32",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-x86-64",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-x86-64-posix",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-x86-64-win32",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-i686",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-i686-posix",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-i686-win32",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-x86-64",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-x86-64-posix",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-x86-64-win32",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-i686",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-i686-posix",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-i686-win32",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-x86-64",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-x86-64-posix",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-x86-64-win32",
+            "binary_version": "10.3.0-14ubuntu1+24.3"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:22.04:LTS",
+        "name": "gcc-mingw-w64",
+        "purl": "pkg:deb/ubuntu/gcc-mingw-w64@24.3?arch=source&distro=jammy"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "24.2",
+        "24.3"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-msp430",
+            "binary_version": "4.6.3~mspgcc-20120406-7.1ubuntu3"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:22.04:LTS",
+        "name": "gcc-msp430",
+        "purl": "pkg:deb/ubuntu/gcc-msp430@4.6.3~mspgcc-20120406-7.1ubuntu3?arch=source&distro=jammy"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "4.6.3~mspgcc-20120406-7.1ubuntu3"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-arm-none-eabi",
+            "binary_version": "15:13.2.rel1-2"
+          },
+          {
+            "binary_name": "gcc-arm-none-eabi-source",
+            "binary_version": "15:13.2.rel1-2"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:24.04:LTS",
+        "name": "gcc-arm-none-eabi",
+        "purl": "pkg:deb/ubuntu/gcc-arm-none-eabi@15:13.2.rel1-2?arch=source&distro=noble"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "15:12.2.rel1-1",
+        "15:13.2.rel1-1",
+        "15:13.2.rel1-2"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-h8300-hms",
+            "binary_version": "1:3.4.6+dfsg2-4.2"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:24.04:LTS",
+        "name": "gcc-h8300-hms",
+        "purl": "pkg:deb/ubuntu/gcc-h8300-hms@1:3.4.6+dfsg2-4.2?arch=source&distro=noble"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "1:3.4.6+dfsg2-4.2"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "g++-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-base",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686-posix-runtime",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686-win32-runtime",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64-posix-runtime",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64-win32-runtime",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:24.04:LTS",
+        "name": "gcc-mingw-w64",
+        "purl": "pkg:deb/ubuntu/gcc-mingw-w64@26.1?arch=source&distro=noble"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "25.3",
+        "26.1"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-arm-none-eabi",
+            "binary_version": "15:14.2.rel1-1"
+          },
+          {
+            "binary_name": "gcc-arm-none-eabi-source",
+            "binary_version": "15:14.2.rel1-1"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:25.10",
+        "name": "gcc-arm-none-eabi",
+        "purl": "pkg:deb/ubuntu/gcc-arm-none-eabi@15:14.2.rel1-1?arch=source&distro=questing"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "15:14.2.rel1-1"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-h8300-hms",
+            "binary_version": "1:3.4.6+dfsg2-4.2"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:25.10",
+        "name": "gcc-h8300-hms",
+        "purl": "pkg:deb/ubuntu/gcc-h8300-hms@1:3.4.6+dfsg2-4.2?arch=source&distro=questing"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "1:3.4.6+dfsg2-4.2"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "g++-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-base",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686-posix-runtime",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686-win32-runtime",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64-posix-runtime",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64-win32-runtime",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:25.10",
+        "name": "gcc-mingw-w64",
+        "purl": "pkg:deb/ubuntu/gcc-mingw-w64@26.1?arch=source&distro=questing"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "26.1"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-arm-none-eabi",
+            "binary_version": "15:14.2.rel1-1"
+          },
+          {
+            "binary_name": "gcc-arm-none-eabi-source",
+            "binary_version": "15:14.2.rel1-1"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:26.04",
+        "name": "gcc-arm-none-eabi",
+        "purl": "pkg:deb/ubuntu/gcc-arm-none-eabi@15:14.2.rel1-1?arch=source&distro=resolute"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "15:14.2.rel1-1"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "gcc-h8300-hms",
+            "binary_version": "1:3.4.6+dfsg2-12"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:26.04",
+        "name": "gcc-h8300-hms",
+        "purl": "pkg:deb/ubuntu/gcc-h8300-hms@1:3.4.6+dfsg2-12?arch=source&distro=resolute"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "1:3.4.6+dfsg2-4.2",
+        "1:3.4.6+dfsg2-9",
+        "1:3.4.6+dfsg2-10",
+        "1:3.4.6+dfsg2-11",
+        "1:3.4.6+dfsg2-12"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "g++-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "g++-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-base",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686-posix-runtime",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-i686-win32-runtime",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64-posix-runtime",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gcc-mingw-w64-x86-64-win32-runtime",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gfortran-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gnat-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc++-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-i686",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-i686-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-i686-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-x86-64",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-x86-64-posix",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          },
+          {
+            "binary_name": "gobjc-mingw-w64-x86-64-win32",
+            "binary_version": "13.2.0-6ubuntu1+26.1"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:26.04",
+        "name": "gcc-mingw-w64",
+        "purl": "pkg:deb/ubuntu/gcc-mingw-w64@26.1?arch=source&distro=resolute"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "26.1"
+      ]
+    }
+  ],
+  "aliases": [],
+  "details": "operator new[] sometimes returns pointers to heap blocks which are too small.  When a new array is allocated, the C++ run-time has to calculate its size.  The product may exceed the maximum value which can be stored in a machine register.  This error is ignored, and the truncated value is used for the heap allocation. This may lead to heap overflows and therefore security bugs. (See http://cert.uni-stuttgart.de/advisories/calloc.php for further references.)",
+  "id": "UBUNTU-CVE-2002-2439",
+  "modified": "2026-04-27T14:11:52Z",
+  "published": "2019-10-23T18:15:00Z",
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://ubuntu.com/security/CVE-2002-2439"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://www.cve.org/CVERecord?id=CVE-2002-2439"
+    }
+  ],
+  "related": [],
+  "schema_version": "1.7.0",
+  "severity": [
+    {
+      "score": "low",
+      "type": "Ubuntu"
+    }
+  ],
+  "upstream": [
+    "CVE-2002-2439"
+  ]
+}

--- a/grype/db/v6/build/transformers/osv/testdata/UBUNTU-CVE-2006-20001.json
+++ b/grype/db/v6/build/transformers/osv/testdata/UBUNTU-CVE-2006-20001.json
@@ -1,0 +1,514 @@
+{
+  "affected": [
+    {
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "apache2",
+            "binary_version": "2.4.7-1ubuntu4.22+esm10"
+          },
+          {
+            "binary_name": "apache2-bin",
+            "binary_version": "2.4.7-1ubuntu4.22+esm10"
+          },
+          {
+            "binary_name": "apache2-data",
+            "binary_version": "2.4.7-1ubuntu4.22+esm10"
+          },
+          {
+            "binary_name": "apache2-mpm-event",
+            "binary_version": "2.4.7-1ubuntu4.22+esm10"
+          },
+          {
+            "binary_name": "apache2-mpm-itk",
+            "binary_version": "2.4.7-1ubuntu4.22+esm10"
+          },
+          {
+            "binary_name": "apache2-mpm-prefork",
+            "binary_version": "2.4.7-1ubuntu4.22+esm10"
+          },
+          {
+            "binary_name": "apache2-mpm-worker",
+            "binary_version": "2.4.7-1ubuntu4.22+esm10"
+          },
+          {
+            "binary_name": "apache2-suexec",
+            "binary_version": "2.4.7-1ubuntu4.22+esm10"
+          },
+          {
+            "binary_name": "apache2-suexec-custom",
+            "binary_version": "2.4.7-1ubuntu4.22+esm10"
+          },
+          {
+            "binary_name": "apache2-suexec-pristine",
+            "binary_version": "2.4.7-1ubuntu4.22+esm10"
+          },
+          {
+            "binary_name": "apache2-utils",
+            "binary_version": "2.4.7-1ubuntu4.22+esm10"
+          },
+          {
+            "binary_name": "apache2.2-bin",
+            "binary_version": "2.4.7-1ubuntu4.22+esm10"
+          },
+          {
+            "binary_name": "libapache2-mod-macro",
+            "binary_version": "1:2.4.7-1ubuntu4.22+esm10"
+          },
+          {
+            "binary_name": "libapache2-mod-proxy-html",
+            "binary_version": "1:2.4.7-1ubuntu4.22+esm10"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:Pro:14.04:LTS",
+        "name": "apache2",
+        "purl": "pkg:deb/ubuntu/apache2@2.4.7-1ubuntu4.22+esm10?arch=source&distro=esm-infra-legacy/trusty"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "2.4.6-2ubuntu2",
+        "2.4.6-2ubuntu3",
+        "2.4.6-2ubuntu4",
+        "2.4.7-1ubuntu1",
+        "2.4.7-1ubuntu2",
+        "2.4.7-1ubuntu3",
+        "2.4.7-1ubuntu4",
+        "2.4.7-1ubuntu4.1",
+        "2.4.7-1ubuntu4.4",
+        "2.4.7-1ubuntu4.5",
+        "2.4.7-1ubuntu4.6",
+        "2.4.7-1ubuntu4.7",
+        "2.4.7-1ubuntu4.8",
+        "2.4.7-1ubuntu4.9",
+        "2.4.7-1ubuntu4.10",
+        "2.4.7-1ubuntu4.11",
+        "2.4.7-1ubuntu4.13",
+        "2.4.7-1ubuntu4.15",
+        "2.4.7-1ubuntu4.16",
+        "2.4.7-1ubuntu4.17",
+        "2.4.7-1ubuntu4.18",
+        "2.4.7-1ubuntu4.19",
+        "2.4.7-1ubuntu4.20",
+        "2.4.7-1ubuntu4.21",
+        "2.4.7-1ubuntu4.22",
+        "2.4.7-1ubuntu4.22+esm1",
+        "2.4.7-1ubuntu4.22+esm2",
+        "2.4.7-1ubuntu4.22+esm3",
+        "2.4.7-1ubuntu4.22+esm4",
+        "2.4.7-1ubuntu4.22+esm5",
+        "2.4.7-1ubuntu4.22+esm6",
+        "2.4.7-1ubuntu4.22+esm8",
+        "2.4.7-1ubuntu4.22+esm9",
+        "2.4.7-1ubuntu4.22+esm10"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "availability": "Available with Ubuntu Pro (Infra-only): https://ubuntu.com/pro",
+        "binaries": [
+          {
+            "binary_name": "apache2",
+            "binary_version": "2.4.18-2ubuntu3.17+esm8"
+          },
+          {
+            "binary_name": "apache2-bin",
+            "binary_version": "2.4.18-2ubuntu3.17+esm8"
+          },
+          {
+            "binary_name": "apache2-data",
+            "binary_version": "2.4.18-2ubuntu3.17+esm8"
+          },
+          {
+            "binary_name": "apache2-suexec-custom",
+            "binary_version": "2.4.18-2ubuntu3.17+esm8"
+          },
+          {
+            "binary_name": "apache2-suexec-pristine",
+            "binary_version": "2.4.18-2ubuntu3.17+esm8"
+          },
+          {
+            "binary_name": "apache2-utils",
+            "binary_version": "2.4.18-2ubuntu3.17+esm8"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:Pro:16.04:LTS",
+        "name": "apache2",
+        "purl": "pkg:deb/ubuntu/apache2@2.4.18-2ubuntu3.17+esm8?arch=source&distro=esm-infra/xenial"
+      },
+      "ranges": [
+        {
+          "database_specific": {
+            "anchore": {
+              "fixes": [
+                {
+                  "date": "2023-01-17",
+                  "kind": "advisory",
+                  "version": "2.4.18-2ubuntu3.17+esm8"
+                }
+              ]
+            }
+          },
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.4.18-2ubuntu3.17+esm8"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "2.4.12-2ubuntu2",
+        "2.4.17-1ubuntu1",
+        "2.4.17-2ubuntu1",
+        "2.4.17-3ubuntu1",
+        "2.4.18-1ubuntu1",
+        "2.4.18-2ubuntu1",
+        "2.4.18-2ubuntu2",
+        "2.4.18-2ubuntu3",
+        "2.4.18-2ubuntu3.1",
+        "2.4.18-2ubuntu3.2",
+        "2.4.18-2ubuntu3.3",
+        "2.4.18-2ubuntu3.4",
+        "2.4.18-2ubuntu3.5",
+        "2.4.18-2ubuntu3.7",
+        "2.4.18-2ubuntu3.8",
+        "2.4.18-2ubuntu3.9",
+        "2.4.18-2ubuntu3.10",
+        "2.4.18-2ubuntu3.12",
+        "2.4.18-2ubuntu3.13",
+        "2.4.18-2ubuntu3.14",
+        "2.4.18-2ubuntu3.15",
+        "2.4.18-2ubuntu3.17",
+        "2.4.18-2ubuntu3.17+esm1",
+        "2.4.18-2ubuntu3.17+esm2",
+        "2.4.18-2ubuntu3.17+esm3",
+        "2.4.18-2ubuntu3.17+esm4",
+        "2.4.18-2ubuntu3.17+esm5",
+        "2.4.18-2ubuntu3.17+esm6",
+        "2.4.18-2ubuntu3.17+esm7"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "availability": "No subscription required",
+        "binaries": [
+          {
+            "binary_name": "apache2",
+            "binary_version": "2.4.29-1ubuntu4.26"
+          },
+          {
+            "binary_name": "apache2-bin",
+            "binary_version": "2.4.29-1ubuntu4.26"
+          },
+          {
+            "binary_name": "apache2-data",
+            "binary_version": "2.4.29-1ubuntu4.26"
+          },
+          {
+            "binary_name": "apache2-suexec-custom",
+            "binary_version": "2.4.29-1ubuntu4.26"
+          },
+          {
+            "binary_name": "apache2-suexec-pristine",
+            "binary_version": "2.4.29-1ubuntu4.26"
+          },
+          {
+            "binary_name": "apache2-utils",
+            "binary_version": "2.4.29-1ubuntu4.26"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:18.04:LTS",
+        "name": "apache2",
+        "purl": "pkg:deb/ubuntu/apache2@2.4.29-1ubuntu4.26?arch=source&distro=bionic"
+      },
+      "ranges": [
+        {
+          "database_specific": {
+            "anchore": {
+              "fixes": [
+                {
+                  "date": "2023-01-17",
+                  "kind": "advisory",
+                  "version": "2.4.29-1ubuntu4.26"
+                }
+              ]
+            }
+          },
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.4.29-1ubuntu4.26"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "2.4.27-2ubuntu3",
+        "2.4.29-1ubuntu1",
+        "2.4.29-1ubuntu2",
+        "2.4.29-1ubuntu3",
+        "2.4.29-1ubuntu4",
+        "2.4.29-1ubuntu4.1",
+        "2.4.29-1ubuntu4.2",
+        "2.4.29-1ubuntu4.3",
+        "2.4.29-1ubuntu4.4",
+        "2.4.29-1ubuntu4.5",
+        "2.4.29-1ubuntu4.6",
+        "2.4.29-1ubuntu4.7",
+        "2.4.29-1ubuntu4.8",
+        "2.4.29-1ubuntu4.10",
+        "2.4.29-1ubuntu4.11",
+        "2.4.29-1ubuntu4.12",
+        "2.4.29-1ubuntu4.13",
+        "2.4.29-1ubuntu4.14",
+        "2.4.29-1ubuntu4.16",
+        "2.4.29-1ubuntu4.17",
+        "2.4.29-1ubuntu4.18",
+        "2.4.29-1ubuntu4.19",
+        "2.4.29-1ubuntu4.20",
+        "2.4.29-1ubuntu4.21",
+        "2.4.29-1ubuntu4.22",
+        "2.4.29-1ubuntu4.23",
+        "2.4.29-1ubuntu4.24",
+        "2.4.29-1ubuntu4.25"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "availability": "No subscription required",
+        "binaries": [
+          {
+            "binary_name": "apache2",
+            "binary_version": "2.4.41-4ubuntu3.13"
+          },
+          {
+            "binary_name": "apache2-bin",
+            "binary_version": "2.4.41-4ubuntu3.13"
+          },
+          {
+            "binary_name": "apache2-data",
+            "binary_version": "2.4.41-4ubuntu3.13"
+          },
+          {
+            "binary_name": "apache2-suexec-custom",
+            "binary_version": "2.4.41-4ubuntu3.13"
+          },
+          {
+            "binary_name": "apache2-suexec-pristine",
+            "binary_version": "2.4.41-4ubuntu3.13"
+          },
+          {
+            "binary_name": "apache2-utils",
+            "binary_version": "2.4.41-4ubuntu3.13"
+          },
+          {
+            "binary_name": "libapache2-mod-md",
+            "binary_version": "2.4.41-4ubuntu3.13"
+          },
+          {
+            "binary_name": "libapache2-mod-proxy-uwsgi",
+            "binary_version": "2.4.41-4ubuntu3.13"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:20.04:LTS",
+        "name": "apache2",
+        "purl": "pkg:deb/ubuntu/apache2@2.4.41-4ubuntu3.13?arch=source&distro=focal"
+      },
+      "ranges": [
+        {
+          "database_specific": {
+            "anchore": {
+              "fixes": [
+                {
+                  "date": "2023-01-17",
+                  "kind": "advisory",
+                  "version": "2.4.41-4ubuntu3.13"
+                }
+              ]
+            }
+          },
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.4.41-4ubuntu3.13"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "2.4.41-1ubuntu1",
+        "2.4.41-4ubuntu1",
+        "2.4.41-4ubuntu2",
+        "2.4.41-4ubuntu3",
+        "2.4.41-4ubuntu3.1",
+        "2.4.41-4ubuntu3.3",
+        "2.4.41-4ubuntu3.4",
+        "2.4.41-4ubuntu3.5",
+        "2.4.41-4ubuntu3.6",
+        "2.4.41-4ubuntu3.7",
+        "2.4.41-4ubuntu3.8",
+        "2.4.41-4ubuntu3.9",
+        "2.4.41-4ubuntu3.10",
+        "2.4.41-4ubuntu3.11",
+        "2.4.41-4ubuntu3.12"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "availability": "No subscription required",
+        "binaries": [
+          {
+            "binary_name": "apache2",
+            "binary_version": "2.4.52-1ubuntu4.3"
+          },
+          {
+            "binary_name": "apache2-bin",
+            "binary_version": "2.4.52-1ubuntu4.3"
+          },
+          {
+            "binary_name": "apache2-data",
+            "binary_version": "2.4.52-1ubuntu4.3"
+          },
+          {
+            "binary_name": "apache2-suexec-custom",
+            "binary_version": "2.4.52-1ubuntu4.3"
+          },
+          {
+            "binary_name": "apache2-suexec-pristine",
+            "binary_version": "2.4.52-1ubuntu4.3"
+          },
+          {
+            "binary_name": "apache2-utils",
+            "binary_version": "2.4.52-1ubuntu4.3"
+          },
+          {
+            "binary_name": "libapache2-mod-md",
+            "binary_version": "2.4.52-1ubuntu4.3"
+          },
+          {
+            "binary_name": "libapache2-mod-proxy-uwsgi",
+            "binary_version": "2.4.52-1ubuntu4.3"
+          }
+        ]
+      },
+      "package": {
+        "ecosystem": "Ubuntu:22.04:LTS",
+        "name": "apache2",
+        "purl": "pkg:deb/ubuntu/apache2@2.4.52-1ubuntu4.3?arch=source&distro=jammy"
+      },
+      "ranges": [
+        {
+          "database_specific": {
+            "anchore": {
+              "fixes": [
+                {
+                  "date": "2023-01-17",
+                  "kind": "advisory",
+                  "version": "2.4.52-1ubuntu4.3"
+                }
+              ]
+            }
+          },
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.4.52-1ubuntu4.3"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "2.4.48-3.1ubuntu3",
+        "2.4.48-3.1ubuntu4",
+        "2.4.51-2ubuntu1",
+        "2.4.52-1ubuntu1",
+        "2.4.52-1ubuntu2",
+        "2.4.52-1ubuntu4",
+        "2.4.52-1ubuntu4.1",
+        "2.4.52-1ubuntu4.2"
+      ]
+    }
+  ],
+  "aliases": [],
+  "details": "A carefully crafted If: request header can cause a memory read, or write of a single zero byte, in a pool (heap) memory location beyond the header value sent. This could cause the process to crash. This issue affects Apache HTTP Server 2.4.54 and earlier.",
+  "id": "UBUNTU-CVE-2006-20001",
+  "modified": "2026-04-22T07:37:33Z",
+  "published": "2023-01-17T20:15:00Z",
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://ubuntu.com/security/CVE-2006-20001"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://www.openwall.com/lists/oss-security/2023/01/17/5"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://httpd.apache.org/security/vulnerabilities_24.html#CVE-2006-20001"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://httpd.apache.org/security/vulnerabilities_24.html"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://ubuntu.com/security/notices/USN-5834-1"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://ubuntu.com/security/notices/USN-5839-1"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://www.cve.org/CVERecord?id=CVE-2006-20001"
+    }
+  ],
+  "related": [
+    "USN-5834-1",
+    "USN-5839-1"
+  ],
+  "schema_version": "1.7.0",
+  "severity": [
+    {
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "type": "CVSS_V3"
+    },
+    {
+      "score": "medium",
+      "type": "Ubuntu"
+    }
+  ],
+  "upstream": [
+    "CVE-2006-20001"
+  ]
+}

--- a/grype/db/v6/build/transformers/osv/testdata/UBUNTU-CVE-2008-7320.json
+++ b/grype/db/v6/build/transformers/osv/testdata/UBUNTU-CVE-2008-7320.json
@@ -1,0 +1,150 @@
+{
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Ubuntu:Pro:16.04:LTS",
+        "name": "seahorse"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "3.16.0-1ubuntu1",
+        "3.18.0-2ubuntu1"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Ubuntu:Pro:18.04:LTS",
+        "name": "seahorse"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "3.20.0-3.1",
+        "3.20.0-4",
+        "3.20.0-5"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Ubuntu:20.04:LTS",
+        "name": "seahorse"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "3.32.2-1",
+        "3.34-1",
+        "3.35.91-1",
+        "3.36-1"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Ubuntu:22.04:LTS",
+        "name": "seahorse"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "40.0-2",
+        "41.0-1",
+        "41.0-2"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Ubuntu:24.04:LTS",
+        "name": "seahorse"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "43.0-1build1",
+        "43.0-3",
+        "43.0-3build1",
+        "43.0-3build2"
+      ]
+    }
+  ],
+  "aliases": [],
+  "details": "** DISPUTED ** GNOME Seahorse through 3.30 allows physically proximate attackers to read plaintext passwords by using the quickAllow dialog at an unattended workstation, if the keyring is unlocked. NOTE: this is disputed by a software maintainer because the behavior represents a design decision.",
+  "id": "UBUNTU-CVE-2008-7320",
+  "modified": "2018-11-18T19:29:00Z",
+  "published": "2018-11-18T19:29:00Z",
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://ubuntu.com/security/CVE-2008-7320"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://bugs.launchpad.net/ubuntu/+source/seahorse/+bug/189774"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://bugs.launchpad.net/ubuntu/+source/seahorse/+bug/189774/comments/13"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://bugzilla.gnome.org/show_bug.cgi?id=551036"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://www.bountysource.com/issues/3849352-seahorse-shows-passwords-without-verification"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://www.cve.org/CVERecord?id=CVE-2008-7320"
+    }
+  ],
+  "related": [],
+  "schema_version": "1.6.3",
+  "severity": [
+    {
+      "score": "CVSS:3.0/AV:P/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "type": "CVSS_V3"
+    }
+  ],
+  "withdrawn": "2025-06-23T15:52:31Z"
+}

--- a/grype/db/v6/build/transformers/osv/testdata/UBUNTU-CVE-2023-38545.json
+++ b/grype/db/v6/build/transformers/osv/testdata/UBUNTU-CVE-2023-38545.json
@@ -1,0 +1,178 @@
+{
+  "affected": [
+    {
+      "ecosystem_specific": {
+        "availability": "No subscription required",
+        "binaries": [
+          {
+            "binary_name": "curl",
+            "binary_version": "7.81.0-1ubuntu1.14"
+          },
+          {
+            "binary_name": "libcurl3-gnutls",
+            "binary_version": "7.81.0-1ubuntu1.14"
+          },
+          {
+            "binary_name": "libcurl3-nss",
+            "binary_version": "7.81.0-1ubuntu1.14"
+          },
+          {
+            "binary_name": "libcurl4",
+            "binary_version": "7.81.0-1ubuntu1.14"
+          }
+        ],
+        "priority_reason": "Upstream curl developer has rated this issue as high"
+      },
+      "package": {
+        "ecosystem": "Ubuntu:22.04:LTS",
+        "name": "curl",
+        "purl": "pkg:deb/ubuntu/curl@7.81.0-1ubuntu1.14?arch=source&distro=jammy"
+      },
+      "ranges": [
+        {
+          "database_specific": {
+            "anchore": {
+              "fixes": [
+                {
+                  "date": "2023-10-11",
+                  "kind": "advisory",
+                  "version": "7.81.0-1ubuntu1.14"
+                }
+              ]
+            }
+          },
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.81.0-1ubuntu1.14"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "7.74.0-1.3ubuntu2",
+        "7.74.0-1.3ubuntu3",
+        "7.80.0-3",
+        "7.81.0-1",
+        "7.81.0-1ubuntu1.1",
+        "7.81.0-1ubuntu1.2",
+        "7.81.0-1ubuntu1.3",
+        "7.81.0-1ubuntu1.4",
+        "7.81.0-1ubuntu1.6",
+        "7.81.0-1ubuntu1.7",
+        "7.81.0-1ubuntu1.8",
+        "7.81.0-1ubuntu1.10",
+        "7.81.0-1ubuntu1.11",
+        "7.81.0-1ubuntu1.13"
+      ]
+    },
+    {
+      "ecosystem_specific": {
+        "availability": "No subscription required",
+        "binaries": [
+          {
+            "binary_name": "curl",
+            "binary_version": "8.2.1-1ubuntu3.1"
+          },
+          {
+            "binary_name": "libcurl3-gnutls",
+            "binary_version": "8.2.1-1ubuntu3.1"
+          },
+          {
+            "binary_name": "libcurl3-nss",
+            "binary_version": "8.2.1-1ubuntu3.1"
+          },
+          {
+            "binary_name": "libcurl4",
+            "binary_version": "8.2.1-1ubuntu3.1"
+          }
+        ],
+        "priority_reason": "Upstream curl developer has rated this issue as high"
+      },
+      "package": {
+        "ecosystem": "Ubuntu:24.04:LTS",
+        "name": "curl",
+        "purl": "pkg:deb/ubuntu/curl@8.2.1-1ubuntu3.1?arch=source&distro=noble"
+      },
+      "ranges": [
+        {
+          "database_specific": {
+            "anchore": {
+              "fixes": [
+                {
+                  "date": "2023-10-11",
+                  "kind": "advisory",
+                  "version": "8.2.1-1ubuntu3.1"
+                }
+              ]
+            }
+          },
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "8.2.1-1ubuntu3.1"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ],
+      "versions": [
+        "8.2.1-1ubuntu3"
+      ]
+    }
+  ],
+  "aliases": [],
+  "details": "This flaw makes curl overflow a heap based buffer in the SOCKS5 proxy handshake. When curl is asked to pass along the host name to the SOCKS5 proxy to allow that to resolve the address instead of it getting done by curl itself, the maximum length that host name can be is 255 bytes. If the host name is detected to be longer, curl switches to local name resolving and instead passes on the resolved address only. Due to this bug, the local variable that means \"let the host resolve the name\" could get the wrong value during a slow SOCKS5 handshake, and contrary to the intention, copy the too long host name to the target buffer instead of copying just the resolved address there. The target buffer being a heap based buffer, and the host name coming from the URL that curl has been told to operate with.",
+  "id": "UBUNTU-CVE-2023-38545",
+  "modified": "2026-04-22T07:45:24Z",
+  "published": "2023-10-11T06:00:00Z",
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://ubuntu.com/security/CVE-2023-38545"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://curl.se/docs/CVE-2023-38545.html"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://ubuntu.com/security/notices/USN-6429-1"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://ubuntu.com/security/notices/USN-6429-3"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://www.cve.org/CVERecord?id=CVE-2023-38545"
+    }
+  ],
+  "related": [
+    "USN-6429-1",
+    "USN-6429-3"
+  ],
+  "schema_version": "1.7.0",
+  "severity": [
+    {
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "type": "CVSS_V3"
+    },
+    {
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "type": "CVSS_V3"
+    },
+    {
+      "score": "high",
+      "type": "Ubuntu"
+    }
+  ],
+  "upstream": [
+    "CVE-2023-38545"
+  ]
+}

--- a/grype/db/v6/build/transformers/osv/transform.go
+++ b/grype/db/v6/build/transformers/osv/transform.go
@@ -49,4 +49,5 @@ var strategies = []Strategy{
 	bitnamiStrategy{},
 	govulndbStrategy{},
 	rootioStrategy{},
+	ubuntuStrategy{},
 }

--- a/grype/db/v6/build/transformers/osv/transform_ubuntu.go
+++ b/grype/db/v6/build/transformers/osv/transform_ubuntu.go
@@ -1,0 +1,331 @@
+package osv
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/anchore/grype/grype/db/data"
+	"github.com/anchore/grype/grype/db/internal/codename"
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal"
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
+	"github.com/anchore/grype/grype/db/provider"
+	db "github.com/anchore/grype/grype/db/v6"
+	"github.com/anchore/grype/grype/db/v6/build/transformers"
+	"github.com/anchore/grype/grype/db/v6/build/transformers/internal"
+	"github.com/anchore/grype/grype/db/v6/name"
+	"github.com/anchore/syft/syft/pkg"
+)
+
+// ubuntuStrategy handles UBUNTU-CVE-* records from Canonical's published OSV
+// feed (osv-all.tar.xz). These records describe vulnerable version ranges of
+// Ubuntu source packages — AK semantics — and must produce DB rows that are
+// indistinguishable from what the OS-schema transformer produces for Ubuntu
+// records today, because the dpkg matcher already queries against those rows
+// via search.ByPackageName + search.ByDistro.
+//
+// The ubuntu strategy diverges from alma/bitnami/rootio in three load-bearing
+// ways:
+//
+//   - CVE aliases come from the record's top-level `upstream` field, not
+//     `aliases`. Canonical leaves `aliases` empty and puts the CVE link in
+//     `upstream`. The unmarshal wrapper exposes this via vuln.Upstream.
+//   - Vendor severity is `severity[].type == "Ubuntu"` with a lowercase string
+//     score ("high"/"medium"/"low"/"negligible"). This maps to the CHMLN
+//     scheme — the same scheme the legacy OS transformer uses for its
+//     Vulnerability.Severity string, so downstream consumers don't have to
+//     branch on transformer source.
+//   - Records with `withdrawn` set are skipped entirely. Canonical retracted
+//     the CVE; emitting it would produce stale hits.
+const (
+	ubuntu           = "ubuntu"
+	ubuntuESMChannel = "esm"
+	ubuntuPkgFormat  = "dpkg"
+)
+
+type ubuntuStrategy struct{}
+
+func (ubuntuStrategy) Matches(id string) bool {
+	return strings.HasPrefix(id, "UBUNTU-CVE-")
+}
+
+func (ubuntuStrategy) Transform(vuln unmarshal.OSVVulnerability, state provider.State) ([]data.Entry, error) {
+	// Withdrawn records are dropped. The legacy passthrough is the only path
+	// a Canonical-retracted CVE can still reach the DB (if a frozen row
+	// survives in the legacy results.db for an EOL release).
+	if !vuln.Withdrawn.IsZero() {
+		return nil, nil
+	}
+
+	severities, err := ubuntuSeverities(vuln)
+	if err != nil {
+		return nil, fmt.Errorf("unable to obtain ubuntu severities: %w", err)
+	}
+
+	// The vulnerability is keyed by its upstream CVE — that's the identifier
+	// users have always seen for Ubuntu records (legacy OS-schema records set
+	// VulnerabilityHandle.Name directly to "CVE-..."). The UBUNTU-CVE-* id is
+	// Canonical's internal record key; storing it would change the column in
+	// every existing report.
+	//
+	// If there is no upstream (e.g. some withdrawn 1.6.3 records — not
+	// reached today since withdrawn records are already dropped above), fall
+	// back to the OSV record id so we don't silently lose the row.
+	primaryID, extraAliases := splitUbuntuUpstream(vuln)
+
+	in := []any{
+		db.VulnerabilityHandle{
+			Name:          primaryID,
+			ProviderID:    state.Provider,
+			Provider:      provider.Model(state),
+			Status:        db.VulnerabilityActive,
+			ModifiedDate:  &vuln.Modified,
+			PublishedDate: &vuln.Published,
+			BlobValue: &db.VulnerabilityBlob{
+				ID:          primaryID,
+				Description: vuln.Details,
+				References:  ubuntuReferences(vuln),
+				Aliases:     extraAliases,
+				Severities:  severities,
+			},
+		},
+	}
+
+	for _, aph := range ubuntuAffectedPackages(vuln, extraAliases) {
+		in = append(in, aph)
+	}
+	return transformers.NewEntries(in...), nil
+}
+
+// splitUbuntuUpstream picks the primary user-visible ID from the OSV record's
+// upstream field. Real Ubuntu OSV records carry exactly one upstream CVE
+// (the wrapper around vuln.ID), so the dominant case is upstream=[CVE-X] →
+// primary=CVE-X, extras=nil. The rare multi-upstream case (a single Ubuntu
+// CVE wrapping multiple upstream CVEs) keeps the first as primary and stores
+// the rest as aliases. If upstream is missing entirely, fall back to the
+// OSV record id so the row is still emitted.
+func splitUbuntuUpstream(vuln unmarshal.OSVVulnerability) (primary string, extras []string) {
+	if len(vuln.Upstream) == 0 {
+		return vuln.ID, nil
+	}
+	primary = vuln.Upstream[0]
+	if len(vuln.Upstream) > 1 {
+		extras = append([]string{}, vuln.Upstream[1:]...)
+	}
+	return primary, extras
+}
+
+func ubuntuReferences(vuln unmarshal.OSVVulnerability) []db.Reference {
+	var refs []db.Reference
+	for _, ref := range vuln.References {
+		refs = append(refs, db.Reference{
+			URL:  ref.URL,
+			Tags: []string{string(ref.Type)},
+		})
+	}
+	return refs
+}
+
+// ubuntuSeverities normalizes Ubuntu's mixed severity shapes. The Ubuntu vendor
+// severity is a lowercase string ("high"/"medium"/"low"/...); CVSS entries
+// are standard "CVSS:x.y/<vector>" strings. CHMLN-scheme entries lead the
+// slice so downstream rank-ordering picks the vendor severity first, matching
+// the OS transformer's order.
+func ubuntuSeverities(vuln unmarshal.OSVVulnerability) ([]db.Severity, error) {
+	var chmln []db.Severity
+	var cvss []db.Severity
+
+	classify := func(sev osvmodel.Severity) error {
+		if sev.Type == "Ubuntu" {
+			chmln = append(chmln, db.Severity{
+				Scheme: db.SeveritySchemeCHMLN,
+				Value:  strings.ToLower(sev.Score),
+				Rank:   1,
+			})
+			return nil
+		}
+		n, err := normalizeSeverity(sev)
+		if err != nil {
+			return err
+		}
+		n.Rank = 2
+		cvss = append(cvss, n)
+		return nil
+	}
+
+	for _, sev := range vuln.Severity {
+		if err := classify(sev); err != nil {
+			return nil, err
+		}
+	}
+	for _, affected := range vuln.Affected {
+		for _, sev := range affected.Severity {
+			if err := classify(sev); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if len(chmln) == 0 && len(cvss) == 0 {
+		return nil, nil
+	}
+	return append(chmln, cvss...), nil
+}
+
+func ubuntuAffectedPackages(vuln unmarshal.OSVVulnerability, aliases []string) []db.AffectedPackageHandle {
+	if len(vuln.Affected) == 0 {
+		return nil
+	}
+	var aphs []db.AffectedPackageHandle
+	for _, affected := range vuln.Affected {
+		osRow := ubuntuOSFromEcosystem(affected.Package.Ecosystem)
+		if osRow == nil {
+			// Unparseable ecosystem — skip this affected entry rather than
+			// emitting a row the matcher could never resolve.
+			continue
+		}
+		aphs = append(aphs, db.AffectedPackageHandle{
+			Package:         ubuntuPackage(affected.Package),
+			OperatingSystem: osRow,
+			BlobValue: &db.PackageBlob{
+				CVEs:   aliases,
+				Ranges: ubuntuRangesFromAffected(affected),
+			},
+		})
+	}
+	sort.Sort(internal.ByAffectedPackage(aphs))
+	return aphs
+}
+
+func ubuntuPackage(p osvmodel.Package) *db.Package {
+	return &db.Package{
+		Ecosystem: pkg.DebPkg.String(),
+		Name:      name.Normalize(p.Name, pkg.DebPkg),
+	}
+}
+
+// ubuntuRangesFromAffected produces dpkg-typed ranges that match what
+// os.Transform emits for ubuntu records:
+//
+//   - introduced=0 + fixed=X → "< X" range + Fix{Version:X, State:FixedStatus,
+//     Detail.Available:<from anchore.fixes>}. Handled by the shared helper.
+//   - bare introduced=0 (no fixed event) → "" constraint + Fix sentinel. State
+//     depends on the wont-fix disposition surfaced by the vunnel-side VEX
+//     overlay (see ubuntuFixStateForNoFixSentinel below). The shared helper
+//     returns no ranges for this shape, so we add the sentinel here. This
+//     mirrors os.Transform's behavior for an AffectedPackageHandle whose
+//     FixedIn.Version cleans to empty: NotFixedStatus by default, or
+//     WontFixStatus when VendorAdvisory.NoAdvisory was true (the OS-schema
+//     equivalent of what the VEX overlay marks).
+//
+// Without the sentinel the dpkg matcher would see a gap where Canonical says
+// "we acknowledge this CVE but no fix has shipped" — the row would simply
+// not exist in the DB, and the scan would miss the disclosure.
+func ubuntuRangesFromAffected(affected osvmodel.Affected) []db.Range {
+	var ranges []db.Range
+	for _, r := range affected.Ranges {
+		ranges = append(ranges, getGrypeRangesFromRange(r, ubuntuRangeType(r.Type))...)
+	}
+	if len(ranges) == 0 && len(affected.Ranges) > 0 {
+		ranges = []db.Range{{
+			Version: db.Version{Type: ubuntuRangeType(affected.Ranges[0].Type)},
+			Fix:     &db.Fix{State: ubuntuFixStateForNoFixSentinel(affected)},
+		}}
+	}
+	return ranges
+}
+
+// ubuntuFixStateForNoFixSentinel reads the vunnel-side VEX overlay annotation
+// to decide whether a no-fix sentinel range should be NotFixed (default,
+// "Canonical hasn't shipped a fix yet") or WontFix (Canonical explicitly
+// decided not to fix this on this release).
+//
+// The vunnel ubuntu provider stamps
+//
+//	affected[].database_specific.anchore.status = "wont-fix"
+//
+// onto sliced OSV records whose (cve, distro, source-pkg) tuple is
+// marked won't-fix in Canonical's OpenVEX feed. Canonical's published OSV
+// records do NOT carry this signal directly (they collapse six tracker
+// statuses into one OSV shape — see the publisher's status mapping table at
+// documentation.ubuntu.com/security/security-updates/osv/), so vunnel pulls
+// the disposition from the parallel VEX feed and bakes it into the fragment
+// at write time. Reading it here closes the loop.
+func ubuntuFixStateForNoFixSentinel(affected osvmodel.Affected) db.FixStatus {
+	if osvmodel.AffectedExtension(affected.DatabaseSpecific).Status == "wont-fix" {
+		return db.WontFixStatus
+	}
+	return db.NotFixedStatus
+}
+
+// ubuntuRangeType maps OSV's RangeType to grype's version-format string. For
+// Ubuntu the ECOSYSTEM type means dpkg-formatted versions; any other shape
+// falls through to the default so unexpected inputs are caught rather than
+// silently emitted as ECOSYSTEM-typed.
+func ubuntuRangeType(t osvmodel.RangeType) string {
+	if t == osvmodel.RangeEcosystem {
+		return ubuntuPkgFormat
+	}
+	return defaultRangeType(t)
+}
+
+// ubuntuOSFromEcosystem parses Canonical's ecosystem strings. Three real
+// shapes (per actual osv-all.tar.xz records):
+//
+//   - "Ubuntu:24.04:LTS"     — 3-segment, LTS suffix decorative.
+//   - "Ubuntu:25.10"         — 2-segment, interim release.
+//   - "Ubuntu:Pro:14.04:LTS" — 4-segment, Pro/ESM marker in slot 2.
+//
+// Anything else is unparseable; the caller skips that affected entry rather
+// than synthesizing partial OS rows.
+func ubuntuOSFromEcosystem(ecosystem string) *db.OperatingSystem {
+	parts := strings.Split(ecosystem, ":")
+	if len(parts) < 2 || !strings.EqualFold(parts[0], "Ubuntu") {
+		return nil
+	}
+
+	var channel, version string
+	switch {
+	case strings.EqualFold(parts[1], "Pro"):
+		// Ubuntu:Pro:<version>[:LTS]
+		if len(parts) < 3 {
+			return nil
+		}
+		channel = ubuntuESMChannel
+		version = parts[2]
+	default:
+		// Ubuntu:<version>[:LTS]
+		version = parts[1]
+	}
+
+	major, minor, ok := splitUbuntuVersion(version)
+	if !ok {
+		return nil
+	}
+
+	return &db.OperatingSystem{
+		Name:         ubuntu,
+		ReleaseID:    ubuntu,
+		MajorVersion: major,
+		MinorVersion: minor,
+		Channel:      channel,
+		Codename:     codename.LookupOS(ubuntu, major, minor),
+	}
+}
+
+func splitUbuntuVersion(v string) (string, string, bool) {
+	if v == "" {
+		return "", "", false
+	}
+	fields := strings.SplitN(v, ".", 2)
+	major := fields[0]
+	if _, err := strconv.Atoi(major); err != nil {
+		return "", "", false
+	}
+	var minor string
+	if len(fields) > 1 {
+		minor = fields[1]
+	}
+	return major, minor, true
+}

--- a/grype/db/v6/build/transformers/osv/transform_ubuntu_test.go
+++ b/grype/db/v6/build/transformers/osv/transform_ubuntu_test.go
@@ -1,0 +1,818 @@
+package osv
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
+	db "github.com/anchore/grype/grype/db/v6"
+	"github.com/anchore/grype/grype/db/v6/build/transformers"
+)
+
+// TestUbuntuTransform exercises the ubuntu strategy against real UBUNTU-CVE-*
+// fixtures extracted from the on-disk vunnel cache.
+//
+// The contract being locked in here is the *dpkg matcher's* contract — not the
+// alma/bitnami/rootio contract. The dpkg matcher already queries DB rows
+// produced by the legacy OS-schema transformer for Ubuntu records today
+// (grype/db/v6/build/transformers/os/transform.go); the ubuntu OSV strategy
+// must produce rows fungible with those, so that the matcher cannot tell the
+// difference between an OSV-sourced row and a legacy OS-sourced row:
+//
+//   - db.AffectedPackageHandle (AK semantic, matching os.Transform's
+//     getPackages affected path — not the alma/rootio NAK path).
+//   - Package.Ecosystem == "deb" (dpkg matcher gates on syftPkg.DebPkg).
+//   - OperatingSystem with Name="ubuntu", ReleaseID="ubuntu", MajorVersion,
+//     MinorVersion, and Codename populated from the codename lookup; Channel
+//     populated for ESM/Pro releases.
+//   - Range.Version.Type == "dpkg" (matches os.Transform's
+//     fixedInEntry.VersionFormat for ubuntu records).
+//   - Range.Version.Constraint == "< <fix>" when a fixed event exists, "" when
+//     only {introduced:"0"} is present (mirroring the OS transformer's
+//     enforceConstraint behavior for AffectedPackageHandle with empty fixed
+//     version).
+//   - Range.Fix.State == FixedStatus when fix version present;
+//     NotFixedStatus when fix version absent. Detail.Available populated
+//     from database_specific.anchore.fixes[] via the shared
+//     extractFixAvailability helper.
+//
+// Each fixture targets a distinct shape:
+//
+//   - UBUNTU-CVE-2023-38545 (curl): dominant shape — fix events, multi-release
+//     (Ubuntu:22.04:LTS + Ubuntu:24.04:LTS), mixed CVSS_V3 + Ubuntu vendor
+//     severity, anchore fix-availability detail.
+//   - UBUNTU-CVE-2006-20001 (apache2): Pro/ESM coverage — five affecteds
+//     spanning Ubuntu:Pro:14.04:LTS (no fix), Ubuntu:Pro:16.04:LTS (with
+//     +esm-suffixed fix), and three regular LTS releases. Locks in Channel
+//     handling and the not-fixed Pro entry simultaneously.
+//   - UBUNTU-CVE-2001-1593 (a2ps): withdrawn record. Locks in skip behavior.
+//   - UBUNTU-CVE-2008-7320 (seahorse): withdrawn + schema-1.6.3 tail. Locks
+//     in the skip behavior on the older schema variant.
+func TestUbuntuTransform(t *testing.T) {
+	tests := []transformCase{
+		{
+			name:        "UBUNTU-CVE-2023-38545 (curl) — fix events, multi-release, mixed severity",
+			fixturePath: "testdata/UBUNTU-CVE-2023-38545.json",
+			want: []transformers.RelatedEntries{{
+				VulnerabilityHandle: &db.VulnerabilityHandle{
+					// Name and BlobValue.ID are the upstream CVE — that's the
+					// identifier users have always seen for Ubuntu records
+					// in grype output. The OSV record id "UBUNTU-CVE-2023-38545"
+					// is Canonical's internal key and is intentionally not
+					// stored anywhere on the row.
+					Name:          "CVE-2023-38545",
+					Status:        db.VulnerabilityActive,
+					ProviderID:    "osv",
+					Provider:      expectedProvider(),
+					ModifiedDate:  timeRef(time.Date(2026, time.April, 22, 7, 45, 24, 0, time.UTC)),
+					PublishedDate: timeRef(time.Date(2023, time.October, 11, 6, 0, 0, 0, time.UTC)),
+					BlobValue: &db.VulnerabilityBlob{
+						ID:          "CVE-2023-38545",
+						Description: "This flaw makes curl overflow a heap based buffer in the SOCKS5 proxy handshake. When curl is asked to pass along the host name to the SOCKS5 proxy to allow that to resolve the address instead of it getting done by curl itself, the maximum length that host name can be is 255 bytes. If the host name is detected to be longer, curl switches to local name resolving and instead passes on the resolved address only. Due to this bug, the local variable that means \"let the host resolve the name\" could get the wrong value during a slow SOCKS5 handshake, and contrary to the intention, copy the too long host name to the target buffer instead of copying just the resolved address there. The target buffer being a heap based buffer, and the host name coming from the URL that curl has been told to operate with.",
+						References: []db.Reference{
+							{URL: "https://ubuntu.com/security/CVE-2023-38545", Tags: []string{"REPORT"}},
+							{URL: "https://curl.se/docs/CVE-2023-38545.html", Tags: []string{"REPORT"}},
+							{URL: "https://ubuntu.com/security/notices/USN-6429-1", Tags: []string{"ADVISORY"}},
+							{URL: "https://ubuntu.com/security/notices/USN-6429-3", Tags: []string{"ADVISORY"}},
+							{URL: "https://www.cve.org/CVERecord?id=CVE-2023-38545", Tags: []string{"REPORT"}},
+						},
+						// The first (and typically only) upstream CVE is promoted to Name
+						// above; Aliases holds any *additional* upstreams. Most Ubuntu
+						// OSV records carry a single upstream, so this is nil for the
+						// dominant case. Mirrors the legacy OS transformer, whose
+						// getAliases returns Metadata.CVE (empty for real ubuntu records).
+						Aliases: nil,
+						// Ubuntu vendor severity goes through the CHMLN scheme (lowercase
+						// "high"/"medium"/"low"/"negligible"/"unknown") — same mapping the
+						// legacy OS transformer uses for the vulnerability.Severity string,
+						// so OSV-sourced and OS-sourced rows are indistinguishable downstream.
+						// CHMLN comes first, then CVSS entries in source order; the legacy
+						// transformer emits the same ordering.
+						Severities: []db.Severity{
+							{Scheme: db.SeveritySchemeCHMLN, Value: "high", Rank: 1},
+							{Scheme: db.SeveritySchemeCVSS, Value: db.CVSSSeverity{
+								Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+								Version: "3.1",
+							}, Rank: 2},
+							{Scheme: db.SeveritySchemeCVSS, Value: db.CVSSSeverity{
+								Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+								Version: "3.1",
+							}, Rank: 2},
+						},
+					},
+				},
+				Related: affectedPkgSlice(
+					db.AffectedPackageHandle{
+						Package: &db.Package{
+							Name:      "curl",
+							Ecosystem: "deb",
+						},
+						OperatingSystem: &db.OperatingSystem{
+							Name:         "ubuntu",
+							ReleaseID:    "ubuntu",
+							MajorVersion: "22",
+							MinorVersion: "04",
+							Codename:     "jammy",
+						},
+						BlobValue: &db.PackageBlob{
+							// Single-upstream case → no "extra" CVEs to surface; the
+							// upstream is already the row's primary Name. Mirrors
+							// legacy ubuntu PackageBlob.CVEs (which is empty since
+							// Metadata.CVE is empty on those records).
+							CVEs: nil,
+							Ranges: []db.Range{{
+								Version: db.Version{
+									Type:       "dpkg",
+									Constraint: "< 7.81.0-1ubuntu1.14",
+								},
+								Fix: &db.Fix{
+									Version: "7.81.0-1ubuntu1.14",
+									State:   db.FixedStatus,
+									Detail: &db.FixDetail{
+										Available: &db.FixAvailability{
+											Date: timeRef(time.Date(2023, time.October, 11, 0, 0, 0, 0, time.UTC)),
+											Kind: "advisory",
+										},
+									},
+								},
+							}},
+						},
+					},
+					db.AffectedPackageHandle{
+						Package: &db.Package{
+							Name:      "curl",
+							Ecosystem: "deb",
+						},
+						OperatingSystem: &db.OperatingSystem{
+							Name:         "ubuntu",
+							ReleaseID:    "ubuntu",
+							MajorVersion: "24",
+							MinorVersion: "04",
+							Codename:     "noble",
+						},
+						BlobValue: &db.PackageBlob{
+							// Single-upstream case → no "extra" CVEs to surface; the
+							// upstream is already the row's primary Name. Mirrors
+							// legacy ubuntu PackageBlob.CVEs (which is empty since
+							// Metadata.CVE is empty on those records).
+							CVEs: nil,
+							Ranges: []db.Range{{
+								Version: db.Version{
+									Type:       "dpkg",
+									Constraint: "< 8.2.1-1ubuntu3.1",
+								},
+								Fix: &db.Fix{
+									Version: "8.2.1-1ubuntu3.1",
+									State:   db.FixedStatus,
+									Detail: &db.FixDetail{
+										Available: &db.FixAvailability{
+											Date: timeRef(time.Date(2023, time.October, 11, 0, 0, 0, 0, time.UTC)),
+											Kind: "advisory",
+										},
+									},
+								},
+							}},
+						},
+					},
+				),
+			}},
+		},
+		{
+			name:        "UBUNTU-CVE-2006-20001 (apache2) — Pro/ESM mix, no-fix Pro entry, +esm fix suffix",
+			fixturePath: "testdata/UBUNTU-CVE-2006-20001.json",
+			want: []transformers.RelatedEntries{{
+				VulnerabilityHandle: &db.VulnerabilityHandle{
+					Name:          "CVE-2006-20001",
+					Status:        db.VulnerabilityActive,
+					ProviderID:    "osv",
+					Provider:      expectedProvider(),
+					ModifiedDate:  timeRef(time.Date(2026, time.April, 22, 7, 37, 33, 0, time.UTC)),
+					PublishedDate: timeRef(time.Date(2023, time.January, 17, 20, 15, 0, 0, time.UTC)),
+					BlobValue: &db.VulnerabilityBlob{
+						ID:          "CVE-2006-20001",
+						Description: "A carefully crafted If: request header can cause a memory read, or write of a single zero byte, in a pool (heap) memory location beyond the header value sent. This could cause the process to crash. This issue affects Apache HTTP Server 2.4.54 and earlier.",
+						References: []db.Reference{
+							{URL: "https://ubuntu.com/security/CVE-2006-20001", Tags: []string{"REPORT"}},
+							{URL: "https://www.openwall.com/lists/oss-security/2023/01/17/5", Tags: []string{"REPORT"}},
+							{URL: "https://httpd.apache.org/security/vulnerabilities_24.html#CVE-2006-20001", Tags: []string{"REPORT"}},
+							{URL: "https://httpd.apache.org/security/vulnerabilities_24.html", Tags: []string{"REPORT"}},
+							{URL: "https://ubuntu.com/security/notices/USN-5834-1", Tags: []string{"ADVISORY"}},
+							{URL: "https://ubuntu.com/security/notices/USN-5839-1", Tags: []string{"ADVISORY"}},
+							{URL: "https://www.cve.org/CVERecord?id=CVE-2006-20001", Tags: []string{"REPORT"}},
+						},
+						Aliases: nil,
+						Severities: []db.Severity{
+							{Scheme: db.SeveritySchemeCHMLN, Value: "medium", Rank: 1},
+							{Scheme: db.SeveritySchemeCVSS, Value: db.CVSSSeverity{
+								Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+								Version: "3.1",
+							}, Rank: 2},
+						},
+					},
+				},
+				Related: affectedPkgSlice(
+					// Sort is by package name, then ecosystem, then constraint. All five
+					// entries share Name="apache2" and Ecosystem="deb"; constraint then
+					// tiebreaks: "" < "< 2.4.18-..." < "< 2.4.29-..." < "< 2.4.41-..." <
+					// "< 2.4.52-...". That puts Pro:14.04 (no fix, empty constraint) first
+					// and the rest in ascending fix-version order.
+					db.AffectedPackageHandle{
+						// Pro:14.04 — no fix shipped. Empty constraint + NotFixedStatus
+						// matches the legacy OS transformer's behavior for an
+						// AffectedPackageHandle whose FixedIn.Version cleans to empty.
+						Package: &db.Package{
+							Name:      "apache2",
+							Ecosystem: "deb",
+						},
+						OperatingSystem: &db.OperatingSystem{
+							Name:         "ubuntu",
+							ReleaseID:    "ubuntu",
+							MajorVersion: "14",
+							MinorVersion: "04",
+							Codename:     "trusty",
+							// Channel="esm" locks in the canonical name for Ubuntu Pro/ESM
+							// fix data — mirrors the existing FixChannel convention
+							// (distro.FixChannel.Name for RHEL EUS is "eus", per the
+							// short-channel-name pattern). This is a fresh design decision;
+							// no existing legacy data carried a channel, so this test pins
+							// the contract.
+							Channel: "esm",
+						},
+						BlobValue: &db.PackageBlob{
+							CVEs: nil,
+							Ranges: []db.Range{{
+								Version: db.Version{
+									Type:       "dpkg",
+									Constraint: "",
+								},
+								Fix: &db.Fix{
+									State: db.NotFixedStatus,
+								},
+							}},
+						},
+					},
+					db.AffectedPackageHandle{
+						// Pro:16.04 — fix shipped with +esm suffix. The Pro tier means
+						// Channel="esm"; the version string itself is opaque to the
+						// strategy.
+						Package: &db.Package{
+							Name:      "apache2",
+							Ecosystem: "deb",
+						},
+						OperatingSystem: &db.OperatingSystem{
+							Name:         "ubuntu",
+							ReleaseID:    "ubuntu",
+							MajorVersion: "16",
+							MinorVersion: "04",
+							Codename:     "xenial",
+							Channel:      "esm",
+						},
+						BlobValue: &db.PackageBlob{
+							CVEs: nil,
+							Ranges: []db.Range{{
+								Version: db.Version{
+									Type:       "dpkg",
+									Constraint: "< 2.4.18-2ubuntu3.17+esm8",
+								},
+								Fix: &db.Fix{
+									Version: "2.4.18-2ubuntu3.17+esm8",
+									State:   db.FixedStatus,
+									Detail: &db.FixDetail{
+										Available: &db.FixAvailability{
+											Date: timeRef(time.Date(2023, time.January, 17, 0, 0, 0, 0, time.UTC)),
+											Kind: "advisory",
+										},
+									},
+								},
+							}},
+						},
+					},
+					db.AffectedPackageHandle{
+						Package: &db.Package{
+							Name:      "apache2",
+							Ecosystem: "deb",
+						},
+						OperatingSystem: &db.OperatingSystem{
+							Name:         "ubuntu",
+							ReleaseID:    "ubuntu",
+							MajorVersion: "18",
+							MinorVersion: "04",
+							Codename:     "bionic",
+						},
+						BlobValue: &db.PackageBlob{
+							CVEs: nil,
+							Ranges: []db.Range{{
+								Version: db.Version{
+									Type:       "dpkg",
+									Constraint: "< 2.4.29-1ubuntu4.26",
+								},
+								Fix: &db.Fix{
+									Version: "2.4.29-1ubuntu4.26",
+									State:   db.FixedStatus,
+									Detail: &db.FixDetail{
+										Available: &db.FixAvailability{
+											Date: timeRef(time.Date(2023, time.January, 17, 0, 0, 0, 0, time.UTC)),
+											Kind: "advisory",
+										},
+									},
+								},
+							}},
+						},
+					},
+					db.AffectedPackageHandle{
+						Package: &db.Package{
+							Name:      "apache2",
+							Ecosystem: "deb",
+						},
+						OperatingSystem: &db.OperatingSystem{
+							Name:         "ubuntu",
+							ReleaseID:    "ubuntu",
+							MajorVersion: "20",
+							MinorVersion: "04",
+							Codename:     "focal",
+						},
+						BlobValue: &db.PackageBlob{
+							CVEs: nil,
+							Ranges: []db.Range{{
+								Version: db.Version{
+									Type:       "dpkg",
+									Constraint: "< 2.4.41-4ubuntu3.13",
+								},
+								Fix: &db.Fix{
+									Version: "2.4.41-4ubuntu3.13",
+									State:   db.FixedStatus,
+									Detail: &db.FixDetail{
+										Available: &db.FixAvailability{
+											Date: timeRef(time.Date(2023, time.January, 17, 0, 0, 0, 0, time.UTC)),
+											Kind: "advisory",
+										},
+									},
+								},
+							}},
+						},
+					},
+					db.AffectedPackageHandle{
+						Package: &db.Package{
+							Name:      "apache2",
+							Ecosystem: "deb",
+						},
+						OperatingSystem: &db.OperatingSystem{
+							Name:         "ubuntu",
+							ReleaseID:    "ubuntu",
+							MajorVersion: "22",
+							MinorVersion: "04",
+							Codename:     "jammy",
+						},
+						BlobValue: &db.PackageBlob{
+							CVEs: nil,
+							Ranges: []db.Range{{
+								Version: db.Version{
+									Type:       "dpkg",
+									Constraint: "< 2.4.52-1ubuntu4.3",
+								},
+								Fix: &db.Fix{
+									Version: "2.4.52-1ubuntu4.3",
+									State:   db.FixedStatus,
+									Detail: &db.FixDetail{
+										Available: &db.FixAvailability{
+											Date: timeRef(time.Date(2023, time.January, 17, 0, 0, 0, 0, time.UTC)),
+											Kind: "advisory",
+										},
+									},
+								},
+							}},
+						},
+					},
+				),
+			}},
+		},
+		{
+			// Withdrawn records are skipped entirely. Canonical retracted the CVE
+			// for this release; there's nothing to emit. Mirrors the alma/bitnami
+			// approach of "no entries" rather than "emit with Status=Rejected" —
+			// downstream consumers don't have to filter, and a future user
+			// scanning an EOL image against a CVE Canonical retracted won't get a
+			// stale hit. The legacy OS-schema record (if any survives in the
+			// legacy/ passthrough for this CVE) is emitted unchanged and is the
+			// only path a withdrawn-by-OSV CVE can still reach the DB.
+			name:        "UBUNTU-CVE-2001-1593 (a2ps) — withdrawn, skipped",
+			fixturePath: "testdata/UBUNTU-CVE-2001-1593.json",
+			want:        nil,
+		},
+		{
+			// Same skip path on the older schema variant; this fixture also lacks
+			// an `upstream` field (so a non-skipped path would need to handle
+			// nil-aliases too).
+			name:        "UBUNTU-CVE-2008-7320 (seahorse) — withdrawn + schema-1.6.3, skipped",
+			fixturePath: "testdata/UBUNTU-CVE-2008-7320.json",
+			want:        nil,
+		},
+	}
+	runTransformCases(t, tests)
+}
+
+// TestUbuntuStrategyMatches locks in the dispatch envelope — every ID that
+// the strategy claims, and (critically) every ID shape it must NOT claim. The
+// strategy registry is order-sensitive (first Matches wins), so a strategy
+// that over-claims could silently steal records from another provider. The
+// negative cases below catch:
+//
+//   - ALSA-/ALBA-/ALEA- (alma's territory)
+//   - BIT-               (bitnami)
+//   - ROOT-              (root.io)
+//   - USN-               (USN ingestion is deferred; the records exist in
+//     osv/usn/ but no strategy should be picking them up today)
+//   - GHSA-/CVE- generic OSV IDs (unscoped — should fall through to default
+//     skip with a warning, not be hijacked by ubuntu)
+//   - lowercased "ubuntu-cve-..." (vunnel writes the identifier lowercased
+//     when keying its results.db, but the OSV record's `id` field is
+//     uppercase. Matches() must gate on the uppercase form because Transform
+//     is invoked with the raw OSV record. Lowercase here would indicate the
+//     wrong shape was handed in.)
+func TestUbuntuStrategyMatches(t *testing.T) {
+	tests := []struct {
+		id   string
+		want bool
+	}{
+		{id: "UBUNTU-CVE-2023-38545", want: true},
+		{id: "UBUNTU-CVE-2001-1593", want: true},
+		// year boundary — still UBUNTU-CVE-, still claimed
+		{id: "UBUNTU-CVE-2026-0001", want: true},
+
+		// negative — other OSV providers
+		{id: "ALSA-2020:1636", want: false},
+		{id: "ALBA-2024:0001", want: false},
+		{id: "ALEA-2024:0001", want: false},
+		{id: "BIT-apache-2020-11984", want: false},
+		{id: "ROOT-OS-UBUNTU-2204-CVE-2025-68973", want: false},
+
+		// USN parsing is deferred — strategy should not claim USN records.
+		{id: "USN-6429-1", want: false},
+		{id: "USN-5834-1", want: false},
+
+		// generic / unscoped OSV IDs
+		{id: "GHSA-xxxx-yyyy-zzzz", want: false},
+		{id: "CVE-2023-38545", want: false},
+
+		// shape sentinels
+		{id: "", want: false},
+		{id: "ubuntu-cve-2023-38545", want: false}, // lowercase: matcher input is the OSV record's uppercase ID
+		{id: "UBUNTU-USN-6429-1", want: false},     // hypothetical USN-flavored ubuntu ID — still not ours
+		{id: "UBUNTU-CVE", want: false},            // prefix-only, no actual CVE id
+	}
+	s := ubuntuStrategy{}
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			if got := s.Matches(tt.id); got != tt.want {
+				t.Errorf("ubuntuStrategy.Matches(%q) = %v, want %v", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUbuntuOSFromEcosystem locks in the ecosystem-string parser. Real records
+// emit three shapes:
+//
+//   - "Ubuntu:22.04:LTS" — 3-segment, LTS suffix is decorative.
+//   - "Ubuntu:25.10"     — 2-segment, interim release.
+//   - "Ubuntu:Pro:14.04:LTS" — 4-segment, Pro/ESM channel.
+//
+// The dpkg matcher's search.ByDistro criteria gates on (Name, MajorVersion,
+// MinorVersion, Channel), so all four must land correctly for the matcher to
+// resolve queries against these OS rows. Codename is populated via the same
+// codename lookup the legacy transformer uses (`codename.LookupOS`); rows
+// without a codename in the table get an empty Codename rather than failing.
+func TestUbuntuOSFromEcosystem(t *testing.T) {
+	tests := []struct {
+		name      string
+		ecosystem string
+		want      *db.OperatingSystem
+	}{
+		{
+			name:      "standard LTS 3-segment",
+			ecosystem: "Ubuntu:22.04:LTS",
+			want: &db.OperatingSystem{
+				Name:         "ubuntu",
+				ReleaseID:    "ubuntu",
+				MajorVersion: "22",
+				MinorVersion: "04",
+				Codename:     "jammy",
+			},
+		},
+		{
+			name:      "trusty (oldest covered LTS)",
+			ecosystem: "Ubuntu:14.04:LTS",
+			want: &db.OperatingSystem{
+				Name:         "ubuntu",
+				ReleaseID:    "ubuntu",
+				MajorVersion: "14",
+				MinorVersion: "04",
+				Codename:     "trusty",
+			},
+		},
+		{
+			name:      "noble (current LTS)",
+			ecosystem: "Ubuntu:24.04:LTS",
+			want: &db.OperatingSystem{
+				Name:         "ubuntu",
+				ReleaseID:    "ubuntu",
+				MajorVersion: "24",
+				MinorVersion: "04",
+				Codename:     "noble",
+			},
+		},
+		{
+			name:      "interim 2-segment (no :LTS)",
+			ecosystem: "Ubuntu:25.10",
+			want: &db.OperatingSystem{
+				Name:         "ubuntu",
+				ReleaseID:    "ubuntu",
+				MajorVersion: "25",
+				MinorVersion: "10",
+				Codename:     "questing",
+			},
+		},
+		{
+			name:      "Pro 4-segment with :LTS",
+			ecosystem: "Ubuntu:Pro:14.04:LTS",
+			want: &db.OperatingSystem{
+				Name:         "ubuntu",
+				ReleaseID:    "ubuntu",
+				MajorVersion: "14",
+				MinorVersion: "04",
+				Codename:     "trusty",
+				Channel:      "esm",
+			},
+		},
+		{
+			name:      "Pro 4-segment, current LTS",
+			ecosystem: "Ubuntu:Pro:22.04:LTS",
+			want: &db.OperatingSystem{
+				Name:         "ubuntu",
+				ReleaseID:    "ubuntu",
+				MajorVersion: "22",
+				MinorVersion: "04",
+				Codename:     "jammy",
+				Channel:      "esm",
+			},
+		},
+
+		// --- negative cases ---
+		//
+		// The strategy is the only caller of this function, and it discards
+		// the affected entry on nil return. We want every malformed input to
+		// produce nil rather than a partially-populated OperatingSystem the
+		// matcher would then half-resolve.
+		{
+			name:      "empty string",
+			ecosystem: "",
+			want:      nil,
+		},
+		{
+			name:      "single segment, no version",
+			ecosystem: "Ubuntu",
+			want:      nil,
+		},
+		{
+			name:      "wrong distro",
+			ecosystem: "Debian:11",
+			want:      nil,
+		},
+		{
+			name:      "non-numeric version major",
+			ecosystem: "Ubuntu:focal",
+			want:      nil,
+		},
+		{
+			name:      "Pro with no version",
+			ecosystem: "Ubuntu:Pro",
+			want:      nil,
+		},
+		{
+			name:      "Pro with non-numeric version",
+			ecosystem: "Ubuntu:Pro:jammy:LTS",
+			want:      nil,
+		},
+		{
+			name:      "lowercase 'ubuntu' (case-insensitive distro match)",
+			ecosystem: "ubuntu:22.04:LTS",
+			want: &db.OperatingSystem{
+				Name:         "ubuntu",
+				ReleaseID:    "ubuntu",
+				MajorVersion: "22",
+				MinorVersion: "04",
+				Codename:     "jammy",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ubuntuOSFromEcosystem(tt.ecosystem)
+			if got == nil || tt.want == nil {
+				if got != tt.want {
+					t.Errorf("ubuntuOSFromEcosystem(%q) = %v, want %v", tt.ecosystem, got, tt.want)
+				}
+				return
+			}
+			if *got != *tt.want {
+				t.Errorf("ubuntuOSFromEcosystem(%q):\n  got:  %+v\n  want: %+v", tt.ecosystem, *got, *tt.want)
+			}
+		})
+	}
+}
+
+// TestUbuntuRangesFromAffected locks in the range-shape decisions independent
+// of any specific fixture. The shared getGrypeRangesFromRange helper already
+// handles introduced/fixed pairs correctly (alma/bitnami/rootio share it), but
+// it returns an empty slice when an affected entry only carries
+// {introduced:"0"} with no fixed event. The legacy OS transformer's
+// AffectedPackageHandle path produces an empty-constraint range with
+// NotFixedStatus for that condition (FixedIn with empty Version), so the
+// ubuntu OSV strategy needs to do the same — otherwise the dpkg matcher will
+// see a hole where Canonical says "we acknowledge this CVE but no fix has
+// shipped." `ubuntuRangesFromAffected` wraps the shared helper and adds that
+// sentinel.
+func TestUbuntuRangesFromAffected(t *testing.T) {
+	tests := []struct {
+		name     string
+		affected osvmodel.Affected
+		want     []db.Range
+	}{
+		{
+			name: "introduced=0 + fixed produces < fix range with FixedStatus and fix availability",
+			affected: osvmodel.Affected{
+				Ranges: []osvmodel.Range{{
+					Type: osvmodel.RangeEcosystem,
+					Events: []osvmodel.Event{
+						{Introduced: "0"},
+						{Fixed: "7.81.0-1ubuntu1.14"},
+					},
+					DatabaseSpecific: map[string]any{
+						"anchore": map[string]any{
+							"fixes": []any{
+								map[string]any{
+									"version": "7.81.0-1ubuntu1.14",
+									"date":    "2023-10-11",
+									"kind":    "advisory",
+								},
+							},
+						},
+					},
+				}},
+			},
+			want: []db.Range{{
+				Version: db.Version{Type: "dpkg", Constraint: "< 7.81.0-1ubuntu1.14"},
+				Fix: &db.Fix{
+					Version: "7.81.0-1ubuntu1.14",
+					State:   db.FixedStatus,
+					Detail: &db.FixDetail{
+						Available: &db.FixAvailability{
+							Date: timeRef(time.Date(2023, time.October, 11, 0, 0, 0, 0, time.UTC)),
+							Kind: "advisory",
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "bare introduced=0 produces empty-constraint range with NotFixedStatus",
+			affected: osvmodel.Affected{
+				Ranges: []osvmodel.Range{{
+					Type: osvmodel.RangeEcosystem,
+					Events: []osvmodel.Event{
+						{Introduced: "0"},
+					},
+				}},
+			},
+			want: []db.Range{{
+				Version: db.Version{Type: "dpkg", Constraint: ""},
+				Fix:     &db.Fix{State: db.NotFixedStatus},
+			}},
+		},
+		{
+			name: "fix with +esm suffix preserved verbatim",
+			affected: osvmodel.Affected{
+				Ranges: []osvmodel.Range{{
+					Type: osvmodel.RangeEcosystem,
+					Events: []osvmodel.Event{
+						{Introduced: "0"},
+						{Fixed: "2.4.18-2ubuntu3.17+esm8"},
+					},
+				}},
+			},
+			want: []db.Range{{
+				Version: db.Version{Type: "dpkg", Constraint: "< 2.4.18-2ubuntu3.17+esm8"},
+				Fix: &db.Fix{
+					Version: "2.4.18-2ubuntu3.17+esm8",
+					State:   db.FixedStatus,
+				},
+			}},
+		},
+		{
+			// vunnel stamps database_specific.anchore.status = "wont-fix" onto sliced
+			// records whose (cve, distro, source-pkg) tuple is marked won't-fix in
+			// Canonical's OpenVEX feed. The no-fix sentinel range we emit here must
+			// honor that signal — otherwise this is the user-visible regression vs.
+			// the v3 OS-schema path (which used VendorAdvisory.NoAdvisory:true →
+			// WontFixStatus for the same semantic).
+			name: "bare introduced=0 with vex wont-fix annotation produces WontFixStatus sentinel",
+			affected: osvmodel.Affected{
+				DatabaseSpecific: map[string]any{
+					"anchore": map[string]any{
+						"status": "wont-fix",
+					},
+				},
+				Ranges: []osvmodel.Range{{
+					Type: osvmodel.RangeEcosystem,
+					Events: []osvmodel.Event{
+						{Introduced: "0"},
+					},
+				}},
+			},
+			want: []db.Range{{
+				Version: db.Version{Type: "dpkg", Constraint: ""},
+				Fix:     &db.Fix{State: db.WontFixStatus},
+			}},
+		},
+		{
+			// status set but not "wont-fix" → fall back to NotFixedStatus. Forward-compatible
+			// with any future status values vunnel might emit.
+			name: "bare introduced=0 with unrecognized anchore.status falls back to NotFixedStatus",
+			affected: osvmodel.Affected{
+				DatabaseSpecific: map[string]any{
+					"anchore": map[string]any{
+						"status": "some-future-value",
+					},
+				},
+				Ranges: []osvmodel.Range{{
+					Type: osvmodel.RangeEcosystem,
+					Events: []osvmodel.Event{
+						{Introduced: "0"},
+					},
+				}},
+			},
+			want: []db.Range{{
+				Version: db.Version{Type: "dpkg", Constraint: ""},
+				Fix:     &db.Fix{State: db.NotFixedStatus},
+			}},
+		},
+		{
+			// anchore key present but no status sub-key → NotFixedStatus.
+			name: "bare introduced=0 with anchore but no status key falls back to NotFixedStatus",
+			affected: osvmodel.Affected{
+				DatabaseSpecific: map[string]any{
+					"anchore": map[string]any{
+						"fixes": []any{},
+					},
+				},
+				Ranges: []osvmodel.Range{{
+					Type: osvmodel.RangeEcosystem,
+					Events: []osvmodel.Event{
+						{Introduced: "0"},
+					},
+				}},
+			},
+			want: []db.Range{{
+				Version: db.Version{Type: "dpkg", Constraint: ""},
+				Fix:     &db.Fix{State: db.NotFixedStatus},
+			}},
+		},
+		{
+			// wont-fix annotation is ignored when there IS a fixed event — the shared
+			// helper produces the FixedStatus range and the no-fix sentinel doesn't fire.
+			// Forward-protects against a confusing combination (annotation says wont-fix
+			// but Canonical also published a fix on the same release).
+			name: "wont-fix annotation ignored when a fixed event is present",
+			affected: osvmodel.Affected{
+				DatabaseSpecific: map[string]any{
+					"anchore": map[string]any{
+						"status": "wont-fix",
+					},
+				},
+				Ranges: []osvmodel.Range{{
+					Type: osvmodel.RangeEcosystem,
+					Events: []osvmodel.Event{
+						{Introduced: "0"},
+						{Fixed: "1.2.3-0ubuntu1"},
+					},
+				}},
+			},
+			want: []db.Range{{
+				Version: db.Version{Type: "dpkg", Constraint: "< 1.2.3-0ubuntu1"},
+				Fix: &db.Fix{
+					Version: "1.2.3-0ubuntu1",
+					State:   db.FixedStatus,
+				},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ubuntuRangesFromAffected(tt.affected)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ubuntuRangesFromAffected:\n  got:  %+v\n  want: %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/grype/matcher/dpkg/matcher_ubuntu_test.go
+++ b/grype/matcher/dpkg/matcher_ubuntu_test.go
@@ -1,0 +1,193 @@
+package dpkg
+
+import (
+	"testing"
+
+	"github.com/anchore/grype/grype/distro"
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/internal/dbtest"
+	"github.com/anchore/syft/syft/artifact"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+// ubuntu/dpkg matching is the end-to-end coverage for the vunnel ubuntu OSV
+// rewrite: the fixtures under internal/dbtest/testdata/shared/all/ubuntu/ are
+// real records extracted from the post-rewrite vunnel cache (mixed-schema
+// results.db: 49k OSV-1.7.0 + 585 OSV-1.6.3 + 176k legacy OS-1.1.0). These
+// tests assert that the new osv ubuntu strategy produces DB rows that the
+// existing dpkg matcher can resolve — i.e. that an OSV-sourced row and a
+// legacy-OS-sourced row are functionally indistinguishable to the matcher.
+
+const ubuntuReasonDistroPackageFixed = "DistroPackageFixed"
+
+// Ubuntu Pro / ESM distro for tests against ESM channel rows. distro.New
+// parses the "+esm" suffix into the Channels slice; that flows through
+// search.ByDistro and matches OperatingSystem rows whose Channel field is
+// "esm" (what the ubuntu strategy writes for Ubuntu:Pro:* ecosystems).
+var ubuntu1604ESM = distro.New(distro.Ubuntu, "16.04+esm", "")
+
+// === OSV path: ubuntu strategy → AffectedPackageHandle → dpkg matcher ===
+
+// TestMatcherDpkg_Ubuntu_DirectMatch_OSV is the load-bearing case. curl
+// 7.81.0-1ubuntu1.13 on jammy is vulnerable to CVE-2023-38545 per
+// UBUNTU-CVE-2023-38545 (fix: 7.81.0-1ubuntu1.14). If this test fails, the
+// new ubuntu OSV strategy is not producing rows the dpkg matcher can find,
+// and the whole vunnel rewrite is blocked.
+func TestMatcherDpkg_Ubuntu_DirectMatch_OSV(t *testing.T) {
+	dbtest.SharedDBs(t, "all").
+		SelectOnly("ubuntu-cve-2023-38545").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			matcher := Matcher{}
+			p := dbtest.NewPackage("curl", "7.81.0-1ubuntu1.13", syftPkg.DebPkg).
+				WithDistro(dbtest.Ubuntu2204).
+				Build()
+
+			db.Match(t, &matcher, p).
+				SelectMatch("CVE-2023-38545").
+				SelectDetailByType(match.ExactDirectMatch).
+				AsDistroSearch()
+		})
+}
+
+// TestMatcherDpkg_Ubuntu_IndirectMatch_OSV exercises source indirection
+// against an OSV-sourced row: the SBOM has the binary libcurl4 (which is one
+// of the binaries listed in UBUNTU-CVE-2023-38545.affected[0].ecosystem_specific.binaries),
+// but the DB row is keyed on the source package "curl". The dpkg matcher
+// fans out via pkg.UpstreamPackages and resolves to the source-keyed row.
+//
+// This is the test that proves we can skip storing binary expansions in the
+// DB and rely on the matcher's existing source-indirection logic — exactly
+// the design decision baked into the ubuntu strategy.
+func TestMatcherDpkg_Ubuntu_IndirectMatch_OSV(t *testing.T) {
+	dbtest.SharedDBs(t, "all").
+		SelectOnly("ubuntu-cve-2023-38545").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			matcher := Matcher{}
+			p := dbtest.NewPackage("libcurl4", "7.81.0-1ubuntu1.13", syftPkg.DebPkg).
+				WithDistro(dbtest.Ubuntu2204).
+				WithUpstream("curl", "").
+				Build()
+
+			db.Match(t, &matcher, p).
+				SelectMatch("CVE-2023-38545").
+				SelectDetailByType(match.ExactIndirectMatch).
+				AsDistroSearch()
+		})
+}
+
+// TestMatcherDpkg_Ubuntu_FixedVersionProducesIgnore_OSV is the negative case
+// against an OSV row: curl is at the exact fix version, so the matcher
+// resolves the CVE row, sees the pkg version is >= the constraint, and emits
+// a DistroPackageFixed ignore instead of a match. This locks in that the
+// "< fix" constraint produced by the ubuntu strategy is actually being
+// evaluated correctly by the dpkg version comparator.
+func TestMatcherDpkg_Ubuntu_FixedVersionProducesIgnore_OSV(t *testing.T) {
+	dbtest.SharedDBs(t, "all").
+		SelectOnly("ubuntu-cve-2023-38545").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			matcher := Matcher{}
+			pkgID := pkg.ID("curl-jammy-fixed")
+			p := dbtest.NewPackage("curl", "7.81.0-1ubuntu1.14", syftPkg.DebPkg). // exact fix version
+												WithID(pkgID).
+												WithDistro(dbtest.Ubuntu2204).
+												Build()
+
+			// Primary ID is the upstream CVE; with no extra aliases on this
+			// record, OwnershipIgnores emits exactly one ignore filter.
+			db.Match(t, &matcher, p).Ignores().
+				SelectRelatedPackageIgnore(ubuntuReasonDistroPackageFixed, "CVE-2023-38545").
+				ForPackage(pkgID).
+				WithRelationshipType(artifact.OwnershipByFileOverlapRelationship)
+		})
+}
+
+// TestMatcherDpkg_Ubuntu_NoFixOSVStillMatches covers the ~38% of OSV records
+// that carry only {introduced:"0"} with no fixed event. Vunnel emits these as
+// AffectedPackageHandle with empty constraint + NotFixedStatus (per the no-fix
+// sentinel the ubuntu strategy adds); the dpkg matcher must treat an empty
+// constraint as "always vulnerable" — otherwise these disclosures vanish.
+//
+// UBUNTU-CVE-2006-20001 (apache2) has the no-fix shape on Ubuntu:Pro:14.04:LTS.
+// The Pro:14.04 row carries Channel="esm"; we exercise it via the Pro distro
+// below in TestMatcherDpkg_Ubuntu_Pro_NoFixMatch.
+
+// === OSV Pro / ESM path ===
+
+// TestMatcherDpkg_Ubuntu_Pro_DirectMatch verifies the Channel="esm" row
+// produced for Ubuntu:Pro:16.04:LTS resolves when the SBOM distro carries the
+// "+esm" channel suffix. apache2 2.4.18-2ubuntu3.10 on Ubuntu Pro 16.04 is
+// vulnerable to CVE-2006-20001 (fix: 2.4.18-2ubuntu3.17+esm8).
+func TestMatcherDpkg_Ubuntu_Pro_DirectMatch(t *testing.T) {
+	dbtest.SharedDBs(t, "all").
+		SelectOnly("ubuntu-cve-2006-20001").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			matcher := Matcher{}
+			p := dbtest.NewPackage("apache2", "2.4.18-2ubuntu3.10", syftPkg.DebPkg).
+				WithDistro(ubuntu1604ESM).
+				Build()
+
+			// SelectDetailByDistro pins the SearchedBy distro to the +esm
+			// form, which is what the matcher reports back when the channel
+			// is parsed off the package's distro version. Using AsDistroSearch()
+			// here would trip the package-vs-searched-by consistency check
+			// because p.Distro.Version is the suffix-stripped "16.04" while
+			// the matcher reports "16.04+esm" — by design, per the cross-
+			// namespace assertion docstring.
+			db.Match(t, &matcher, p).
+				SelectMatch("CVE-2006-20001").
+				SelectDetailByDistro("ubuntu", "16.04+esm").
+				HasMatchType(match.ExactDirectMatch)
+		})
+}
+
+// === Legacy OS-schema path (unchanged behavior, regression net) ===
+
+// TestMatcherDpkg_Ubuntu_DirectMatch_Legacy verifies that legacy OS-schema
+// records — produced by the unchanged os.Transform path for EOL/interim
+// releases that Canonical's OSV feed has dropped — continue to match exactly
+// as they did before the rewrite. curl 7.88.1-8ubuntu1 on 23.04 is vulnerable
+// per ubuntu:23.04/cve-2023-38545 (legacy fix: 7.88.1-8ubuntu2.3).
+//
+// 23.04 is interim (not LTS, not in Canonical's OSV feed). It only reaches
+// the DB via the legacy passthrough, so this is the regression net for the
+// mixed-schema-in-one-results.db design decision in the vunnel spec.
+func TestMatcherDpkg_Ubuntu_DirectMatch_Legacy(t *testing.T) {
+	dbtest.SharedDBs(t, "all").
+		SelectOnly("ubuntu:23.04/cve-2023-38545").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			matcher := Matcher{}
+			p := dbtest.NewPackage("curl", "7.88.1-8ubuntu1", syftPkg.DebPkg).
+				WithDistro(distro.New(distro.Ubuntu, "23.04", "")).
+				Build()
+
+			db.Match(t, &matcher, p).
+				SelectMatch("CVE-2023-38545").
+				SelectDetailByType(match.ExactDirectMatch).
+				AsDistroSearch()
+		})
+}
+
+// === Negative: distro the DB has no rows for ===
+
+// TestMatcherDpkg_Ubuntu_NoMatchOnUnknownRelease asserts the matcher emits
+// nothing — neither match nor ignore — when the SBOM's distro doesn't match
+// any OS row in the DB. This is the third class of negative case (beyond
+// "fixed version" and "wrong package"), and it sanity-checks that
+// search.ByDistro is actually gating queries by distro (not just package
+// name).
+//
+// We use Ubuntu 18.04, which has no row in the small fixture set (our
+// fixtures only carry 12.04/12.10/14.04/22.04/23.04/23.10/24.04/Pro:14/16).
+func TestMatcherDpkg_Ubuntu_NoMatchOnUnknownRelease(t *testing.T) {
+	dbtest.SharedDBs(t, "all").
+		SelectOnly("ubuntu-cve-2023-38545").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			matcher := Matcher{}
+			p := dbtest.NewPackage("curl", "7.58.0-2ubuntu3.6", syftPkg.DebPkg).
+				WithDistro(dbtest.Ubuntu1804).
+				Build()
+
+			db.Match(t, &matcher, p).IsEmpty()
+		})
+}

--- a/internal/dbtest/selection.go
+++ b/internal/dbtest/selection.go
@@ -48,8 +48,12 @@ func matchesSelection(identifier string, patterns []string) bool {
 //     Example: "debian:10/CVE-2024-1234" matches "debian:10/cve-2024-1234"
 //   - Namespace only (contains ":" but no "/"): prefix match (case-insensitive)
 //     Example: "debian:10" matches "debian:10/CVE-2024-1234", "debian:10/cve-2024-5678", etc.
-//   - CVE ID only (no ":" or "/"): suffix match (case-insensitive)
-//     Example: "CVE-2024-1234" matches "debian:10/cve-2024-1234", "ubuntu:20.04/CVE-2024-1234", etc.
+//   - Bare ID (no ":" or "/"): exact-or-suffix match (case-insensitive). Matches
+//     either an identifier equal to the pattern (e.g. an OSV record whose
+//     identifier is "ubuntu-cve-2023-38545") or any "<namespace>/<pattern>"
+//     identifier (e.g. legacy "ubuntu:23.04/cve-2023-38545").
+//     Example: "CVE-2024-1234" matches "debian:10/cve-2024-1234"; "ubuntu-cve-2023-38545"
+//     matches the bare-id OSV record of the same name.
 func matchesPattern(identifier, pattern string) bool {
 	identifier = strings.ToLower(identifier)
 	pattern = strings.ToLower(pattern)
@@ -64,8 +68,9 @@ func matchesPattern(identifier, pattern string) bool {
 		return strings.HasPrefix(identifier, pattern+"/")
 	}
 
-	// CVE ID: matches */CVE-ID
-	return strings.HasSuffix(identifier, "/"+pattern)
+	// bare ID: exact match (OSV-style identifiers carry no namespace) OR
+	// "<namespace>/<pattern>" suffix (legacy namespaced identifiers).
+	return identifier == pattern || strings.HasSuffix(identifier, "/"+pattern)
 }
 
 // filterResultFiles returns paths to result files whose identifiers match the selection patterns.

--- a/internal/dbtest/testdata/shared/all/db-lock.json
+++ b/internal/dbtest/testdata/shared/all/db-lock.json
@@ -1,5 +1,5 @@
 {
-  "content_hash": "d5f1982b4cbedc76",
+  "content_hash": "f9e1aa4271806c2b",
   "created_at": "2026-03-12T20:50:04.428614Z",
   "regenerated_at": "2026-03-24T11:17:43.450187Z",
   "providers": {
@@ -10,6 +10,10 @@
     "nvd": {
       "vunnel_version": "vunnel@0.55.2.post5+b0ff778",
       "timestamp": "2026-03-11T16:25:08.266565Z"
+    },
+    "ubuntu": {
+      "vunnel_version": "vunnel@0.58.0",
+      "timestamp": "2026-05-20T21:16:58.213122Z"
     }
   }
 }

--- a/internal/dbtest/testdata/shared/all/db.yaml
+++ b/internal/dbtest/testdata/shared/all/db.yaml
@@ -1,12 +1,21 @@
 auto-generate: true
 extractions:
-  debian:
-    - "debian:10/CVE-2024-0727"
-    - "debian:11/CVE-2024-0727"
-    - "debian:11/CVE-2022-0778"
-    - "debian:11/CVE-2023-0286"
-    - "debian:12/CVE-2024-0727"
-  nvd:
-    - "CVE-2024-0727"
-    - "CVE-2022-0778"
-    - "CVE-2023-0286"
+    debian:
+        - debian:10/CVE-2024-0727
+        - debian:11/CVE-2024-0727
+        - debian:11/CVE-2022-0778
+        - debian:11/CVE-2023-0286
+        - debian:12/CVE-2024-0727
+    nvd:
+        - CVE-2024-0727
+        - CVE-2022-0778
+        - CVE-2023-0286
+    ubuntu:
+        - cve-2023-38545
+        - ubuntu-cve-2002-2439
+        - ubuntu-cve-2001-1593
+        - ubuntu-cve-2008-7320
+        - ubuntu:12.04/cve-2013-2118
+        - cve-2014-0160
+        - ubuntu-cve-2006-20001
+        - ubuntu-cve-2006-20001

--- a/internal/dbtest/testdata/shared/all/ubuntu/metadata.json
+++ b/internal/dbtest/testdata/shared/all/ubuntu/metadata.json
@@ -1,0 +1,19 @@
+{
+  "provider": "ubuntu",
+  "version": 3,
+  "processor": "vunnel@0.58.0",
+  "schema": {
+    "version": "1.0.3",
+    "url": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/provider-workspace-state/schema-1.0.3.json"
+  },
+  "urls": [
+    "https://security-metadata.canonical.com/osv/osv-all.tar.xz"
+  ],
+  "timestamp": "2026-05-20T21:16:58Z",
+  "listing": {
+    "path": "results/listing.xxh64",
+    "digest": "7f1fcb737ac5d1df",
+    "algorithm": "xxh64"
+  },
+  "store": "flat-file"
+}

--- a/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu-cve-2001-1593.json
+++ b/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu-cve-2001-1593.json
@@ -1,0 +1,78 @@
+{
+  "identifier": "ubuntu-cve-2001-1593",
+  "item": {
+    "affected": [
+      {
+        "ecosystem_specific": {
+          "availability": "No subscription required",
+          "binaries": [
+            {
+              "binary_name": "a2ps",
+              "binary_version": "1:4.14-1.2"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:14.04:LTS",
+          "name": "a2ps",
+          "purl": "pkg:deb/ubuntu/a2ps@1:4.14-1.2?arch=source\u0026distro=trusty"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2014-04-05",
+                    "kind": "advisory",
+                    "version": "1:4.14-1.2"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "1:4.14-1.2"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "1:4.14-1.1"
+        ]
+      }
+    ],
+    "aliases": [],
+    "details": "Jakub Wilk found that a2ps, a tool to convert text and other types of files to PostScript, insecurely used a temporary file in spy_user(). A local attacker could use this flaw to perform a symbolic link attack to modify an arbitrary file accessible to the user running a2ps.",
+    "id": "UBUNTU-CVE-2001-1593",
+    "modified": "2025-07-16T04:49:52Z",
+    "published": "2014-04-05T21:55:00Z",
+    "references": [
+      {
+        "type": "REPORT",
+        "url": "https://ubuntu.com/security/CVE-2001-1593"
+      },
+      {
+        "type": "REPORT",
+        "url": "https://www.cve.org/CVERecord?id=CVE-2001-1593"
+      }
+    ],
+    "related": [],
+    "schema_version": "1.7.0",
+    "severity": [
+      {
+        "score": "low",
+        "type": "Ubuntu"
+      }
+    ],
+    "upstream": [
+      "CVE-2001-1593"
+    ],
+    "withdrawn": "2025-07-18T16:42:37Z"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.7.0.json"
+}

--- a/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu-cve-2002-2439.json
+++ b/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu-cve-2002-2439.json
@@ -1,0 +1,2370 @@
+{
+  "identifier": "ubuntu-cve-2002-2439",
+  "item": {
+    "affected": [
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "cpp-4.7",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "g++-4.7",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "g++-4.7-multilib",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "gcc-4.7",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "gcc-4.7-base",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "gcc-4.7-locales",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "gcc-4.7-multilib",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "gcc-4.7-source",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "gccgo-4.7",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "gccgo-4.7-multilib",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "gfortran-4.7",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "gfortran-4.7-multilib",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "gobjc++-4.7",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "gobjc++-4.7-multilib",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "gobjc-4.7",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "gobjc-4.7-multilib",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "lib32go0",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "lib64go0",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "libgo0",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "libstdc++6-4.7-pic",
+              "binary_version": "4.7.3-12ubuntu1"
+            },
+            {
+              "binary_name": "libx32go0",
+              "binary_version": "4.7.3-12ubuntu1"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:14.04:LTS",
+          "name": "gcc-4.7",
+          "purl": "pkg:deb/ubuntu/gcc-4.7@4.7.3-12ubuntu1?arch=source\u0026distro=trusty"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "4.7.3-7ubuntu3",
+          "4.7.3-8ubuntu1",
+          "4.7.3-9ubuntu1",
+          "4.7.3-9ubuntu2",
+          "4.7.3-10ubuntu1",
+          "4.7.3-11ubuntu1",
+          "4.7.3-12ubuntu1"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "g++-mingw-w64",
+              "binary_version": "4.8.2-10ubuntu2+12"
+            },
+            {
+              "binary_name": "g++-mingw-w64-i686",
+              "binary_version": "4.8.2-10ubuntu2+12"
+            },
+            {
+              "binary_name": "g++-mingw-w64-x86-64",
+              "binary_version": "4.8.2-10ubuntu2+12"
+            },
+            {
+              "binary_name": "gcc-mingw-w64",
+              "binary_version": "4.8.2-10ubuntu2+12"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-base",
+              "binary_version": "4.8.2-10ubuntu2+12"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686",
+              "binary_version": "4.8.2-10ubuntu2+12"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64",
+              "binary_version": "4.8.2-10ubuntu2+12"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64",
+              "binary_version": "4.8.2-10ubuntu2+12"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-i686",
+              "binary_version": "4.8.2-10ubuntu2+12"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-x86-64",
+              "binary_version": "4.8.2-10ubuntu2+12"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64",
+              "binary_version": "4.8.2-10ubuntu2+12"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-i686",
+              "binary_version": "4.8.2-10ubuntu2+12"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-x86-64",
+              "binary_version": "4.8.2-10ubuntu2+12"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64",
+              "binary_version": "4.8.2-10ubuntu2+12"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-i686",
+              "binary_version": "4.8.2-10ubuntu2+12"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-x86-64",
+              "binary_version": "4.8.2-10ubuntu2+12"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:14.04:LTS",
+          "name": "gcc-mingw-w64",
+          "purl": "pkg:deb/ubuntu/gcc-mingw-w64@12?arch=source\u0026distro=trusty"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "8",
+          "9",
+          "11",
+          "12"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "cpp-4.7",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "g++-4.7",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "g++-4.7-multilib",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "gcc-4.7",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "gcc-4.7-base",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "gcc-4.7-locales",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "gcc-4.7-multilib",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "gcc-4.7-source",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "gccgo-4.7",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "gccgo-4.7-multilib",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "gfortran-4.7",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "gfortran-4.7-multilib",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "gobjc++-4.7",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "gobjc++-4.7-multilib",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "gobjc-4.7",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "gobjc-4.7-multilib",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "lib32go0",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "lib64go0",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "libgo0",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "libstdc++6-4.7-pic",
+              "binary_version": "4.7.4-3ubuntu12"
+            },
+            {
+              "binary_name": "libx32go0",
+              "binary_version": "4.7.4-3ubuntu12"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:16.04:LTS",
+          "name": "gcc-4.7",
+          "purl": "pkg:deb/ubuntu/gcc-4.7@4.7.4-3ubuntu12?arch=source\u0026distro=xenial"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "4.7.4-3ubuntu3",
+          "4.7.4-3ubuntu7",
+          "4.7.4-3ubuntu9",
+          "4.7.4-3ubuntu10",
+          "4.7.4-3ubuntu11",
+          "4.7.4-3ubuntu12"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "cpp-4.7-arm-linux-gnueabi",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "g++-4.7-arm-linux-gnueabi",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "g++-4.7-multilib-arm-linux-gnueabi",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gcc-4.7-arm-linux-gnueabi",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gcc-4.7-arm-linux-gnueabi-base",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gcc-4.7-multilib-arm-linux-gnueabi",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gccgo-4.7-arm-linux-gnueabi",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gfortran-4.7-arm-linux-gnueabi",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gfortran-4.7-multilib-arm-linux-gnueabi",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gobjc++-4.7-arm-linux-gnueabi",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gobjc++-4.7-multilib-arm-linux-gnueabi",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gobjc-4.7-arm-linux-gnueabi",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gobjc-4.7-multilib-arm-linux-gnueabi",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libgcc-4.7-dev-armel-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libgfortran-4.7-dev-armel-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libgo0-armel-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libgo0-dbg-armel-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libhfgcc-4.7-dev-armel-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libhfgfortran-4.7-dev-armel-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libhfobjc-4.7-dev-armel-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libhfstdc++6-4.7-dbg-armel-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libhfstdc++6-4.7-dev-armel-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libobjc-4.7-dev-armel-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libstdc++6-4.7-dbg-armel-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libstdc++6-4.7-dev-armel-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libstdc++6-4.7-pic-armel-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:16.04:LTS",
+          "name": "gcc-4.7-armel-cross",
+          "purl": "pkg:deb/ubuntu/gcc-4.7-armel-cross@3?arch=source\u0026distro=xenial"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "1.86",
+          "1.90",
+          "3"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "cpp-4.7-arm-linux-gnueabihf",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "g++-4.7-arm-linux-gnueabihf",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "g++-4.7-multilib-arm-linux-gnueabihf",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gcc-4.7-arm-linux-gnueabihf",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gcc-4.7-arm-linux-gnueabihf-base",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gcc-4.7-multilib-arm-linux-gnueabihf",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gccgo-4.7-arm-linux-gnueabihf",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gfortran-4.7-arm-linux-gnueabihf",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gfortran-4.7-multilib-arm-linux-gnueabihf",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gobjc++-4.7-arm-linux-gnueabihf",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gobjc++-4.7-multilib-arm-linux-gnueabihf",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gobjc-4.7-arm-linux-gnueabihf",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "gobjc-4.7-multilib-arm-linux-gnueabihf",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libgcc-4.7-dev-armhf-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libgfortran-4.7-dev-armhf-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libgo0-armhf-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libgo0-dbg-armhf-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libobjc-4.7-dev-armhf-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libsfgcc-4.7-dev-armhf-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libsfgfortran-4.7-dev-armhf-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libsfobjc-4.7-dev-armhf-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libsfstdc++6-4.7-dbg-armhf-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libsfstdc++6-4.7-dev-armhf-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libstdc++6-4.7-dbg-armhf-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libstdc++6-4.7-dev-armhf-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            },
+            {
+              "binary_name": "libstdc++6-4.7-pic-armhf-cross",
+              "binary_version": "4.7.4-3ubuntu12cross3"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:16.04:LTS",
+          "name": "gcc-4.7-armhf-cross",
+          "purl": "pkg:deb/ubuntu/gcc-4.7-armhf-cross@3?arch=source\u0026distro=xenial"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "1.86",
+          "1.87",
+          "3"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-arm-linux-androideabi",
+              "binary_version": "0.20130705.1-0ubuntu9"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:16.04:LTS",
+          "name": "gcc-arm-linux-androideabi",
+          "purl": "pkg:deb/ubuntu/gcc-arm-linux-androideabi@0.20130705.1-0ubuntu9?arch=source\u0026distro=xenial"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "0.20130705.1-0ubuntu8",
+          "0.20130705.1-0ubuntu9"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-arm-none-eabi",
+              "binary_version": "15:4.9.3+svn231177-1"
+            },
+            {
+              "binary_name": "gcc-arm-none-eabi-source",
+              "binary_version": "15:4.9.3+svn231177-1"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:16.04:LTS",
+          "name": "gcc-arm-none-eabi",
+          "purl": "pkg:deb/ubuntu/gcc-arm-none-eabi@15:4.9.3+svn231177-1?arch=source\u0026distro=xenial"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "15:4.9.3+svn227297-1",
+          "15:4.9.3+svn227297-1build1",
+          "15:4.9.3+svn231177-1"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-h8300-hms",
+              "binary_version": "1:3.4.6+dfsg2-4ubuntu1"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:16.04:LTS",
+          "name": "gcc-h8300-hms",
+          "purl": "pkg:deb/ubuntu/gcc-h8300-hms@1:3.4.6+dfsg2-4ubuntu1?arch=source\u0026distro=xenial"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "1:3.4.6+dfsg2-4ubuntu1"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-i686-linux-android",
+              "binary_version": "9"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:16.04:LTS",
+          "name": "gcc-i686-linux-android",
+          "purl": "pkg:deb/ubuntu/gcc-i686-linux-android@9?arch=source\u0026distro=xenial"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "7",
+          "9"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "g++-mingw-w64",
+              "binary_version": "5.3.1-8ubuntu3+17"
+            },
+            {
+              "binary_name": "g++-mingw-w64-i686",
+              "binary_version": "5.3.1-8ubuntu3+17"
+            },
+            {
+              "binary_name": "g++-mingw-w64-x86-64",
+              "binary_version": "5.3.1-8ubuntu3+17"
+            },
+            {
+              "binary_name": "gcc-mingw-w64",
+              "binary_version": "5.3.1-8ubuntu3+17"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-base",
+              "binary_version": "5.3.1-8ubuntu3+17"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686",
+              "binary_version": "5.3.1-8ubuntu3+17"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64",
+              "binary_version": "5.3.1-8ubuntu3+17"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64",
+              "binary_version": "5.3.1-8ubuntu3+17"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-i686",
+              "binary_version": "5.3.1-8ubuntu3+17"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-x86-64",
+              "binary_version": "5.3.1-8ubuntu3+17"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64",
+              "binary_version": "5.3.1-8ubuntu3+17"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-i686",
+              "binary_version": "5.3.1-8ubuntu3+17"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-x86-64",
+              "binary_version": "5.3.1-8ubuntu3+17"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64",
+              "binary_version": "5.3.1-8ubuntu3+17"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-i686",
+              "binary_version": "5.3.1-8ubuntu3+17"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-x86-64",
+              "binary_version": "5.3.1-8ubuntu3+17"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:16.04:LTS",
+          "name": "gcc-mingw-w64",
+          "purl": "pkg:deb/ubuntu/gcc-mingw-w64@17?arch=source\u0026distro=xenial"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "15.4",
+          "15.7",
+          "15.7build1",
+          "16build1",
+          "17"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-msp430",
+              "binary_version": "4.6.3~mspgcc-20120406-7ubuntu3"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:16.04:LTS",
+          "name": "gcc-msp430",
+          "purl": "pkg:deb/ubuntu/gcc-msp430@4.6.3~mspgcc-20120406-7ubuntu3?arch=source\u0026distro=xenial"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "4.6.3~mspgcc-20120406-7ubuntu3"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-arm-none-eabi",
+              "binary_version": "15:6.3.1+svn253039-1build1"
+            },
+            {
+              "binary_name": "gcc-arm-none-eabi-source",
+              "binary_version": "15:6.3.1+svn253039-1build1"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:18.04:LTS",
+          "name": "gcc-arm-none-eabi",
+          "purl": "pkg:deb/ubuntu/gcc-arm-none-eabi@15:6.3.1+svn253039-1build1?arch=source\u0026distro=bionic"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "15:5.4.1+svn241155-1",
+          "15:6.3.1+svn253039-1",
+          "15:6.3.1+svn253039-1build1"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-h8300-hms",
+              "binary_version": "1:3.4.6+dfsg2-4ubuntu3"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:18.04:LTS",
+          "name": "gcc-h8300-hms",
+          "purl": "pkg:deb/ubuntu/gcc-h8300-hms@1:3.4.6+dfsg2-4ubuntu3?arch=source\u0026distro=bionic"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "1:3.4.6+dfsg2-4ubuntu1",
+          "1:3.4.6+dfsg2-4ubuntu3"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "g++-mingw-w64",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-i686",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-x86-64",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-base",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-i686",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-x86-64",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-i686",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-x86-64",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-i686",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-x86-64",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-i686",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-x86-64",
+              "binary_version": "7.3.0-11ubuntu1+20.2build1"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:18.04:LTS",
+          "name": "gcc-mingw-w64",
+          "purl": "pkg:deb/ubuntu/gcc-mingw-w64@20.2build1?arch=source\u0026distro=bionic"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "19.3",
+          "20",
+          "20.1",
+          "20.2",
+          "20.2build1"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-msp430",
+              "binary_version": "4.6.3~mspgcc-20120406-7ubuntu5"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:18.04:LTS",
+          "name": "gcc-msp430",
+          "purl": "pkg:deb/ubuntu/gcc-msp430@4.6.3~mspgcc-20120406-7ubuntu5?arch=source\u0026distro=bionic"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "4.6.3~mspgcc-20120406-7ubuntu4",
+          "4.6.3~mspgcc-20120406-7ubuntu5"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-arm-none-eabi",
+              "binary_version": "15:9-2019-q4-0ubuntu1"
+            },
+            {
+              "binary_name": "gcc-arm-none-eabi-source",
+              "binary_version": "15:9-2019-q4-0ubuntu1"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:20.04:LTS",
+          "name": "gcc-arm-none-eabi",
+          "purl": "pkg:deb/ubuntu/gcc-arm-none-eabi@15:9-2019-q4-0ubuntu1?arch=source\u0026distro=focal"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "15:7-2018-q2-6",
+          "15:8-2019-q3-1",
+          "15:9-2019-q4-0ubuntu1"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-h8300-hms",
+              "binary_version": "1:3.4.6+dfsg2-4.1"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:20.04:LTS",
+          "name": "gcc-h8300-hms",
+          "purl": "pkg:deb/ubuntu/gcc-h8300-hms@1:3.4.6+dfsg2-4.1?arch=source\u0026distro=focal"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "1:3.4.6+dfsg2-4ubuntu3",
+          "1:3.4.6+dfsg2-4.1"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "g++-mingw-w64",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "g++-mingw-w64-i686",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "g++-mingw-w64-x86-64",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "gcc-mingw-w64",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-base",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-i686",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-x86-64",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "gnat-mingw-w64",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-i686",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-x86-64",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-i686",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-x86-64",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-i686",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-x86-64",
+              "binary_version": "9.3.0-7ubuntu1+22~exp1ubuntu4"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:20.04:LTS",
+          "name": "gcc-mingw-w64",
+          "purl": "pkg:deb/ubuntu/gcc-mingw-w64@22~exp1ubuntu4?arch=source\u0026distro=focal"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "22~exp1ubuntu2",
+          "22~exp1ubuntu3",
+          "22~exp1ubuntu4"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-msp430",
+              "binary_version": "4.6.3~mspgcc-20120406-7.1ubuntu3"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:20.04:LTS",
+          "name": "gcc-msp430",
+          "purl": "pkg:deb/ubuntu/gcc-msp430@4.6.3~mspgcc-20120406-7.1ubuntu3?arch=source\u0026distro=focal"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "4.6.3~mspgcc-20120406-7.1ubuntu3"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-arm-none-eabi",
+              "binary_version": "15:10.3-2021.07-4"
+            },
+            {
+              "binary_name": "gcc-arm-none-eabi-source",
+              "binary_version": "15:10.3-2021.07-4"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:22.04:LTS",
+          "name": "gcc-arm-none-eabi",
+          "purl": "pkg:deb/ubuntu/gcc-arm-none-eabi@15:10.3-2021.07-4?arch=source\u0026distro=jammy"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "15:9-2019-q4-0ubuntu2",
+          "15:10.3-2021.07-1",
+          "15:10.3-2021.07-2",
+          "15:10.3-2021.07-3",
+          "15:10.3-2021.07-4"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-h8300-hms",
+              "binary_version": "1:3.4.6+dfsg2-4.2"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:22.04:LTS",
+          "name": "gcc-h8300-hms",
+          "purl": "pkg:deb/ubuntu/gcc-h8300-hms@1:3.4.6+dfsg2-4.2?arch=source\u0026distro=jammy"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "1:3.4.6+dfsg2-4.1",
+          "1:3.4.6+dfsg2-4.2"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "g++-mingw-w64",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "g++-mingw-w64-i686",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "g++-mingw-w64-i686-posix",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "g++-mingw-w64-i686-win32",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "g++-mingw-w64-x86-64",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "g++-mingw-w64-x86-64-posix",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "g++-mingw-w64-x86-64-win32",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gcc-mingw-w64",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-base",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686-posix",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686-posix-runtime",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686-win32",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686-win32-runtime",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64-posix",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64-posix-runtime",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64-win32",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64-win32-runtime",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-i686",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-i686-posix",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-i686-win32",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-x86-64",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-x86-64-posix",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-x86-64-win32",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gnat-mingw-w64",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-i686",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-i686-posix",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-i686-win32",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-x86-64",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-x86-64-posix",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-x86-64-win32",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-i686",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-i686-posix",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-i686-win32",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-x86-64",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-x86-64-posix",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-x86-64-win32",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-i686",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-i686-posix",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-i686-win32",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-x86-64",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-x86-64-posix",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-x86-64-win32",
+              "binary_version": "10.3.0-14ubuntu1+24.3"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:22.04:LTS",
+          "name": "gcc-mingw-w64",
+          "purl": "pkg:deb/ubuntu/gcc-mingw-w64@24.3?arch=source\u0026distro=jammy"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "24.2",
+          "24.3"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-msp430",
+              "binary_version": "4.6.3~mspgcc-20120406-7.1ubuntu3"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:22.04:LTS",
+          "name": "gcc-msp430",
+          "purl": "pkg:deb/ubuntu/gcc-msp430@4.6.3~mspgcc-20120406-7.1ubuntu3?arch=source\u0026distro=jammy"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "4.6.3~mspgcc-20120406-7.1ubuntu3"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-arm-none-eabi",
+              "binary_version": "15:13.2.rel1-2"
+            },
+            {
+              "binary_name": "gcc-arm-none-eabi-source",
+              "binary_version": "15:13.2.rel1-2"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:24.04:LTS",
+          "name": "gcc-arm-none-eabi",
+          "purl": "pkg:deb/ubuntu/gcc-arm-none-eabi@15:13.2.rel1-2?arch=source\u0026distro=noble"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "15:12.2.rel1-1",
+          "15:13.2.rel1-1",
+          "15:13.2.rel1-2"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-h8300-hms",
+              "binary_version": "1:3.4.6+dfsg2-4.2"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:24.04:LTS",
+          "name": "gcc-h8300-hms",
+          "purl": "pkg:deb/ubuntu/gcc-h8300-hms@1:3.4.6+dfsg2-4.2?arch=source\u0026distro=noble"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "1:3.4.6+dfsg2-4.2"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "g++-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-base",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686-posix-runtime",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686-win32-runtime",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64-posix-runtime",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64-win32-runtime",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:24.04:LTS",
+          "name": "gcc-mingw-w64",
+          "purl": "pkg:deb/ubuntu/gcc-mingw-w64@26.1?arch=source\u0026distro=noble"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "25.3",
+          "26.1"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-arm-none-eabi",
+              "binary_version": "15:14.2.rel1-1"
+            },
+            {
+              "binary_name": "gcc-arm-none-eabi-source",
+              "binary_version": "15:14.2.rel1-1"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:25.10",
+          "name": "gcc-arm-none-eabi",
+          "purl": "pkg:deb/ubuntu/gcc-arm-none-eabi@15:14.2.rel1-1?arch=source\u0026distro=questing"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "15:14.2.rel1-1"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-h8300-hms",
+              "binary_version": "1:3.4.6+dfsg2-4.2"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:25.10",
+          "name": "gcc-h8300-hms",
+          "purl": "pkg:deb/ubuntu/gcc-h8300-hms@1:3.4.6+dfsg2-4.2?arch=source\u0026distro=questing"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "1:3.4.6+dfsg2-4.2"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "g++-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-base",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686-posix-runtime",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686-win32-runtime",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64-posix-runtime",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64-win32-runtime",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:25.10",
+          "name": "gcc-mingw-w64",
+          "purl": "pkg:deb/ubuntu/gcc-mingw-w64@26.1?arch=source\u0026distro=questing"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "26.1"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-arm-none-eabi",
+              "binary_version": "15:14.2.rel1-1"
+            },
+            {
+              "binary_name": "gcc-arm-none-eabi-source",
+              "binary_version": "15:14.2.rel1-1"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:26.04",
+          "name": "gcc-arm-none-eabi",
+          "purl": "pkg:deb/ubuntu/gcc-arm-none-eabi@15:14.2.rel1-1?arch=source\u0026distro=resolute"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "15:14.2.rel1-1"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "gcc-h8300-hms",
+              "binary_version": "1:3.4.6+dfsg2-12"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:26.04",
+          "name": "gcc-h8300-hms",
+          "purl": "pkg:deb/ubuntu/gcc-h8300-hms@1:3.4.6+dfsg2-12?arch=source\u0026distro=resolute"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "1:3.4.6+dfsg2-4.2",
+          "1:3.4.6+dfsg2-9",
+          "1:3.4.6+dfsg2-10",
+          "1:3.4.6+dfsg2-11",
+          "1:3.4.6+dfsg2-12"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "g++-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "g++-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-base",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686-posix-runtime",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-i686-win32-runtime",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64-posix-runtime",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gcc-mingw-w64-x86-64-win32-runtime",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gfortran-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gnat-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc++-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-i686",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-i686-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-i686-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-x86-64",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-x86-64-posix",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            },
+            {
+              "binary_name": "gobjc-mingw-w64-x86-64-win32",
+              "binary_version": "13.2.0-6ubuntu1+26.1"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:26.04",
+          "name": "gcc-mingw-w64",
+          "purl": "pkg:deb/ubuntu/gcc-mingw-w64@26.1?arch=source\u0026distro=resolute"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "26.1"
+        ]
+      }
+    ],
+    "aliases": [],
+    "details": "operator new[] sometimes returns pointers to heap blocks which are too small.  When a new array is allocated, the C++ run-time has to calculate its size.  The product may exceed the maximum value which can be stored in a machine register.  This error is ignored, and the truncated value is used for the heap allocation. This may lead to heap overflows and therefore security bugs. (See http://cert.uni-stuttgart.de/advisories/calloc.php for further references.)",
+    "id": "UBUNTU-CVE-2002-2439",
+    "modified": "2026-04-27T14:11:52Z",
+    "published": "2019-10-23T18:15:00Z",
+    "references": [
+      {
+        "type": "REPORT",
+        "url": "https://ubuntu.com/security/CVE-2002-2439"
+      },
+      {
+        "type": "REPORT",
+        "url": "https://www.cve.org/CVERecord?id=CVE-2002-2439"
+      }
+    ],
+    "related": [],
+    "schema_version": "1.7.0",
+    "severity": [
+      {
+        "score": "low",
+        "type": "Ubuntu"
+      }
+    ],
+    "upstream": [
+      "CVE-2002-2439"
+    ]
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.7.0.json"
+}

--- a/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu-cve-2006-20001.json
+++ b/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu-cve-2006-20001.json
@@ -1,0 +1,518 @@
+{
+  "identifier": "ubuntu-cve-2006-20001",
+  "item": {
+    "affected": [
+      {
+        "ecosystem_specific": {
+          "binaries": [
+            {
+              "binary_name": "apache2",
+              "binary_version": "2.4.7-1ubuntu4.22+esm10"
+            },
+            {
+              "binary_name": "apache2-bin",
+              "binary_version": "2.4.7-1ubuntu4.22+esm10"
+            },
+            {
+              "binary_name": "apache2-data",
+              "binary_version": "2.4.7-1ubuntu4.22+esm10"
+            },
+            {
+              "binary_name": "apache2-mpm-event",
+              "binary_version": "2.4.7-1ubuntu4.22+esm10"
+            },
+            {
+              "binary_name": "apache2-mpm-itk",
+              "binary_version": "2.4.7-1ubuntu4.22+esm10"
+            },
+            {
+              "binary_name": "apache2-mpm-prefork",
+              "binary_version": "2.4.7-1ubuntu4.22+esm10"
+            },
+            {
+              "binary_name": "apache2-mpm-worker",
+              "binary_version": "2.4.7-1ubuntu4.22+esm10"
+            },
+            {
+              "binary_name": "apache2-suexec",
+              "binary_version": "2.4.7-1ubuntu4.22+esm10"
+            },
+            {
+              "binary_name": "apache2-suexec-custom",
+              "binary_version": "2.4.7-1ubuntu4.22+esm10"
+            },
+            {
+              "binary_name": "apache2-suexec-pristine",
+              "binary_version": "2.4.7-1ubuntu4.22+esm10"
+            },
+            {
+              "binary_name": "apache2-utils",
+              "binary_version": "2.4.7-1ubuntu4.22+esm10"
+            },
+            {
+              "binary_name": "apache2.2-bin",
+              "binary_version": "2.4.7-1ubuntu4.22+esm10"
+            },
+            {
+              "binary_name": "libapache2-mod-macro",
+              "binary_version": "1:2.4.7-1ubuntu4.22+esm10"
+            },
+            {
+              "binary_name": "libapache2-mod-proxy-html",
+              "binary_version": "1:2.4.7-1ubuntu4.22+esm10"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:Pro:14.04:LTS",
+          "name": "apache2",
+          "purl": "pkg:deb/ubuntu/apache2@2.4.7-1ubuntu4.22+esm10?arch=source\u0026distro=esm-infra-legacy/trusty"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "2.4.6-2ubuntu2",
+          "2.4.6-2ubuntu3",
+          "2.4.6-2ubuntu4",
+          "2.4.7-1ubuntu1",
+          "2.4.7-1ubuntu2",
+          "2.4.7-1ubuntu3",
+          "2.4.7-1ubuntu4",
+          "2.4.7-1ubuntu4.1",
+          "2.4.7-1ubuntu4.4",
+          "2.4.7-1ubuntu4.5",
+          "2.4.7-1ubuntu4.6",
+          "2.4.7-1ubuntu4.7",
+          "2.4.7-1ubuntu4.8",
+          "2.4.7-1ubuntu4.9",
+          "2.4.7-1ubuntu4.10",
+          "2.4.7-1ubuntu4.11",
+          "2.4.7-1ubuntu4.13",
+          "2.4.7-1ubuntu4.15",
+          "2.4.7-1ubuntu4.16",
+          "2.4.7-1ubuntu4.17",
+          "2.4.7-1ubuntu4.18",
+          "2.4.7-1ubuntu4.19",
+          "2.4.7-1ubuntu4.20",
+          "2.4.7-1ubuntu4.21",
+          "2.4.7-1ubuntu4.22",
+          "2.4.7-1ubuntu4.22+esm1",
+          "2.4.7-1ubuntu4.22+esm2",
+          "2.4.7-1ubuntu4.22+esm3",
+          "2.4.7-1ubuntu4.22+esm4",
+          "2.4.7-1ubuntu4.22+esm5",
+          "2.4.7-1ubuntu4.22+esm6",
+          "2.4.7-1ubuntu4.22+esm8",
+          "2.4.7-1ubuntu4.22+esm9",
+          "2.4.7-1ubuntu4.22+esm10"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "availability": "Available with Ubuntu Pro (Infra-only): https://ubuntu.com/pro",
+          "binaries": [
+            {
+              "binary_name": "apache2",
+              "binary_version": "2.4.18-2ubuntu3.17+esm8"
+            },
+            {
+              "binary_name": "apache2-bin",
+              "binary_version": "2.4.18-2ubuntu3.17+esm8"
+            },
+            {
+              "binary_name": "apache2-data",
+              "binary_version": "2.4.18-2ubuntu3.17+esm8"
+            },
+            {
+              "binary_name": "apache2-suexec-custom",
+              "binary_version": "2.4.18-2ubuntu3.17+esm8"
+            },
+            {
+              "binary_name": "apache2-suexec-pristine",
+              "binary_version": "2.4.18-2ubuntu3.17+esm8"
+            },
+            {
+              "binary_name": "apache2-utils",
+              "binary_version": "2.4.18-2ubuntu3.17+esm8"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:Pro:16.04:LTS",
+          "name": "apache2",
+          "purl": "pkg:deb/ubuntu/apache2@2.4.18-2ubuntu3.17+esm8?arch=source\u0026distro=esm-infra/xenial"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2023-01-17",
+                    "kind": "advisory",
+                    "version": "2.4.18-2ubuntu3.17+esm8"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "2.4.18-2ubuntu3.17+esm8"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "2.4.12-2ubuntu2",
+          "2.4.17-1ubuntu1",
+          "2.4.17-2ubuntu1",
+          "2.4.17-3ubuntu1",
+          "2.4.18-1ubuntu1",
+          "2.4.18-2ubuntu1",
+          "2.4.18-2ubuntu2",
+          "2.4.18-2ubuntu3",
+          "2.4.18-2ubuntu3.1",
+          "2.4.18-2ubuntu3.2",
+          "2.4.18-2ubuntu3.3",
+          "2.4.18-2ubuntu3.4",
+          "2.4.18-2ubuntu3.5",
+          "2.4.18-2ubuntu3.7",
+          "2.4.18-2ubuntu3.8",
+          "2.4.18-2ubuntu3.9",
+          "2.4.18-2ubuntu3.10",
+          "2.4.18-2ubuntu3.12",
+          "2.4.18-2ubuntu3.13",
+          "2.4.18-2ubuntu3.14",
+          "2.4.18-2ubuntu3.15",
+          "2.4.18-2ubuntu3.17",
+          "2.4.18-2ubuntu3.17+esm1",
+          "2.4.18-2ubuntu3.17+esm2",
+          "2.4.18-2ubuntu3.17+esm3",
+          "2.4.18-2ubuntu3.17+esm4",
+          "2.4.18-2ubuntu3.17+esm5",
+          "2.4.18-2ubuntu3.17+esm6",
+          "2.4.18-2ubuntu3.17+esm7"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "availability": "No subscription required",
+          "binaries": [
+            {
+              "binary_name": "apache2",
+              "binary_version": "2.4.29-1ubuntu4.26"
+            },
+            {
+              "binary_name": "apache2-bin",
+              "binary_version": "2.4.29-1ubuntu4.26"
+            },
+            {
+              "binary_name": "apache2-data",
+              "binary_version": "2.4.29-1ubuntu4.26"
+            },
+            {
+              "binary_name": "apache2-suexec-custom",
+              "binary_version": "2.4.29-1ubuntu4.26"
+            },
+            {
+              "binary_name": "apache2-suexec-pristine",
+              "binary_version": "2.4.29-1ubuntu4.26"
+            },
+            {
+              "binary_name": "apache2-utils",
+              "binary_version": "2.4.29-1ubuntu4.26"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:18.04:LTS",
+          "name": "apache2",
+          "purl": "pkg:deb/ubuntu/apache2@2.4.29-1ubuntu4.26?arch=source\u0026distro=bionic"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2023-01-17",
+                    "kind": "advisory",
+                    "version": "2.4.29-1ubuntu4.26"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "2.4.29-1ubuntu4.26"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "2.4.27-2ubuntu3",
+          "2.4.29-1ubuntu1",
+          "2.4.29-1ubuntu2",
+          "2.4.29-1ubuntu3",
+          "2.4.29-1ubuntu4",
+          "2.4.29-1ubuntu4.1",
+          "2.4.29-1ubuntu4.2",
+          "2.4.29-1ubuntu4.3",
+          "2.4.29-1ubuntu4.4",
+          "2.4.29-1ubuntu4.5",
+          "2.4.29-1ubuntu4.6",
+          "2.4.29-1ubuntu4.7",
+          "2.4.29-1ubuntu4.8",
+          "2.4.29-1ubuntu4.10",
+          "2.4.29-1ubuntu4.11",
+          "2.4.29-1ubuntu4.12",
+          "2.4.29-1ubuntu4.13",
+          "2.4.29-1ubuntu4.14",
+          "2.4.29-1ubuntu4.16",
+          "2.4.29-1ubuntu4.17",
+          "2.4.29-1ubuntu4.18",
+          "2.4.29-1ubuntu4.19",
+          "2.4.29-1ubuntu4.20",
+          "2.4.29-1ubuntu4.21",
+          "2.4.29-1ubuntu4.22",
+          "2.4.29-1ubuntu4.23",
+          "2.4.29-1ubuntu4.24",
+          "2.4.29-1ubuntu4.25"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "availability": "No subscription required",
+          "binaries": [
+            {
+              "binary_name": "apache2",
+              "binary_version": "2.4.41-4ubuntu3.13"
+            },
+            {
+              "binary_name": "apache2-bin",
+              "binary_version": "2.4.41-4ubuntu3.13"
+            },
+            {
+              "binary_name": "apache2-data",
+              "binary_version": "2.4.41-4ubuntu3.13"
+            },
+            {
+              "binary_name": "apache2-suexec-custom",
+              "binary_version": "2.4.41-4ubuntu3.13"
+            },
+            {
+              "binary_name": "apache2-suexec-pristine",
+              "binary_version": "2.4.41-4ubuntu3.13"
+            },
+            {
+              "binary_name": "apache2-utils",
+              "binary_version": "2.4.41-4ubuntu3.13"
+            },
+            {
+              "binary_name": "libapache2-mod-md",
+              "binary_version": "2.4.41-4ubuntu3.13"
+            },
+            {
+              "binary_name": "libapache2-mod-proxy-uwsgi",
+              "binary_version": "2.4.41-4ubuntu3.13"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:20.04:LTS",
+          "name": "apache2",
+          "purl": "pkg:deb/ubuntu/apache2@2.4.41-4ubuntu3.13?arch=source\u0026distro=focal"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2023-01-17",
+                    "kind": "advisory",
+                    "version": "2.4.41-4ubuntu3.13"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "2.4.41-4ubuntu3.13"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "2.4.41-1ubuntu1",
+          "2.4.41-4ubuntu1",
+          "2.4.41-4ubuntu2",
+          "2.4.41-4ubuntu3",
+          "2.4.41-4ubuntu3.1",
+          "2.4.41-4ubuntu3.3",
+          "2.4.41-4ubuntu3.4",
+          "2.4.41-4ubuntu3.5",
+          "2.4.41-4ubuntu3.6",
+          "2.4.41-4ubuntu3.7",
+          "2.4.41-4ubuntu3.8",
+          "2.4.41-4ubuntu3.9",
+          "2.4.41-4ubuntu3.10",
+          "2.4.41-4ubuntu3.11",
+          "2.4.41-4ubuntu3.12"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "availability": "No subscription required",
+          "binaries": [
+            {
+              "binary_name": "apache2",
+              "binary_version": "2.4.52-1ubuntu4.3"
+            },
+            {
+              "binary_name": "apache2-bin",
+              "binary_version": "2.4.52-1ubuntu4.3"
+            },
+            {
+              "binary_name": "apache2-data",
+              "binary_version": "2.4.52-1ubuntu4.3"
+            },
+            {
+              "binary_name": "apache2-suexec-custom",
+              "binary_version": "2.4.52-1ubuntu4.3"
+            },
+            {
+              "binary_name": "apache2-suexec-pristine",
+              "binary_version": "2.4.52-1ubuntu4.3"
+            },
+            {
+              "binary_name": "apache2-utils",
+              "binary_version": "2.4.52-1ubuntu4.3"
+            },
+            {
+              "binary_name": "libapache2-mod-md",
+              "binary_version": "2.4.52-1ubuntu4.3"
+            },
+            {
+              "binary_name": "libapache2-mod-proxy-uwsgi",
+              "binary_version": "2.4.52-1ubuntu4.3"
+            }
+          ]
+        },
+        "package": {
+          "ecosystem": "Ubuntu:22.04:LTS",
+          "name": "apache2",
+          "purl": "pkg:deb/ubuntu/apache2@2.4.52-1ubuntu4.3?arch=source\u0026distro=jammy"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2023-01-17",
+                    "kind": "advisory",
+                    "version": "2.4.52-1ubuntu4.3"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "2.4.52-1ubuntu4.3"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "2.4.48-3.1ubuntu3",
+          "2.4.48-3.1ubuntu4",
+          "2.4.51-2ubuntu1",
+          "2.4.52-1ubuntu1",
+          "2.4.52-1ubuntu2",
+          "2.4.52-1ubuntu4",
+          "2.4.52-1ubuntu4.1",
+          "2.4.52-1ubuntu4.2"
+        ]
+      }
+    ],
+    "aliases": [],
+    "details": "A carefully crafted If: request header can cause a memory read, or write of a single zero byte, in a pool (heap) memory location beyond the header value sent. This could cause the process to crash. This issue affects Apache HTTP Server 2.4.54 and earlier.",
+    "id": "UBUNTU-CVE-2006-20001",
+    "modified": "2026-04-22T07:37:33Z",
+    "published": "2023-01-17T20:15:00Z",
+    "references": [
+      {
+        "type": "REPORT",
+        "url": "https://ubuntu.com/security/CVE-2006-20001"
+      },
+      {
+        "type": "REPORT",
+        "url": "https://www.openwall.com/lists/oss-security/2023/01/17/5"
+      },
+      {
+        "type": "REPORT",
+        "url": "https://httpd.apache.org/security/vulnerabilities_24.html#CVE-2006-20001"
+      },
+      {
+        "type": "REPORT",
+        "url": "https://httpd.apache.org/security/vulnerabilities_24.html"
+      },
+      {
+        "type": "ADVISORY",
+        "url": "https://ubuntu.com/security/notices/USN-5834-1"
+      },
+      {
+        "type": "ADVISORY",
+        "url": "https://ubuntu.com/security/notices/USN-5839-1"
+      },
+      {
+        "type": "REPORT",
+        "url": "https://www.cve.org/CVERecord?id=CVE-2006-20001"
+      }
+    ],
+    "related": [
+      "USN-5834-1",
+      "USN-5839-1"
+    ],
+    "schema_version": "1.7.0",
+    "severity": [
+      {
+        "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "type": "CVSS_V3"
+      },
+      {
+        "score": "medium",
+        "type": "Ubuntu"
+      }
+    ],
+    "upstream": [
+      "CVE-2006-20001"
+    ]
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.7.0.json"
+}

--- a/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu-cve-2008-7320.json
+++ b/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu-cve-2008-7320.json
@@ -1,0 +1,154 @@
+{
+  "identifier": "ubuntu-cve-2008-7320",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "Ubuntu:Pro:16.04:LTS",
+          "name": "seahorse"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "3.16.0-1ubuntu1",
+          "3.18.0-2ubuntu1"
+        ]
+      },
+      {
+        "package": {
+          "ecosystem": "Ubuntu:Pro:18.04:LTS",
+          "name": "seahorse"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "3.20.0-3.1",
+          "3.20.0-4",
+          "3.20.0-5"
+        ]
+      },
+      {
+        "package": {
+          "ecosystem": "Ubuntu:20.04:LTS",
+          "name": "seahorse"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "3.32.2-1",
+          "3.34-1",
+          "3.35.91-1",
+          "3.36-1"
+        ]
+      },
+      {
+        "package": {
+          "ecosystem": "Ubuntu:22.04:LTS",
+          "name": "seahorse"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "40.0-2",
+          "41.0-1",
+          "41.0-2"
+        ]
+      },
+      {
+        "package": {
+          "ecosystem": "Ubuntu:24.04:LTS",
+          "name": "seahorse"
+        },
+        "ranges": [
+          {
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "43.0-1build1",
+          "43.0-3",
+          "43.0-3build1",
+          "43.0-3build2"
+        ]
+      }
+    ],
+    "aliases": [],
+    "details": "** DISPUTED ** GNOME Seahorse through 3.30 allows physically proximate attackers to read plaintext passwords by using the quickAllow dialog at an unattended workstation, if the keyring is unlocked. NOTE: this is disputed by a software maintainer because the behavior represents a design decision.",
+    "id": "UBUNTU-CVE-2008-7320",
+    "modified": "2018-11-18T19:29:00Z",
+    "published": "2018-11-18T19:29:00Z",
+    "references": [
+      {
+        "type": "REPORT",
+        "url": "https://ubuntu.com/security/CVE-2008-7320"
+      },
+      {
+        "type": "REPORT",
+        "url": "https://bugs.launchpad.net/ubuntu/+source/seahorse/+bug/189774"
+      },
+      {
+        "type": "REPORT",
+        "url": "https://bugs.launchpad.net/ubuntu/+source/seahorse/+bug/189774/comments/13"
+      },
+      {
+        "type": "REPORT",
+        "url": "https://bugzilla.gnome.org/show_bug.cgi?id=551036"
+      },
+      {
+        "type": "REPORT",
+        "url": "https://www.bountysource.com/issues/3849352-seahorse-shows-passwords-without-verification"
+      },
+      {
+        "type": "REPORT",
+        "url": "https://www.cve.org/CVERecord?id=CVE-2008-7320"
+      }
+    ],
+    "related": [],
+    "schema_version": "1.6.3",
+    "severity": [
+      {
+        "score": "CVSS:3.0/AV:P/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "type": "CVSS_V3"
+      }
+    ],
+    "withdrawn": "2025-06-23T15:52:31Z"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.3.json"
+}

--- a/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu-cve-2023-38545.json
+++ b/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu-cve-2023-38545.json
@@ -1,0 +1,182 @@
+{
+  "identifier": "ubuntu-cve-2023-38545",
+  "item": {
+    "affected": [
+      {
+        "ecosystem_specific": {
+          "availability": "No subscription required",
+          "binaries": [
+            {
+              "binary_name": "curl",
+              "binary_version": "7.81.0-1ubuntu1.14"
+            },
+            {
+              "binary_name": "libcurl3-gnutls",
+              "binary_version": "7.81.0-1ubuntu1.14"
+            },
+            {
+              "binary_name": "libcurl3-nss",
+              "binary_version": "7.81.0-1ubuntu1.14"
+            },
+            {
+              "binary_name": "libcurl4",
+              "binary_version": "7.81.0-1ubuntu1.14"
+            }
+          ],
+          "priority_reason": "Upstream curl developer has rated this issue as high"
+        },
+        "package": {
+          "ecosystem": "Ubuntu:22.04:LTS",
+          "name": "curl",
+          "purl": "pkg:deb/ubuntu/curl@7.81.0-1ubuntu1.14?arch=source\u0026distro=jammy"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2023-10-11",
+                    "kind": "advisory",
+                    "version": "7.81.0-1ubuntu1.14"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "7.81.0-1ubuntu1.14"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "7.74.0-1.3ubuntu2",
+          "7.74.0-1.3ubuntu3",
+          "7.80.0-3",
+          "7.81.0-1",
+          "7.81.0-1ubuntu1.1",
+          "7.81.0-1ubuntu1.2",
+          "7.81.0-1ubuntu1.3",
+          "7.81.0-1ubuntu1.4",
+          "7.81.0-1ubuntu1.6",
+          "7.81.0-1ubuntu1.7",
+          "7.81.0-1ubuntu1.8",
+          "7.81.0-1ubuntu1.10",
+          "7.81.0-1ubuntu1.11",
+          "7.81.0-1ubuntu1.13"
+        ]
+      },
+      {
+        "ecosystem_specific": {
+          "availability": "No subscription required",
+          "binaries": [
+            {
+              "binary_name": "curl",
+              "binary_version": "8.2.1-1ubuntu3.1"
+            },
+            {
+              "binary_name": "libcurl3-gnutls",
+              "binary_version": "8.2.1-1ubuntu3.1"
+            },
+            {
+              "binary_name": "libcurl3-nss",
+              "binary_version": "8.2.1-1ubuntu3.1"
+            },
+            {
+              "binary_name": "libcurl4",
+              "binary_version": "8.2.1-1ubuntu3.1"
+            }
+          ],
+          "priority_reason": "Upstream curl developer has rated this issue as high"
+        },
+        "package": {
+          "ecosystem": "Ubuntu:24.04:LTS",
+          "name": "curl",
+          "purl": "pkg:deb/ubuntu/curl@8.2.1-1ubuntu3.1?arch=source\u0026distro=noble"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2023-10-11",
+                    "kind": "advisory",
+                    "version": "8.2.1-1ubuntu3.1"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "8.2.1-1ubuntu3.1"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ],
+        "versions": [
+          "8.2.1-1ubuntu3"
+        ]
+      }
+    ],
+    "aliases": [],
+    "details": "This flaw makes curl overflow a heap based buffer in the SOCKS5 proxy handshake. When curl is asked to pass along the host name to the SOCKS5 proxy to allow that to resolve the address instead of it getting done by curl itself, the maximum length that host name can be is 255 bytes. If the host name is detected to be longer, curl switches to local name resolving and instead passes on the resolved address only. Due to this bug, the local variable that means \"let the host resolve the name\" could get the wrong value during a slow SOCKS5 handshake, and contrary to the intention, copy the too long host name to the target buffer instead of copying just the resolved address there. The target buffer being a heap based buffer, and the host name coming from the URL that curl has been told to operate with.",
+    "id": "UBUNTU-CVE-2023-38545",
+    "modified": "2026-04-22T07:45:24Z",
+    "published": "2023-10-11T06:00:00Z",
+    "references": [
+      {
+        "type": "REPORT",
+        "url": "https://ubuntu.com/security/CVE-2023-38545"
+      },
+      {
+        "type": "REPORT",
+        "url": "https://curl.se/docs/CVE-2023-38545.html"
+      },
+      {
+        "type": "ADVISORY",
+        "url": "https://ubuntu.com/security/notices/USN-6429-1"
+      },
+      {
+        "type": "ADVISORY",
+        "url": "https://ubuntu.com/security/notices/USN-6429-3"
+      },
+      {
+        "type": "REPORT",
+        "url": "https://www.cve.org/CVERecord?id=CVE-2023-38545"
+      }
+    ],
+    "related": [
+      "USN-6429-1",
+      "USN-6429-3"
+    ],
+    "schema_version": "1.7.0",
+    "severity": [
+      {
+        "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "type": "CVSS_V3"
+      },
+      {
+        "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+        "type": "CVSS_V3"
+      },
+      {
+        "score": "high",
+        "type": "Ubuntu"
+      }
+    ],
+    "upstream": [
+      "CVE-2023-38545"
+    ]
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.7.0.json"
+}

--- a/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu@12.04/cve-2013-2118.json
+++ b/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu@12.04/cve-2013-2118.json
@@ -1,0 +1,26 @@
+{
+  "identifier": "ubuntu:12.04/cve-2013-2118",
+  "item": {
+    "Vulnerability": {
+      "Description": "",
+      "FixedIn": [
+        {
+          "Available": null,
+          "Name": "spip",
+          "NamespaceName": "ubuntu:12.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "None",
+          "VersionFormat": "dpkg"
+        }
+      ],
+      "Link": "https://ubuntu.com/security/CVE-2013-2118",
+      "Metadata": {},
+      "Name": "CVE-2013-2118",
+      "NamespaceName": "ubuntu:12.04",
+      "Severity": "Medium"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu@12.04/cve-2014-0160.json
+++ b/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu@12.04/cve-2014-0160.json
@@ -1,0 +1,29 @@
+{
+  "identifier": "ubuntu:12.04/cve-2014-0160",
+  "item": {
+    "Vulnerability": {
+      "Description": "",
+      "FixedIn": [
+        {
+          "Available": {
+            "Date": "2026-04-29",
+            "Kind": "first-observed"
+          },
+          "Name": "openssl",
+          "NamespaceName": "ubuntu:12.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "1.0.1-4ubuntu5.12",
+          "VersionFormat": "dpkg"
+        }
+      ],
+      "Link": "https://ubuntu.com/security/CVE-2014-0160",
+      "Metadata": {},
+      "Name": "CVE-2014-0160",
+      "NamespaceName": "ubuntu:12.04",
+      "Severity": "High"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu@12.10/cve-2014-0160.json
+++ b/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu@12.10/cve-2014-0160.json
@@ -1,0 +1,29 @@
+{
+  "identifier": "ubuntu:12.10/cve-2014-0160",
+  "item": {
+    "Vulnerability": {
+      "Description": "",
+      "FixedIn": [
+        {
+          "Available": {
+            "Date": "2026-04-29",
+            "Kind": "first-observed"
+          },
+          "Name": "openssl",
+          "NamespaceName": "ubuntu:12.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "1.0.1c-3ubuntu2.7",
+          "VersionFormat": "dpkg"
+        }
+      ],
+      "Link": "https://ubuntu.com/security/CVE-2014-0160",
+      "Metadata": {},
+      "Name": "CVE-2014-0160",
+      "NamespaceName": "ubuntu:12.10",
+      "Severity": "High"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu@23.04/cve-2023-38545.json
+++ b/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu@23.04/cve-2023-38545.json
@@ -1,0 +1,29 @@
+{
+  "identifier": "ubuntu:23.04/cve-2023-38545",
+  "item": {
+    "Vulnerability": {
+      "Description": "",
+      "FixedIn": [
+        {
+          "Available": {
+            "Date": "2026-04-29",
+            "Kind": "first-observed"
+          },
+          "Name": "curl",
+          "NamespaceName": "ubuntu:23.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "7.88.1-8ubuntu2.3",
+          "VersionFormat": "dpkg"
+        }
+      ],
+      "Link": "https://ubuntu.com/security/CVE-2023-38545",
+      "Metadata": {},
+      "Name": "CVE-2023-38545",
+      "NamespaceName": "ubuntu:23.04",
+      "Severity": "High"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu@23.10/cve-2023-38545.json
+++ b/internal/dbtest/testdata/shared/all/ubuntu/results/ubuntu@23.10/cve-2023-38545.json
@@ -1,0 +1,29 @@
+{
+  "identifier": "ubuntu:23.10/cve-2023-38545",
+  "item": {
+    "Vulnerability": {
+      "Description": "",
+      "FixedIn": [
+        {
+          "Available": {
+            "Date": "2026-04-29",
+            "Kind": "first-observed"
+          },
+          "Name": "curl",
+          "NamespaceName": "ubuntu:23.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "8.2.1-1ubuntu3.1",
+          "VersionFormat": "dpkg"
+        }
+      ],
+      "Link": "https://ubuntu.com/security/CVE-2023-38545",
+      "Metadata": {},
+      "Name": "CVE-2023-38545",
+      "NamespaceName": "ubuntu:23.10",
+      "Severity": "High"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}


### PR DESCRIPTION
Includes moving on from the google osv-scanner model to our own, since the osv-scanner models are no longer maintained.