### PR TITLE
fix(zarf): swap warn messages for debug

### DIFF
--- a/grype/pkg/zarf_provider.go
+++ b/grype/pkg/zarf_provider.go
@@ -130,17 +130,10 @@ func readSBOMsFromTar(r io.Reader, config ProviderConfig, applyChannel func(*dis
 			continue
 		}
 
-		log.WithFields("entry", hdr.Name).Debug("reading SBOM from Zarf package")
+		log.WithFields("entry", hdr.Name, "size", hdr.Size).Debug("reading SBOM from Zarf package")
 
-		buf, err := io.ReadAll(io.LimitReader(sbomTar, maxSBOMEntryBytes))
-		if err != nil {
-			log.WithFields("entry", hdr.Name, "error", err).Warn("skipping unreadable SBOM entry in Zarf package")
-			continue
-		}
-
-		s, fmtID, err := readSBOM(bytes.NewReader(buf))
-		if err != nil {
-			log.WithFields("entry", hdr.Name, "error", err).Warn("skipping unreadable SBOM entry in Zarf package")
+		s, fmtID, ok := readSBOMEntry(sbomTar, hdr)
+		if !ok {
 			continue
 		}
 		decodedCount++
@@ -172,6 +165,29 @@ func readSBOMsFromTar(r io.Reader, config ProviderConfig, applyChannel func(*dis
 	}
 
 	return allPackages, mergedSBOM, nil
+}
+
+// readSBOMEntry reads and decodes a single SBOM entry from sboms.tar, logging
+// and returning ok=false if the entry should be skipped.
+func readSBOMEntry(sbomTar *tar.Reader, hdr *tar.Header) (s *sbom.SBOM, fmtID sbom.FormatID, ok bool) {
+	if hdr.Size > maxSBOMEntryBytes {
+		log.WithFields("entry", hdr.Name, "size", hdr.Size, "max", maxSBOMEntryBytes).Debug("skipping SBOM entry in Zarf package: exceeds max entry size")
+		return nil, "", false
+	}
+
+	buf, err := io.ReadAll(io.LimitReader(sbomTar, maxSBOMEntryBytes))
+	if err != nil {
+		log.WithFields("entry", hdr.Name, "error", err).Debug("failed to read SBOM entry in Zarf package")
+		return nil, "", false
+	}
+
+	s, fmtID, err = readSBOM(bytes.NewReader(buf))
+	if err != nil {
+		log.WithFields("entry", hdr.Name, "error", err).Debug("failed to decode SBOM entry in Zarf package")
+		return nil, "", false
+	}
+
+	return s, fmtID, true
 }
 
 // mergeSBOM adds artifacts from src into dst for downstream formatting.


### PR DESCRIPTION
## Description

Initially I implemented the sbom.tar file iteration to emit warnings for files that were unable to be decoded by the sbom reader - knowing that those files would someday be removed and not knowing that this should have been a debug. 

I pulled out the read logic to appease linting (function length) and updated the warnings to debug logs with unique messages (easier to distinguish _which_ problem is occurring). 

Looking at the read logic more, I noticed there was a potential for silent reads on an sbom greater than the max allowed size (should this size change at all?) to which is would simply read that allowed size and then likely fail for a decode error. So I added a quick check for size as well. 

## Issue
Fixes #3516 