### PR TITLE
feat(govulndb): emit golang.org/x/net vulns from govlundb

### DIFF
--- a/grype/db/v6/build/transformers/osv/transform_go_vuln_db.go
+++ b/grype/db/v6/build/transformers/osv/transform_go_vuln_db.go
@@ -38,12 +38,29 @@ func (govulndbStrategy) Matches(id string) bool {
 	return strings.HasPrefix(id, "GO-")
 }
 
+// govulndbEmits reports whether grype emits records for a govulndb affected
+// package. For general third-party Go modules the go vuln db carries odd version
+// ranges (a source of false positives) and duplicates advisories grype already
+// gets from GHSA, so those packages are dropped. Two classes are kept because
+// they are both absent from GHSA and versioned by the Go team itself — so the
+// strange-range drawback that motivates dropping third-party modules does not
+// apply:
+//   - the "stdlib" pseudo-module: the core language, statically linked into
+//     every Go binary.
+//   - the golang.org/x/* extended standard libraries (golang.org/x/net,
+//     golang.org/x/crypto, golang.org/x/text, …).
+func govulndbEmits(name string) bool {
+	return strings.EqualFold(name, "stdlib") ||
+		strings.HasPrefix(name, "golang.org/x/")
+}
+
 func (govulndbStrategy) Transform(vuln unmarshal.OSVVulnerability, state provider.State) ([]data.Entry, error) {
 	affected := govulndbAffectedPackages(vuln)
 	if len(affected) == 0 {
-		// stdlib-only: every affected package was filtered out (or there were
-		// none). Emitting just the vulnerability handle would write an orphaned
-		// record that can never match a package, so skip the advisory entirely.
+		// every affected package was filtered out (or there were none): only the
+		// stdlib and golang.org/x/* modules are emitted (see govulndbEmits).
+		// Emitting just the vulnerability handle would write an orphaned record
+		// that can never match a package, so skip the advisory entirely.
 		return nil, nil
 	}
 
@@ -104,8 +121,7 @@ func govulndbAffectedPackages(vuln unmarshal.OSVVulnerability) []db.AffectedPack
 	}
 	var aphs []db.AffectedPackageHandle
 	for _, affected := range vuln.Affected {
-		if !strings.EqualFold(affected.Package.Name, "stdlib") {
-			// for now, only stdlib is helping
+		if !govulndbEmits(affected.Package.Name) {
 			continue
 		}
 		aphs = append(aphs, db.AffectedPackageHandle{

--- a/grype/db/v6/build/transformers/osv/transform_go_vuln_db_test.go
+++ b/grype/db/v6/build/transformers/osv/transform_go_vuln_db_test.go
@@ -2,6 +2,7 @@ package osv
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -11,14 +12,16 @@ import (
 )
 
 // TestGoVulnDBTransform exercises the govulndb strategy end-to-end against a real
-// GO-* fixture. The transformer is currently stdlib-only (non-stdlib affected
-// packages are dropped):
+// GO-* fixture. The transformer emits the stdlib pseudo-module and the
+// golang.org/x/* extended standard libraries (see govulndbEmits); other
+// third-party modules are dropped.
 //
 //   - GO-2022-0969: a MIXED record listing both "stdlib" and "golang.org/x/net".
-//     The want below contains ONLY the stdlib handle, so this case also asserts
-//     that the non-stdlib package is filtered out. The stdlib range is multi-window
+//     Both survive the emit filter, so the want below contains BOTH handles
+//     (golang.org/x/net sorts before stdlib). The stdlib range is multi-window
 //     (< 1.18.6 || >= 1.19.0-0,< 1.19.1), exercising the comma-separated constraint
-//     normalization the Go version comparator needs.
+//     normalization the Go version comparator needs; the golang.org/x/net range is
+//     a single pseudo-version window, exercising the golang.org/x/* emit path.
 func TestGoVulnDBTransform(t *testing.T) {
 	tests := []transformCase{
 		{
@@ -49,6 +52,25 @@ func TestGoVulnDBTransform(t *testing.T) {
 					},
 				},
 				Related: affectedPkgSlice(
+					db.AffectedPackageHandle{
+						Package: &db.Package{
+							Name:      "golang.org/x/net",
+							Ecosystem: "go-module",
+						},
+						BlobValue: &db.PackageBlob{
+							CVEs: []string{"CVE-2022-27664", "GHSA-69cg-p879-7622"},
+							Ranges: []db.Range{{
+								Version: db.Version{
+									Type:       "go",
+									Constraint: "<0.0.0-20220906165146-f3363e06e74c",
+								},
+								Fix: &db.Fix{
+									Version: "0.0.0-20220906165146-f3363e06e74c",
+									State:   db.FixedStatus,
+								},
+							}},
+						},
+					},
 					db.AffectedPackageHandle{
 						Package: &db.Package{
 							Name:      "stdlib",
@@ -152,11 +174,12 @@ func TestEventsToRanges(t *testing.T) {
 	}
 }
 
-// TestGoVulnDB_NonStdlibEmitsNothing guards the stdlib-only behavior: an advisory
-// whose only affected package is non-stdlib (here github.com/gin-gonic/gin) must
-// produce NO entries at all — not an orphaned vulnerability handle with zero
-// affected packages. Transform returns early when every affected package is
-// filtered out, so a non-stdlib GO record never reaches the DB.
+// TestGoVulnDB_NonStdlibEmitsNothing guards the drop path for general third-party
+// modules: an advisory whose only affected package is a non-emitted module (here
+// github.com/gin-gonic/gin — not stdlib and not golang.org/x/*) must produce NO
+// entries at all — not an orphaned vulnerability handle with zero affected
+// packages. Transform returns early when every affected package is filtered out,
+// so such a GO record never reaches the DB.
 func TestGoVulnDB_NonStdlibEmitsNothing(t *testing.T) {
 	vulns := loadFixture(t, "testdata/GO-2020-0001.json")
 	if len(vulns) != 1 {
@@ -210,11 +233,14 @@ func TestGoVulnDB_WithdrawnStdlibIsRejected(t *testing.T) {
 	}
 }
 
-// TestGoVulnDB_FiltersNonStdlibFromMixedRecord pins the stdlib-only filter on a
-// real MIXED advisory: GO-2022-0969 lists both "stdlib" and "golang.org/x/net".
-// Only the stdlib affected package may survive — the golang.org/x/net handle must
-// be dropped — so per-package filtering is asserted on a single record.
-func TestGoVulnDB_FiltersNonStdlibFromMixedRecord(t *testing.T) {
+// TestGoVulnDB_EmitsStdlibAndGolangOrgX pins the emit filter on a real MIXED
+// advisory: GO-2022-0969 lists both "stdlib" and "golang.org/x/net". Both classes
+// are emitted — stdlib because it is statically linked into every Go binary, and
+// golang.org/x/net because the golang.org/x/* extended standard libraries are
+// versioned by the Go team and absent from GHSA, so they don't carry the
+// false-positive/duplicate baggage that motivates dropping general third-party
+// modules. Per-package filtering is asserted on a single record.
+func TestGoVulnDB_EmitsStdlibAndGolangOrgX(t *testing.T) {
 	vulns := loadFixture(t, "testdata/GO-2022-0969.json")
 	if len(vulns) != 1 {
 		t.Fatalf("expected 1 vuln, got %d", len(vulns))
@@ -226,14 +252,28 @@ func TestGoVulnDB_FiltersNonStdlibFromMixedRecord(t *testing.T) {
 		fixtureNames = append(fixtureNames, a.Package.Name)
 	}
 	if len(fixtureNames) < 2 {
-		t.Fatalf("fixture is not mixed (need stdlib + non-stdlib), got %v", fixtureNames)
+		t.Fatalf("fixture is not mixed (need stdlib + golang.org/x/*), got %v", fixtureNames)
 	}
 
-	var got []string
+	got := map[string]bool{}
 	for _, aph := range govulndbAffectedPackages(vulns[0]) {
-		got = append(got, aph.Package.Name)
+		got[aph.Package.Name] = true
 	}
-	if len(got) != 1 || got[0] != "stdlib" {
-		t.Errorf("expected only [stdlib] to survive the filter, got %v (fixture had %v)", got, fixtureNames)
+	for _, want := range []string{"stdlib", "golang.org/x/net"} {
+		if !got[want] {
+			t.Errorf("expected %q to survive the emit filter, got %v (fixture had %v)", want, keys(got), fixtureNames)
+		}
 	}
+	if len(got) != 2 {
+		t.Errorf("expected exactly [stdlib golang.org/x/net] to survive, got %v (fixture had %v)", keys(got), fixtureNames)
+	}
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/grype/matcher/golang/govulndb_test.go
+++ b/grype/matcher/golang/govulndb_test.go
@@ -10,13 +10,15 @@ import (
 )
 
 // TestMatcherGolang_GoVulnDB drives ecosystem-name matching against Go vuln DB
-// (vuln.go.dev) records via the govulndb vunnel provider. The transformer is
-// currently stdlib-only (non-stdlib affected packages are dropped to avoid the
-// false-positive load from module-path/range mismatches), so this test only
-// covers the "stdlib" pseudo-module. The non-stdlib cases (gin, grafana,
-// mattermost, docker/cli, k8s) were removed because those packages no longer
-// produce matches; transformer-level behavior for custom_ranges, withdrawn
-// status, etc. remains covered by the unit tests in the osv transformer package.
+// (vuln.go.dev) records via the govulndb vunnel provider. The transformer emits
+// the "stdlib" pseudo-module and the golang.org/x/* extended standard libraries;
+// general third-party modules are dropped to avoid the false-positive load from
+// module-path/range mismatches. This test covers the "stdlib" pseudo-module; the
+// golang.org/x/* path is covered by TestMatcherGolang_GoVulnDB_GolangOrgX. The
+// general third-party cases (gin, grafana, mattermost, docker/cli, k8s) were
+// removed because those packages no longer produce matches; transformer-level
+// behavior for custom_ranges, withdrawn status, etc. remains covered by the unit
+// tests in the osv transformer package.
 func TestMatcherGolang_GoVulnDB(t *testing.T) {
 	// GO-2023-1840 declares stdlib vulnerable for everything below 1.19.10 (plus
 	// a later [1.20.0, 1.20.5) window). The sub-1.19.10 cases below use a version
@@ -57,6 +59,63 @@ func TestMatcherGolang_GoVulnDB(t *testing.T) {
 			name:       "stdlib past all fixed versions: no match",
 			pkgName:    "stdlib",
 			pkgVersion: "go1.25.0",
+		},
+	}
+
+	dbtest.DBs(t, "govulndb-go").Run(func(t *testing.T, db *dbtest.DB) {
+		matcher := NewGolangMatcher(MatcherConfig{})
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				p := dbtest.NewPackage(tt.pkgName, tt.pkgVersion, syftPkg.GoModulePkg).
+					WithLanguage(syftPkg.Go).
+					WithMetadata(pkg.GolangBinMetadata{}).
+					Build()
+
+				findings := db.Match(t, matcher, p)
+
+				if len(tt.expectIDs) == 0 {
+					findings.IsEmpty()
+					return
+				}
+
+				for _, id := range tt.expectIDs {
+					findings.SelectMatch(id).
+						SelectDetailByType(match.ExactDirectMatch).
+						AsEcosystemSearch()
+				}
+			})
+		}
+	})
+}
+
+// TestMatcherGolang_GoVulnDB_GolangOrgX covers the golang.org/x/* extended
+// standard libraries, which the transformer now emits alongside stdlib (they are
+// versioned by the Go team and absent from GHSA, so they avoid the false-positive
+// load that keeps general third-party Go modules out). GO-2022-0969 also lists
+// golang.org/x/net as affected below the pseudo-version
+// 0.0.0-20220906165146-f3363e06e74c, so a golang.org/x/net package under that fix
+// must match and one at/after it must not.
+func TestMatcherGolang_GoVulnDB_GolangOrgX(t *testing.T) {
+	tests := []struct {
+		name       string
+		pkgName    string
+		pkgVersion string
+		expectIDs  []string // empty means no match expected
+	}{
+		{
+			// pseudo-version older than GO-2022-0969's fix (a Feb 2022 commit
+			// predates the Sep 2022 fix pseudo-version), so it is vulnerable.
+			name:       "golang.org/x/net before fix pseudo-version: GO-2022-0969 flags it",
+			pkgName:    "golang.org/x/net",
+			pkgVersion: "v0.0.0-20220225172249-27dd8689420f",
+			expectIDs:  []string{"GO-2022-0969"},
+		},
+		{
+			// a tagged release well past the fix pseudo-version: no match.
+			name:       "golang.org/x/net past fix: no match",
+			pkgName:    "golang.org/x/net",
+			pkgVersion: "v0.17.0",
 		},
 	}
 


### PR DESCRIPTION
These packages are not covered by GHSA and generally have well-formed versions, so emit them.