### PR TITLE
Pass contents: read to check-gate workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,7 @@ jobs:
 
   check-gate:
     permissions:
+      contents: read
       checks: read # required for getting the status of specific check names
     uses: anchore/workflows/.github/workflows/check-gate.yaml@b3e328b5ae31ba96297e2ed9a6124e5e6352a4c5 # v0.7.0
     with:


### PR DESCRIPTION
Otherwise it doesn't have enough permissions to do its job.

See analogous failure in Syft: https://github.com/anchore/syft/actions/runs/26844411675 : 

> The workflow is not valid. .github/workflows/release.yaml (Line: 34, Col: 3): Error calling workflow 'anchore/workflows/.github/workflows/check-gate.yaml@b3e328b5ae31ba96297e2ed9a6124e5e6352a4c5'. The nested job 'wait-for-check' is requesting 'contents: read', but is only allowed 'contents: none'.

Same would happen here.