### PR TITLE
fix: avoid panic on invalid RHEL version IDs

### DIFF
--- a/grype/distro/distro.go
+++ b/grype/distro/distro.go
@@ -176,10 +176,11 @@ func NewFromRelease(release linux.Release, channels []FixChannel) (*Distro, erro
 			continue
 		}
 
-		selectedVersionObj = version.New(ver, version.SemanticFormat)
+		versionObj := version.New(ver, version.SemanticFormat)
 
-		if selectedVersionObj.Validate() == nil {
+		if versionObj.Validate() == nil {
 			selectedVersion = ver
+			selectedVersionObj = versionObj
 			break
 		}
 	}

--- a/grype/distro/distro_test.go
+++ b/grype/distro/distro_test.go
@@ -319,6 +319,18 @@ func Test_NewDistroFromRelease(t *testing.T) {
 	}
 }
 
+func Test_NewDistroFromRelease_DoesNotPanicOnInvalidRHELVersionID(t *testing.T) {
+	require.NotPanics(t, func() {
+		d, err := NewFromRelease(linux.Release{
+			ID:        "rhel",
+			VersionID: "7.cv00",
+		}, testFixChannels())
+		require.NoError(t, err)
+		assert.Equal(t, RedHat, d.Type)
+		assert.Equal(t, "7.cv00", d.Version)
+	})
+}
+
 func Test_NewDistroFromRelease_Coverage(t *testing.T) {
 	observedDistros := stringutil.NewStringSet()
 	definedDistros := stringutil.NewStringSet()


### PR DESCRIPTION
## Summary

- avoid passing invalid semantic distro versions into fix-channel constraint evaluation
- add a regression test for malformed RHEL `versionID` values such as `7.cv00`

## Testing

```
go test ./grype/distro -run Test_NewDistroFromRelease_DoesNotPanicOnInvalidRHELVersionID -count=1
go test ./grype/distro -count=1
```