### PR TITLE
fix: preserve VEX justification in applied ignore rules

### DIFF
--- a/grype/vex/csaf/implementation.go
+++ b/grype/vex/csaf/implementation.go
@@ -203,17 +203,17 @@ func matchingRule(ignoreRules []match.IgnoreRule, m match.Match, advMatch *advis
 		// any status with any vulnerability. Alternatively, if the vulnerability
 		// is set, the rule applies if it is the same in the advisory match and the rule.
 		if rule.Vulnerability == "" || advMatch.cve() == rule.Vulnerability {
-			return &rule
-		}
-
-		// If the rule applies to a VEX justification it needs to match the
-		// advisory match statement, note that justifications only apply to not_affected:
-		if matchesVexStatus(advMatch.Status, vexStatus.NotAffected) && rule.VexJustification != "" &&
-			rule.VexJustification != advMatch.statement() {
-			continue
-		}
-
-		if advMatch.cve() == rule.Vulnerability {
+			// If the rule applies to a VEX justification it needs to match the
+			// advisory match statement, note that justifications only apply to not_affected:
+			if matchesVexStatus(advMatch.Status, vexStatus.NotAffected) && rule.VexJustification != "" &&
+				rule.VexJustification != advMatch.statement() {
+				continue
+			}
+			// Preserve the VEX justification from the advisory when the
+			// rule did not specify one (e.g. status-only ignore rules).
+			if rule.VexJustification == "" {
+				rule.VexJustification = advMatch.statement()
+			}
 			return &rule
 		}
 	}

--- a/grype/vex/openvex/implementation.go
+++ b/grype/vex/openvex/implementation.go
@@ -300,12 +300,20 @@ func matchingRule(ignoreRules []match.IgnoreRule, m match.Match, statement *open
 		// If the vulnerability is blank in the rule it means we will honor
 		// any status with any vulnerability.
 		if rule.Vulnerability == "" {
+			// Preserve the VEX justification from the statement when the
+			// rule did not specify one (e.g. status-only ignore rules).
+			if rule.VexJustification == "" {
+				rule.VexJustification = string(statement.Justification)
+			}
 			return &rule
 		}
 
 		// If the vulnerability is set, the rule applies if it is the same
 		// in the statement and the rule.
 		if statement.Vulnerability.Matches(rule.Vulnerability) {
+			if rule.VexJustification == "" {
+				rule.VexJustification = string(statement.Justification)
+			}
 			return &rule
 		}
 	}

--- a/grype/vex/processor_test.go
+++ b/grype/vex/processor_test.go
@@ -134,8 +134,9 @@ func TestProcessor_ApplyVEX(t *testing.T) {
 			wantIgnoredMatches: []match.IgnoredMatch{{
 				Match: libCryptoCVE_2023_1255,
 				AppliedIgnoreRules: []match.IgnoreRule{{
-					Namespace: "vex",
-					VexStatus: string(status.Fixed),
+					Namespace:        "vex",
+					VexJustification: "Class with vulnerable code was removed before shipping.",
+					VexStatus:        string(status.Fixed),
 				}},
 			}},
 		},
@@ -158,9 +159,10 @@ func TestProcessor_ApplyVEX(t *testing.T) {
 			wantIgnoredMatches: []match.IgnoredMatch{{
 				Match: libCryptoCVE_2023_1255,
 				AppliedIgnoreRules: []match.IgnoreRule{{
-					Namespace:     "vex",
-					Vulnerability: "CVE-2023-1255",
-					VexStatus:     string(status.Fixed),
+					Namespace:        "vex",
+					Vulnerability:    "CVE-2023-1255",
+					VexJustification: "Class with vulnerable code was removed before shipping.",
+					VexStatus:        string(status.Fixed),
 				}},
 			}},
 		},


### PR DESCRIPTION
Fixes #2828

## Problem

When a VEX `not_affected` or `fixed` statement matches a status-only ignore rule (e.g. `- vex-status: not_affected` without specifying `vex-justification`), the `vex-justification` field is missing from `appliedIgnoreRules` in the JSON output.

The root cause is in both `openvex/implementation.go` and `csaf/implementation.go` `matchingRule` functions: when a user-provided rule matches, it's returned as-is without enriching the `VexJustification` field from the VEX statement.

Additionally, in the CSAF implementation, the justification filter check (lines 209-214) was unreachable because the earlier return at line 206 exits before it.

## Fix

Both OpenVEX and CSAF `matchingRule` functions now:
1. Enrich returned rules with the statement's justification when `VexJustification` is empty
2. In CSAF, move the justification filter check before the return so it's actually evaluated

This ensures status-only ignore rules correctly populate `vex-justification` from the matched VEX statement.

## Testing

- `go test ./grype/vex/... ./grype/presenter/models/ -count=1` — all pass
- Updated test expectations for CSAF tests that now correctly include the justification