### PR TITLE
Do not fail a combined (OR) constraint when a sibling operand errors

### DIFF
--- a/grype/version/combined_constraint.go
+++ b/grype/version/combined_constraint.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -55,17 +56,21 @@ func (c combinedConstraint) Satisfied(version *Version) (bool, error) {
 		return false, fmt.Errorf("cannot evaluate combined constraint with nil version")
 	}
 
+	var errs error
 	for _, op := range c.OrOperands {
 		satisfied, err := op.Satisfied(version)
 		if err != nil {
-			return false, fmt.Errorf("error evaluating constraint %s: %w", op, err)
+			// OR semantics: a sibling operand may still be satisfied, so keep
+			// evaluating and only surface the error if nothing matches.
+			errs = errors.Join(errs, fmt.Errorf("error evaluating constraint %s: %w", op, err))
+			continue
 		}
 		if satisfied {
 			return true, nil
 		}
 	}
 
-	return false, nil
+	return false, errs
 }
 
 func uniqueConstraints(constraints ...Constraint) []Constraint {

--- a/grype/version/combined_constraint_test.go
+++ b/grype/version/combined_constraint_test.go
@@ -238,7 +238,9 @@ func TestCombinedConstraint_Satisfied_WithErrors(t *testing.T) {
 		wantErr    require.ErrorAssertionFunc
 	}{
 		{
-			name: "error from first constraint",
+			// OR semantics: an error from an earlier operand must not fail the
+			// whole constraint when a later operand is satisfied.
+			name: "no error when a later operand satisfies despite an earlier error",
 			constraint: combinedConstraint{
 				OrOperands: []Constraint{
 					mockConstraint{value: ">= 1.0.0", format: SemanticFormat, returnErr: true},
@@ -246,7 +248,7 @@ func TestCombinedConstraint_Satisfied_WithErrors(t *testing.T) {
 				},
 			},
 			version: New("1.5.0", SemanticFormat),
-			wantErr: require.Error,
+			wantErr: require.NoError,
 		},
 		{
 			name: "error from second constraint when first doesn't satisfy",


### PR DESCRIPTION
`combinedConstraint.Satisfied` (an OR of sub-constraints) returns immediately on the first operand that returns an error:

```go
for _, op := range c.OrOperands {
    satisfied, err := op.Satisfied(version)
    if err != nil {
        return false, fmt.Errorf("error evaluating constraint %s: %w", op, err)
    }
    if satisfied {
        return true, nil
    }
}
return false, nil
```

For OR semantics that is order-dependent: if operand A errors but operand B is satisfied, the constraint really is satisfied, yet this returns an error.

That is not contained locally. In `grype/search/version_constraint.go`, `constraintFuncCriteria.MatchesVulnerability` turns any constraint error into a dropped vulnerability (its own comment notes it "has the effect of dropping the vulnerability in the case an error occurs parsing a package or other version"). So an erroring operand ordered before a matching operand becomes a real false negative. A per-operand error is reachable when one OR branch carries a constraint-version that fails to parse (for example an rpm constraint with a non-numeric epoch) while another branch legitimately matches. `CombineConstraints` is used to build these OR constraints in the RHEL-EUS matcher.

Fix: accumulate operand errors with `errors.Join` and `continue`; return `true` as soon as any operand is satisfied, and only surface the joined error if nothing matched.

I updated the existing `TestCombinedConstraint_Satisfied_WithErrors` case that asserted the old abort-on-first-error behavior (an error from an earlier operand while a later operand is satisfied is now `NoError`). Ran `go test ./grype/version/` locally (passes).
