### PR TITLE
fix: add unaffected results to db search vuln, fix alias results

### DIFF
--- a/cmd/grype/cli/commands/db_search.go
+++ b/cmd/grype/cli/commands/db_search.go
@@ -158,6 +158,12 @@ func runDBSearchMatches(opts dbSearchMatchOptions) error {
 		return err
 	}
 
+	if opts.Vulnerability.IncludeAliases {
+		for i := range opts.Vulnerability.Specs {
+			opts.Vulnerability.Specs[i].IncludeAliases = true
+		}
+	}
+
 	rows, queryErr := dbsearch.FindMatches(reader, dbsearch.AffectedPackagesOptions{
 		Vulnerability:         opts.Vulnerability.Specs,
 		Package:               opts.Package.PkgSpecs,

--- a/cmd/grype/cli/commands/db_search_vuln.go
+++ b/cmd/grype/cli/commands/db_search_vuln.go
@@ -85,8 +85,9 @@ func runDBSearchVulnerabilities(opts dbSearchVulnerabilityOptions) error {
 	}
 
 	rows, err := dbsearch.FindVulnerabilities(reader, dbsearch.VulnerabilitiesOptions{
-		Vulnerability: opts.Vulnerability.Specs,
-		RecordLimit:   opts.Bounds.RecordLimit,
+		Vulnerability:  opts.Vulnerability.Specs,
+		RecordLimit:    opts.Bounds.RecordLimit,
+		IncludeAliases: opts.Vulnerability.IncludeAliases,
 	})
 	if err != nil {
 		return err

--- a/cmd/grype/cli/commands/internal/dbsearch/affected_packages.go
+++ b/cmd/grype/cli/commands/internal/dbsearch/affected_packages.go
@@ -195,6 +195,8 @@ func toOS(os *v6.OperatingSystem) *OperatingSystem {
 func FindAffectedPackages(reader interface {
 	v6.AffectedPackageStoreReader
 	v6.AffectedCPEStoreReader
+	v6.UnaffectedPackageStoreReader
+	v6.UnaffectedCPEStoreReader
 	v6.VulnerabilityDecoratorStoreReader
 }, criteria AffectedPackagesOptions,
 ) ([]AffectedPackage, error) {
@@ -211,9 +213,11 @@ func FindAffectedPackages(reader interface {
 	return newAffectedPackageRows(allAffectedPkgs, allAffectedCPEs), nil
 }
 
-func findAffectedPackages(reader interface { //nolint:funlen,gocognit
+func findAffectedPackages(reader interface { //nolint:funlen,gocognit,gocyclo
 	v6.AffectedPackageStoreReader
 	v6.AffectedCPEStoreReader
+	v6.UnaffectedPackageStoreReader
+	v6.UnaffectedCPEStoreReader
 	v6.VulnerabilityDecoratorStoreReader
 }, config AffectedPackagesOptions,
 ) ([]affectedPackageWithDecorations, []affectedCPEWithDecorations, error) {
@@ -286,6 +290,33 @@ func findAffectedPackages(reader interface { //nolint:funlen,gocognit
 			}
 			return nil, nil, fmt.Errorf("unable to get affected packages for %s: %w", vulnSpecs, err)
 		}
+
+		unaffectedPkgs, err := reader.GetUnaffectedPackages(pkgSpec, &v6.GetPackageOptions{
+			PreloadOS:             true,
+			PreloadPackage:        true,
+			PreloadPackageCPEs:    false,
+			PreloadVulnerability:  true,
+			PreloadBlob:           true,
+			OSs:                   osSpecs,
+			Vulnerabilities:       vulnSpecs,
+			AllowBroadCPEMatching: config.AllowBroadCPEMatching,
+			Limit:                 config.RecordLimit,
+		})
+
+		for i := range unaffectedPkgs {
+			p := v6.AffectedPackageHandle(unaffectedPkgs[i])
+			markUnaffected(&p.BlobValue)
+			allAffectedPkgs = append(allAffectedPkgs, affectedPackageWithDecorations{
+				AffectedPackageHandle: p,
+			})
+		}
+
+		if err != nil {
+			if errors.Is(err, v6.ErrLimitReached) {
+				return allAffectedPkgs, allAffectedCPEs, err
+			}
+			return nil, nil, fmt.Errorf("unable to get unaffected packages for %s: %w", vulnSpecs, err)
+		}
 	}
 
 	if osSpecs.IsAny() {
@@ -319,8 +350,63 @@ func findAffectedPackages(reader interface { //nolint:funlen,gocognit
 				}
 				return nil, nil, fmt.Errorf("unable to get affected cpes for %s: %w", vulnSpecs, err)
 			}
+
+			unaffectedCPEs, err := reader.GetUnaffectedCPEs(searchCPE, &v6.GetCPEOptions{
+				PreloadCPE:            true,
+				PreloadVulnerability:  true,
+				PreloadBlob:           true,
+				Vulnerabilities:       vulnSpecs,
+				AllowBroadCPEMatching: config.AllowBroadCPEMatching,
+				Limit:                 config.RecordLimit,
+			})
+
+			for i := range unaffectedCPEs {
+				p := v6.AffectedCPEHandle(unaffectedCPEs[i])
+				if p.BlobValue != nil && len(p.BlobValue.Ranges) > 0 {
+					for r := range p.BlobValue.Ranges {
+						p.BlobValue.Ranges[r].Fix.Version += " (unaffected)"
+					}
+				} else {
+					if p.BlobValue == nil {
+						p.BlobValue = &v6.PackageBlob{}
+					}
+					p.BlobValue.Ranges = append(p.BlobValue.Ranges, v6.Range{
+						Fix: &v6.Fix{
+							Version: "unaffected",
+						},
+					})
+				}
+				allAffectedCPEs = append(allAffectedCPEs, affectedCPEWithDecorations{
+					AffectedCPEHandle: p,
+				})
+			}
+
+			if err != nil {
+				if errors.Is(err, v6.ErrLimitReached) {
+					return allAffectedPkgs, allAffectedCPEs, err
+				}
+				return nil, nil, fmt.Errorf("unable to get affected cpes for %s: %w", vulnSpecs, err)
+			}
 		}
 	}
 
 	return allAffectedPkgs, allAffectedCPEs, nil
+}
+
+func markUnaffected(i **v6.PackageBlob) {
+	if *i == nil {
+		*i = &v6.PackageBlob{}
+	}
+	b := *i
+	if len(b.Ranges) > 0 {
+		for r := range b.Ranges {
+			b.Ranges[r].Version.Constraint += " (unaffected)"
+		}
+	} else {
+		b.Ranges = append(b.Ranges, v6.Range{
+			Version: v6.Version{
+				Constraint: "(unaffected)",
+			},
+		})
+	}
 }

--- a/cmd/grype/cli/commands/internal/dbsearch/affected_packages_test.go
+++ b/cmd/grype/cli/commands/internal/dbsearch/affected_packages_test.go
@@ -453,6 +453,40 @@ func TestAffectedPackages(t *testing.T) {
 		},
 	}, nil)
 
+	mockReader.On("GetUnaffectedPackages", mock.Anything, mock.Anything).Return([]v6.UnaffectedPackageHandle{
+		{
+			Package: &v6.Package{Name: "pkg1", Ecosystem: "ecosystem1"},
+			OperatingSystem: &v6.OperatingSystem{
+				Name:         "Linux",
+				MajorVersion: "5",
+				MinorVersion: "10",
+			},
+			Vulnerability: &v6.VulnerabilityHandle{
+				Name:          "CVE-1234-5679",
+				Provider:      &v6.Provider{ID: "provider2"},
+				Status:        "not affected",
+				PublishedDate: ptr(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+				ModifiedDate:  ptr(time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)),
+				BlobValue:     &v6.VulnerabilityBlob{Description: "Test vulnerability"},
+			},
+			BlobValue: &v6.PackageBlob{
+				CVEs: []string{"CVE-1234-5679"},
+				Ranges: []v6.Range{
+					{
+						Version: v6.Version{
+							Type:       "semver",
+							Constraint: ">=2.3.0",
+						},
+						Fix: &v6.Fix{
+							Version: "2.2.0",
+							State:   "fixed",
+						},
+					},
+				},
+			},
+		},
+	}, nil)
+
 	mockReader.On("GetAffectedCPEs", mock.Anything, mock.Anything).Return([]v6.AffectedCPEHandle{
 		{
 			CPE: &v6.Cpe{Part: "a", Vendor: "vendor1", Product: "product1"},
@@ -479,11 +513,55 @@ func TestAffectedPackages(t *testing.T) {
 		},
 	}, nil)
 
+	mockReader.On("GetUnaffectedCPEs", mock.Anything, mock.Anything).Return([]v6.UnaffectedCPEHandle{
+		{
+			CPE: &v6.Cpe{Part: "a", Vendor: "vendor1", Product: "product1"},
+			Vulnerability: &v6.VulnerabilityHandle{
+				Name:      "CVE-9876-5433",
+				Provider:  &v6.Provider{ID: "provider2"},
+				BlobValue: &v6.VulnerabilityBlob{Description: "CPE vulnerability description"},
+			},
+			BlobValue: &v6.PackageBlob{
+				CVEs: []string{"CVE-9876-54311"},
+				Ranges: []v6.Range{
+					{
+						Version: v6.Version{
+							Type:       "rpm",
+							Constraint: ">=7.5.0",
+						},
+						Fix: &v6.Fix{
+							Version: "7.5.0",
+							State:   "fixed",
+						},
+					},
+				},
+			},
+		},
+	}, nil)
+
 	mockReader.On("GetKnownExploitedVulnerabilities", "CVE-1234-5678").Return([]v6.KnownExploitedVulnerabilityHandle{
 		{
 			Cve: "CVE-1234-5678",
 			BlobValue: &v6.KnownExploitedVulnerabilityBlob{
 				Cve:                        "CVE-1234-5678",
+				VendorProject:              "LinuxFoundation",
+				Product:                    "Linux",
+				DateAdded:                  ptr(time.Date(2025, 2, 2, 0, 0, 0, 0, time.UTC)),
+				RequiredAction:             "Yes",
+				DueDate:                    ptr(time.Date(2025, 2, 2, 0, 0, 0, 0, time.UTC)),
+				KnownRansomwareCampaignUse: "Known",
+				Notes:                      "note!",
+				URLs:                       []string{"https://example.com"},
+				CWEs:                       []string{"CWE-1234"},
+			},
+		},
+	}, nil)
+
+	mockReader.On("GetKnownExploitedVulnerabilities", "CVE-1234-5679").Return([]v6.KnownExploitedVulnerabilityHandle{
+		{
+			Cve: "CVE-1234-5679",
+			BlobValue: &v6.KnownExploitedVulnerabilityBlob{
+				Cve:                        "CVE-1234-5679",
 				VendorProject:              "LinuxFoundation",
 				Product:                    "Linux",
 				DateAdded:                  ptr(time.Date(2025, 2, 2, 0, 0, 0, 0, time.UTC)),
@@ -515,6 +593,24 @@ func TestAffectedPackages(t *testing.T) {
 		},
 	}, nil)
 
+	mockReader.On("GetKnownExploitedVulnerabilities", "CVE-9876-5433").Return([]v6.KnownExploitedVulnerabilityHandle{
+		{
+			Cve: "CVE-9876-5433",
+			BlobValue: &v6.KnownExploitedVulnerabilityBlob{
+				Cve:                        "CVE-9876-5433",
+				VendorProject:              "vendor1",
+				Product:                    "product1",
+				DateAdded:                  ptr(time.Date(2025, 2, 3, 0, 0, 0, 0, time.UTC)),
+				RequiredAction:             "Yes",
+				DueDate:                    ptr(time.Date(2025, 2, 3, 0, 0, 0, 0, time.UTC)),
+				KnownRansomwareCampaignUse: "Known",
+				Notes:                      "note!",
+				URLs:                       []string{"https://example.com"},
+				CWEs:                       []string{"CWE-5678"},
+			},
+		},
+	}, nil)
+
 	mockReader.On("GetEpss", "CVE-1234-5678").Return([]v6.EpssHandle{
 		{
 			Cve:        "CVE-1234-5678",
@@ -524,9 +620,27 @@ func TestAffectedPackages(t *testing.T) {
 		},
 	}, nil)
 
+	mockReader.On("GetEpss", "CVE-1234-5679").Return([]v6.EpssHandle{
+		{
+			Cve:        "CVE-1234-5679",
+			Epss:       0.893,
+			Percentile: 0.99,
+			Date:       time.Date(2025, 2, 24, 0, 0, 0, 0, time.UTC),
+		},
+	}, nil)
+
 	mockReader.On("GetEpss", "CVE-9876-5432").Return([]v6.EpssHandle{
 		{
 			Cve:        "CVE-9876-5432",
+			Epss:       0.938,
+			Percentile: 0.9222,
+			Date:       time.Date(2025, 2, 25, 0, 0, 0, 0, time.UTC),
+		},
+	}, nil)
+
+	mockReader.On("GetEpss", "CVE-9876-5433").Return([]v6.EpssHandle{
+		{
+			Cve:        "CVE-9876-5433",
 			Epss:       0.938,
 			Percentile: 0.9222,
 			Date:       time.Date(2025, 2, 25, 0, 0, 0, 0, time.UTC),
@@ -597,6 +711,58 @@ func TestAffectedPackages(t *testing.T) {
 		},
 		{
 			Vulnerability: VulnerabilityInfo{
+				VulnerabilityBlob: v6.VulnerabilityBlob{Description: "Test vulnerability"},
+				Severity:          "unknown",
+				Provider:          "provider2",
+				Status:            "not affected",
+				PublishedDate:     ptr(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+				ModifiedDate:      ptr(time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)),
+				KnownExploited: []KnownExploited{
+					{
+						CVE:                        "CVE-1234-5679",
+						VendorProject:              "LinuxFoundation",
+						Product:                    "Linux",
+						DateAdded:                  "2025-02-02",
+						RequiredAction:             "Yes",
+						DueDate:                    "2025-02-02",
+						KnownRansomwareCampaignUse: "Known",
+						Notes:                      "note!",
+						URLs:                       []string{"https://example.com"},
+						CWEs:                       []string{"CWE-1234"},
+					},
+				},
+				EPSS: []EPSS{
+					{
+						CVE:        "CVE-1234-5679",
+						EPSS:       0.893,
+						Percentile: 0.99,
+						Date:       "2025-02-24",
+					},
+				},
+			},
+			AffectedPackageInfo: AffectedPackageInfo{
+				OS:        &OperatingSystem{Name: "Linux", Version: "5.10"},
+				Package:   &Package{Name: "pkg1", Ecosystem: "ecosystem1"},
+				Namespace: "provider2:distro:Linux:5.10",
+				Detail: v6.PackageBlob{
+					CVEs: []string{"CVE-1234-5679"},
+					Ranges: []v6.Range{
+						{
+							Version: v6.Version{
+								Type:       "semver",
+								Constraint: ">=2.3.0 (unaffected)",
+							},
+							Fix: &v6.Fix{
+								Version: "2.2.0",
+								State:   "fixed",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Vulnerability: VulnerabilityInfo{
 				VulnerabilityBlob: v6.VulnerabilityBlob{Description: "CPE vulnerability description"},
 				Severity:          "unknown",
 				Provider:          "provider2",
@@ -636,6 +802,54 @@ func TestAffectedPackages(t *testing.T) {
 							},
 							Fix: &v6.Fix{
 								Version: "2.5.0",
+								State:   "fixed",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Vulnerability: VulnerabilityInfo{
+				VulnerabilityBlob: v6.VulnerabilityBlob{Description: "CPE vulnerability description"},
+				Severity:          "unknown",
+				Provider:          "provider2",
+				KnownExploited: []KnownExploited{
+					{
+						CVE:                        "CVE-9876-5433",
+						VendorProject:              "vendor1",
+						Product:                    "product1",
+						DateAdded:                  "2025-02-03",
+						RequiredAction:             "Yes",
+						DueDate:                    "2025-02-03",
+						KnownRansomwareCampaignUse: "Known",
+						Notes:                      "note!",
+						URLs:                       []string{"https://example.com"},
+						CWEs:                       []string{"CWE-5678"},
+					},
+				},
+				EPSS: []EPSS{
+					{
+						CVE:        "CVE-9876-5433",
+						EPSS:       0.938,
+						Percentile: 0.9222,
+						Date:       "2025-02-25",
+					},
+				},
+			},
+			AffectedPackageInfo: AffectedPackageInfo{
+				CPE:       &CPE{Part: "a", Vendor: "vendor1", Product: "product1"},
+				Namespace: "provider2:cpe",
+				Detail: v6.PackageBlob{
+					CVEs: []string{"CVE-9876-54311"},
+					Ranges: []v6.Range{
+						{
+							Version: v6.Version{
+								Type:       "rpm",
+								Constraint: ">=7.5.0",
+							},
+							Fix: &v6.Fix{
+								Version: "7.5.0 (unaffected)",
 								State:   "fixed",
 							},
 						},
@@ -852,12 +1066,20 @@ func TestFindAffectedPackages(t *testing.T) {
 				m.On("GetAffectedPackages", expected.pkg, mock.MatchedBy(func(actual *v6.GetPackageOptions) bool {
 					return cmp.Equal(actual, expected.options)
 				})).Return([]v6.AffectedPackageHandle{}, nil).Once()
+
+				m.On("GetUnaffectedPackages", expected.pkg, mock.MatchedBy(func(actual *v6.GetPackageOptions) bool {
+					return cmp.Equal(actual, expected.options)
+				})).Return([]v6.UnaffectedPackageHandle{}, nil).Once()
 			}
 
 			for _, expected := range tc.expectedCPECalls {
 				m.On("GetAffectedCPEs", expected.cpe, mock.MatchedBy(func(actual *v6.GetCPEOptions) bool {
 					return cmp.Equal(actual, expected.options)
 				})).Return([]v6.AffectedCPEHandle{}, nil).Once()
+
+				m.On("GetUnaffectedCPEs", expected.cpe, mock.MatchedBy(func(actual *v6.GetCPEOptions) bool {
+					return cmp.Equal(actual, expected.options)
+				})).Return([]v6.UnaffectedCPEHandle{}, nil).Once()
 			}
 
 			_, _, err := findAffectedPackages(m, tc.config)
@@ -880,9 +1102,19 @@ func (m *affectedMockReader) GetAffectedPackages(pkgSpec *v6.PackageSpecifier, o
 	return args.Get(0).([]v6.AffectedPackageHandle), args.Error(1)
 }
 
+func (m *affectedMockReader) GetUnaffectedPackages(pkgSpec *v6.PackageSpecifier, options *v6.GetPackageOptions) ([]v6.UnaffectedPackageHandle, error) {
+	args := m.Called(pkgSpec, options)
+	return args.Get(0).([]v6.UnaffectedPackageHandle), args.Error(1)
+}
+
 func (m *affectedMockReader) GetAffectedCPEs(cpeSpec *cpe.Attributes, options *v6.GetCPEOptions) ([]v6.AffectedCPEHandle, error) {
 	args := m.Called(cpeSpec, options)
 	return args.Get(0).([]v6.AffectedCPEHandle), args.Error(1)
+}
+
+func (m *affectedMockReader) GetUnaffectedCPEs(cpeSpec *cpe.Attributes, options *v6.GetCPEOptions) ([]v6.UnaffectedCPEHandle, error) {
+	args := m.Called(cpeSpec, options)
+	return args.Get(0).([]v6.UnaffectedCPEHandle), args.Error(1)
 }
 
 func (m *affectedMockReader) GetKnownExploitedVulnerabilities(cve string) ([]v6.KnownExploitedVulnerabilityHandle, error) {

--- a/cmd/grype/cli/commands/internal/dbsearch/matches.go
+++ b/cmd/grype/cli/commands/internal/dbsearch/matches.go
@@ -120,6 +120,8 @@ func newMatchesRows(affectedPkgs []affectedPackageWithDecorations, affectedCPEs 
 func FindMatches(reader interface {
 	v6.AffectedPackageStoreReader
 	v6.AffectedCPEStoreReader
+	v6.UnaffectedPackageStoreReader
+	v6.UnaffectedCPEStoreReader
 	v6.VulnerabilityDecoratorStoreReader
 }, criteria AffectedPackagesOptions) (Matches, error) {
 	allAffectedPkgs, allAffectedCPEs, fetchErr := findAffectedPackages(reader, criteria)

--- a/cmd/grype/cli/commands/internal/dbsearch/vulnerabilities.go
+++ b/cmd/grype/cli/commands/internal/dbsearch/vulnerabilities.go
@@ -123,8 +123,9 @@ type vulnerabilityAffectedPackageJoin struct {
 }
 
 type VulnerabilitiesOptions struct {
-	Vulnerability v6.VulnerabilitySpecifiers
-	RecordLimit   int
+	Vulnerability  v6.VulnerabilitySpecifiers
+	RecordLimit    int
+	IncludeAliases bool
 }
 
 func newVulnerabilityRows(vaps ...vulnerabilityAffectedPackageJoin) (rows []Vulnerability) {
@@ -191,9 +192,10 @@ func newOperatingSystems(oss []v6.OperatingSystem) (os []OperatingSystem) {
 	return os
 }
 
-func FindVulnerabilities(reader interface { //nolint:funlen
+func FindVulnerabilities(reader interface { //nolint:funlen,gocognit
 	v6.VulnerabilityStoreReader
 	v6.AffectedPackageStoreReader
+	v6.UnaffectedPackageStoreReader
 	v6.VulnerabilityDecoratorStoreReader
 }, config VulnerabilitiesOptions,
 ) ([]Vulnerability, error) {
@@ -230,6 +232,23 @@ func FindVulnerabilities(reader interface { //nolint:funlen
 			PreloadOS: true,
 			Vulnerabilities: []v6.VulnerabilitySpecifier{
 				{
+					ID:             vuln.ID,
+					IncludeAliases: config.IncludeAliases,
+				},
+			},
+			Limit: config.RecordLimit,
+		})
+		if fetchErr != nil {
+			if !errors.Is(fetchErr, v6.ErrLimitReached) {
+				return nil, fmt.Errorf("unable to get affected packages: %w", fetchErr)
+			}
+			limitReached = true
+		}
+
+		unaffected, fetchErr := reader.GetUnaffectedPackages(nil, &v6.GetPackageOptions{
+			PreloadOS: true,
+			Vulnerabilities: []v6.VulnerabilitySpecifier{
+				{
 					ID: vuln.ID,
 				},
 			},
@@ -244,6 +263,14 @@ func FindVulnerabilities(reader interface { //nolint:funlen
 
 		distros := make(map[v6.ID]v6.OperatingSystem)
 		for _, a := range affected {
+			if a.OperatingSystem != nil {
+				if _, ok := distros[a.OperatingSystem.ID]; !ok {
+					distros[a.OperatingSystem.ID] = *a.OperatingSystem
+				}
+			}
+		}
+
+		for _, a := range unaffected {
 			if a.OperatingSystem != nil {
 				if _, ok := distros[a.OperatingSystem.ID]; !ok {
 					distros[a.OperatingSystem.ID] = *a.OperatingSystem
@@ -266,7 +293,13 @@ func FindVulnerabilities(reader interface { //nolint:funlen
 			AffectedPackages: len(affected),
 		})
 
-		if errors.Is(fetchErr, v6.ErrLimitReached) {
+		pairs = append(pairs, vulnerabilityAffectedPackageJoin{
+			Vulnerability:    vuln,
+			OperatingSystems: distrosSlice,
+			AffectedPackages: len(unaffected),
+		})
+
+		if limitReached {
 			break
 		}
 	}

--- a/cmd/grype/cli/commands/internal/dbsearch/vulnerabilities_test.go
+++ b/cmd/grype/cli/commands/internal/dbsearch/vulnerabilities_test.go
@@ -258,6 +258,12 @@ func TestVulnerabilities(t *testing.T) {
 		},
 	}, nil)
 
+	mockReader.On("GetUnaffectedPackages", mock.Anything, mock.Anything).Return([]v6.UnaffectedPackageHandle{
+		{
+			OperatingSystem: &v6.OperatingSystem{Name: "Linux", MajorVersion: "5", MinorVersion: "10"},
+		},
+	}, nil)
+
 	mockReader.On("GetKnownExploitedVulnerabilities", "CVE-1234-5678").Return([]v6.KnownExploitedVulnerabilityHandle{
 		{
 			Cve: "CVE-1234-5678",
@@ -289,6 +295,61 @@ func TestVulnerabilities(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []Vulnerability{
+		{
+			VulnerabilityInfo: VulnerabilityInfo{
+				VulnerabilityBlob: v6.VulnerabilityBlob{
+					Description: "Test description",
+					Severities: []v6.Severity{
+						{
+							Scheme: "CVSS",
+							Value: CVSSSeverity{
+								Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+								Version: "3.1",
+								Metrics: CvssMetrics{
+									BaseScore:           7.5,
+									ExploitabilityScore: ptr(3.9),
+									ImpactScore:         ptr(3.6),
+								},
+							},
+							Source: "nvd",
+							Rank:   1,
+						},
+					},
+				},
+				Severity:      "high",
+				Provider:      "provider1",
+				Status:        "active",
+				PublishedDate: ptr(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)),
+				ModifiedDate:  ptr(time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC)),
+				WithdrawnDate: nil,
+				KnownExploited: []KnownExploited{
+					{
+						CVE:                        "CVE-1234-5678",
+						VendorProject:              "LinuxFoundation",
+						Product:                    "Linux",
+						DateAdded:                  "2025-02-02",
+						RequiredAction:             "Yes",
+						DueDate:                    "2025-02-02",
+						KnownRansomwareCampaignUse: "Known",
+						Notes:                      "note!",
+						URLs:                       []string{"https://example.com"},
+						CWEs:                       []string{"CWE-1234"},
+					},
+				},
+				EPSS: []EPSS{
+					{
+						CVE:        "CVE-1234-5678",
+						EPSS:       0.893,
+						Percentile: 0.99,
+						Date:       "2025-02-24",
+					},
+				},
+			},
+			OperatingSystems: []OperatingSystem{
+				{Name: "Linux", Version: "5.10"},
+			},
+			AffectedPackages: 1,
+		},
 		{
 			VulnerabilityInfo: VulnerabilityInfo{
 				VulnerabilityBlob: v6.VulnerabilityBlob{
@@ -390,6 +451,8 @@ func TestFindVulnerabilities_DecorationErrors(t *testing.T) {
 
 			mockReader.On("GetAffectedPackages", mock.Anything, mock.Anything).Return([]v6.AffectedPackageHandle{}, nil)
 
+			mockReader.On("GetUnaffectedPackages", mock.Anything, mock.Anything).Return([]v6.UnaffectedPackageHandle{}, nil)
+
 			mockReader.On("GetKnownExploitedVulnerabilities", "CVE-2021-22947").Return(
 				[]v6.KnownExploitedVulnerabilityHandle{}, tt.kevErr,
 			)
@@ -403,7 +466,7 @@ func TestFindVulnerabilities_DecorationErrors(t *testing.T) {
 			})
 
 			require.NoError(t, err, "decoration errors should not propagate as fatal errors")
-			require.Len(t, results, 1)
+			require.Len(t, results, 2)
 			require.Equal(t, "Test vuln", results[0].VulnerabilityBlob.Description)
 			require.Empty(t, results[0].KnownExploited)
 			require.Empty(t, results[0].EPSS)
@@ -423,6 +486,11 @@ func (m *mockVulnReader) GetVulnerabilities(vuln *v6.VulnerabilitySpecifier, con
 func (m *mockVulnReader) GetAffectedPackages(pkg *v6.PackageSpecifier, config *v6.GetPackageOptions) ([]v6.AffectedPackageHandle, error) {
 	args := m.Called(pkg, config)
 	return args.Get(0).([]v6.AffectedPackageHandle), args.Error(1)
+}
+
+func (m *mockVulnReader) GetUnaffectedPackages(pkg *v6.PackageSpecifier, config *v6.GetPackageOptions) ([]v6.UnaffectedPackageHandle, error) {
+	args := m.Called(pkg, config)
+	return args.Get(0).([]v6.UnaffectedPackageHandle), args.Error(1)
 }
 
 func (m *mockVulnReader) GetKnownExploitedVulnerabilities(cve string) ([]v6.KnownExploitedVulnerabilityHandle, error) {

--- a/cmd/grype/cli/options/database_search_vulnerabilities.go
+++ b/cmd/grype/cli/options/database_search_vulnerabilities.go
@@ -12,6 +12,7 @@ import (
 
 type DBSearchVulnerabilities struct {
 	VulnerabilityIDs []string `yaml:"vulnerability-ids" json:"vulnerability-ids" mapstructure:"vulnerability-ids"`
+	IncludeAliases   bool     `yaml:"include-aliases" json:"include-aliases" mapstructure:"include-aliases"`
 	UseVulnIDFlag    bool     `yaml:"-" json:"-" mapstructure:"-"`
 
 	PublishedAfter string `yaml:"published-after" json:"published-after" mapstructure:"published-after"`
@@ -26,6 +27,7 @@ type DBSearchVulnerabilities struct {
 func (c *DBSearchVulnerabilities) AddFlags(flags clio.FlagSet) {
 	if c.UseVulnIDFlag {
 		flags.StringArrayVarP(&c.VulnerabilityIDs, "vuln", "", "only show results for the given vulnerability ID")
+		flags.BoolVarP(&c.IncludeAliases, "include-aliases", "", "include vulnerabilities that are aliases of the given vulnerability ID")
 	}
 	flags.StringVarP(&c.PublishedAfter, "published-after", "", "only show vulnerabilities originally published after the given date (format: YYYY-MM-DD)")
 	flags.StringVarP(&c.ModifiedAfter, "modified-after", "", "only show vulnerabilities originally published or modified since the given date (format: YYYY-MM-DD)")

--- a/grype/db/v6/db_metadata_store_test.go
+++ b/grype/db/v6/db_metadata_store_test.go
@@ -67,6 +67,8 @@ func setupTestStore(t testing.TB, d ...string) *store {
 
 	}
 
+	t.Logf("using temp dir: %s", dir)
+
 	s, err := newStore(Config{
 		DBDirPath: dir,
 	}, true, true)

--- a/grype/db/v6/vulnerability_store.go
+++ b/grype/db/v6/vulnerability_store.go
@@ -350,13 +350,29 @@ func handleVulnerabilityOptions(base, parentQuery *gorm.DB, configs ...Vulnerabi
 	}
 
 	orConditions := base.Model(&VulnerabilityHandle{})
-	var includeAliasJoin bool
 	for _, config := range configs {
 		query := base.Model(&VulnerabilityHandle{})
 		if config.Name != "" {
 			if config.IncludeAliases {
-				includeAliasJoin = true
-				query = query.Where("vulnerability_handles.name = ? collate nocase OR vulnerability_aliases.alias = ?  collate nocase", config.Name, config.Name)
+				// select all vulnerabilities that are directly named, directly aliased, or aliased from an alias
+				// since these will impact filtering, for example:
+				// a GO vulnerability has a CVE alias it is filtered by a GHSA record with a CVE alias
+				// so we need to see 2 levels deep and check both sides of the name-alias map in all directions
+				query = query.Where(`(vulnerability_handles.name collate nocase in (
+					select ?
+					union
+					select a.name from vulnerability_aliases a where a.alias = ? collate nocase
+					union
+					select a.alias from vulnerability_aliases a where a.name = ? collate nocase
+					union
+					select a.alias from vulnerability_aliases a join vulnerability_aliases b on a.name = b.alias where b.name = ? collate nocase
+					union
+					select a.alias from vulnerability_aliases a join vulnerability_aliases b on a.name = b.name where b.alias = ? collate nocase
+					union
+					select a.name from vulnerability_aliases a join vulnerability_aliases b on a.alias = b.alias where b.name = ? collate nocase
+					union
+					select a.name from vulnerability_aliases a join vulnerability_aliases b on a.alias = b.name where b.alias = ? collate nocase
+					))`, config.Name, config.Name, config.Name, config.Name, config.Name, config.Name, config.Name)
 			} else {
 				query = query.Where("vulnerability_handles.name = ?  collate nocase", config.Name)
 			}
@@ -383,10 +399,6 @@ func handleVulnerabilityOptions(base, parentQuery *gorm.DB, configs ...Vulnerabi
 		}
 
 		orConditions = orConditions.Or(query)
-	}
-
-	if includeAliasJoin {
-		parentQuery = parentQuery.Joins("LEFT JOIN vulnerability_aliases ON vulnerability_aliases.name = vulnerability_handles.name collate nocase")
 	}
 
 	return parentQuery.Where(orConditions), nil


### PR DESCRIPTION
This PR makes some fixes to `grype db search` and `grype db search --include-aliases` to get a more appropriate set of records.

Currently, in Grype matching there are _many factors_ that affect whether a package is deemed vulnerable and often the determination requires information from multiple sources such as GHSA and SUSE to avoid false positives. If a user is trying to get details about a specific vulnerability, we need to include unaffected records and aliases to get most of the big picture about what's going on.

To see all\* the records that will impact a particular package, we need unaffected records and to go 2 levels deep in aliases.

Take the newly added GO vulnerabilities, for example: `GO-2026-5005`. If I run:
```
$ grype db search --vuln GO-2026-5005
VULNERABILITY  PACKAGE              ECOSYSTEM  NAMESPACE             VERSION CONSTRAINT  
GO-2026-5005   golang.org/x/crypto  go-module  govulndb:language:go  <0.52.0
```
Perfect: I see there's just a single record with a version constraint.

But wait... let's say I _don't see that result_ but I'm using something that looks like version 0.50.0 -- how can I figure out what's going on?

Previously `--include-aliases` would include a single-level of aliases, so `db search --vuln GO-2026-5005 --include-aliases` would find a single alias for the `GO-2026-5005` record: `CVE-2026-39833` and include both of those results. But there are more records that will come into play, especially: [GHSA-jppx-rxg9-jmrx](https://github.com/advisories/GHSA-jppx-rxg9-jmrx) -- perhaps there are corrected version ranges or a vendor has asserted that this particular package is not vulnerable for _their distributed version_ of the package. Previously, you wouldn't see any information about this because it's a second-level alias: no alias information exist directly from the GO vuln to the GHSA vuln but both of these alias to `CVE-2026-39833`, so `--include-aliases` needs to account for this.

Additionally, vulnerabilities may be filtered by entries in the _unaffected packages_ set, which are stored in a separate table and not returned by _affected_ packages queries. This PR adds the records to `db search` with an `(unaffected)` label at the end of the constraint to indicate Grype will match against that range as an _unaffected filter_ rather than a _vulnerable range_. _This is probably the part that needs the most discussion._

We need to be able to correctly identify records should be considered _unaffected_ in both the table and in JSON output. The current implementation in this PR is just to get a discussion started and looks something like:
```
% grype db search CVE-2024-27282
VULNERABILITY   PACKAGE                                      ECOSYSTEM  NAMESPACE                               VERSION CONSTRAINT                                                      
CVE-2024-27282  cpe:2.3:a:ruby-lang:ruby:*:*:*:*:*:ruby:*:*  ruby       nvd:cpe                                 < 3.0.7 || >= 3.1.0, < 3.1.5 || >= 3.2.0, < 3.2.4 || >= 3.3.0, < 3.3.1  
CVE-2024-27282  jruby                                        deb        ubuntu:distro:ubuntu:14.04                                                                                      
CVE-2024-27282  jruby                                        deb        ubuntu:distro:ubuntu:16.04                                                                                      
CVE-2024-27282  jruby                                        deb        ubuntu:distro:ubuntu:18.04                                                                                      
CVE-2024-27282  jruby                                        deb        ubuntu:distro:ubuntu:20.04                                                                                      
CVE-2024-27282  jruby                                        deb        ubuntu:distro:ubuntu:23.10                                                                                      
CVE-2024-27282  jruby                                        deb        ubuntu:distro:ubuntu:24.04                                                                                      
CVE-2024-27282  jruby                                        deb        ubuntu:distro:ubuntu:25.10                                                                                      
CVE-2024-27282  jruby                                        deb        ubuntu:distro:ubuntu:26.04                                                                                      
CVE-2024-27282  libruby2_1-2_1                               rpm        sles:distro:sles:12.2                   (unaffected)                                                            
CVE-2024-27282  libruby2_1-2_1                               rpm        sles:distro:sles:12.4                   = 3.0.1 (unaffected)                                                            
CVE-2024-27282  libruby2_1-2_1                               rpm        sles:distro:sles:12.5                   (unaffected)                                                            
CVE-2024-27282  libruby2_5-2_5                               rpm        sles:distro:sles:15                     (unaffected)                                                            
CVE-2024-27282  libruby2_5-2_5                               rpm        sles:distro:sles:15.1                   (unaffected)                                                            
CVE-2024-27282  libruby2_5-2_5                               rpm        sles:distro:sles:15.2                   <= 3.05 (unaffected)     
...
```

I think ideally we would instead include a status column and these would be `Not-Affected` / `Unaffected` or similar. There is a [VulnerabilityStatus](https://github.com/anchore/grype/blob/fc88fade29f0ac740fd84f0b25c1bbb059be0c05/grype/db/v6/enumerations.go#L7-L23) on the data model which is seems to be unset some of the time but appears to be the right spot for this to be conveyed, however: adding records with an unknown new status might result in them being interpreted as _vulnerable_ by consumers. Grype itself only considered [withdrawn and rejected](https://github.com/anchore/grype/blob/fc88fade29f0ac740fd84f0b25c1bbb059be0c05/grype/matcher/internal/only_non_withdrawn_vulnerabilities.go#L12) to be "not vulnerable" types of statuses.

All that said, without this information, `db search` is very difficult to use to understand the scope of grype's matching about a particular vulnerability. We need a a way of displaying this information to users, ideally without needing to remember to execute multiple queries to get enough pertinent information. It's pretty confusing when searching for a vulnerability only to find it looks like something different should be happening.


\
\
\* still not necessarily all
