### PR TITLE
feat(RHEL): respect multiple RHSAs based on stream in version

### DIFF
--- a/grype/db/internal/provider/unmarshal/os_vulnerability.go
+++ b/grype/db/internal/provider/unmarshal/os_vulnerability.go
@@ -24,10 +24,29 @@ type OSFixedIn struct {
 	Version         string `json:"Version"`
 	VersionFormat   string `json:"VersionFormat"`
 	VulnerableRange string `json:"VulnerableRange"`
-	Available       struct {
+	// AdditionalAdvisoryFixes lists fix builds called out by the contributing advisories beyond
+	// the canonical (highest) one in Version, each paired with the advisory that shipped it.
+	// When more than one advisory fixes the same package at the same upstream base across
+	// different minor streams, the streams cannot be partitioned with a VulnerableRange (the
+	// leading release is a single total order). Each entry becomes a "= <evr>" unaffected handle
+	// carrying its advisory, so a host running exactly its stream's fix build is not falsely
+	// flagged and grype can report which advisory shipped that build. Optional and additive:
+	// absent in older data, and ignored by older grype.
+	AdditionalAdvisoryFixes []OSAdvisoryFix `json:"AdditionalAdvisoryFixes,omitempty"`
+	Available               struct {
 		Date string `json:"Date,omitempty"`
 		Kind string `json:"Kind,omitempty"`
 	} `json:"Available,omitempty"`
+}
+
+// OSAdvisoryFix pairs a specific fix EVR with the advisory that shipped it. Used by
+// OSFixedIn.AdditionalAdvisoryFixes to carry per-stream fix provenance.
+type OSAdvisoryFix struct {
+	Version  string `json:"Version"`
+	Advisory struct {
+		ID   string `json:"ID"`
+		Link string `json:"Link"`
+	} `json:"Advisory"`
 }
 
 type OSFixedIns []OSFixedIn

--- a/grype/db/v6/build/transformers/os/transform.go
+++ b/grype/db/v6/build/transformers/os/transform.go
@@ -134,6 +134,13 @@ func getPackages(vuln unmarshal.OSVulnerability) ([]db.AffectedPackageHandle, []
 		}
 		aph.BlobValue.Ranges = ranges
 		afs = append(afs, aph)
+
+		// Emit an "= <evr>" unaffected handle for every distinct fix version the advisories
+		// called out (UnaffectedVersions). When several same-base streams collapse to one
+		// affected record ("< highest fix"), a host running exactly its own stream's fix build
+		// otherwise reports as vulnerable; these exact-match unaffected records let the matcher
+		// suppress that. Additive: groups without UnaffectedVersions are unchanged.
+		unafs = append(unafs, exactUnaffectedHandles(group, fixedIns, vuln, qualifiers)...)
 	}
 
 	// stable ordering
@@ -141,6 +148,59 @@ func getPackages(vuln unmarshal.OSVulnerability) ([]db.AffectedPackageHandle, []
 	sort.Sort(internal.ByUnaffectedPackage(unafs))
 
 	return afs, unafs
+}
+
+// exactUnaffectedHandles turns each FixedIn.AdditionalAdvisoryFixes entry into an unaffected
+// package handle constrained to that exact version ("= <evr>"), carrying the advisory that
+// shipped that build as a fix reference. These ride alongside the affected handle (which still
+// carries the coarse "< highest fix" constraint) so that a host at exactly a called-out fix
+// build matches an unaffected record and the matcher can drop the otherwise-false-positive
+// disclosure - and report which advisory's fix the host already carries. The rpm-modularity
+// qualifier mirrors the affected handle so modular hosts match the right stream.
+func exactUnaffectedHandles(group groupIndex, fixedIns []unmarshal.OSFixedIn, vuln unmarshal.OSVulnerability, qualifiers *db.PackageQualifiers) []db.UnaffectedPackageHandle {
+	seen := strset.New()
+	var out []db.UnaffectedPackageHandle
+	for _, f := range fixedIns {
+		for _, af := range f.AdditionalAdvisoryFixes {
+			v := strings.TrimSpace(af.Version)
+			if v == "" || seen.Has(v) {
+				continue
+			}
+			seen.Add(v)
+
+			fix := &db.Fix{Version: v, State: db.NotAffectedFixStatus}
+			if af.Advisory.ID != "" || af.Advisory.Link != "" {
+				fix.Detail = &db.FixDetail{
+					References: []db.Reference{
+						{
+							ID:   af.Advisory.ID,
+							URL:  af.Advisory.Link,
+							Tags: []string{db.AdvisoryReferenceTag},
+						},
+					},
+				}
+			}
+
+			out = append(out, db.UnaffectedPackageHandle{
+				OperatingSystem: getOperatingSystem(group.osName, group.id, group.osVersion, group.osChannel),
+				Package:         getPackage(group),
+				BlobValue: &db.PackageBlob{
+					CVEs:       getAliases(vuln),
+					Qualifiers: qualifiers,
+					Ranges: []db.Range{
+						{
+							Version: db.Version{
+								Type:       f.VersionFormat,
+								Constraint: fmt.Sprintf("= %s", v),
+							},
+							Fix: fix,
+						},
+					},
+				},
+			})
+		}
+	}
+	return out
 }
 
 func getFix(fixedInEntry unmarshal.OSFixedIn) *db.Fix {

--- a/grype/db/v6/build/transformers/os/transform_test.go
+++ b/grype/db/v6/build/transformers/os/transform_test.go
@@ -1825,3 +1825,62 @@ func timeRef(ti time.Time) *time.Time {
 func strRef(s string) *string {
 	return &s
 }
+
+func TestExactUnaffectedHandlesCarryAdvisory(t *testing.T) {
+	// a same-base multi-stream RHEL record: the canonical fix is the highest EVR, and
+	// AdditionalAdvisoryFixes lists every called-out fix build paired with its advisory.
+	var vuln unmarshal.OSVulnerability
+	vuln.Vulnerability.Name = "CVE-2024-10458"
+	vuln.Vulnerability.NamespaceName = "rhel:9"
+
+	mkFix := func(version, id, link string) unmarshal.OSAdvisoryFix {
+		var f unmarshal.OSAdvisoryFix
+		f.Version = version
+		f.Advisory.ID = id
+		f.Advisory.Link = link
+		return f
+	}
+
+	fixedIn := unmarshal.OSFixedIn{
+		Name:          "firefox",
+		NamespaceName: "rhel:9",
+		Version:       "0:128.4.0-1.el9_5",
+		VersionFormat: "rpm",
+		AdditionalAdvisoryFixes: []unmarshal.OSAdvisoryFix{
+			mkFix("0:128.4.0-1.el9_4", "RHSA-2024:8726", "https://access.redhat.com/errata/RHSA-2024:8726"),
+			mkFix("0:128.4.0-1.el9_5", "RHSA-2024:9554", "https://access.redhat.com/errata/RHSA-2024:9554"),
+		},
+	}
+	vuln.Vulnerability.FixedIn = unmarshal.OSFixedIns{fixedIn}
+
+	afs, unafs := getPackages(vuln)
+
+	// the affected handle is unchanged: still the coarse "< highest fix" constraint.
+	require.Len(t, afs, 1)
+	require.Len(t, afs[0].BlobValue.Ranges, 1)
+	assert.Equal(t, "< 0:128.4.0-1.el9_5", afs[0].BlobValue.Ranges[0].Version.Constraint)
+
+	// one exact-match unaffected handle per called-out fix, each carrying its advisory.
+	require.Len(t, unafs, 2)
+	byConstraint := map[string]db.Range{}
+	for _, u := range unafs {
+		require.Len(t, u.BlobValue.Ranges, 1)
+		byConstraint[u.BlobValue.Ranges[0].Version.Constraint] = u.BlobValue.Ranges[0]
+	}
+
+	for _, tc := range []struct{ constraint, version, advisory, link string }{
+		{"= 0:128.4.0-1.el9_4", "0:128.4.0-1.el9_4", "RHSA-2024:8726", "https://access.redhat.com/errata/RHSA-2024:8726"},
+		{"= 0:128.4.0-1.el9_5", "0:128.4.0-1.el9_5", "RHSA-2024:9554", "https://access.redhat.com/errata/RHSA-2024:9554"},
+	} {
+		r, ok := byConstraint[tc.constraint]
+		require.True(t, ok, "missing unaffected handle for %s", tc.constraint)
+		require.NotNil(t, r.Fix)
+		assert.Equal(t, db.NotAffectedFixStatus, r.Fix.State)
+		assert.Equal(t, tc.version, r.Fix.Version)
+		require.NotNil(t, r.Fix.Detail)
+		require.Len(t, r.Fix.Detail.References, 1)
+		assert.Equal(t, tc.advisory, r.Fix.Detail.References[0].ID)
+		assert.Equal(t, tc.link, r.Fix.Detail.References[0].URL)
+		assert.Contains(t, r.Fix.Detail.References[0].Tags, db.AdvisoryReferenceTag)
+	}
+}

--- a/grype/matcher/internal/ignores.go
+++ b/grype/matcher/internal/ignores.go
@@ -12,8 +12,17 @@ import (
 func OwnershipIgnores(p pkg.Package, reason string, ignoredVulnerabilities ...vulnerability.Vulnerability) []match.IgnoreFilter {
 	var ignores []match.IgnoreFilter
 
+	// the same vulnerability can reach here from more than one source record (e.g. an
+	// exact-match unaffected handle plus the affected record it overrides), which would
+	// otherwise emit duplicate, identical ignore filters.
+	seen := make(map[string]struct{})
+
 	for _, ignoredVulnerability := range ignoredVulnerabilities {
 		for _, ignoreVulnID := range collectVulnerabilityIDs(ignoredVulnerability) {
+			if _, ok := seen[ignoreVulnID]; ok {
+				continue
+			}
+			seen[ignoreVulnID] = struct{}{}
 			ignores = append(ignores, match.IgnoreRelatedPackage{
 				Reason:           reason,
 				RelationshipType: artifact.OwnershipByFileOverlapRelationship,

--- a/grype/matcher/rpm/matcher.go
+++ b/grype/matcher/rpm/matcher.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/scylladb/go-set/strset"
+
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/matcher/internal"
 	"github.com/anchore/grype/grype/matcher/internal/result"
@@ -265,26 +267,76 @@ func (m *Matcher) standardMatches(provider result.Provider, searchPkg pkg.Packag
 		return nil, nil, fmt.Errorf("matcher failed to fetch disclosures for distro=%q pkg=%q: %w", searchPkg.Distro, searchPkg.Name, err)
 	}
 
-	unaffectedCriteria := []vulnerability.Criteria{
+	// Fetch ALL unaffected (per-stream fix) records for this package, unfiltered by the host
+	// version. These carry every called-out per-stream fix build ("= <evr>") plus the advisory
+	// that shipped it. Option A's stream selection (below) needs all of them, not just the one
+	// the host happens to sit exactly on, so that it can pick the host's own minor stream and
+	// compare against it.
+	streamCriteria := []vulnerability.Criteria{
 		search.ByPackageName(searchPkg.Name),
 		search.ByDistro(*searchPkg.Distro),
 		internal.OnlyQualifiedPackages(searchPkg),
-		internal.OnlyVulnerableVersions(pkgVersion),
 		search.ForUnaffected(),
 	}
-	unaffectedCriteria = append(unaffectedCriteria, extra...)
+	streamCriteria = append(streamCriteria, extra...)
 
-	unaffected, err := provider.FindResults(unaffectedCriteria...)
+	streamUnaffected, err := provider.FindResults(streamCriteria...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("matcher failed to fetch unaffected for distro=%q pkg=%q: %w", searchPkg.Distro, searchPkg.Name, err)
 	}
 
 	disclosures := all.Filter(internal.OnlyVulnerableVersions(pkgVersion))
 
-	// return all unaffected vulns for this version
-	unaffected = unaffected.Merge(all.Remove(disclosures))
+	// Option A: matcher-side per-stream selection for RHEL same-base multi-stream fixes. Using the
+	// installed package's own dist-tag minor, suppress disclosures the host's stream already fixed
+	// and rewrite the reported fix version to the host's reachable stream build for the ones it has
+	// not. Disclosures with no matching stream are returned unchanged for the coarse handling below.
+	disclosures, streamSuppressed := applyStreamSelection(searchPkg, disclosures, streamUnaffected)
 
-	return disclosures.ToMatches(), internal.OwnershipIgnores(searchPkg, IgnoreReasonDistroNotVulnerable, unaffected.Vulnerabilities()...), nil
+	// The host may also sit exactly on a called-out fix build whose stream did not match the
+	// selection above (e.g. a different-minor build that still equals an unaffected record). Keep
+	// the prior exact-match suppression as a backstop so those are not falsely flagged.
+	exactUnaffected := streamUnaffected.Filter(internal.OnlyVulnerableVersions(pkgVersion))
+	disclosuresBeforeUnaffected := disclosures
+	disclosures = disclosures.Remove(exactUnaffected)
+	logExactFixSuppression(searchPkg, disclosuresBeforeUnaffected.Remove(disclosures), exactUnaffected)
+
+	// Collect everything we want to surface as "distro not vulnerable" ignores: the exact-match
+	// unaffected records, the stream-selected suppressions, and any unaffected disclosures for this
+	// version.
+	ignoredSet := exactUnaffected.Merge(streamSuppressed).Merge(all.Remove(disclosures).Remove(streamSuppressed))
+
+	return disclosures.ToMatches(), internal.OwnershipIgnores(searchPkg, IgnoreReasonDistroNotVulnerable, ignoredSet.Vulnerabilities()...), nil
+}
+
+// logExactFixSuppression records, at trace level, each disclosure that an exact-match
+// unaffected record overrode - i.e. the host already runs a specific advisory's fix build for
+// its own stream - so the "why" behind a dropped same-base false positive is observable. The
+// fix build and advisory come from the matching unaffected records.
+func logExactFixSuppression(p pkg.Package, suppressed, unaffected result.Set) {
+	if len(suppressed) == 0 {
+		return
+	}
+	suppressedIDs := strset.New()
+	for id := range suppressed {
+		suppressedIDs.Add(id)
+	}
+	for _, v := range unaffected.Vulnerabilities() {
+		if !suppressedIDs.Has(v.ID) {
+			continue
+		}
+		var advisories []string
+		for _, a := range v.Advisories {
+			advisories = append(advisories, a.ID)
+		}
+		log.WithFields(
+			"package", p.Name,
+			"version", p.Version,
+			"vulnerability", v.ID,
+			"fix", strings.Join(v.Fix.Versions, ","),
+			"advisories", strings.Join(advisories, ","),
+		).Trace("rpm: host runs a known advisory fix build for its stream; suppressing same-base false positive")
+	}
 }
 
 func addEpochIfApplicable(p *pkg.Package) {

--- a/grype/matcher/rpm/rhel_multi_rhsa_extra_test.go
+++ b/grype/matcher/rpm/rhel_multi_rhsa_extra_test.go
@@ -1,0 +1,241 @@
+package rpm
+
+import (
+	"testing"
+
+	"github.com/anchore/grype/grype/distro"
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/grype/internal/dbtest"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+// These exercise additional multi-RHSA partitioned-stream records mined from a real
+// vunnel cache (see datasources/rhel/scripts/find_multi_rhsa_results.py). They extend
+// the CVE-2024-8088/python3.9 coverage in rhel_multi_rhsa_test.go to dimensions that
+// case does not touch: a 3-stream partition with an epoch bump mid-range (podman), a
+// fold of three advisories including an RHBA (microcode_ctl), and a modular package
+// (go-toolset). As with that file, dbtest runs the real grype-db transform over the
+// verbatim vunnel record, so these validate the whole vunnel -> grype-db -> grype path.
+
+// rhelDirectRPMHost builds a plain RHEL binary RPM whose name equals the source RPM the
+// RHEL data is keyed on, so the matcher's direct path engages (no source indirection).
+// epoch is set in metadata so the epoch comparison is exercised explicitly.
+func rhelDirectRPMHost(name string, d *distro.Distro, epoch int, version string, id pkg.ID) *dbtest.PackageBuilder {
+	return dbtest.NewPackage(name, version, syftPkg.RpmPkg).
+		WithID(id).
+		WithDistro(d).
+		WithMetadata(pkg.RpmMetadata{Epoch: intPtr(epoch)})
+}
+
+// CVE-2025-9566 fixes podman in rhel:10 across three upstream bases, and the epoch bumps
+// from 6 to 7 between the oldest stream and the newer two. vunnel folds all three RHSAs
+// into one record with a three-clause VulnerableRange:
+//
+//	< 6:5.4.0-13.el10_0 || >= 7:5.6.0, < 7:5.6.0-5.el10_1 || >= 7:5.8.0, < 7:5.8.0-2.el10
+//
+// The interesting properties versus the python3.9 case: a third stream, and an epoch
+// pivot that the >= base clauses must respect (a 6:5.4.0 build is not >= 7:5.6.0).
+func TestRpmMultiRHSA_CVE2025_9566_ThreeStreamsWithEpochBump(t *testing.T) {
+	dbtest.DBs(t, "rhel-multi-rhsa").
+		SelectOnly("rhel:10/cve-2025-9566").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			rhel10 := distro.New(distro.RedHat, "10.1", "")
+
+			cases := []struct {
+				name       string
+				epoch      int
+				version    string
+				vulnerable bool
+				why        string
+			}{
+				{
+					name:       "below lowest-stream fix",
+					epoch:      6,
+					version:    "6:5.4.0-12.el10_0",
+					vulnerable: true,
+					why:        "one release behind the 10.0 fix; < 6:5.4.0-13.el10_0",
+				},
+				{
+					name:       "at lowest-stream fix",
+					epoch:      6,
+					version:    "6:5.4.0-13.el10_0",
+					vulnerable: false,
+					why:        "carries the 10.0 fix; not >= 7:5.6.0 so it falls into no later clause",
+				},
+				{
+					name:       "in middle stream below its fix",
+					epoch:      7,
+					version:    "7:5.6.0-3.el10_1",
+					vulnerable: true,
+					why:        ">= 7:5.6.0 and < 7:5.6.0-5.el10_1",
+				},
+				{
+					name:       "at middle-stream fix",
+					epoch:      7,
+					version:    "7:5.6.0-5.el10_1",
+					vulnerable: false,
+					why:        "carries the 10.1 fix",
+				},
+				{
+					name:       "in fixed middle stream, above its fix, below newest base",
+					epoch:      7,
+					version:    "7:5.7.0-1.el10",
+					vulnerable: false,
+					why:        ">= 7:5.6.0 but not < 7:5.6.0-5, and not >= 7:5.8.0 - in no clause",
+				},
+				{
+					name:       "in newest stream below its fix",
+					epoch:      7,
+					version:    "7:5.8.0-1.el10",
+					vulnerable: true,
+					why:        ">= 7:5.8.0 and < 7:5.8.0-2.el10",
+				},
+				{
+					name:       "at newest-stream fix",
+					epoch:      7,
+					version:    "7:5.8.0-2.el10",
+					vulnerable: false,
+					why:        "carries the newest GA fix",
+				},
+			}
+
+			for _, c := range cases {
+				t.Run(c.name, func(t *testing.T) {
+					matcher := Matcher{}
+					pkgID := pkg.ID("podman-" + c.version)
+					p := rhelDirectRPMHost("podman", rhel10, c.epoch, c.version, pkgID).Build()
+					if c.vulnerable {
+						db.Match(t, &matcher, p).
+							SelectMatch("CVE-2025-9566").
+							SelectDetailByType(match.ExactDirectMatch).
+							AsDistroSearch()
+					} else {
+						db.Match(t, &matcher, p).
+							Ignores().
+							SelectRelatedPackageIgnore(IgnoreReasonDistroNotVulnerable, "CVE-2025-9566")
+					}
+				})
+			}
+		})
+}
+
+// The newest stream's build is the canonical fix and all three RHSAs are folded on.
+func TestRpmMultiRHSA_CVE2025_9566_FixAndAdvisories(t *testing.T) {
+	dbtest.DBs(t, "rhel-multi-rhsa").
+		SelectOnly("rhel:10/cve-2025-9566").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			matcher := Matcher{}
+			p := rhelDirectRPMHost("podman", distro.New(distro.RedHat, "10.1", ""), 6, "6:5.4.0-12.el10_0", pkg.ID("podman")).Build()
+
+			sf := db.Match(t, &matcher, p).SelectMatch("CVE-2025-9566")
+			sf.HasFix(vulnerability.FixStateFixed, "7:5.8.0-2.el10").
+				HasAdvisories("RHSA-2026:18289", "RHSA-2025:20983", "RHSA-2025:15901")
+			sf.SelectDetailByType(match.ExactDirectMatch).AsDistroSearch()
+		})
+}
+
+// CVE-2020-8696 fixes microcode_ctl in rhel:8 in two upstream bases, but three advisories
+// touched the bucket - including an RHBA (a bugfix advisory, not a security one). vunnel
+// folds and de-duplicates all three onto the single record. This checks that the fold
+// keeps every distinct advisory regardless of RH*A type.
+func TestRpmMultiRHSA_CVE2020_8696_FoldsRHBA(t *testing.T) {
+	dbtest.DBs(t, "rhel-multi-rhsa").
+		SelectOnly("rhel:8/cve-2020-8696").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			matcher := Matcher{}
+			// well below the lowest stream's fix (4:20200609-...) - genuinely vulnerable.
+			p := rhelDirectRPMHost("microcode_ctl", distro.New(distro.RedHat, "8.3", ""), 4, "4:20191115-4.20200602.2.el8_2", pkg.ID("microcode_ctl")).Build()
+
+			sf := db.Match(t, &matcher, p).SelectMatch("CVE-2020-8696")
+			sf.HasFix(vulnerability.FixStateFixed, "4:20210216-1.20210608.1.el8_4").
+				HasAdvisories("RHSA-2021:3027", "RHBA-2021:0621", "RHSA-2020:5085")
+			sf.SelectDetailByType(match.ExactDirectMatch).AsDistroSearch()
+		})
+}
+
+func TestRpmMultiRHSA_CVE2020_8696_PartitionedStreams(t *testing.T) {
+	dbtest.DBs(t, "rhel-multi-rhsa").
+		SelectOnly("rhel:8/cve-2020-8696").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			rhel8 := distro.New(distro.RedHat, "8.4", "")
+
+			// VulnerableRange:
+			//   < 4:20200609-2.20210216.1.el8_3 || >= 4:20210216, < 4:20210216-1.20210608.1.el8_4
+			cases := []struct {
+				name       string
+				version    string
+				vulnerable bool
+			}{
+				{"below lowest-stream fix", "4:20191115-4.20200602.2.el8_2", true},
+				{"at lowest-stream fix", "4:20200609-2.20210216.1.el8_3", false},
+				{"in newest stream below its fix", "4:20210216-1.20210501.1.el8_4", true},
+				{"at newest-stream fix", "4:20210216-1.20210608.1.el8_4", false},
+			}
+
+			for _, c := range cases {
+				t.Run(c.name, func(t *testing.T) {
+					matcher := Matcher{}
+					pkgID := pkg.ID("microcode_ctl-" + c.version)
+					p := rhelDirectRPMHost("microcode_ctl", rhel8, 4, c.version, pkgID).Build()
+					if c.vulnerable {
+						db.Match(t, &matcher, p).
+							SelectMatch("CVE-2020-8696").
+							SelectDetailByType(match.ExactDirectMatch).
+							AsDistroSearch()
+					} else {
+						db.Match(t, &matcher, p).
+							Ignores().
+							SelectRelatedPackageIgnore(IgnoreReasonDistroNotVulnerable, "CVE-2020-8696")
+					}
+				})
+			}
+		})
+}
+
+// CVE-2023-45288 fixes go-toolset in rhel:8 in two upstream bases within a module
+// (Module=go-toolset:rhel8). The partition must hold inside the module-qualified record:
+//
+//	< 0:1.20.12-1.module+el8.9.0+21033+5795bdf6 || >= 0:1.21.9, < 0:1.21.9-1.module+el8.10.0+21671+b35c3b78
+func TestRpmMultiRHSA_CVE2023_45288_ModularPartition(t *testing.T) {
+	dbtest.DBs(t, "rhel-multi-rhsa").
+		SelectOnly("rhel:8/cve-2023-45288").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			rhel8 := distro.New(distro.RedHat, "8.10", "")
+
+			cases := []struct {
+				name       string
+				version    string
+				vulnerable bool
+			}{
+				{"below lowest-stream fix", "0:1.20.11-1.module+el8.9.0+20000+aaaaaaaa", true},
+				{"at lowest-stream fix", "0:1.20.12-1.module+el8.9.0+21033+5795bdf6", false},
+				{"in newest stream below its fix", "0:1.21.9-1.module+el8.10.0+21000+00000000", true},
+				{"at newest-stream fix", "0:1.21.9-1.module+el8.10.0+21671+b35c3b78", false},
+			}
+
+			for _, c := range cases {
+				t.Run(c.name, func(t *testing.T) {
+					matcher := Matcher{}
+					pkgID := pkg.ID("go-toolset-" + c.version)
+					p := rhelDirectRPMHost("go-toolset", rhel8, 0, c.version, pkgID).
+						WithMetadata(pkg.RpmMetadata{
+							Epoch:           intPtr(0),
+							ModularityLabel: strPtr("go-toolset:rhel8:8100020240426:b35c3b78"),
+						}).
+						Build()
+					if c.vulnerable {
+						db.Match(t, &matcher, p).
+							SelectMatch("CVE-2023-45288").
+							SelectDetailByType(match.ExactDirectMatch).
+							AsDistroSearch()
+					} else {
+						db.Match(t, &matcher, p).
+							Ignores().
+							SelectRelatedPackageIgnore(IgnoreReasonDistroNotVulnerable, "CVE-2023-45288")
+					}
+				})
+			}
+		})
+}

--- a/grype/matcher/rpm/rhel_reviewer_feedback_test.go
+++ b/grype/matcher/rpm/rhel_reviewer_feedback_test.go
@@ -1,0 +1,154 @@
+package rpm
+
+import (
+	"testing"
+
+	"github.com/anchore/grype/grype/distro"
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/grype/internal/dbtest"
+	"github.com/anchore/syft/syft/artifact"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+// These cases come from an expert reviewer's findings on two real images:
+//   - a python 3.12 image (RHEL 9.4)
+//   - an OSE console image (RHEL 9.2)
+// Each uses the actual installed package version from that image's SBOM and the real
+// vunnel record (OSE records include the AdditionalAdvisoryFixes vunnel should emit). They
+// assert the reviewer's expected-correct outcome, so any that fail mark behavior we have not
+// fixed yet.
+
+// rhelIndirectRPMHost models a binary RPM whose source RPM differs (e.g. libcurl-minimal built
+// from the curl source RPM), engaging the matcher's source-indirection path that the RHEL data
+// (keyed on the source RPM) requires.
+func rhelIndirectRPMHost(binary, source string, d *distro.Distro, epoch int, version string, id pkg.ID) pkg.Package {
+	return dbtest.NewPackage(binary, version, syftPkg.RpmPkg).
+		WithID(id).
+		WithDistro(d).
+		WithUpstream(source, version).
+		WithMetadata(pkg.RpmMetadata{Epoch: intPtr(epoch)}).
+		Build()
+}
+
+// --- python 3.12 image, RHEL 9.4 ---
+
+func TestReviewerFeedback_PythonImage(t *testing.T) {
+	dbtest.DBs(t, "rhel-reviewer-feedback").
+		SelectOnly("rhel:9/cve-2023-25433", "rhel:9/cve-2021-20197", "rhel:9/cve-2025-59464", "rhel:9/cve-2026-2100").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			rhel94 := distro.New(distro.RedHat, "9.4", "")
+
+			// CVE-2023-25433 (libtiff) - Red Hat lists RHEL 9 as affected, no fix yet: must be reported.
+			t.Run("libtiff affected/no-fix is reported", func(t *testing.T) {
+				p := rhelDirectRPMHost("libtiff", rhel94, 0, "0:4.4.0-12.el9", pkg.ID("libtiff")).Build()
+				db.Match(t, &Matcher{}, p).
+					SelectMatch("CVE-2023-25433").
+					SelectDetailByType(match.ExactDirectMatch).
+					AsDistroSearch()
+			})
+
+			// CVE-2021-20197 (binutils) - same: affected on RHEL 9, no fix.
+			t.Run("binutils affected/no-fix is reported", func(t *testing.T) {
+				p := rhelDirectRPMHost("binutils", rhel94, 0, "0:2.35.2-43.el9", pkg.ID("binutils")).Build()
+				db.Match(t, &Matcher{}, p).
+					SelectMatch("CVE-2021-20197").
+					SelectDetailByType(match.ExactDirectMatch).
+					AsDistroSearch()
+			})
+
+			// CVE-2025-59464 (nodejs:20) - marked will-not-fix: reported with a wont-fix state.
+			t.Run("nodejs:20 wont-fix is reported as wont-fix", func(t *testing.T) {
+				p := dbtest.NewPackage("nodejs", "1:20.16.0-1.module+el9.4.0+22197+9e60f127", syftPkg.RpmPkg).
+					WithID(pkg.ID("nodejs")).
+					WithDistro(rhel94).
+					WithMetadata(pkg.RpmMetadata{
+						Epoch:           intPtr(1),
+						ModularityLabel: strPtr("nodejs:20:9040020240807145403:rhel9"),
+					}).
+					Build()
+				db.Match(t, &Matcher{}, p).
+					SelectMatch("CVE-2025-59464").
+					HasFix(vulnerability.FixStateWontFix).
+					SelectDetailByType(match.ExactDirectMatch).
+					AsDistroSearch()
+			})
+
+			// CVE-2026-2100 (p11-kit) - affected per RHSA-2026:18599, fixed in 0:0.26.2-1.el9.
+			t.Run("p11-kit below the fix is reported", func(t *testing.T) {
+				p := rhelDirectRPMHost("p11-kit", rhel94, 0, "0:0.25.3-2.el9", pkg.ID("p11-kit")).Build()
+				sf := db.Match(t, &Matcher{}, p).SelectMatch("CVE-2026-2100")
+				sf.HasFix(vulnerability.FixStateFixed, "0:0.26.2-1.el9")
+				sf.SelectDetailByType(match.ExactDirectMatch).AsDistroSearch()
+			})
+		})
+}
+
+// --- OSE console image, RHEL 9.2 ---
+//
+// Each package below carries the fix for its 9.2 stream (its .el9_2.N release is at or past the
+// 9.2 RHSA's build) but sits below the later 9.3 build that vunnel collapses to as the canonical
+// fix. The reviewer's point ("not picking up both advisories") is that grype only knows the 9.3
+// advisory and therefore false-positives the patched 9.2 host. Correct outcome: not vulnerable.
+
+func TestReviewerFeedback_OSEImage(t *testing.T) {
+	dbtest.DBs(t, "rhel-reviewer-feedback").
+		SelectOnly("rhel:9/cve-2023-4813", "rhel:9/cve-2023-4806", "rhel:9/cve-2023-38545", "rhel:9/cve-2023-38546", "rhel:9/cve-2023-44487").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			rhel92 := distro.New(distro.RedHat, "9.2", "")
+
+			// glibc 2.34-60.el9_2.14 carries the 9.2 fix (RHSA-2023:5453 shipped -60.el9_2.7).
+			for _, cve := range []string{"CVE-2023-4813", "CVE-2023-4806"} {
+				t.Run("glibc patched on 9.2 stream not flagged: "+cve, func(t *testing.T) {
+					p := rhelDirectRPMHost("glibc", rhel92, 0, "0:2.34-60.el9_2.14", pkg.ID("glibc-"+cve)).Build()
+					// glibc's two CVEs are loaded together and both suppress on the 9.2 stream, so
+					// the sibling CVE also produces an ignore; scope this subtest to the one CVE.
+					db.Match(t, &Matcher{}, p).
+						Ignores().
+						SkipCompleteness().
+						SelectRelatedPackageIgnore(IgnoreReasonDistroNotVulnerable, cve)
+				})
+			}
+
+			// libcurl-minimal 7.76.1-23.el9_2.7 carries the 9.2 fix (RHSA-2023:5763 shipped -23.el9_2.4).
+			for _, cve := range []string{"CVE-2023-38545", "CVE-2023-38546"} {
+				t.Run("curl patched on 9.2 stream not flagged: "+cve, func(t *testing.T) {
+					pkgID := pkg.ID("libcurl-minimal-" + cve)
+					p := rhelIndirectRPMHost("libcurl-minimal", "curl", rhel92, 0, "0:7.76.1-23.el9_2.7", pkgID)
+					// curl's two CVEs are loaded together and both suppress on the 9.2 stream, so the
+					// sibling CVE also produces an ignore; scope this subtest to the one CVE.
+					db.Match(t, &Matcher{}, p).
+						Ignores().
+						SkipCompleteness().
+						SelectRelatedPackageIgnore(IgnoreReasonDistroNotVulnerable, cve).
+						ForPackage(pkgID).
+						WithRelationshipType(artifact.OwnershipByFileOverlapRelationship)
+				})
+			}
+
+			// libnghttp2 1.43.0-5.el9_2.3 carries the 9.2 fix (RHSA-2023:5838 shipped -5.el9_2.1).
+			t.Run("nghttp2 patched on 9.2 stream not flagged: CVE-2023-44487", func(t *testing.T) {
+				pkgID := pkg.ID("libnghttp2")
+				p := rhelIndirectRPMHost("libnghttp2", "nghttp2", rhel92, 0, "0:1.43.0-5.el9_2.3", pkgID)
+				db.Match(t, &Matcher{}, p).
+					Ignores().
+					SelectRelatedPackageIgnore(IgnoreReasonDistroNotVulnerable, "CVE-2023-44487").
+					ForPackage(pkgID).
+					WithRelationshipType(artifact.OwnershipByFileOverlapRelationship)
+			})
+
+			// A genuinely-vulnerable older curl layer (below the 9.2 fix -23.el9_2.4) must still be
+			// reported - and should surface BOTH advisories (the reviewer's "pick up both") and the
+			// 9.2 stream fix, not the 9.3 build.
+			t.Run("curl below 9.2 fix is reported with both advisories and the 9.2 fix", func(t *testing.T) {
+				pkgID := pkg.ID("libcurl-minimal-vuln")
+				p := rhelIndirectRPMHost("libcurl-minimal", "curl", rhel92, 0, "0:7.76.1-23.el9_2.1", pkgID)
+				// Both curl CVEs are loaded and both are vulnerable below the 9.2 fix; scope to one.
+				sf := db.Match(t, &Matcher{}, p).SkipCompleteness().SelectMatch("CVE-2023-38545")
+				sf.HasFix(vulnerability.FixStateFixed, "0:7.76.1-23.el9_2.4").
+					HasAdvisories("RHSA-2023:6745", "RHSA-2023:5763")
+				sf.SelectDetailByType(match.ExactIndirectMatch).AsDistroSearch()
+			})
+		})
+}

--- a/grype/matcher/rpm/rhel_same_base_rhsa_test.go
+++ b/grype/matcher/rpm/rhel_same_base_rhsa_test.go
@@ -1,0 +1,128 @@
+package rpm
+
+import (
+	"testing"
+
+	"github.com/anchore/grype/grype/distro"
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/internal/dbtest"
+)
+
+// Same-base multi-stream RHEL fixes: Red Hat patches one package at the SAME upstream
+// base across several minors (e.g. firefox 128.4.0 rebuilt as -1.el9_4 and -1.el9_5).
+// No VulnerableRange can separate these - the leading release is a single total order, so
+// vunnel collapses them to the highest-EVR build and a host running its own stream's fix
+// is falsely flagged. The fix: vunnel emits an UnaffectedVersions list of every called-out
+// fix EVR, the OS transformer turns each into a "= <evr>" unaffected handle, and the
+// matcher lets an exact-fix unaffected record suppress the coarse "below highest" match.
+//
+// These tests assert the post-fix behavior; they fail against the unmodified
+// transformer+matcher (the host-at-its-stream-fix cases report a false positive).
+
+func TestRpmSameBaseRHSA_Firefox_DistTagOnly(t *testing.T) {
+	dbtest.DBs(t, "rhel-same-base-rhsa").
+		SelectOnly("rhel:9/cve-2024-10458").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			rhel9 := distro.New(distro.RedHat, "9.4", "")
+
+			cases := []struct {
+				name       string
+				version    string
+				vulnerable bool
+				why        string
+			}{
+				{
+					name:       "host at the 9.4 stream fix",
+					version:    "0:128.4.0-1.el9_4",
+					vulnerable: false,
+					why:        "exact called-out fix for the 9.4 branch; only the dist tag makes it < the 9.5 build",
+				},
+				{
+					name:       "host at the 9.5 stream fix",
+					version:    "0:128.4.0-1.el9_5",
+					vulnerable: false,
+					why:        "exact called-out fix for the 9.5 branch (also the collapsed highest)",
+				},
+				{
+					name:       "host genuinely below all fixes",
+					version:    "0:128.3.0-1.el9_4",
+					vulnerable: true,
+					why:        "older upstream than either fix and matches no unaffected handle",
+				},
+			}
+
+			for _, c := range cases {
+				t.Run(c.name, func(t *testing.T) {
+					matcher := Matcher{}
+					pkgID := pkg.ID("firefox-" + c.version)
+					p := rhelDirectRPMHost("firefox", rhel9, 0, c.version, pkgID).Build()
+					if c.vulnerable {
+						db.Match(t, &matcher, p).
+							SelectMatch("CVE-2024-10458").
+							SelectDetailByType(match.ExactDirectMatch).
+							AsDistroSearch()
+					} else {
+						db.Match(t, &matcher, p).
+							Ignores().
+							SelectRelatedPackageIgnore(IgnoreReasonDistroNotVulnerable, "CVE-2024-10458")
+					}
+				})
+			}
+		})
+}
+
+// The inverted case: by EVR the GA `.el8` build (425.3.1) outranks the 8.6 EUS backport
+// (372.26.1), so the collapsed highest is the GA build and an 8.6 host at its own fix is
+// flagged. The exact-fix unaffected handle must rescue it.
+func TestRpmSameBaseRHSA_Kernel_Inverted(t *testing.T) {
+	dbtest.DBs(t, "rhel-same-base-rhsa").
+		SelectOnly("rhel:8/cve-2022-48943").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			rhel8 := distro.New(distro.RedHat, "8.6", "")
+
+			cases := []struct {
+				name       string
+				version    string
+				vulnerable bool
+				why        string
+			}{
+				{
+					name:       "host at the 8.6 EUS stream fix",
+					version:    "0:4.18.0-372.26.1.el8_6",
+					vulnerable: false,
+					why:        "exact 8.6 fix; EVR ranks it below the GA build only because 372 < 425",
+				},
+				{
+					name:       "host at the GA stream fix",
+					version:    "0:4.18.0-425.3.1.el8",
+					vulnerable: false,
+					why:        "exact GA fix (the collapsed highest)",
+				},
+				{
+					name:       "host genuinely below its stream fix",
+					version:    "0:4.18.0-300.10.1.el8_6",
+					vulnerable: true,
+					why:        "below the 8.6 fix and matches no unaffected handle",
+				},
+			}
+
+			for _, c := range cases {
+				t.Run(c.name, func(t *testing.T) {
+					matcher := Matcher{}
+					pkgID := pkg.ID("kernel-" + c.version)
+					p := rhelDirectRPMHost("kernel", rhel8, 0, c.version, pkgID).Build()
+					if c.vulnerable {
+						db.Match(t, &matcher, p).
+							SelectMatch("CVE-2022-48943").
+							SelectDetailByType(match.ExactDirectMatch).
+							AsDistroSearch()
+					} else {
+						db.Match(t, &matcher, p).
+							Ignores().
+							SelectRelatedPackageIgnore(IgnoreReasonDistroNotVulnerable, "CVE-2022-48943")
+					}
+				})
+			}
+		})
+}

--- a/grype/matcher/rpm/rhel_stream.go
+++ b/grype/matcher/rpm/rhel_stream.go
@@ -1,0 +1,209 @@
+package rpm
+
+import (
+	"strings"
+
+	"github.com/anchore/grype/grype/matcher/internal/result"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/version"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/grype/internal/log"
+)
+
+// streamFix is a single per-stream called-out fix build extracted from an unaffected record:
+// the fix EVR, its dist-tag minor (the N in .elM_N), and the advisory that shipped it.
+type streamFix struct {
+	evr      string
+	minor    int
+	hasMinor bool
+	advisory vulnerability.Advisory
+}
+
+// applyStreamSelection implements Option A "matcher-side stream selection" for RHEL same-base
+// multi-stream fixes.
+//
+// Red Hat sometimes fixes a package on several minor streams at the SAME upstream base, where only
+// the .elN_M dist tag differs. Hydra flattens these under one "RHEL N" record, so vunnel collapses
+// them to the single highest-EVR build. That makes grype false-positive a host that already carries
+// its own stream's (lower-EVR) fix, because EVR is a single total order and cannot represent the
+// per-minor branches.
+//
+// Option A keeps one disclosure record per CVE but carries every per-stream fix build + its advisory
+// as unaffected ("= <evr>") records. Here we read the INSTALLED package's own dist-tag minor, select
+// the per-stream fix whose dist-tag minor matches, and compare the installed version against it:
+//
+//   - installed >= its stream's fix  -> not vulnerable: move the disclosure to suppressed.
+//   - installed <  its stream's fix  -> vulnerable: keep it, but rewrite Fix.Versions to THAT
+//     stream's fix (not the collapsed highest build) so the reported remediation is reachable.
+//
+// Refine-or-fallback: if the package has no dist-tag minor, or no stream fix matches that minor,
+// the disclosure is left untouched for the caller's coarse "< highest fix" handling. This never
+// introduces a false negative - we only suppress when we positively matched the host's own stream.
+//
+// Returns (refinedDisclosures, suppressed). suppressed carries the per-vuln advisory of the matched
+// stream fix so the caller can emit an accurate ignore.
+func applyStreamSelection(searchPkg pkg.Package, disclosures, streamUnaffected result.Set) (refined, suppressed result.Set) {
+	hostMinor, hostHasMinor := hostStreamMinor(searchPkg.Version)
+	if !hostHasMinor {
+		// no dist-tag minor on the installed package: cannot reason about streams, fall back.
+		return disclosures, result.Set{}
+	}
+
+	pkgVersion := version.New(searchPkg.Version, version.RpmFormat)
+
+	refined = result.Set{}
+	suppressed = result.Set{}
+
+	for id, results := range disclosures {
+		fixes := streamFixesForID(id, streamUnaffected)
+		matched, ok := selectStreamFixForMinor(fixes, hostMinor)
+		if !ok {
+			// no called-out stream fix matches the host's minor: leave for coarse handling.
+			refined[id] = results
+			continue
+		}
+
+		fixVersion := version.New(matched.evr, version.RpmFormat)
+		cmp, err := pkgVersion.Compare(fixVersion)
+		if err != nil {
+			log.WithFields("package", searchPkg.Name, "vulnerability", id, "fix", matched.evr, "error", err).
+				Trace("rpm: failed to compare installed version against stream fix; falling back to coarse handling")
+			refined[id] = results
+			continue
+		}
+
+		if cmp >= 0 {
+			// installed >= the host's own stream fix: not vulnerable on this stream. Suppress.
+			suppressed[id] = withAdvisory(results, matched.advisory)
+			log.WithFields(
+				"package", searchPkg.Name,
+				"version", searchPkg.Version,
+				"vulnerability", id,
+				"streamFix", matched.evr,
+				"advisory", matched.advisory.ID,
+			).Trace("rpm: host is at/above its own stream's fix build; suppressing same-base false positive")
+			continue
+		}
+
+		// installed < the host's own stream fix: still vulnerable, but the reachable remediation is
+		// THIS stream's build, not the collapsed highest one. Rewrite the reported fix version.
+		refined[id] = rewriteFixVersion(results, matched.evr)
+	}
+
+	return refined, suppressed
+}
+
+// hostStreamMinor extracts the dist-tag minor (the N in .elM_N) from an installed RPM version.
+// Reuses the same release-parsing primitives as the EUS path. Returns ok=false when there is no
+// dist-tag minor (e.g. a plain .elM build, or no dist tag at all).
+func hostStreamMinor(rpmVersion string) (minor int, ok bool) {
+	release := extractReleaseFromRPMVersion(rpmVersion)
+	major, minor, found := extractRHELVersionFromRelease(release)
+	if !found || major == 0 {
+		return 0, false
+	}
+	// extractRHELVersionFromRelease returns minor=0 both for ".elM" (no minor) and ".elM_0".
+	// We only want to key on streams that actually carry a minor, so require the "_" marker.
+	if !strings.Contains(release, "_") {
+		return 0, false
+	}
+	return minor, true
+}
+
+// streamFixesForID collects the per-stream fix builds (EVR + dist-tag minor + advisory) from the
+// unaffected records that share an identity with the given disclosure ID.
+func streamFixesForID(id string, streamUnaffected result.Set) []streamFix {
+	var out []streamFix
+	results, ok := streamUnaffected[id]
+	if !ok {
+		return out
+	}
+	for _, r := range results {
+		for _, v := range r.Vulnerabilities {
+			evr := evrFromConstraint(v)
+			if evr == "" {
+				continue
+			}
+			minor, hasMinor := hostStreamMinor(evr)
+			sf := streamFix{evr: evr, minor: minor, hasMinor: hasMinor}
+			if len(v.Advisories) > 0 {
+				sf.advisory = v.Advisories[0]
+			}
+			out = append(out, sf)
+		}
+	}
+	return out
+}
+
+// evrFromConstraint extracts the EVR from a "= <evr>" unaffected constraint. The exact-match
+// unaffected handles emitted by the transformer encode the per-stream fix build as "= <evr>".
+func evrFromConstraint(v vulnerability.Vulnerability) string {
+	if v.Constraint == nil {
+		return ""
+	}
+	raw := strings.TrimSpace(v.Constraint.Value())
+	raw = strings.TrimPrefix(raw, "=")
+	return strings.TrimSpace(raw)
+}
+
+// selectStreamFixForMinor returns the stream fix whose dist-tag minor equals the host's minor.
+func selectStreamFixForMinor(fixes []streamFix, hostMinor int) (streamFix, bool) {
+	for _, f := range fixes {
+		if f.hasMinor && f.minor == hostMinor {
+			return f, true
+		}
+	}
+	return streamFix{}, false
+}
+
+// rewriteFixVersion returns a copy of the disclosure results with each vulnerability's reported fix
+// version replaced by the host's own stream fix build, so grype reports a reachable remediation
+// rather than the collapsed highest-stream build. Advisories are left intact (the disclosure already
+// carries every contributing advisory via its AdvisorySummary).
+func rewriteFixVersion(results []result.Result, evr string) []result.Result {
+	out := make([]result.Result, 0, len(results))
+	for _, r := range results {
+		nr := r
+		nr.Vulnerabilities = make([]vulnerability.Vulnerability, 0, len(r.Vulnerabilities))
+		for _, v := range r.Vulnerabilities {
+			nv := v
+			if nv.Fix.State == vulnerability.FixStateFixed {
+				nv.Fix.Versions = []string{evr}
+			}
+			nr.Vulnerabilities = append(nr.Vulnerabilities, nv)
+		}
+		out = append(out, nr)
+	}
+	return out
+}
+
+// withAdvisory returns a copy of the results with the matched stream advisory ensured present on each
+// vulnerability, so a suppression ignore can reference the advisory whose fix the host already runs.
+func withAdvisory(results []result.Result, adv vulnerability.Advisory) []result.Result {
+	if adv.ID == "" && adv.Link == "" {
+		return results
+	}
+	out := make([]result.Result, 0, len(results))
+	for _, r := range results {
+		nr := r
+		nr.Vulnerabilities = make([]vulnerability.Vulnerability, 0, len(r.Vulnerabilities))
+		for _, v := range r.Vulnerabilities {
+			nv := v
+			if !hasAdvisory(nv.Advisories, adv) {
+				nv.Advisories = append(append([]vulnerability.Advisory(nil), nv.Advisories...), adv)
+			}
+			nr.Vulnerabilities = append(nr.Vulnerabilities, nv)
+		}
+		out = append(out, nr)
+	}
+	return out
+}
+
+func hasAdvisory(advisories []vulnerability.Advisory, adv vulnerability.Advisory) bool {
+	for _, a := range advisories {
+		if a.ID == adv.ID {
+			return true
+		}
+	}
+	return false
+}

--- a/grype/matcher/rpm/testdata/rhel-multi-rhsa/db.yaml
+++ b/grype/matcher/rpm/testdata/rhel-multi-rhsa/db.yaml
@@ -1,7 +1,19 @@
-# Hand-authored fixture (auto-generate disabled). The single rhel:9 record is the
-# verbatim OS-schema output of vunnel's RHEL provider for CVE-2024-8088 after the
-# multi-RHSA phase-1 change (distinct upstream bases -> partitioned VulnerableRange).
+# Hand-authored fixture (auto-generate disabled). Each record is the verbatim
+# OS-schema output of vunnel's RHEL provider after the multi-RHSA phase-1 change
+# (distinct upstream bases for the same package/CVE/major -> a single FixedIn with
+# a partitioned VulnerableRange and the folded RHSAs), trimmed to the one FixedIn
+# entry under test. Records were mined from a real vunnel cache with
+# datasources/rhel/scripts/find_multi_rhsa_results.py, which surfaces every
+# VulnerableRange-bearing record (the precise marker for this shape).
+#
+#   rhel:9/cve-2024-8088   python3.9      2 streams, 2 RHSAs (the original case)
+#   rhel:10/cve-2025-9566  podman         3 streams, 3 RHSAs, epoch bump 6->7 mid-range
+#   rhel:8/cve-2020-8696   microcode_ctl  2 streams, 3 RHSAs incl. an RHBA (advisory fold)
+#   rhel:8/cve-2023-45288  go-toolset     2 streams, modular (Module=go-toolset:rhel8)
 auto-generate: false
 extractions:
     rhel:
         - rhel:9/cve-2024-8088
+        - rhel:10/cve-2025-9566
+        - rhel:8/cve-2020-8696
+        - rhel:8/cve-2023-45288

--- a/grype/matcher/rpm/testdata/rhel-multi-rhsa/rhel/results/rhel@10/cve-2025-9566.json
+++ b/grype/matcher/rpm/testdata/rhel-multi-rhsa/rhel/results/rhel@10/cve-2025-9566.json
@@ -1,0 +1,42 @@
+{
+  "identifier": "rhel:10/cve-2025-9566",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [],
+      "Description": "There's a vulnerability in podman where an attacker may use the kube play command to overwrite host files when the kube file container a Secrete or a ConfigMap volume mount and such volume contains a symbolic link to a host file path. In a successful attack, the attacker can only control the target file to be overwritten but not the content to be written into the file.\nBinary-Affected: podman\nUpstream-version-introduced: v4.0.0\nUpstream-version-fixed: v5.6.1",
+      "FixedIn": [
+        {
+          "Module": null,
+          "Name": "podman",
+          "NamespaceName": "rhel:10",
+          "VendorAdvisory": {
+            "AdvisorySummary": [
+              {
+                "ID": "RHSA-2026:18289",
+                "Link": "https://access.redhat.com/errata/RHSA-2026:18289"
+              },
+              {
+                "ID": "RHSA-2025:20983",
+                "Link": "https://access.redhat.com/errata/RHSA-2025:20983"
+              },
+              {
+                "ID": "RHSA-2025:15901",
+                "Link": "https://access.redhat.com/errata/RHSA-2025:15901"
+              }
+            ],
+            "NoAdvisory": false
+          },
+          "Version": "7:5.8.0-2.el10",
+          "VersionFormat": "rpm",
+          "VulnerableRange": "< 6:5.4.0-13.el10_0 || >= 7:5.6.0, < 7:5.6.0-5.el10_1 || >= 7:5.8.0, < 7:5.8.0-2.el10"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2025-9566",
+      "Metadata": {},
+      "Name": "CVE-2025-9566",
+      "NamespaceName": "rhel:10",
+      "Severity": "High"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/grype/matcher/rpm/testdata/rhel-multi-rhsa/rhel/results/rhel@8/cve-2020-8696.json
+++ b/grype/matcher/rpm/testdata/rhel-multi-rhsa/rhel/results/rhel@8/cve-2020-8696.json
@@ -1,0 +1,42 @@
+{
+  "identifier": "rhel:8/cve-2020-8696",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [],
+      "Description": "A flaw was found in the Intel Advanced Vector Extensions (AVX) implementation, where a local authenticated attacker with the ability to execute AVX instructions can gather the AVX register state from previous AVX executions. This vulnerability allows information disclosure of the AVX register state.",
+      "FixedIn": [
+        {
+          "Module": null,
+          "Name": "microcode_ctl",
+          "NamespaceName": "rhel:8",
+          "VendorAdvisory": {
+            "AdvisorySummary": [
+              {
+                "ID": "RHSA-2021:3027",
+                "Link": "https://access.redhat.com/errata/RHSA-2021:3027"
+              },
+              {
+                "ID": "RHBA-2021:0621",
+                "Link": "https://access.redhat.com/errata/RHBA-2021:0621"
+              },
+              {
+                "ID": "RHSA-2020:5085",
+                "Link": "https://access.redhat.com/errata/RHSA-2020:5085"
+              }
+            ],
+            "NoAdvisory": false
+          },
+          "Version": "4:20210216-1.20210608.1.el8_4",
+          "VersionFormat": "rpm",
+          "VulnerableRange": "< 4:20200609-2.20210216.1.el8_3 || >= 4:20210216, < 4:20210216-1.20210608.1.el8_4"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2020-8696",
+      "Metadata": {},
+      "Name": "CVE-2020-8696",
+      "NamespaceName": "rhel:8",
+      "Severity": "Medium"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/grype/matcher/rpm/testdata/rhel-multi-rhsa/rhel/results/rhel@8/cve-2023-45288.json
+++ b/grype/matcher/rpm/testdata/rhel-multi-rhsa/rhel/results/rhel@8/cve-2023-45288.json
@@ -1,0 +1,38 @@
+{
+  "identifier": "rhel:8/cve-2023-45288",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [],
+      "Description": "A vulnerability was discovered with the implementation of the HTTP/2 protocol in the Go programming language. There were insufficient limitations on the amount of CONTINUATION frames sent within a single stream. An attacker could potentially exploit this to cause a Denial of Service (DoS) attack.",
+      "FixedIn": [
+        {
+          "Module": "go-toolset:rhel8",
+          "Name": "go-toolset",
+          "NamespaceName": "rhel:8",
+          "VendorAdvisory": {
+            "AdvisorySummary": [
+              {
+                "ID": "RHSA-2024:3259",
+                "Link": "https://access.redhat.com/errata/RHSA-2024:3259"
+              },
+              {
+                "ID": "RHSA-2024:1962",
+                "Link": "https://access.redhat.com/errata/RHSA-2024:1962"
+              }
+            ],
+            "NoAdvisory": false
+          },
+          "Version": "0:1.21.9-1.module+el8.10.0+21671+b35c3b78",
+          "VersionFormat": "rpm",
+          "VulnerableRange": "< 0:1.20.12-1.module+el8.9.0+21033+5795bdf6 || >= 0:1.21.9, < 0:1.21.9-1.module+el8.10.0+21671+b35c3b78"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2023-45288",
+      "Metadata": {},
+      "Name": "CVE-2023-45288",
+      "NamespaceName": "rhel:8",
+      "Severity": "High"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/grype/matcher/rpm/testdata/rhel-reviewer-feedback/db.yaml
+++ b/grype/matcher/rpm/testdata/rhel-reviewer-feedback/db.yaml
@@ -1,0 +1,15 @@
+# Hand-authored fixture (auto-generate disabled). Records mirror what vunnel's RHEL provider
+# emits (or should emit, with AdditionalAdvisoryFixes) for the packages/CVEs an expert reviewer
+# flagged on two real images: a python 3.12 image (rhel 9.4) and an OSE console image (rhel 9.2).
+auto-generate: false
+extractions:
+    rhel:
+        - rhel:9/cve-2023-25433
+        - rhel:9/cve-2025-59464
+        - rhel:9/cve-2026-2100
+        - rhel:9/cve-2021-20197
+        - rhel:9/cve-2023-4813
+        - rhel:9/cve-2023-4806
+        - rhel:9/cve-2023-38545
+        - rhel:9/cve-2023-38546
+        - rhel:9/cve-2023-44487

--- a/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/metadata.json
+++ b/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/metadata.json
@@ -1,0 +1,18 @@
+{
+  "provider": "rhel",
+  "version": 1,
+  "processor": "vunnel@multi-rhsa-phase-1",
+  "schema": {
+    "version": "1.0.3",
+    "url": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/provider-workspace-state/schema-1.0.3.json"
+  },
+  "urls": [
+    "https://access.redhat.com/hydra/rest/securitydata/cve.json"
+  ],
+  "timestamp": "2026-06-01T00:00:00Z",
+  "listing": {
+    "path": "results/listing.xxh64",
+    "algorithm": "xxh64"
+  },
+  "store": "flat-file"
+}

--- a/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2021-20197.json
+++ b/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2021-20197.json
@@ -1,0 +1,28 @@
+{
+  "identifier": "rhel:9/cve-2021-20197",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [],
+      "Description": "reviewer-feedback fixture for CVE-2021-20197",
+      "FixedIn": [
+        {
+          "Module": null,
+          "Name": "binutils",
+          "NamespaceName": "rhel:9",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "None",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2021-20197",
+      "Metadata": {},
+      "Name": "CVE-2021-20197",
+      "NamespaceName": "rhel:9",
+      "Severity": "Medium"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2023-25433.json
+++ b/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2023-25433.json
@@ -1,0 +1,28 @@
+{
+  "identifier": "rhel:9/cve-2023-25433",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [],
+      "Description": "reviewer-feedback fixture for CVE-2023-25433",
+      "FixedIn": [
+        {
+          "Module": null,
+          "Name": "libtiff",
+          "NamespaceName": "rhel:9",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "None",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2023-25433",
+      "Metadata": {},
+      "Name": "CVE-2023-25433",
+      "NamespaceName": "rhel:9",
+      "Severity": "Medium"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2023-38545.json
+++ b/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2023-38545.json
@@ -1,0 +1,53 @@
+{
+  "identifier": "rhel:9/cve-2023-38545",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [],
+      "Description": "reviewer-feedback fixture for CVE-2023-38545",
+      "FixedIn": [
+        {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:6745",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:6745"
+              },
+              "Version": "0:7.76.1-26.el9_3.2"
+            },
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5763",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5763"
+              },
+              "Version": "0:7.76.1-23.el9_2.4"
+            }
+          ],
+          "Module": null,
+          "Name": "curl",
+          "NamespaceName": "rhel:9",
+          "VendorAdvisory": {
+            "AdvisorySummary": [
+              {
+                "ID": "RHSA-2023:6745",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:6745"
+              },
+              {
+                "ID": "RHSA-2023:5763",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5763"
+              }
+            ],
+            "NoAdvisory": false
+          },
+          "Version": "0:7.76.1-26.el9_3.2",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2023-38545",
+      "Metadata": {},
+      "Name": "CVE-2023-38545",
+      "NamespaceName": "rhel:9",
+      "Severity": "High"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2023-38546.json
+++ b/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2023-38546.json
@@ -1,0 +1,53 @@
+{
+  "identifier": "rhel:9/cve-2023-38546",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [],
+      "Description": "reviewer-feedback fixture for CVE-2023-38546",
+      "FixedIn": [
+        {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:6745",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:6745"
+              },
+              "Version": "0:7.76.1-26.el9_3.2"
+            },
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5763",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5763"
+              },
+              "Version": "0:7.76.1-23.el9_2.4"
+            }
+          ],
+          "Module": null,
+          "Name": "curl",
+          "NamespaceName": "rhel:9",
+          "VendorAdvisory": {
+            "AdvisorySummary": [
+              {
+                "ID": "RHSA-2023:6745",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:6745"
+              },
+              {
+                "ID": "RHSA-2023:5763",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5763"
+              }
+            ],
+            "NoAdvisory": false
+          },
+          "Version": "0:7.76.1-26.el9_3.2",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2023-38546",
+      "Metadata": {},
+      "Name": "CVE-2023-38546",
+      "NamespaceName": "rhel:9",
+      "Severity": "Low"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2023-44487.json
+++ b/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2023-44487.json
@@ -1,0 +1,53 @@
+{
+  "identifier": "rhel:9/cve-2023-44487",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [],
+      "Description": "reviewer-feedback fixture for CVE-2023-44487",
+      "FixedIn": [
+        {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:6746",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:6746"
+              },
+              "Version": "0:1.43.0-5.el9_3.1"
+            },
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5838",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5838"
+              },
+              "Version": "0:1.43.0-5.el9_2.1"
+            }
+          ],
+          "Module": null,
+          "Name": "nghttp2",
+          "NamespaceName": "rhel:9",
+          "VendorAdvisory": {
+            "AdvisorySummary": [
+              {
+                "ID": "RHSA-2023:6746",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:6746"
+              },
+              {
+                "ID": "RHSA-2023:5838",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5838"
+              }
+            ],
+            "NoAdvisory": false
+          },
+          "Version": "0:1.43.0-5.el9_3.1",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2023-44487",
+      "Metadata": {},
+      "Name": "CVE-2023-44487",
+      "NamespaceName": "rhel:9",
+      "Severity": "High"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2023-4806.json
+++ b/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2023-4806.json
@@ -1,0 +1,53 @@
+{
+  "identifier": "rhel:9/cve-2023-4806",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [],
+      "Description": "reviewer-feedback fixture for CVE-2023-4806",
+      "FixedIn": [
+        {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHBA-2024:2413",
+                "Link": "https://access.redhat.com/errata/RHBA-2024:2413"
+              },
+              "Version": "0:2.34-100.el9"
+            },
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5453",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5453"
+              },
+              "Version": "0:2.34-60.el9_2.7"
+            }
+          ],
+          "Module": null,
+          "Name": "glibc",
+          "NamespaceName": "rhel:9",
+          "VendorAdvisory": {
+            "AdvisorySummary": [
+              {
+                "ID": "RHBA-2024:2413",
+                "Link": "https://access.redhat.com/errata/RHBA-2024:2413"
+              },
+              {
+                "ID": "RHSA-2023:5453",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5453"
+              }
+            ],
+            "NoAdvisory": false
+          },
+          "Version": "0:2.34-100.el9",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2023-4806",
+      "Metadata": {},
+      "Name": "CVE-2023-4806",
+      "NamespaceName": "rhel:9",
+      "Severity": "Medium"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2023-4813.json
+++ b/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2023-4813.json
@@ -1,0 +1,53 @@
+{
+  "identifier": "rhel:9/cve-2023-4813",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [],
+      "Description": "reviewer-feedback fixture for CVE-2023-4813",
+      "FixedIn": [
+        {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHBA-2024:2413",
+                "Link": "https://access.redhat.com/errata/RHBA-2024:2413"
+              },
+              "Version": "0:2.34-100.el9"
+            },
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5453",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5453"
+              },
+              "Version": "0:2.34-60.el9_2.7"
+            }
+          ],
+          "Module": null,
+          "Name": "glibc",
+          "NamespaceName": "rhel:9",
+          "VendorAdvisory": {
+            "AdvisorySummary": [
+              {
+                "ID": "RHBA-2024:2413",
+                "Link": "https://access.redhat.com/errata/RHBA-2024:2413"
+              },
+              {
+                "ID": "RHSA-2023:5453",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5453"
+              }
+            ],
+            "NoAdvisory": false
+          },
+          "Version": "0:2.34-100.el9",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2023-4813",
+      "Metadata": {},
+      "Name": "CVE-2023-4813",
+      "NamespaceName": "rhel:9",
+      "Severity": "Medium"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2025-59464.json
+++ b/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2025-59464.json
@@ -1,0 +1,28 @@
+{
+  "identifier": "rhel:9/cve-2025-59464",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [],
+      "Description": "reviewer-feedback fixture for CVE-2025-59464",
+      "FixedIn": [
+        {
+          "Module": "nodejs:20",
+          "Name": "nodejs",
+          "NamespaceName": "rhel:9",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": true
+          },
+          "Version": "None",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2025-59464",
+      "Metadata": {},
+      "Name": "CVE-2025-59464",
+      "NamespaceName": "rhel:9",
+      "Severity": "Medium"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2026-2100.json
+++ b/grype/matcher/rpm/testdata/rhel-reviewer-feedback/rhel/results/rhel@9/cve-2026-2100.json
@@ -1,0 +1,33 @@
+{
+  "identifier": "rhel:9/cve-2026-2100",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [],
+      "Description": "reviewer-feedback fixture for CVE-2026-2100",
+      "FixedIn": [
+        {
+          "Module": null,
+          "Name": "p11-kit",
+          "NamespaceName": "rhel:9",
+          "VendorAdvisory": {
+            "AdvisorySummary": [
+              {
+                "ID": "RHSA-2026:18599",
+                "Link": "https://access.redhat.com/errata/RHSA-2026:18599"
+              }
+            ],
+            "NoAdvisory": false
+          },
+          "Version": "0:0.26.2-1.el9",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2026-2100",
+      "Metadata": {},
+      "Name": "CVE-2026-2100",
+      "NamespaceName": "rhel:9",
+      "Severity": "Medium"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/grype/matcher/rpm/testdata/rhel-same-base-rhsa/db.yaml
+++ b/grype/matcher/rpm/testdata/rhel-same-base-rhsa/db.yaml
@@ -1,0 +1,15 @@
+# Hand-authored fixture (auto-generate disabled). Same-base multi-stream RHEL records:
+# more than one RHSA fixes the same package at the SAME upstream base across different
+# minors, so no VulnerableRange can partition them (the leading release is a total order).
+# Each record carries the proposed additive AdditionalAdvisoryFixes field listing every
+# called-out fix EVR paired with its advisory, which the OS transformer turns into "= <evr>"
+# unaffected handles (with the advisory as a fix reference) so a host running exactly its
+# stream's fix build is not falsely flagged - and grype can report which advisory shipped it.
+#
+#   rhel:9/cve-2024-10458  firefox  128.4.0-1.el9_4 vs -1.el9_5 (dist-tag-only)
+#   rhel:8/cve-2022-48943  kernel   372.26.1.el8_6 vs 425.3.1.el8 (inverted: GA outranks EUS)
+auto-generate: false
+extractions:
+    rhel:
+        - rhel:9/cve-2024-10458
+        - rhel:8/cve-2022-48943

--- a/grype/matcher/rpm/testdata/rhel-same-base-rhsa/rhel/metadata.json
+++ b/grype/matcher/rpm/testdata/rhel-same-base-rhsa/rhel/metadata.json
@@ -1,0 +1,18 @@
+{
+  "provider": "rhel",
+  "version": 1,
+  "processor": "vunnel@multi-rhsa-phase-1",
+  "schema": {
+    "version": "1.0.3",
+    "url": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/provider-workspace-state/schema-1.0.3.json"
+  },
+  "urls": [
+    "https://access.redhat.com/hydra/rest/securitydata/cve.json"
+  ],
+  "timestamp": "2026-06-01T00:00:00Z",
+  "listing": {
+    "path": "results/listing.xxh64",
+    "algorithm": "xxh64"
+  },
+  "store": "flat-file"
+}

--- a/grype/matcher/rpm/testdata/rhel-same-base-rhsa/rhel/results/rhel@8/cve-2022-48943.json
+++ b/grype/matcher/rpm/testdata/rhel-same-base-rhsa/rhel/results/rhel@8/cve-2022-48943.json
@@ -1,0 +1,53 @@
+{
+  "identifier": "rhel:8/cve-2022-48943",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [],
+      "Description": "A flaw was found in the Linux kernel. (inverted same-base fixture: GA build outranks the EUS backport by EVR)",
+      "FixedIn": [
+        {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2022:6460",
+                "Link": "https://access.redhat.com/errata/RHSA-2022:6460"
+              },
+              "Version": "0:4.18.0-372.26.1.el8_6"
+            },
+            {
+              "Advisory": {
+                "ID": "RHSA-2022:7683",
+                "Link": "https://access.redhat.com/errata/RHSA-2022:7683"
+              },
+              "Version": "0:4.18.0-425.3.1.el8"
+            }
+          ],
+          "Module": null,
+          "Name": "kernel",
+          "NamespaceName": "rhel:8",
+          "VendorAdvisory": {
+            "AdvisorySummary": [
+              {
+                "ID": "RHSA-2022:6460",
+                "Link": "https://access.redhat.com/errata/RHSA-2022:6460"
+              },
+              {
+                "ID": "RHSA-2022:7683",
+                "Link": "https://access.redhat.com/errata/RHSA-2022:7683"
+              }
+            ],
+            "NoAdvisory": false
+          },
+          "Version": "0:4.18.0-425.3.1.el8",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2022-48943",
+      "Metadata": {},
+      "Name": "CVE-2022-48943",
+      "NamespaceName": "rhel:8",
+      "Severity": "Medium"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/grype/matcher/rpm/testdata/rhel-same-base-rhsa/rhel/results/rhel@9/cve-2024-10458.json
+++ b/grype/matcher/rpm/testdata/rhel-same-base-rhsa/rhel/results/rhel@9/cve-2024-10458.json
@@ -1,0 +1,53 @@
+{
+  "identifier": "rhel:9/cve-2024-10458",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [],
+      "Description": "A flaw was found in firefox. (same-base multi-stream fixture for testing exact-fix unaffected handles)",
+      "FixedIn": [
+        {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2024:8726",
+                "Link": "https://access.redhat.com/errata/RHSA-2024:8726"
+              },
+              "Version": "0:128.4.0-1.el9_4"
+            },
+            {
+              "Advisory": {
+                "ID": "RHSA-2024:9554",
+                "Link": "https://access.redhat.com/errata/RHSA-2024:9554"
+              },
+              "Version": "0:128.4.0-1.el9_5"
+            }
+          ],
+          "Module": null,
+          "Name": "firefox",
+          "NamespaceName": "rhel:9",
+          "VendorAdvisory": {
+            "AdvisorySummary": [
+              {
+                "ID": "RHSA-2024:8726",
+                "Link": "https://access.redhat.com/errata/RHSA-2024:8726"
+              },
+              {
+                "ID": "RHSA-2024:9554",
+                "Link": "https://access.redhat.com/errata/RHSA-2024:9554"
+              }
+            ],
+            "NoAdvisory": false
+          },
+          "Version": "0:128.4.0-1.el9_5",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2024-10458",
+      "Metadata": {},
+      "Name": "CVE-2024-10458",
+      "NamespaceName": "rhel:9",
+      "Severity": "Medium"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}


### PR DESCRIPTION
Previously, when multiple RHSAs fixed the same RPM in the same major version of RHEL, Grype was only able to match based on the one with the highest epoch-version-release (EVR). Change grype to now choose the right RHSA if multiple are available based on the elN_M suffix that the fixed versions carry.