### PR TITLE
feat: add Echo OSV language strategy (pip/npm/maven)

### DIFF
--- a/grype/db/v6/blobs.go
+++ b/grype/db/v6/blobs.go
@@ -159,6 +159,11 @@ type PackageQualifiers struct {
 	// RootIO indicates that the vulnerability applies only to Root IO packages (packages with Root IO fixes).
 	// When true, standard packages will not match this vulnerability (NAK pattern).
 	RootIO *bool `json:"rootio,omitempty"`
+
+	// Echo indicates that the vulnerability applies only to Echo-patched language packages
+	// (identified by a "+echo.N" version suffix). When true, non-Echo packages will not match
+	// this vulnerability (NAK pattern).
+	Echo *bool `json:"echo,omitempty"`
 }
 
 // Range defines a specific range of package versions pertaining to a vulnerability.

--- a/grype/db/v6/build/transformers/osv/testdata/ECHO-maven-0001.json
+++ b/grype/db/v6/build/transformers/osv/testdata/ECHO-maven-0001.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "1.6.1",
+  "id": "ECHO-maven-0001",
+  "modified": "2024-12-15T14:30:00Z",
+  "published": "2024-12-10T09:00:00Z",
+  "aliases": [
+    "CVE-2024-22259"
+  ],
+  "summary": "spring-web URL parsing open redirect / SSRF",
+  "details": "spring-web before 5.3.32+echo.1 is vulnerable to open redirect and SSRF via crafted input.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Echo:Maven",
+        "name": "org.springframework:spring-web",
+        "purl": "pkg:maven/org.springframework/spring-web"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.3.32+echo.1"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-22259"
+    }
+  ],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:N"
+    }
+  ],
+  "database_specific": {
+    "source": "Echo",
+    "anchore": {
+      "record_type": "advisory"
+    }
+  }
+}

--- a/grype/db/v6/build/transformers/osv/testdata/ECHO-npm-0001.json
+++ b/grype/db/v6/build/transformers/osv/testdata/ECHO-npm-0001.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "1.6.1",
+  "id": "ECHO-npm-0001",
+  "modified": "2024-12-15T14:30:00Z",
+  "published": "2024-12-10T09:00:00Z",
+  "aliases": [
+    "CVE-2022-29078"
+  ],
+  "summary": "ejs template injection",
+  "details": "The ejs library before 3.1.10+echo.1 is vulnerable to server-side template injection.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Echo:npm",
+        "name": "ejs",
+        "purl": "pkg:npm/ejs"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.1.10+echo.1"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-29078"
+    }
+  ],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    }
+  ],
+  "database_specific": {
+    "source": "Echo",
+    "anchore": {
+      "record_type": "advisory"
+    }
+  }
+}

--- a/grype/db/v6/build/transformers/osv/testdata/ECHO-pypi-0001.json
+++ b/grype/db/v6/build/transformers/osv/testdata/ECHO-pypi-0001.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "1.6.1",
+  "id": "ECHO-pypi-0001",
+  "modified": "2024-12-15T14:30:00Z",
+  "published": "2024-12-10T09:00:00Z",
+  "aliases": [
+    "CVE-2023-32681"
+  ],
+  "summary": "requests leaks Proxy-Authorization header",
+  "details": "The requests library before 2.14.2+echo.1 leaks the Proxy-Authorization header on redirect.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Echo:PyPi",
+        "name": "requests",
+        "purl": "pkg:pypi/requests"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.14.2+echo.1"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-32681"
+    }
+  ],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+    }
+  ],
+  "database_specific": {
+    "source": "Echo",
+    "anchore": {
+      "record_type": "advisory"
+    }
+  }
+}

--- a/grype/db/v6/build/transformers/osv/transform.go
+++ b/grype/db/v6/build/transformers/osv/transform.go
@@ -47,6 +47,7 @@ type Strategy interface {
 var strategies = []Strategy{
 	almaStrategy{},
 	bitnamiStrategy{},
+	echoStrategy{},
 	govulndbStrategy{},
 	rootioStrategy{},
 }

--- a/grype/db/v6/build/transformers/osv/transform_echo.go
+++ b/grype/db/v6/build/transformers/osv/transform_echo.go
@@ -1,0 +1,159 @@
+package osv
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/anchore/grype/grype/db/data"
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal"
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
+	"github.com/anchore/grype/grype/db/provider"
+	db "github.com/anchore/grype/grype/db/v6"
+	"github.com/anchore/grype/grype/db/v6/build/transformers"
+	"github.com/anchore/grype/grype/db/v6/build/transformers/internal"
+	"github.com/anchore/grype/grype/db/v6/name"
+	"github.com/anchore/grype/internal/log"
+	"github.com/anchore/syft/syft/pkg"
+)
+
+// echoStrategy handles ECHO-* records from Echo's OSV feed. Echo ships patched
+// builds of upstream language packages (PyPI/npm/Maven) identified by a
+// "+echo.N" version suffix. These records are *advisories* (NAK semantics):
+// they describe the version range carrying Echo's fix so the upstream disclosure
+// is suppressed on the patched build.
+type echoStrategy struct{}
+
+func (echoStrategy) Matches(id string) bool {
+	return strings.HasPrefix(id, "ECHO-")
+}
+
+func (echoStrategy) Transform(vuln unmarshal.OSVVulnerability, state provider.State) ([]data.Entry, error) {
+	severities, err := getSeverities(vuln)
+	if err != nil {
+		return nil, fmt.Errorf("unable to obtain severities: %w", err)
+	}
+
+	// Echo records may carry the upstream CVE in either `aliases` or `related`;
+	// merge both so the full CVE set rides on the vulnerability blob and on each
+	// unaffected package handle (lets the language matcher cross-reference the
+	// Echo NAK to the upstream GHSA/NVD disclosure for the same CVE).
+	aliases := append([]string{}, vuln.Aliases...)
+	aliases = append(aliases, vuln.Related...)
+
+	in := []any{
+		db.VulnerabilityHandle{
+			Name:          vuln.ID,
+			ProviderID:    state.Provider,
+			Provider:      provider.Model(state),
+			Status:        db.VulnerabilityActive,
+			ModifiedDate:  &vuln.Modified,
+			PublishedDate: &vuln.Published,
+			BlobValue: &db.VulnerabilityBlob{
+				ID:          vuln.ID,
+				Description: vuln.Details,
+				References:  echoReferences(vuln),
+				Aliases:     aliases,
+				Severities:  severities,
+			},
+		},
+	}
+
+	for _, uph := range echoUnaffectedPackages(vuln, aliases) {
+		in = append(in, uph)
+	}
+	return transformers.NewEntries(in...), nil
+}
+
+func echoReferences(vuln unmarshal.OSVVulnerability) []db.Reference {
+	var refs []db.Reference
+	for _, ref := range vuln.References {
+		refID := ""
+		if ref.Type == osvmodel.ReferenceAdvisory {
+			refID = vuln.ID
+		}
+		refs = append(refs, db.Reference{
+			ID:   refID,
+			URL:  ref.URL,
+			Tags: []string{string(ref.Type)},
+		})
+	}
+	return refs
+}
+
+func echoUnaffectedPackages(vuln unmarshal.OSVVulnerability, aliases []string) []db.UnaffectedPackageHandle {
+	if len(vuln.Affected) == 0 {
+		return nil
+	}
+	echoOnly := true
+	var uphs []db.UnaffectedPackageHandle
+	for _, affected := range vuln.Affected {
+		ecosystem := affected.Package.Ecosystem
+		pkgType := echoPackageType(ecosystem)
+		if pkgType == "" {
+			// OS-level "Echo" entries (no language suffix) are owned by the
+			// echo OS provider; any other ecosystem is upstream drift. The
+			// vunnel echo-osv provider already filters to language ecosystems,
+			// so this is defensive — skip rather than emit an unusable entry.
+			log.WithFields("id", vuln.ID, "ecosystem", ecosystem, "package", affected.Package.Name).
+				Trace("echo record uses a non-language ecosystem; skipping (handled by the echo OS provider, or add a case to echoPackageType)")
+			continue
+		}
+
+		var ranges []db.Range
+		for _, r := range affected.Ranges {
+			ranges = append(ranges, getGrypeUnaffectedRangesFromRange(r, defaultRangeType(r.Type))...)
+		}
+
+		uphs = append(uphs, db.UnaffectedPackageHandle{
+			Package: echoPackage(affected.Package, pkgType),
+			BlobValue: &db.PackageBlob{
+				CVEs:   aliases,
+				Ranges: ranges,
+				// Gate the NAK to actual Echo builds: the unaffected range is
+				// open-ended (">= X+echo.1"), which on an upstream-named package
+				// would otherwise leak onto plain higher versions (e.g. a plain
+				// "26.1" that is still vulnerable upstream). The echo runtime
+				// qualifier requires the scanned package to carry the "+echo.N"
+				// suffix, so non-Echo packages don't match this NAK.
+				Qualifiers: &db.PackageQualifiers{Echo: &echoOnly},
+			},
+		})
+	}
+	sort.Sort(internal.ByUnaffectedPackage(uphs))
+	return uphs
+}
+
+// echoPackageType resolves the grype package type from the OSV ecosystem
+// string. Every Echo language ecosystem is prefixed "Echo:":
+//
+//	"Echo:PyPi", "Echo:npm", "Echo:Maven"
+//
+// OS-level "Echo" entries (no language suffix) and any unrecognized ecosystem
+// return "" and are skipped by the caller. The suffix match is case-insensitive
+// (the feed uses "PyPi"; OSV/osv.dev use "PyPI").
+func echoPackageType(ecosystem string) pkg.Type {
+	rest, ok := strings.CutPrefix(ecosystem, "Echo:")
+	if !ok || rest == "" {
+		return ""
+	}
+	switch strings.ToLower(rest) {
+	case "pypi", "python", "pip":
+		return pkg.PythonPkg
+	case "npm":
+		return pkg.NpmPkg
+	case "maven", "java":
+		return pkg.JavaPkg
+	}
+	return ""
+}
+
+// echoPackage builds the db.Package, keeping the upstream package name verbatim
+// from the OSV record. Ecosystem is canonicalized to the grype package-type string
+// and the name is normalized per package type (e.g. PEP 503 for PythonPkg).
+func echoPackage(p osvmodel.Package, pkgType pkg.Type) *db.Package {
+	return &db.Package{
+		Ecosystem: pkgType.String(),
+		Name:      name.Normalize(p.Name, pkgType),
+	}
+}

--- a/grype/db/v6/build/transformers/osv/transform_echo_test.go
+++ b/grype/db/v6/build/transformers/osv/transform_echo_test.go
@@ -1,0 +1,99 @@
+package osv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	db "github.com/anchore/grype/grype/db/v6"
+	"github.com/anchore/grype/grype/db/v6/build/transformers"
+	"github.com/anchore/syft/syft/pkg"
+)
+
+// TestEchoTransform exercises the echo strategy against the three language
+// ecosystems Echo publishes: PyPI, npm, and Maven. Echo ships patched builds of
+// upstream packages with a "+echo.N" suffix; each record is emitted as a single
+// UnaffectedPackageHandle (NAK) keyed by the UPSTREAM package name, with NO
+// qualifier — the "+echo.N" version range scopes it on its own.
+func TestEchoTransform(t *testing.T) {
+	tests := []struct {
+		name               string
+		fixturePath        string
+		pkgType            pkg.Type
+		expectedPkgName    string
+		expectedCVE        string
+		expectedFixVersion string
+	}{
+		{
+			name:               "Echo PyPI package",
+			fixturePath:        "testdata/ECHO-pypi-0001.json",
+			pkgType:            pkg.PythonPkg,
+			expectedPkgName:    "requests",
+			expectedCVE:        "CVE-2023-32681",
+			expectedFixVersion: "2.14.2+echo.1",
+		},
+		{
+			name:               "Echo npm package",
+			fixturePath:        "testdata/ECHO-npm-0001.json",
+			pkgType:            pkg.NpmPkg,
+			expectedPkgName:    "ejs",
+			expectedCVE:        "CVE-2022-29078",
+			expectedFixVersion: "3.1.10+echo.1",
+		},
+		{
+			name: "Echo Maven package",
+			// JavaResolver.Normalize leaves groupId:artifactId verbatim.
+			fixturePath:        "testdata/ECHO-maven-0001.json",
+			pkgType:            pkg.JavaPkg,
+			expectedPkgName:    "org.springframework:spring-web",
+			expectedCVE:        "CVE-2024-22259",
+			expectedFixVersion: "5.3.32+echo.1",
+		},
+	}
+
+	for _, testToRun := range tests {
+		test := testToRun
+		t.Run(test.name, func(tt *testing.T) {
+			vulns := loadFixture(tt, test.fixturePath)
+			require.Len(tt, vulns, 1, "fixture should contain exactly one vulnerability")
+
+			vuln := vulns[0]
+			require.True(tt, echoStrategy{}.Matches(vuln.ID), "ID prefix should match the echo strategy")
+
+			entries, err := Transform(vuln, inputProviderState())
+			require.NoError(tt, err)
+			require.Len(tt, entries, 1, "one RelatedEntries wrapping the vuln + unaffected handle")
+
+			rel, ok := entries[0].Data.(transformers.RelatedEntries)
+			require.True(tt, ok, "entry data should be RelatedEntries")
+
+			require.NotNil(tt, rel.VulnerabilityHandle)
+			require.Equal(tt, "osv", rel.VulnerabilityHandle.ProviderID)
+			require.NotNil(tt, rel.VulnerabilityHandle.BlobValue)
+			require.Contains(tt, rel.VulnerabilityHandle.BlobValue.Aliases, test.expectedCVE)
+
+			require.Len(tt, rel.Related, 1, "echo emits exactly one unaffected package handle per language fixture")
+			uph, ok := rel.Related[0].(db.UnaffectedPackageHandle)
+			require.True(tt, ok, "related entry must be UnaffectedPackageHandle (NAK), not AffectedPackageHandle")
+
+			require.NotNil(tt, uph.Package)
+			require.Equal(tt, test.expectedPkgName, uph.Package.Name, "echo keeps the upstream package name (no prefix)")
+			require.Equal(tt, test.pkgType.String(), uph.Package.Ecosystem)
+			require.Nil(tt, uph.OperatingSystem, "language packages carry no OS metadata")
+
+			require.NotNil(tt, uph.BlobValue)
+			require.Contains(tt, uph.BlobValue.CVEs, test.expectedCVE)
+			// The NAK must carry the Echo qualifier so suppression is gated to
+			// actual Echo builds ("+echo.N"); without it the open-ended range
+			// would leak onto plain higher upstream versions.
+			require.NotNil(tt, uph.BlobValue.Qualifiers, "echo NAK must carry qualifiers")
+			require.NotNil(tt, uph.BlobValue.Qualifiers.Echo, "Echo qualifier must be set")
+			require.True(tt, *uph.BlobValue.Qualifiers.Echo)
+
+			require.Len(tt, uph.BlobValue.Ranges, 1)
+			constraint := uph.BlobValue.Ranges[0].Version.Constraint
+			require.Contains(tt, constraint, ">=", "unaffected range constraint must use >= (versions at/above the echo fix are safe)")
+			require.Contains(tt, constraint, test.expectedFixVersion)
+		})
+	}
+}

--- a/grype/db/v6/db.go
+++ b/grype/db/v6/db.go
@@ -24,7 +24,7 @@ const (
 	Revision = 1
 
 	// Addition indicates how many changes have been introduced that are compatible with all historical data
-	Addition = 7
+	Addition = 8
 
 	// v6 model changelog:
 	// 6.0.0: Initial version 🎉
@@ -48,6 +48,10 @@ const (
 	//        architecture). The field's semantics are unchanged; the rename drops the rpm-
 	//        specific prefix because the value already lives in PackageQualifiers and can
 	//        carry any architecture string for future arch-scoped advisories.
+	// 6.1.8: Add Echo field to PackageQualifiers (used by the OSV echo strategy to mark
+	//        vulnerabilities that only apply to Echo-patched language packages; the echo
+	//        runtime qualifier in pkg/qualifier/echo filters non-Echo packages out via the
+	//        NAK pattern, keyed off the "+echo.N" version suffix rather than a name prefix)
 )
 
 const (

--- a/grype/db/v6/vulnerability.go
+++ b/grype/db/v6/vulnerability.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/anchore/grype/grype/pkg/qualifier"
 	"github.com/anchore/grype/grype/pkg/qualifier/architecture"
+	"github.com/anchore/grype/grype/pkg/qualifier/echo"
 	"github.com/anchore/grype/grype/pkg/qualifier/platformcpe"
 	"github.com/anchore/grype/grype/pkg/qualifier/rootio"
 	"github.com/anchore/grype/grype/pkg/qualifier/rpmmodularity"
@@ -316,6 +317,9 @@ func toPackageQualifiers(qualifiers *PackageQualifiers) []qualifier.Qualifier {
 	}
 	if qualifiers.RootIO != nil && *qualifiers.RootIO {
 		out = append(out, rootio.New())
+	}
+	if qualifiers.Echo != nil && *qualifiers.Echo {
+		out = append(out, echo.New())
 	}
 	return out
 }

--- a/grype/matcher/internal/language.go
+++ b/grype/matcher/internal/language.go
@@ -7,11 +7,28 @@ import (
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/matcher/internal/result"
 	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/pkg/qualifier/echo"
 	"github.com/anchore/grype/grype/search"
 	"github.com/anchore/grype/grype/version"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal/log"
 )
+
+// unaffectedVersionCriteria returns the version criteria used to evaluate
+// unaffected (NAK) records. Echo-patched builds of SemVer-versioned packages
+// (e.g. npm) need the echo-aware format: SemVer excludes the "+echo.N" build
+// number from precedence, so under the default format a NAK fixed at
+// "+echo.2" would also suppress the still-vulnerable "+echo.1" build.
+// Disclosures intentionally keep the default format — upstream advisories are
+// written against upstream versions and must keep treating "X+echo.N" as "X"
+// (e.g. an unfixed "<= X" advisory must still apply to X+echo.N).
+func unaffectedVersionCriteria(p pkg.Package, defaultCriteria vulnerability.Criteria) vulnerability.Criteria {
+	format := pkg.VersionFormat(p)
+	if (format == version.UnknownFormat || format == version.SemanticFormat) && echo.IsEchoBuild(p.Version) {
+		return OnlyVulnerableVersions(version.New(p.Version, version.EchoFormat))
+	}
+	return defaultCriteria
+}
 
 func MatchPackageByLanguage(store vulnerability.Provider, p pkg.Package, matcherType match.MatcherType) ([]match.Match, []match.IgnoreFilter, error) {
 	if isUnknownVersion(p.Version) {
@@ -21,6 +38,7 @@ func MatchPackageByLanguage(store vulnerability.Provider, p pkg.Package, matcher
 
 	provider := result.NewProvider(store, p, matcherType)
 	versionCriteria := OnlyVulnerableVersions(version.New(p.Version, pkg.VersionFormat(p)))
+	nakVersionCriteria := unaffectedVersionCriteria(p, versionCriteria)
 
 	disclosures := result.Set{}
 	unaffected := result.Set{}
@@ -43,7 +61,7 @@ func MatchPackageByLanguage(store vulnerability.Provider, p pkg.Package, matcher
 		}
 		disclosures = disclosures.Merge(all.Filter(versionCriteria))
 
-		nakCriteria := append(slices.Clone(criteria), search.ForUnaffected(), versionCriteria)
+		nakCriteria := append(slices.Clone(criteria), search.ForUnaffected(), nakVersionCriteria)
 		u, err := provider.FindResults(nakCriteria...)
 		if err != nil {
 			return nil, nil, fmt.Errorf("matcher failed to fetch resolution language=%q pkg=%q: %w", p.Language, name, err)
@@ -82,7 +100,7 @@ func MatchPackageByEcosystemPackageName(vp vulnerability.Provider, p pkg.Package
 	disclosures := all.Filter(versionCriteria)
 
 	// we want to perform the same results, but look for explicit naks, which indicates that a vulnerability should not apply
-	criteria = append(criteria, search.ForUnaffected(), versionCriteria)
+	criteria = append(criteria, search.ForUnaffected(), unaffectedVersionCriteria(p, versionCriteria))
 	unaffected, err := provider.FindResults(criteria...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("matcher failed to fetch resolution language=%q pkg=%q: %w", p.Language, p.Name, err)

--- a/grype/matcher/internal/language_test.go
+++ b/grype/matcher/internal/language_test.go
@@ -392,3 +392,44 @@ func Test_unaffectedPackageIgnoreRules(t *testing.T) {
 		})
 	}
 }
+
+func Test_unaffectedVersionCriteria(t *testing.T) {
+	// the fuzzy "unknown"-format constraint is the shape NAK ranges take after
+	// the DB's "ecosystem" range type falls through version.ParseFormat
+	nakConstraint := version.MustGetConstraint(">= 3.1.9+echo.2", version.UnknownFormat)
+	vuln := vulnerability.Vulnerability{Constraint: nakConstraint}
+
+	npmEcho := pkg.Package{Name: "ejs", Version: "3.1.9+echo.1", Type: syftPkg.NpmPkg}
+	defaultCriteria := OnlyVulnerableVersions(version.New(npmEcho.Version, pkg.VersionFormat(npmEcho)))
+
+	// sanity: under the default format, SemVer ignores the +echo.N build
+	// number and the still-vulnerable +echo.1 build satisfies the NAK
+	matches, _, err := defaultCriteria.MatchesVulnerability(vuln)
+	require.NoError(t, err)
+	assert.True(t, matches, "expected the default format to be blind to +echo.N (if this fails, the workaround may no longer be needed)")
+
+	// the echo-aware NAK criteria distinguishes the builds: +echo.1 stays vulnerable...
+	matches, _, err = unaffectedVersionCriteria(npmEcho, defaultCriteria).MatchesVulnerability(vuln)
+	require.NoError(t, err)
+	assert.False(t, matches, "the still-vulnerable +echo.1 build must not match the NAK")
+
+	// ...while the fixed +echo.2 build is suppressed
+	fixed := pkg.Package{Name: "ejs", Version: "3.1.9+echo.2", Type: syftPkg.NpmPkg}
+	matches, _, err = unaffectedVersionCriteria(fixed, defaultCriteria).MatchesVulnerability(vuln)
+	require.NoError(t, err)
+	assert.True(t, matches)
+
+	// non-echo packages keep the default criteria untouched
+	plain := pkg.Package{Name: "ejs", Version: "3.1.9", Type: syftPkg.NpmPkg}
+	assert.Same(t, defaultCriteria, unaffectedVersionCriteria(plain, defaultCriteria))
+
+	// ecosystems whose native format already orders +echo.N (e.g. python's
+	// PEP 440 local versions) keep the default criteria untouched
+	pyEcho := pkg.Package{Name: "requests", Version: "2.14.2+echo.1", Type: syftPkg.PythonPkg}
+	assert.Same(t, defaultCriteria, unaffectedVersionCriteria(pyEcho, defaultCriteria))
+
+	// a bare "+echo" suffix is not a valid Echo build (Echo builds always
+	// carry "+echo.N"); it must not be treated as one
+	bare := pkg.Package{Name: "ejs", Version: "3.1.9+echo", Type: syftPkg.NpmPkg}
+	assert.Same(t, defaultCriteria, unaffectedVersionCriteria(bare, defaultCriteria))
+}

--- a/grype/pkg/qualifier/echo/qualifier.go
+++ b/grype/pkg/qualifier/echo/qualifier.go
@@ -1,0 +1,33 @@
+package echo
+
+import (
+	"regexp"
+
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/pkg/qualifier"
+)
+
+// echoLocalSegmentRe matches Echo's "+echo.N" version segment (e.g. the
+// "+echo.1" in "2.14.2+echo.1"), the signal that a scanned package is an
+// Echo-patched build rather than an upstream one.
+var echoLocalSegmentRe = regexp.MustCompile(`\+echo\.\d+`)
+
+// echoQualifier is a NAK qualifier: it only ever appears on
+// UnaffectedPackageHandles produced by the echo OSV strategy, and it suppresses
+// a candidate match only when the scanned package is itself an Echo build.
+// Echo keeps upstream package names, so the Echo build is identified by its "+echo.N" version suffix.	
+// This prevents the open-ended unaffected range (">= X+echo.1") from leaking onto plain upstream versions:
+// a non-Echo package fails the qualifier, so the NAK is filtered out and the upstream disclosure stands.
+type echoQualifier struct{}
+
+// New returns the echo qualifier. There is no per-instance state.
+func New() qualifier.Qualifier {
+	return echoQualifier{}
+}
+
+// Satisfied returns true when the scanned package is an Echo build, detected by
+// the "+echo.N" version suffix. A non-Echo package fails the qualifier, which
+// causes the NAK to be filtered out of search results.
+func (echoQualifier) Satisfied(p pkg.Package) (bool, error) {
+	return echoLocalSegmentRe.MatchString(p.Version), nil
+}

--- a/grype/pkg/qualifier/echo/qualifier.go
+++ b/grype/pkg/qualifier/echo/qualifier.go
@@ -15,7 +15,7 @@ var echoLocalSegmentRe = regexp.MustCompile(`\+echo\.\d+`)
 // echoQualifier is a NAK qualifier: it only ever appears on
 // UnaffectedPackageHandles produced by the echo OSV strategy, and it suppresses
 // a candidate match only when the scanned package is itself an Echo build.
-// Echo keeps upstream package names, so the Echo build is identified by its "+echo.N" version suffix.	
+// Echo keeps upstream package names, so the Echo build is identified by its "+echo.N" version suffix.
 // This prevents the open-ended unaffected range (">= X+echo.1") from leaking onto plain upstream versions:
 // a non-Echo package fails the qualifier, so the NAK is filtered out and the upstream disclosure stands.
 type echoQualifier struct{}
@@ -29,5 +29,11 @@ func New() qualifier.Qualifier {
 // the "+echo.N" version suffix. A non-Echo package fails the qualifier, which
 // causes the NAK to be filtered out of search results.
 func (echoQualifier) Satisfied(p pkg.Package) (bool, error) {
-	return echoLocalSegmentRe.MatchString(p.Version), nil
+	return IsEchoBuild(p.Version), nil
+}
+
+// IsEchoBuild reports whether the version string identifies an Echo-patched
+// build (carries the "+echo.N" suffix).
+func IsEchoBuild(version string) bool {
+	return echoLocalSegmentRe.MatchString(version)
 }

--- a/grype/pkg/qualifier/echo/qualifier_test.go
+++ b/grype/pkg/qualifier/echo/qualifier_test.go
@@ -1,0 +1,35 @@
+package echo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/grype/grype/pkg"
+)
+
+func TestEchoQualifier_Satisfied(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{"echo pypi build", "2.14.2+echo.1", true},
+		{"echo later rebuild", "2.14.2+echo.2", true},
+		{"echo maven build, multi-digit", "5.3.32+echo.10", true},
+		{"plain upstream at base", "2.14.2", false},
+		{"plain upstream higher", "26.1", false},
+		{"plain upstream with non-echo local", "26.1+foo.1", false},
+		{"echo without numeric revision", "1.0+echo", false},
+		{"empty version", "", false},
+	}
+
+	q := New()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := q.Satisfied(pkg.Package{Version: tt.version})
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/grype/version/constraint.go
+++ b/grype/version/constraint.go
@@ -40,6 +40,8 @@ func GetConstraint(constStr string, format Format) (Constraint, error) {
 		c, err = newGenericConstraint(PacmanFormat, constStr)
 	case JVMFormat:
 		c, err = newGenericConstraint(JVMFormat, constStr)
+	case EchoFormat:
+		c, err = newGenericConstraint(EchoFormat, constStr)
 	case UnknownFormat:
 		c, err = newFuzzyConstraint(constStr, "unknown")
 	default:

--- a/grype/version/echo_version.go
+++ b/grype/version/echo_version.go
@@ -1,0 +1,60 @@
+package version
+
+import (
+	"regexp"
+	"strconv"
+)
+
+var _ Comparator = (*echoVersion)(nil)
+
+// echoBuildRe captures the N in Echo's "+echo.N" version suffix.
+var echoBuildRe = regexp.MustCompile(`\+echo\.(\d+)`)
+
+// echoVersion compares Echo-patched builds of SemVer-versioned packages
+// (e.g. npm). SemVer excludes build metadata from precedence, so
+// "3.1.9+echo.1" and "3.1.9+echo.2" compare equal under semantic rules and
+// successive Echo builds of the same upstream version cannot be ordered.
+// This comparator applies semantic ordering first and breaks ties on the
+// echo build number (a version without the suffix has build 0):
+// 3.1.9 < 3.1.9+echo.1 < 3.1.9+echo.2 < 3.1.10.
+type echoVersion struct {
+	semVer semanticVersion
+	build  int
+}
+
+func newEchoVersion(raw string) (echoVersion, error) {
+	semVer, err := newSemanticVersion(raw, false)
+	if err != nil {
+		return echoVersion{}, err
+	}
+	build := 0
+	if m := echoBuildRe.FindStringSubmatch(raw); m != nil {
+		build, err = strconv.Atoi(m[1])
+		if err != nil {
+			return echoVersion{}, invalidFormatError(EchoFormat, raw, err)
+		}
+	}
+	return echoVersion{semVer: semVer, build: build}, nil
+}
+
+func (v echoVersion) Compare(other *Version) (int, error) {
+	if other == nil {
+		return -1, ErrNoVersionProvided
+	}
+
+	o, err := newEchoVersion(other.Raw)
+	if err != nil {
+		return 0, err
+	}
+
+	if result := v.semVer.obj.Compare(o.semVer.obj); result != 0 {
+		return result, nil
+	}
+	switch {
+	case v.build < o.build:
+		return -1, nil
+	case v.build > o.build:
+		return 1, nil
+	}
+	return 0, nil
+}

--- a/grype/version/echo_version_test.go
+++ b/grype/version/echo_version_test.go
@@ -1,0 +1,81 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEchoVersion_Compare(t *testing.T) {
+	tests := []struct {
+		v1   string
+		v2   string
+		want int
+	}{
+		// SemVer ties broken by the +echo.N build number (no suffix = 0)
+		{"3.1.9+echo.1", "3.1.9", 1},
+		{"3.1.9+echo.2", "3.1.9+echo.1", 1},
+		{"3.1.9+echo.10", "3.1.9+echo.2", 1},
+		{"3.1.9+echo.1", "3.1.9+echo.1", 0},
+		// base SemVer ordering is untouched
+		{"3.1.10", "3.1.9+echo.99", 1},
+		{"3.1.9+echo.1", "3.1.10", -1},
+		{"1.0.0-rc.1", "1.0.0", -1},
+		// an echo build of a prerelease stays below the final release
+		{"19.0.0-next.3+echo.1", "19.0.0-next.3", 1},
+		{"19.0.0-next.3+echo.1", "19.0.0", -1},
+		// non-echo versions behave exactly like the semantic comparator
+		{"2.0.0", "1.9.9", 1},
+		{"1.0.0", "1.0.0", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.v1+" vs "+tt.v2, func(t *testing.T) {
+			v1, err := newEchoVersion(tt.v1)
+			require.NoError(t, err)
+
+			got, err := v1.Compare(New(tt.v2, EchoFormat))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEchoConstraint_Satisfied(t *testing.T) {
+	tests := []struct {
+		version    string
+		constraint string
+		satisfied  bool
+	}{
+		// the NAK shape the Echo OSV strategy emits: ">= <fixed echo build>".
+		// The still-vulnerable earlier build must NOT satisfy it (this is the
+		// case SemVer alone cannot express: 3.1.9+echo.1 == 3.1.9+echo.2).
+		{"3.1.9+echo.1", ">= 3.1.9+echo.2", false},
+		{"3.1.9+echo.2", ">= 3.1.9+echo.2", true},
+		{"3.1.9+echo.10", ">= 3.1.9+echo.2", true},
+		{"3.1.10+echo.1", ">= 3.1.9+echo.2", true},
+		{"3.1.9", ">= 3.1.9+echo.1", false},
+		// prerelease echo builds
+		{"19.0.0-next.3+echo.1", ">= 19.0.0-next.3+echo.2", false},
+		{"19.0.0-next.3+echo.2", ">= 19.0.0-next.3+echo.2", true},
+		// range with an upper bound
+		{"3.1.9+echo.1", ">= 3.1.9+echo.1, < 3.1.9+echo.2", true},
+		{"3.1.9+echo.2", ">= 3.1.9+echo.1, < 3.1.9+echo.2", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version+" in "+tt.constraint, func(t *testing.T) {
+			c, err := GetConstraint(tt.constraint, EchoFormat)
+			require.NoError(t, err)
+
+			satisfied, err := c.Satisfied(New(tt.version, EchoFormat))
+			require.NoError(t, err)
+			assert.Equal(t, tt.satisfied, satisfied)
+		})
+	}
+}
+
+func TestParseFormat_Echo(t *testing.T) {
+	assert.Equal(t, EchoFormat, ParseFormat("echo"))
+}

--- a/grype/version/format.go
+++ b/grype/version/format.go
@@ -22,6 +22,7 @@ const (
 	JVMFormat
 	BitnamiFormat
 	PacmanFormat
+	EchoFormat
 )
 
 type Format int
@@ -41,6 +42,7 @@ var formatStr = []string{
 	"JVM",
 	"Bitnami",
 	"Pacman",
+	"Echo",
 }
 
 var Formats = []Format{
@@ -57,6 +59,7 @@ var Formats = []Format{
 	JVMFormat,
 	BitnamiFormat,
 	PacmanFormat,
+	EchoFormat,
 }
 
 func ParseFormat(userStr string) Format {
@@ -88,6 +91,8 @@ func ParseFormat(userStr string) Format {
 		return JVMFormat
 	case strings.ToLower(PacmanFormat.String()), "pacman", pkg.AlpmPkg.String():
 		return PacmanFormat
+	case strings.ToLower(EchoFormat.String()):
+		return EchoFormat
 	}
 	return UnknownFormat
 }

--- a/grype/version/version.go
+++ b/grype/version/version.go
@@ -76,6 +76,8 @@ func (v *Version) getComparator(format Format) (Comparator, error) {
 		comparator, err = newJvmVersion(v.Raw)
 	case PacmanFormat:
 		comparator, err = newPacmanVersion(v.Raw)
+	case EchoFormat:
+		comparator, err = newEchoVersion(v.Raw)
 	case UnknownFormat:
 		comparator, err = newFuzzyVersion(v.Raw)
 	default:


### PR DESCRIPTION
Adds an echo strategy to the OSV transformer for Echo's language-package advisories (Echo:PyPi / Echo:npm / Echo:Maven), emitting NAK/unaffected records keyed by the upstream package name.

Echo keeps upstream names (no prefix), so suppression is scoped by a new Echo package qualifier (schema 6.1.8) that fires only when the scanned package carries the +echo.N version suffix — preventing the open-ended unaffected range from leaking onto plain upstream versions.

Consumes the echo-osv vunnel provider (anchore/vunnel#1174).