### PR TITLE
Add support for expiry date in ignore

### DIFF
--- a/cmd/grype/cli/options/grype.go
+++ b/cmd/grype/cli/options/grype.go
@@ -200,6 +200,7 @@ default is unset which will skip this validation (options: negligible, low, medi
 This is the full set of supported rule fields:
   - vulnerability: CVE-2008-4318
     fix-state: unknown
+	expires-after: "2027-01-01"
     package:
       name: libcurl
       version: 1.5.1

--- a/grype/match/ignore.go
+++ b/grype/match/ignore.go
@@ -1,8 +1,10 @@
 package match
 
 import (
+	"fmt"
 	"regexp"
 	"slices"
+	"time"
 
 	"github.com/bmatcuk/doublestar/v2"
 
@@ -11,6 +13,37 @@ import (
 	"github.com/anchore/grype/internal/log"
 	"github.com/anchore/syft/syft/artifact"
 )
+
+// expiresAfterDateFmt is the date layout accepted for IgnoreRule.ExpiresAfter (YYYY-MM-DD).
+const expiresAfterDateFmt = "2006-01-02"
+
+// parseExpiresAfter parses a YYYY-MM-DD string into a UTC time.Time.
+// An empty string returns the zero value with no error.
+func parseExpiresAfter(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+	t, err := time.ParseInLocation(expiresAfterDateFmt, s, time.UTC)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid expires-after %q (expected YYYY-MM-DD): %w", s, err)
+	}
+	return t, nil
+}
+
+// isExpiresAfterInPast reports whether the given expires-after string represents a date that has already passed.
+// An empty string is never considered expired. Malformed values are treated as not expired (a warning is logged).
+func isExpiresAfterInPast(s string) bool {
+	if s == "" {
+		return false
+	}
+	t, err := parseExpiresAfter(s)
+	if err != nil {
+		log.WithFields("expires-after", s, "error", err).Warn("ignoring malformed expires-after on ignore rule")
+		return false
+	}
+	// the rule remains active for the entire calendar day it expires on
+	return time.Now().UTC().After(t.Add(24 * time.Hour))
+}
 
 // IgnoreFilter implementations are used to filter matches, returning all applicable IgnoreRule(s) that applied,
 // these could include an IgnoreRule with only a Reason value filled in for synthetically generated rules
@@ -40,6 +73,7 @@ type IgnoreRule struct {
 	VexStatus        string            `yaml:"vex-status" json:"vex-status" mapstructure:"vex-status"`
 	VexJustification string            `yaml:"vex-justification" json:"vex-justification" mapstructure:"vex-justification"`
 	MatchType        Type              `yaml:"match-type" json:"match-type" mapstructure:"match-type"`
+	ExpiresAfter 	 string 		   `yaml:"expires-after,omitempty" json:"expires-after,omitempty" mapstructure:"expires-after"`
 }
 
 // IgnoreRulePackage describes the Package-specific fields that comprise the IgnoreRule.
@@ -138,9 +172,23 @@ func ApplyIgnoreFilters[T IgnoreFilter](matches []Match, filters ...T) ([]Match,
 	return out, ignoredMatches
 }
 
+// Validate returns an error if the rule contains malformed fields. It is intended to be called once
+// during config loading so the user gets a clear error at startup rather than at scan time.
+func (r IgnoreRule) Validate() error {
+	if _, err := parseExpiresAfter(r.ExpiresAfter); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (r IgnoreRule) IgnoreMatch(match Match) []IgnoreRule {
 	// VEX rules are handled by the vex processor
 	if r.VexStatus != "" {
+		return nil
+	}
+
+	// If the rule has an expiry date and it has passed, the rule no longer applies.
+	if isExpiresAfterInPast(r.ExpiresAfter) {
 		return nil
 	}
 

--- a/grype/match/ignore_test.go
+++ b/grype/match/ignore_test.go
@@ -2,9 +2,11 @@ package match
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
@@ -1352,6 +1354,42 @@ func TestShouldIgnore(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name:  "rule applies when expires-after is in the future",
+			match: exampleMatch,
+			rule: IgnoreRule{
+				Vulnerability: exampleMatch.Vulnerability.ID,
+				ExpiresAfter:  time.Now().UTC().Add(48 * time.Hour).Format(expiresAfterDateFmt),
+			},
+			expected: true,
+		},
+		{
+			name:  "rule does not apply when expires-after is in the past",
+			match: exampleMatch,
+			rule: IgnoreRule{
+				Vulnerability: exampleMatch.Vulnerability.ID,
+				ExpiresAfter:  time.Now().UTC().Add(-48 * time.Hour).Format(expiresAfterDateFmt),
+			},
+			expected: false,
+		},
+		{
+			name:  "rule applies when expires-after is empty",
+			match: exampleMatch,
+			rule: IgnoreRule{
+				Vulnerability: exampleMatch.Vulnerability.ID,
+				ExpiresAfter:  "",
+			},
+			expected: true,
+		},
+		{
+			name:  "rule applies (does not crash) when expires-after is malformed",
+			match: exampleMatch,
+			rule: IgnoreRule{
+				Vulnerability: exampleMatch.Vulnerability.ID,
+				ExpiresAfter:  "not-a-date",
+			},
+			expected: true,
+		},
 	}
 
 	for _, testCase := range cases {
@@ -1360,4 +1398,45 @@ func TestShouldIgnore(t *testing.T) {
 			assert.Equal(t, testCase.expected, actual)
 		})
 	}
+}
+
+func TestParseExpiresAfter(t *testing.T) {
+	cases := []struct {
+		name        string
+		input       string
+		expectZero  bool
+		expectError bool
+		expectDate  string
+	}{
+		{name: "valid date", input: "2026-12-31", expectDate: "2026-12-31"},
+		{name: "empty string returns zero with no error", input: "", expectZero: true},
+		{name: "invalid format returns error", input: "31-12-2026", expectError: true},
+		{name: "not a date returns error", input: "tomorrow", expectError: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseExpiresAfter(tc.input)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tc.expectZero {
+				assert.True(t, got.IsZero())
+				return
+			}
+			assert.Equal(t, tc.expectDate, got.Format(expiresAfterDateFmt))
+		})
+	}
+}
+
+func TestIsExpiresAfterInPast(t *testing.T) {
+	past := time.Now().UTC().Add(-48 * time.Hour).Format(expiresAfterDateFmt)
+	future := time.Now().UTC().Add(48 * time.Hour).Format(expiresAfterDateFmt)
+
+	assert.True(t, isExpiresAfterInPast(past), "a past date should be expired")
+	assert.False(t, isExpiresAfterInPast(future), "a future date should not be expired")
+	assert.False(t, isExpiresAfterInPast(""), "empty string should not be expired")
+	assert.False(t, isExpiresAfterInPast("not-a-date"), "malformed input should not be expired (defensive)")
 }


### PR DESCRIPTION
## Summary

This pull request adds support for an `expires-after` field to ignore rules, allowing users to specify a date after which an ignore rule will no longer apply. It includes validation, logic changes, and tests to ensure correct handling of the new field.

## Motivation

Currently the .grype.yml file does does not support the inclusion of an expiry date for vulnerabilities that are intentionally ignored. 


## Changes

* Added a new `expires-after` field to the `IgnoreRule` struct, allowing users to set an expiration date for ignore rules. The rule will be ignored if the current date is after the specified date. [[1]](diffhunk://#diff-83bde8e4dac524c6de53b2a412f439232446a5eb239ee531063515a65dea96e3R76) [[2]](diffhunk://#diff-9c2c54f341da5bb733c5b5978a9c5ce1b85487238a5deae122f66bbda1053d9fR203)
* Implemented helper functions `parseExpiresAfter` and `isExpiresAfterInPast` to parse and evaluate the expiration date, handling empty and malformed values gracefully.
* Updated the `IgnoreRule.IgnoreMatch` method to skip rules whose expiration date has passed.

### Validation and Testing

* Added a `Validate` method to `IgnoreRule` to check for malformed `expires-after` values at config load time, providing early feedback to users.
* Extended and added new tests in `ignore_test.go` to cover various scenarios for the `expires-after` field, including valid, empty, past, future, and malformed dates. 

### Miscellaneous

* Updated documentation/comments and imports to reflect the new feature. 
## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections