### PR TITLE
Fix false positives for literal Go PURLs with subpaths

### DIFF
--- a/grype/pkg/purl_provider.go
+++ b/grype/pkg/purl_provider.go
@@ -24,7 +24,7 @@ type PURLLiteralMetadata struct {
 }
 
 func purlEnhancers(applyChannel func(*distro.Distro) bool) []Enhancer {
-	return []Enhancer{setUpstreamsFromPURL, setDistroFromPURL(applyChannel)}
+	return []Enhancer{setNameFromPURL, setUpstreamsFromPURL, setDistroFromPURL(applyChannel)}
 }
 
 func purlProvider(userInput string, config ProviderConfig, applyChannel func(*distro.Distro) bool) ([]*Package, Context, *sbom.SBOM, error) {
@@ -53,9 +53,25 @@ func getPurlReader(userInput string) (r io.Reader, ctx Context, err error) {
 	return nil, ctx, errDoesNotProvide
 }
 
-func setUpstreamsFromPURL(out *Package, purl packageurl.PackageURL, syftPkg syftPkg.Package) {
+func setNameFromPURL(out *Package, purl packageurl.PackageURL, syftPackage syftPkg.Package) {
+	if syftPackage.Type != syftPkg.GoModulePkg {
+		return
+	}
+
+	if purl.Namespace != "" {
+		out.Name = purl.Namespace + "/" + purl.Name
+	} else {
+		out.Name = purl.Name
+	}
+
+	if purl.Subpath != "" {
+		out.Name += "/" + purl.Subpath
+	}
+}
+
+func setUpstreamsFromPURL(out *Package, purl packageurl.PackageURL, syftPackage syftPkg.Package) {
 	if len(out.Upstreams) == 0 || out.PURL == "" {
-		out.Upstreams = upstreamsFromPURL(purl, syftPkg.Type)
+		out.Upstreams = upstreamsFromPURL(purl, syftPackage.Type)
 	}
 }
 

--- a/grype/pkg/purl_provider_test.go
+++ b/grype/pkg/purl_provider_test.go
@@ -303,6 +303,24 @@ func Test_PurlProvider(t *testing.T) {
 			},
 		},
 		{
+			name:      "include subpath in name when purl is type Golang",
+			userInput: "pkg:golang/github.com/hashicorp/vault@v0.9.0#api/auth/kubernetes",
+			channels:  testFixChannels(),
+			wantContext: Context{
+				Source: &source.Description{
+					Metadata: PURLLiteralMetadata{PURL: "pkg:golang/github.com/hashicorp/vault@v0.9.0#api/auth/kubernetes"},
+				},
+			},
+			wantPkgs: []*Package{
+				{
+					Name:    "github.com/hashicorp/vault/api/auth/kubernetes",
+					Version: "v0.9.0",
+					Type:    pkg.GoModulePkg,
+					PURL:    "pkg:golang/github.com/hashicorp/vault@v0.9.0#api/auth/kubernetes",
+				},
+			},
+		},
+		{
 			name:      "RPM with extended support (auto)",
 			userInput: "pkg:rpm/redhat/systemd-x@239-82.el8_10.2?distro=rhel-8.10+eus",
 			channels:  testFixChannels(), // important! auto applies EUS


### PR DESCRIPTION
fixes the literal `pkg:golang/...#...` scan path from #2838.

right now grype builds `pkg:golang/github.com/hashicorp/vault@v0.9.0#api/auth/kubernetes` as `github.com/hashicorp/vault`, so it can match the wrong module. thats the bug.

this keeps the Go subpath when grype builds a package from a literal PURL. tiny change, no funny business.

repro:
1. run `grype 'pkg:golang/github.com/hashicorp/vault@v0.9.0#api/auth/kubernetes'`
2. before this patch, the package name becomes `github.com/hashicorp/vault`
3. with this patch, it becomes `github.com/hashicorp/vault/api/auth/kubernetes`

checks:
- `go test ./grype/pkg -run Test_PurlProvider`
- `go test ./...` in this env still trips in `test/integration` because `.tool/skopeo` is missing

related:
- #2838
- anchore/syft#4395
