### PR TITLE
Add hand-written OSV model package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/gohugoio/hashstructure v0.6.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.6
-	github.com/google/osv-scanner v1.9.2
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
 	github.com/gookit/color v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -539,8 +539,6 @@ github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIG
 github.com/google/martian/v3 v3.2.1/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9Fc=
 github.com/google/martian/v3 v3.3.3/go.mod h1:iEPrYcgCF7jA9OtScMFQyAlZZ4YXTKEtJ1E6RWzmBA0=
-github.com/google/osv-scanner v1.9.2 h1:N5Arl9SA75afbjmX8mKURgOIaKyuK3NUjCaxDlj1KHI=
-github.com/google/osv-scanner v1.9.2/go.mod h1:ZTL8Dp9z/7Jr9kkQSOGqo8z6Csqt83qMIr58aZVx+pM=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=

--- a/grype/db/internal/provider/unmarshal/osv_vulnerability.go
+++ b/grype/db/internal/provider/unmarshal/osv_vulnerability.go
@@ -3,10 +3,10 @@ package unmarshal
 import (
 	"io"
 
-	"github.com/google/osv-scanner/pkg/models"
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
 )
 
-type OSVVulnerability = models.Vulnerability
+type OSVVulnerability = osvmodel.Vulnerability
 
 func OSVVulnerabilityEntries(reader io.Reader) ([]OSVVulnerability, error) {
 	return unmarshalSingleOrMulti[OSVVulnerability](reader)

--- a/grype/db/internal/provider/unmarshal/osvmodel/vulnerability.go
+++ b/grype/db/internal/provider/unmarshal/osvmodel/vulnerability.go
@@ -1,0 +1,132 @@
+// Package osvmodel is grype's representation of an OSV vulnerability record.
+//
+// The shape mirrors the upstream OSV schema (https://ossf.github.io/osv-schema/)
+// and is maintained by hand. Adding a field used by a new strategy means
+// adding it here with the appropriate JSON tag.
+//
+// We don't take a runtime dep on a third-party OSV library: parsing goes
+// through standard encoding/json into these structs.
+package osvmodel
+
+import "time"
+
+// Vulnerability is an OSV record. ID and Modified are required per spec; all
+// other fields are optional in some part of the OSV ecosystem.
+type Vulnerability struct {
+	SchemaVersion    string         `json:"schema_version,omitempty"`
+	ID               string         `json:"id"`
+	Modified         time.Time      `json:"modified"`
+	Published        time.Time      `json:"published,omitempty"`
+	Withdrawn        time.Time      `json:"withdrawn,omitempty"`
+	Summary          string         `json:"summary,omitempty"`
+	Details          string         `json:"details,omitempty"`
+	Aliases          []string       `json:"aliases,omitempty"`
+	Related          []string       `json:"related,omitempty"`
+	Upstream         []string       `json:"upstream,omitempty"`
+	Severity         []Severity     `json:"severity,omitempty"`
+	Affected         []Affected     `json:"affected,omitempty"`
+	References       []Reference    `json:"references,omitempty"`
+	Credits          []Credit       `json:"credits,omitempty"`
+	DatabaseSpecific map[string]any `json:"database_specific,omitempty"`
+}
+
+type Affected struct {
+	Package           Package        `json:"package,omitempty"`
+	Severity          []Severity     `json:"severity,omitempty"`
+	Ranges            []Range        `json:"ranges,omitempty"`
+	Versions          []string       `json:"versions,omitempty"`
+	EcosystemSpecific map[string]any `json:"ecosystem_specific,omitempty"`
+	DatabaseSpecific  map[string]any `json:"database_specific,omitempty"`
+}
+
+type Package struct {
+	Ecosystem string `json:"ecosystem,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Purl      string `json:"purl,omitempty"`
+}
+
+type Range struct {
+	Type             RangeType      `json:"type,omitempty"`
+	Repo             string         `json:"repo,omitempty"`
+	Events           []Event        `json:"events,omitempty"`
+	DatabaseSpecific map[string]any `json:"database_specific,omitempty"`
+}
+
+// Event is a flattened union of OSV range-event variants. Upstream defines
+// these as a `oneOf` over {introduced} | {fixed} | {last_affected} | {limit};
+// we keep all four as optional fields and callers inspect the non-empty ones.
+type Event struct {
+	Introduced   string `json:"introduced,omitempty"`
+	Fixed        string `json:"fixed,omitempty"`
+	LastAffected string `json:"last_affected,omitempty"`
+	Limit        string `json:"limit,omitempty"`
+}
+
+type Severity struct {
+	Type  SeverityType `json:"type,omitempty"`
+	Score string       `json:"score,omitempty"`
+}
+
+type Reference struct {
+	Type ReferenceType `json:"type,omitempty"`
+	URL  string        `json:"url,omitempty"`
+}
+
+type Credit struct {
+	Name    string     `json:"name,omitempty"`
+	Contact []string   `json:"contact,omitempty"`
+	Type    CreditType `json:"type,omitempty"`
+}
+
+// RangeType is the OSV version-range type.
+type RangeType string
+
+const (
+	RangeGit       RangeType = "GIT"
+	RangeSemVer    RangeType = "SEMVER"
+	RangeEcosystem RangeType = "ECOSYSTEM"
+)
+
+// ReferenceType classifies a reference URL.
+type ReferenceType string
+
+const (
+	ReferenceAdvisory   ReferenceType = "ADVISORY"
+	ReferenceArticle    ReferenceType = "ARTICLE"
+	ReferenceDetection  ReferenceType = "DETECTION"
+	ReferenceDiscussion ReferenceType = "DISCUSSION"
+	ReferenceEvidence   ReferenceType = "EVIDENCE"
+	ReferenceFix        ReferenceType = "FIX"
+	ReferenceGit        ReferenceType = "GIT"
+	ReferenceIntroduced ReferenceType = "INTRODUCED"
+	ReferencePackage    ReferenceType = "PACKAGE"
+	ReferenceReport     ReferenceType = "REPORT"
+	ReferenceWeb        ReferenceType = "WEB"
+)
+
+// SeverityType classifies a severity score; SeverityCVSSV{2,3,4} expect a
+// CVSS vector string, SeverityUbuntu expects one of negligible/low/medium/high/critical.
+type SeverityType string
+
+const (
+	SeverityCVSSV2 SeverityType = "CVSS_V2"
+	SeverityCVSSV3 SeverityType = "CVSS_V3"
+	SeverityCVSSV4 SeverityType = "CVSS_V4"
+	SeverityUbuntu SeverityType = "Ubuntu"
+)
+
+// CreditType classifies a credit entry.
+type CreditType string
+
+const (
+	CreditAnalyst              CreditType = "ANALYST"
+	CreditCoordinator          CreditType = "COORDINATOR"
+	CreditFinder               CreditType = "FINDER"
+	CreditOther                CreditType = "OTHER"
+	CreditRemediationDeveloper CreditType = "REMEDIATION_DEVELOPER" //nolint:gosec // G101 false positive: enum value, not a credential
+	CreditRemediationReviewer  CreditType = "REMEDIATION_REVIEWER"  //nolint:gosec // G101 false positive: enum value, not a credential
+	CreditRemediationVerifier  CreditType = "REMEDIATION_VERIFIER"  //nolint:gosec // G101 false positive: enum value, not a credential
+	CreditReporter             CreditType = "REPORTER"
+	CreditSponsor              CreditType = "SPONSOR"
+	CreditTool                 CreditType = "TOOL"
+)

--- a/grype/db/v6/build/transformers/osv/helpers.go
+++ b/grype/db/v6/build/transformers/osv/helpers.go
@@ -5,9 +5,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/google/osv-scanner/pkg/models"
-
 	"github.com/anchore/grype/grype/db/internal/provider/unmarshal"
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
 	"github.com/anchore/grype/grype/db/internal/versionutil"
 	db "github.com/anchore/grype/grype/db/v6"
 	"github.com/anchore/grype/grype/db/v6/build/transformers/internal"
@@ -64,7 +63,7 @@ import (
 // "semver") — the caller decides this per-provider, since the same OSV
 // RangeType maps differently across providers. See each strategy's own
 // rangeType() function in transform_<provider>.go.
-func getGrypeRangesFromRange(r models.Range, rangeType string) []db.Range { // nolint: gocognit,funlen
+func getGrypeRangesFromRange(r osvmodel.Range, rangeType string) []db.Range { // nolint: gocognit,funlen
 	var ranges []db.Range
 	if len(r.Events) == 0 {
 		return nil
@@ -126,7 +125,7 @@ func getGrypeRangesFromRange(r models.Range, rangeType string) []db.Range { // n
 // getGrypeUnaffectedRangesFromRange inverts the OSV range events into
 // "unaffected" ranges for advisory records. rangeType is the grype-side format
 // string supplied by the calling strategy (see strategy rangeType() helpers).
-func getGrypeUnaffectedRangesFromRange(r models.Range, rangeType string) []db.Range {
+func getGrypeUnaffectedRangesFromRange(r osvmodel.Range, rangeType string) []db.Range {
 	if len(r.Events) == 0 {
 		return nil
 	}
@@ -161,9 +160,9 @@ func normalizeFix(fix string, detail *db.FixDetail) *db.Fix {
 // defaultRangeType is the generic OSV range-type → grype format mapping with
 // no provider-specific overrides. Strategies use this as the fallback for OSV
 // range types they don't have a special interpretation for.
-func defaultRangeType(t models.RangeType) string {
+func defaultRangeType(t osvmodel.RangeType) string {
 	switch t {
-	case models.RangeSemVer, models.RangeEcosystem, models.RangeGit:
+	case osvmodel.RangeSemVer, osvmodel.RangeEcosystem, osvmodel.RangeGit:
 		return strings.ToLower(string(t))
 	default:
 		return "unknown"
@@ -174,7 +173,7 @@ func defaultRangeType(t models.RangeType) string {
 // Fix-availability decoding (database_specific.anchore.fixes)
 // ============================================================================
 
-func extractFixAvailability(r models.Range) map[string]db.FixAvailability {
+func extractFixAvailability(r osvmodel.Range) map[string]db.FixAvailability {
 	fixByVersion := make(map[string]db.FixAvailability)
 
 	dbSpecific, ok := r.DatabaseSpecific["anchore"]
@@ -215,7 +214,7 @@ func parseSingleFixEntry(fixEntry any, fixByVersion map[string]db.FixAvailabilit
 	}
 }
 
-func buildUnaffectedRangesFromEvents(events []models.Event, fixByVersion map[string]db.FixAvailability, rangeType string) []db.Range {
+func buildUnaffectedRangesFromEvents(events []osvmodel.Event, fixByVersion map[string]db.FixAvailability, rangeType string) []db.Range {
 	var ranges []db.Range
 	for _, e := range events {
 		if e.Fixed != "" {
@@ -254,9 +253,9 @@ func extractCVSSInfo(cvss string) (string, string, error) {
 	return matches[1], matches[0], nil
 }
 
-func normalizeSeverity(severity models.Severity) (db.Severity, error) {
+func normalizeSeverity(severity osvmodel.Severity) (db.Severity, error) {
 	switch severity.Type {
-	case models.SeverityCVSSV2, models.SeverityCVSSV3, models.SeverityCVSSV4:
+	case osvmodel.SeverityCVSSV2, osvmodel.SeverityCVSSV3, osvmodel.SeverityCVSSV4:
 		version, vector, err := extractCVSSInfo(severity.Score)
 		if err != nil {
 			return db.Severity{}, err

--- a/grype/db/v6/build/transformers/osv/transform_alma.go
+++ b/grype/db/v6/build/transformers/osv/transform_alma.go
@@ -6,11 +6,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/osv-scanner/pkg/models"
-
 	"github.com/anchore/grype/grype/db/data"
 	"github.com/anchore/grype/grype/db/internal/codename"
 	"github.com/anchore/grype/grype/db/internal/provider/unmarshal"
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
 	"github.com/anchore/grype/grype/db/provider"
 	db "github.com/anchore/grype/grype/db/v6"
 	"github.com/anchore/grype/grype/db/v6/build/transformers"
@@ -78,7 +77,7 @@ func almaReferences(vuln unmarshal.OSVVulnerability) []db.Reference {
 	var refs []db.Reference
 	for _, ref := range vuln.References {
 		refID := ""
-		if ref.Type == models.ReferenceAdvisory {
+		if ref.Type == osvmodel.ReferenceAdvisory {
 			refID = vuln.ID
 		}
 		refs = append(refs, db.Reference{
@@ -98,7 +97,7 @@ func almaUnaffectedPackages(vuln unmarshal.OSVVulnerability) []db.UnaffectedPack
 	for _, affected := range vuln.Affected {
 		uphs = append(uphs, db.UnaffectedPackageHandle{
 			Package:         almaPackage(affected.Package),
-			OperatingSystem: almaOSFromEcosystem(string(affected.Package.Ecosystem)),
+			OperatingSystem: almaOSFromEcosystem(affected.Package.Ecosystem),
 			BlobValue:       almaUnaffectedBlob(vuln, affected),
 		})
 	}
@@ -106,7 +105,7 @@ func almaUnaffectedPackages(vuln unmarshal.OSVVulnerability) []db.UnaffectedPack
 	return uphs
 }
 
-func almaUnaffectedBlob(vuln unmarshal.OSVVulnerability, affected models.Affected) *db.PackageBlob {
+func almaUnaffectedBlob(vuln unmarshal.OSVVulnerability, affected osvmodel.Affected) *db.PackageBlob {
 	var ranges []db.Range
 	for _, r := range affected.Ranges {
 		ranges = append(ranges, getGrypeUnaffectedRangesFromRange(r, almaRangeType(r.Type))...)
@@ -129,7 +128,7 @@ func almaUnaffectedBlob(vuln unmarshal.OSVVulnerability, affected models.Affecte
 	}
 }
 
-func almaPackage(p models.Package) *db.Package {
+func almaPackage(p osvmodel.Package) *db.Package {
 	return &db.Package{
 		Ecosystem: pkg.RpmPkg.String(),
 		Name:      name.Normalize(p.Name, pkg.RpmPkg),
@@ -141,8 +140,8 @@ func almaPackage(p models.Package) *db.Package {
 // other OSV types fall through to the default mapping. AlmaLinux records in
 // practice only use ECOSYSTEM, but the fallback is here so unexpected shapes
 // don't silently become "unknown".
-func almaRangeType(t models.RangeType) string {
-	if t == models.RangeEcosystem {
+func almaRangeType(t osvmodel.RangeType) string {
+	if t == osvmodel.RangeEcosystem {
 		return pkg.RpmPkg.String()
 	}
 	return defaultRangeType(t)
@@ -151,7 +150,7 @@ func almaRangeType(t models.RangeType) string {
 // extractRpmModularity reads ecosystem_specific.rpm_modularity from an OSV
 // affected entry. Only alma emits this in the OSV records we currently
 // consume; other strategies don't have a use for it.
-func extractRpmModularity(affected models.Affected) string {
+func extractRpmModularity(affected osvmodel.Affected) string {
 	if affected.EcosystemSpecific == nil {
 		return ""
 	}

--- a/grype/db/v6/build/transformers/osv/transform_alma_test.go
+++ b/grype/db/v6/build/transformers/osv/transform_alma_test.go
@@ -5,8 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/osv-scanner/pkg/models"
-
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
 	db "github.com/anchore/grype/grype/db/v6"
 	"github.com/anchore/grype/grype/db/v6/build/transformers"
 )
@@ -228,14 +227,14 @@ func TestAlmaTransform(t *testing.T) {
 func TestAlmaRangeConversion(t *testing.T) {
 	tests := []struct {
 		name string
-		rnge models.Range
+		rnge osvmodel.Range
 		want []db.Range
 	}{
 		{
 			name: "ECOSYSTEM range with introduced=0 and fixed produces inverted unaffected range",
-			rnge: models.Range{
-				Type: models.RangeEcosystem,
-				Events: []models.Event{
+			rnge: osvmodel.Range{
+				Type: osvmodel.RangeEcosystem,
+				Events: []osvmodel.Event{
 					{Introduced: "0"},
 					{Fixed: "1.0.28-10.el8"},
 				},
@@ -247,9 +246,9 @@ func TestAlmaRangeConversion(t *testing.T) {
 		},
 		{
 			name: "ECOSYSTEM range with modular RPM fix version",
-			rnge: models.Range{
-				Type: models.RangeEcosystem,
-				Events: []models.Event{
+			rnge: osvmodel.Range{
+				Type: osvmodel.RangeEcosystem,
+				Events: []osvmodel.Event{
 					{Introduced: "0"},
 					{Fixed: "1.6.0-1.module_el8.5.0+2604+960c7771"},
 				},
@@ -261,9 +260,9 @@ func TestAlmaRangeConversion(t *testing.T) {
 		},
 		{
 			name: "ECOSYSTEM range with epoch-prefixed RPM version",
-			rnge: models.Range{
-				Type: models.RangeEcosystem,
-				Events: []models.Event{
+			rnge: osvmodel.Range{
+				Type: osvmodel.RangeEcosystem,
+				Events: []osvmodel.Event{
 					{Introduced: "0"},
 					{Fixed: "2:1.18.1-1.el10_0"},
 				},
@@ -291,12 +290,12 @@ func TestAlmaRangeConversion(t *testing.T) {
 func Test_extractRpmModularity(t *testing.T) {
 	tests := []struct {
 		name     string
-		affected models.Affected
+		affected osvmodel.Affected
 		want     string
 	}{
 		{
 			name: "with rpm_modularity",
-			affected: models.Affected{
+			affected: osvmodel.Affected{
 				EcosystemSpecific: map[string]any{
 					"rpm_modularity": "mariadb:10.3",
 				},
@@ -305,26 +304,26 @@ func Test_extractRpmModularity(t *testing.T) {
 		},
 		{
 			name:     "no ecosystem_specific",
-			affected: models.Affected{EcosystemSpecific: nil},
+			affected: osvmodel.Affected{EcosystemSpecific: nil},
 			want:     "",
 		},
 		{
 			name: "no rpm_modularity key",
-			affected: models.Affected{
+			affected: osvmodel.Affected{
 				EcosystemSpecific: map[string]any{"other_key": "some_value"},
 			},
 			want: "",
 		},
 		{
 			name: "rpm_modularity not string",
-			affected: models.Affected{
+			affected: osvmodel.Affected{
 				EcosystemSpecific: map[string]any{"rpm_modularity": 123},
 			},
 			want: "",
 		},
 		{
 			name: "nodejs modularity",
-			affected: models.Affected{
+			affected: osvmodel.Affected{
 				EcosystemSpecific: map[string]any{"rpm_modularity": "nodejs:16"},
 			},
 			want: "nodejs:16",

--- a/grype/db/v6/build/transformers/osv/transform_bitnami.go
+++ b/grype/db/v6/build/transformers/osv/transform_bitnami.go
@@ -5,10 +5,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/google/osv-scanner/pkg/models"
-
 	"github.com/anchore/grype/grype/db/data"
 	"github.com/anchore/grype/grype/db/internal/provider/unmarshal"
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
 	"github.com/anchore/grype/grype/db/provider"
 	db "github.com/anchore/grype/grype/db/v6"
 	"github.com/anchore/grype/grype/db/v6/build/transformers"
@@ -98,10 +97,10 @@ func bitnamiAffectedPackages(vuln unmarshal.OSVVulnerability) []db.AffectedPacka
 	return aphs
 }
 
-func bitnamiPackage(p models.Package) *db.Package {
+func bitnamiPackage(p osvmodel.Package) *db.Package {
 	pkgType := pkg.TypeFromPURL(p.Purl)
 	return &db.Package{
-		Ecosystem: string(p.Ecosystem),
+		Ecosystem: p.Ecosystem,
 		Name:      name.Normalize(p.Name, pkgType),
 	}
 }
@@ -109,8 +108,8 @@ func bitnamiPackage(p models.Package) *db.Package {
 // bitnamiRangeType maps an OSV range type to the grype version-format string
 // for Bitnami records. SEMVER ranges describe bitnami-flavored semver
 // (separate version comparator); other OSV types fall through to the default.
-func bitnamiRangeType(t models.RangeType) string {
-	if t == models.RangeSemVer {
+func bitnamiRangeType(t osvmodel.RangeType) string {
+	if t == osvmodel.RangeSemVer {
 		return "bitnami"
 	}
 	return defaultRangeType(t)

--- a/grype/db/v6/build/transformers/osv/transform_bitnami_test.go
+++ b/grype/db/v6/build/transformers/osv/transform_bitnami_test.go
@@ -5,8 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/osv-scanner/pkg/models"
-
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
 	db "github.com/anchore/grype/grype/db/v6"
 	"github.com/anchore/grype/grype/db/v6/build/transformers"
 )
@@ -165,14 +164,14 @@ func TestBitnamiTransform(t *testing.T) {
 func TestBitnamiRangeConversion(t *testing.T) {
 	tests := []struct {
 		name string
-		rnge models.Range
+		rnge osvmodel.Range
 		want []db.Range
 	}{
 		{
 			name: "simple introduced -> fixed semver range",
-			rnge: models.Range{
-				Type: models.RangeSemVer,
-				Events: []models.Event{
+			rnge: osvmodel.Range{
+				Type: osvmodel.RangeSemVer,
+				Events: []osvmodel.Event{
 					{Introduced: "12.0.0"},
 					{Fixed: "12.18.4"},
 				},
@@ -184,9 +183,9 @@ func TestBitnamiRangeConversion(t *testing.T) {
 		},
 		{
 			name: "introduced=0 -> fixed produces fixed-only constraint",
-			rnge: models.Range{
-				Type: models.RangeSemVer,
-				Events: []models.Event{
+			rnge: osvmodel.Range{
+				Type: osvmodel.RangeSemVer,
+				Events: []osvmodel.Event{
 					{Introduced: "0"},
 					{Fixed: "3.4.0"},
 				},
@@ -198,9 +197,9 @@ func TestBitnamiRangeConversion(t *testing.T) {
 		},
 		{
 			name: "introduced + last_affected (no fixed event)",
-			rnge: models.Range{
-				Type: models.RangeSemVer,
-				Events: []models.Event{
+			rnge: osvmodel.Range{
+				Type: osvmodel.RangeSemVer,
+				Events: []osvmodel.Event{
 					{Introduced: "2.4.32"},
 					{LastAffected: "2.4.43"},
 				},
@@ -211,9 +210,9 @@ func TestBitnamiRangeConversion(t *testing.T) {
 		},
 		{
 			name: "two disjoint introduced/fixed windows in one range",
-			rnge: models.Range{
-				Type: models.RangeSemVer,
-				Events: []models.Event{
+			rnge: osvmodel.Range{
+				Type: osvmodel.RangeSemVer,
+				Events: []osvmodel.Event{
 					{Introduced: "0"},
 					{Fixed: "3.2.2"},
 					{Introduced: "3.3.0"},
@@ -233,9 +232,9 @@ func TestBitnamiRangeConversion(t *testing.T) {
 		},
 		{
 			name: "range with anchore.fixes metadata attaches FixDetail",
-			rnge: models.Range{
-				Type: models.RangeSemVer,
-				Events: []models.Event{
+			rnge: osvmodel.Range{
+				Type: osvmodel.RangeSemVer,
+				Events: []osvmodel.Event{
 					{Introduced: "12.0.0"},
 					{Fixed: "12.18.4"},
 				},

--- a/grype/db/v6/build/transformers/osv/transform_go_vuln_db.go
+++ b/grype/db/v6/build/transformers/osv/transform_go_vuln_db.go
@@ -6,10 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/osv-scanner/pkg/models"
-
 	"github.com/anchore/grype/grype/db/data"
 	"github.com/anchore/grype/grype/db/internal/provider/unmarshal"
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
 	"github.com/anchore/grype/grype/db/provider"
 	db "github.com/anchore/grype/grype/db/v6"
 	"github.com/anchore/grype/grype/db/v6/build/transformers"
@@ -123,7 +122,7 @@ func govulndbAffectedPackages(vuln unmarshal.OSVVulnerability) []db.AffectedPack
 	return aphs
 }
 
-func govulndbPackage(p models.Package) *db.Package {
+func govulndbPackage(p osvmodel.Package) *db.Package {
 	return &db.Package{
 		Ecosystem: string(pkg.GoModulePkg),
 		Name:      name.Normalize(p.Name, pkg.GoModulePkg),
@@ -135,8 +134,8 @@ func govulndbPackage(p models.Package) *db.Package {
 // the Go-flavored comparator (it understands v0.0.0-<timestamp>-<hash>
 // pseudo-versions, which generic semver does not). Other OSV types fall
 // through to the default mapping; in practice govulndb only emits SEMVER.
-func govulndbRangeType(t models.RangeType) string {
-	if t == models.RangeSemVer {
+func govulndbRangeType(t osvmodel.RangeType) string {
+	if t == osvmodel.RangeSemVer {
 		return "go"
 	}
 	return defaultRangeType(t)

--- a/grype/db/v6/build/transformers/osv/transform_go_vuln_db_test.go
+++ b/grype/db/v6/build/transformers/osv/transform_go_vuln_db_test.go
@@ -5,8 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/osv-scanner/pkg/models"
-
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
 	db "github.com/anchore/grype/grype/db/v6"
 	"github.com/anchore/grype/grype/db/v6/build/transformers"
 )
@@ -171,14 +170,14 @@ func TestGoVulnDBTransform(t *testing.T) {
 func TestGoVulnDBRangeConversion(t *testing.T) {
 	tests := []struct {
 		name string
-		rnge models.Range
+		rnge osvmodel.Range
 		want []db.Range
 	}{
 		{
 			name: "simple introduced=0 -> fixed",
-			rnge: models.Range{
-				Type: models.RangeSemVer,
-				Events: []models.Event{
+			rnge: osvmodel.Range{
+				Type: osvmodel.RangeSemVer,
+				Events: []osvmodel.Event{
 					{Introduced: "0"},
 					{Fixed: "1.6.0"},
 				},
@@ -190,9 +189,9 @@ func TestGoVulnDBRangeConversion(t *testing.T) {
 		},
 		{
 			name: "two disjoint windows in one range (stdlib shape)",
-			rnge: models.Range{
-				Type: models.RangeSemVer,
-				Events: []models.Event{
+			rnge: osvmodel.Range{
+				Type: osvmodel.RangeSemVer,
+				Events: []osvmodel.Event{
 					{Introduced: "0"},
 					{Fixed: "1.18.6"},
 					{Introduced: "1.19.0-0"},
@@ -212,9 +211,9 @@ func TestGoVulnDBRangeConversion(t *testing.T) {
 		},
 		{
 			name: "pseudo-version fixed (golang.org/x/* shape)",
-			rnge: models.Range{
-				Type: models.RangeSemVer,
-				Events: []models.Event{
+			rnge: osvmodel.Range{
+				Type: osvmodel.RangeSemVer,
+				Events: []osvmodel.Event{
 					{Introduced: "0"},
 					{Fixed: "0.0.0-20220906165146-f3363e06e74c"},
 				},

--- a/grype/db/v6/build/transformers/osv/transform_rootio.go
+++ b/grype/db/v6/build/transformers/osv/transform_rootio.go
@@ -6,11 +6,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/osv-scanner/pkg/models"
-
 	"github.com/anchore/grype/grype/db/data"
 	"github.com/anchore/grype/grype/db/internal/codename"
 	"github.com/anchore/grype/grype/db/internal/provider/unmarshal"
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
 	"github.com/anchore/grype/grype/db/provider"
 	db "github.com/anchore/grype/grype/db/v6"
 	"github.com/anchore/grype/grype/db/v6/build/transformers"
@@ -84,7 +83,7 @@ func rootioReferences(vuln unmarshal.OSVVulnerability) []db.Reference {
 	var refs []db.Reference
 	for _, ref := range vuln.References {
 		refID := ""
-		if ref.Type == models.ReferenceAdvisory {
+		if ref.Type == osvmodel.ReferenceAdvisory {
 			refID = vuln.ID
 		}
 		refs = append(refs, db.Reference{
@@ -103,7 +102,7 @@ func rootioUnaffectedPackages(vuln unmarshal.OSVVulnerability, aliases []string)
 	rootIO := true
 	var uphs []db.UnaffectedPackageHandle
 	for _, affected := range vuln.Affected {
-		ecosystem := string(affected.Package.Ecosystem)
+		ecosystem := affected.Package.Ecosystem
 		pkgType := rootioPackageType(ecosystem)
 		if pkgType == "" {
 			// rootio ships occasional records for ecosystems the transformer
@@ -187,8 +186,8 @@ func rootioPackageType(ecosystem string) pkg.Type {
 // Ecosystem is canonicalized to the grype package-type string (e.g.
 // "PyPI" → "python", "Alpine:3.18" → "apk"). Name is normalized per the
 // package type (e.g. PEP 503 for PythonPkg).
-func rootioPackage(p models.Package, pkgType pkg.Type) *db.Package {
-	ecosystem := string(p.Ecosystem)
+func rootioPackage(p osvmodel.Package, pkgType pkg.Type) *db.Package {
+	ecosystem := p.Ecosystem
 	if pkgType != "" {
 		ecosystem = pkgType.String()
 	}

--- a/grype/db/v6/build/transformers/osv/transform_rootio_test.go
+++ b/grype/db/v6/build/transformers/osv/transform_rootio_test.go
@@ -3,10 +3,10 @@ package osv
 import (
 	"testing"
 
-	"github.com/google/osv-scanner/pkg/models"
 	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/grype/grype/db/internal/provider/unmarshal"
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
 	db "github.com/anchore/grype/grype/db/v6"
 	"github.com/anchore/grype/grype/db/v6/build/transformers"
 )
@@ -130,16 +130,16 @@ func TestRootioTransform_RelatedToAliases(t *testing.T) {
 	vuln := unmarshal.OSVVulnerability{}
 	vuln.ID = "ROOT-OS-UBUNTU-2204-CVE-2024-2236"
 	vuln.Related = []string{"CVE-2024-2236"}
-	vuln.Affected = []models.Affected{
+	vuln.Affected = []osvmodel.Affected{
 		{
-			Package: models.Package{
+			Package: osvmodel.Package{
 				Ecosystem: "Root:Ubuntu:22.04",
 				Name:      "rootio-libgcrypt20",
 			},
-			Ranges: []models.Range{
+			Ranges: []osvmodel.Range{
 				{
-					Type: models.RangeEcosystem,
-					Events: []models.Event{
+					Type: osvmodel.RangeEcosystem,
+					Events: []osvmodel.Event{
 						{Introduced: "0"},
 						{Fixed: "1.9.4-3ubuntu3.root.io.2"},
 					},


### PR DESCRIPTION
The osv-scanner project deprecated the exported models.Vulnerability struct grype was using, so the existing alias broke against newer OSV schema versions. Replace it with a hand-maintained osvmodel package covering the OSV v1 schema, swap all OSV strategies and helpers off osv-scanner, and drop the dependency.

New fields land by editing osvmodel/vulnerability.go directly; the strategies that need a field add it in the same PR.

This is a different approach to solve the same issues as https://github.com/anchore/grype/pull/3499 - that PR uses an in-repo _generator_ to make structs like these. This just commits the structs and we have to remember to update them. It's less code but we don't get automatic updates.