### PR TITLE
fix(hummingbird): mark hummingbird distro as rolling

### DIFF
--- a/grype/db/v6/build/transformers/csafvex/transform.go
+++ b/grype/db/v6/build/transformers/csafvex/transform.go
@@ -486,8 +486,12 @@ func getOperatingSystem(productID string, idx *productIndex) *db.OperatingSystem
 	return osFromCPE(cpe)
 }
 
+// rollingLabel marks a rolling-release distro row, matching what the os transformer emits
+// for archlinux.
+const rollingLabel = "rolling"
+
 // osFromCPE extracts OS name and version from a CPE string.
-// Example: "cpe:/a:redhat:hummingbird:1" → name=hummingbird, majorVersion=1
+// Example: "cpe:/a:redhat:hummingbird:1" → name=hummingbird, labelVersion=rolling
 // Example: "cpe:/o:redhat:enterprise_linux:9" → name=redhat:enterprise_linux, majorVersion=9
 func osFromCPE(cpe string) *db.OperatingSystem {
 	// handle both cpe:/ and cpe:2.3: formats
@@ -516,6 +520,13 @@ func osFromCPE(cpe string) *db.OperatingSystem {
 		Name: strings.ToLower(osName),
 	}
 
+	// for rolling distros the CPE version is a product-generation marker, not an OS release;
+	// label the row "rolling" instead of recording a major version
+	if isRollingDistro(os.Name) {
+		os.LabelVersion = rollingLabel
+		return os
+	}
+
 	if len(parts) > 3 && parts[3] != "" && parts[3] != "*" {
 		versionParts := strings.SplitN(parts[3], ".", 2)
 		os.MajorVersion = versionParts[0]
@@ -525,6 +536,24 @@ func osFromCPE(cpe string) *db.OperatingSystem {
 	}
 
 	return os
+}
+
+// isRollingDistro reports whether the named distro is an unconditional rolling release per
+// db.KnownOperatingSystemSpecifierOverrides (the source of truth). Version-conditional rolling
+// overrides (e.g. alpine's _alpha pattern) are excluded since they depend on version data.
+func isRollingDistro(name string) bool {
+	for _, o := range db.KnownOperatingSystemSpecifierOverrides() {
+		if !o.Rolling {
+			continue
+		}
+		if o.Version != "" || o.VersionPattern != "" || o.Codename != "" {
+			continue
+		}
+		if strings.EqualFold(o.Alias, name) {
+			return true
+		}
+	}
+	return false
 }
 
 func versionTypeFromPURL(purl *packageurl.PackageURL) string {

--- a/grype/db/v6/build/transformers/csafvex/transform_test.go
+++ b/grype/db/v6/build/transformers/csafvex/transform_test.go
@@ -184,7 +184,8 @@ func TestTransform_FixedAndNotAffected(t *testing.T) {
 	require.Equal(t, "rpm", aph.Package.Ecosystem)
 	require.NotNil(t, aph.OperatingSystem)
 	require.Equal(t, "hummingbird", aph.OperatingSystem.Name)
-	require.Equal(t, "1", aph.OperatingSystem.MajorVersion)
+	require.Empty(t, aph.OperatingSystem.MajorVersion, "hummingbird is rolling; no major version")
+	require.Equal(t, "rolling", aph.OperatingSystem.LabelVersion)
 	require.Len(t, aph.BlobValue.Ranges, 1)
 	require.Equal(t, "< 1.2.3-1.hum1", aph.BlobValue.Ranges[0].Version.Constraint)
 	require.Equal(t, "rpm", aph.BlobValue.Ranges[0].Version.Type)
@@ -272,13 +273,14 @@ func TestTransform_OSFromCPE(t *testing.T) {
 		wantName  string
 		wantMajor string
 		wantMinor string
+		wantLabel string
 		wantNil   bool
 	}{
 		{
-			name:      "hummingbird URI format",
+			name:      "hummingbird URI format (rolling, version → rolling label)",
 			cpe:       "cpe:/a:redhat:hummingbird:1",
 			wantName:  "hummingbird",
-			wantMajor: "1",
+			wantLabel: "rolling",
 		},
 		{
 			name:      "RHEL URI format",
@@ -304,9 +306,10 @@ func TestTransform_OSFromCPE(t *testing.T) {
 			wantNil: true,
 		},
 		{
-			name:     "CPE with wildcard version",
-			cpe:      "cpe:/a:redhat:hummingbird:*",
-			wantName: "hummingbird",
+			name:      "CPE with wildcard version",
+			cpe:       "cpe:/a:redhat:hummingbird:*",
+			wantName:  "hummingbird",
+			wantLabel: "rolling",
 		},
 	}
 
@@ -320,6 +323,7 @@ func TestTransform_OSFromCPE(t *testing.T) {
 			require.NotNil(t, got)
 			require.Equal(t, tt.wantName, got.Name)
 			require.Equal(t, tt.wantMajor, got.MajorVersion)
+			require.Equal(t, tt.wantLabel, got.LabelVersion)
 			if tt.wantMinor != "" {
 				require.Equal(t, tt.wantMinor, got.MinorVersion)
 			}
@@ -579,10 +583,12 @@ func TestTransform_DropsSrcWhenSameNameBinaryPresent(t *testing.T) {
 		seen = append(seen, emitted{name: aph.Package.Name, os: osName, osMajor: osMajor, arch: arch})
 	}
 
+	// hummingbird is rolling: both platforms emit a version-less OS row. The per-platform
+	// dedup still keys off the relationship platform IDs, not the emitted OS version.
 	want := []emitted{
-		{name: "glibc", os: "hummingbird", osMajor: "1", arch: architecture.ArchBinaryNoArchSpecified},
-		{name: "glibc-common", os: "hummingbird", osMajor: "1", arch: architecture.ArchBinaryNoArchSpecified},
-		{name: "glibc", os: "hummingbird", osMajor: "2", arch: architecture.ArchSource},
+		{name: "glibc", os: "hummingbird", osMajor: "", arch: architecture.ArchBinaryNoArchSpecified},
+		{name: "glibc-common", os: "hummingbird", osMajor: "", arch: architecture.ArchBinaryNoArchSpecified},
+		{name: "glibc", os: "hummingbird", osMajor: "", arch: architecture.ArchSource},
 	}
 
 	require.ElementsMatch(t, want, seen, "hummingbird-1:glibc.src should be dropped (sibling binary present); hummingbird-2:glibc.src should survive (no sibling binary on that platform)")

--- a/grype/matcher/rpm/hummingbird_test.go
+++ b/grype/matcher/rpm/hummingbird_test.go
@@ -38,7 +38,7 @@ func TestHummingbirdMatching_BinaryDirectHit(t *testing.T) {
 
 			findings := db.Match(t, &matcher, p)
 			findings.SelectMatch("CVE-2026-5928").
-				InNamespace("hummingbird:distro:hummingbird:1").
+				InNamespace("hummingbird:distro:hummingbird:rolling").
 				SelectDetailByDistro("hummingbird", "1").
 				HasMatchType(match.ExactDirectMatch)
 		})
@@ -114,7 +114,7 @@ func TestHummingbirdMatching_PerlBDirectFix(t *testing.T) {
 
 			findings := db.Match(t, &matcher, p)
 			findings.SelectMatch("CVE-2018-18311").
-				InNamespace("hummingbird:distro:hummingbird:1").
+				InNamespace("hummingbird:distro:hummingbird:rolling").
 				SelectDetailByDistro("hummingbird", "1").
 				HasMatchType(match.ExactDirectMatch)
 		})


### PR DESCRIPTION
Previous hummingbird work incorrectly marked only the search side (data.go) as having a rolling label. Therefore also mark hummingbird as a rolling distro at database creation time.