### PR TITLE
feat: add minimum severity report filtering

### DIFF
--- a/cmd/grype/cli/commands/report_filter.go
+++ b/cmd/grype/cli/commands/report_filter.go
@@ -1,0 +1,28 @@
+package commands
+
+import (
+	"slices"
+
+	"github.com/anchore/grype/grype/presenter/models"
+	"github.com/anchore/grype/grype/vulnerability"
+)
+
+func filterDocumentByMinSeverity(doc *models.Document, minSeverity *vulnerability.Severity) {
+	if minSeverity == nil {
+		return
+	}
+
+	doc.Matches = slices.DeleteFunc(doc.Matches, func(m models.Match) bool {
+		return vulnerability.ParseSeverity(m.Vulnerability.Severity) < *minSeverity
+	})
+	if doc.Matches == nil {
+		doc.Matches = make([]models.Match, 0)
+	}
+
+	doc.IgnoredMatches = slices.DeleteFunc(doc.IgnoredMatches, func(m models.IgnoredMatch) bool {
+		return vulnerability.ParseSeverity(m.Vulnerability.Severity) < *minSeverity
+	})
+	if doc.IgnoredMatches == nil {
+		doc.IgnoredMatches = make([]models.IgnoredMatch, 0)
+	}
+}

--- a/cmd/grype/cli/commands/report_filter_output_test.go
+++ b/cmd/grype/cli/commands/report_filter_output_test.go
@@ -1,0 +1,166 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/clio"
+	"github.com/anchore/grype/grype/presenter/models"
+	"github.com/anchore/grype/grype/vulnerability"
+	grypeFormat "github.com/anchore/grype/internal/format"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/sbom"
+	syftSource "github.com/anchore/syft/syft/source"
+)
+
+func TestMinSeverityFilteredDocumentIsSharedByAllOutputs(t *testing.T) {
+	doc := newReportFilterTestDocument(t, []string{"Unknown", "Low", "High", "Critical"})
+	filterDocumentByMinSeverity(&doc, severityPointer(vulnerability.HighSeverity))
+
+	outputs := writeReportOutputs(t, doc)
+
+	for format, output := range outputs {
+		t.Run(format, func(t *testing.T) {
+			assert.NotContains(t, output, "CVE-0-unknown")
+			assert.NotContains(t, output, "CVE-1-low")
+			assert.Contains(t, output, "CVE-2-high")
+			assert.Contains(t, output, "CVE-3-critical")
+		})
+	}
+
+	assert.Contains(t, outputs["table"], "suppressed by VEX")
+	assert.Contains(t, outputs["template"], "ignored:CVE-2-high")
+	assert.Contains(t, outputs["template"], "ignored:CVE-3-critical")
+	assertValidJSONReportMetadata(t, outputs["json"])
+	assertValidSARIFStructure(t, outputs["sarif"])
+	assertValidCycloneDXMetadata(t, outputs["cyclonedx-json"])
+}
+
+func TestMinSeverityFullyFilteredDocumentProducesValidEmptyOutputs(t *testing.T) {
+	doc := newReportFilterTestDocument(t, []string{"Unknown", "Low"})
+	filterDocumentByMinSeverity(&doc, severityPointer(vulnerability.CriticalSeverity))
+
+	outputs := writeReportOutputs(t, doc)
+
+	assert.Contains(t, outputs["table"], "No vulnerabilities found")
+	assert.Empty(t, strings.TrimSpace(outputs["template"]))
+
+	var jsonReport map[string]any
+	require.NoError(t, json.Unmarshal([]byte(outputs["json"]), &jsonReport))
+	matches, ok := jsonReport["matches"].([]any)
+	require.True(t, ok, "JSON matches should be an array")
+	assert.Empty(t, matches)
+	assert.NotNil(t, jsonReport["source"])
+	assert.NotNil(t, jsonReport["descriptor"])
+
+	var sarifReport map[string]any
+	require.NoError(t, json.Unmarshal([]byte(outputs["sarif"]), &sarifReport))
+	runs, ok := sarifReport["runs"].([]any)
+	require.True(t, ok)
+	require.Len(t, runs, 1)
+	run := runs[0].(map[string]any)
+	assert.NotNil(t, run["tool"])
+	results, ok := run["results"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, results)
+
+	var cyclonedxReport map[string]any
+	require.NoError(t, json.Unmarshal([]byte(outputs["cyclonedx-json"]), &cyclonedxReport))
+	assert.NotNil(t, cyclonedxReport["metadata"])
+	if rawVulnerabilities, exists := cyclonedxReport["vulnerabilities"]; exists {
+		vulnerabilities, ok := rawVulnerabilities.([]any)
+		require.True(t, ok)
+		assert.Empty(t, vulnerabilities)
+	}
+}
+
+func writeReportOutputs(t *testing.T, doc models.Document) map[string]string {
+	t.Helper()
+
+	dir := t.TempDir()
+	templatePath := filepath.Join(dir, "report.tmpl")
+	templateContents := "{{range .Matches}}match:{{.Vulnerability.ID}}\n{{end}}{{range .IgnoredMatches}}ignored:{{.Vulnerability.ID}}\n{{end}}"
+	require.NoError(t, os.WriteFile(templatePath, []byte(templateContents), 0600))
+
+	formats := []string{"table", "json", "sarif", "template", "cyclonedx-json"}
+	paths := make(map[string]string, len(formats))
+	outputOptions := make([]string, 0, len(formats))
+	for _, format := range formats {
+		path := filepath.Join(dir, strings.ReplaceAll(format, "-", "_")+".out")
+		paths[format] = path
+		outputOptions = append(outputOptions, format+"="+path)
+	}
+
+	writer, err := grypeFormat.MakeScanResultWriter(outputOptions, "", grypeFormat.PresentationConfig{
+		TemplateFilePath: templatePath,
+		ShowSuppressed:   true,
+	})
+	require.NoError(t, err)
+
+	sourceDescription := syftSource.Description{
+		Name:     "test-source",
+		Version:  "1.0.0",
+		Metadata: syftSource.DirectoryMetadata{Path: "/test/source"},
+	}
+	reportPackage := syftPkg.Package{
+		Name:    "component",
+		Version: "1.0.0",
+		Type:    syftPkg.NpmPkg,
+		PURL:    "pkg:npm/component@1.0.0",
+	}
+	reportPackage.SetID()
+	reportSBOM := &sbom.SBOM{
+		Artifacts: sbom.Artifacts{
+			Packages: syftPkg.NewCollection(reportPackage),
+		},
+		Source: sourceDescription,
+	}
+	require.NoError(t, writer.Write(models.PresenterConfig{
+		ID:       clio.Identification{Name: "grype", Version: "test"},
+		Document: doc,
+		SBOM:     reportSBOM,
+	}))
+
+	outputs := make(map[string]string, len(paths))
+	for format, path := range paths {
+		contents, err := os.ReadFile(path)
+		require.NoError(t, err)
+		outputs[format] = string(contents)
+	}
+	return outputs
+}
+
+func assertValidJSONReportMetadata(t *testing.T, output string) {
+	t.Helper()
+	var report map[string]any
+	require.NoError(t, json.Unmarshal([]byte(output), &report))
+	assert.NotNil(t, report["source"])
+	assert.NotNil(t, report["distro"])
+	assert.NotNil(t, report["descriptor"])
+	assert.NotNil(t, report["alertsByPackage"])
+}
+
+func assertValidSARIFStructure(t *testing.T, output string) {
+	t.Helper()
+	var report map[string]any
+	require.NoError(t, json.Unmarshal([]byte(output), &report))
+	runs, ok := report["runs"].([]any)
+	require.True(t, ok)
+	require.Len(t, runs, 1)
+	run := runs[0].(map[string]any)
+	assert.NotNil(t, run["tool"])
+}
+
+func assertValidCycloneDXMetadata(t *testing.T, output string) {
+	t.Helper()
+	var report map[string]any
+	require.NoError(t, json.Unmarshal([]byte(output), &report))
+	assert.NotNil(t, report["metadata"])
+	assert.NotNil(t, report["components"])
+}

--- a/cmd/grype/cli/commands/report_filter_test.go
+++ b/cmd/grype/cli/commands/report_filter_test.go
@@ -1,0 +1,186 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/clio"
+	"github.com/anchore/grype/grype/distro"
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/presenter/models"
+	"github.com/anchore/grype/grype/vulnerability"
+	syftSource "github.com/anchore/syft/syft/source"
+)
+
+func TestFilterDocumentByMinSeverity(t *testing.T) {
+	severities := []string{"Unknown", "Negligible", "Low", "Medium", "High", "Critical"}
+	tests := []struct {
+		name     string
+		min      *vulnerability.Severity
+		expected []string
+	}{
+		{
+			name:     "unset leaves the document unchanged",
+			expected: severities,
+		},
+		{
+			name:     "negligible is inclusive and excludes unknown",
+			min:      severityPointer(vulnerability.NegligibleSeverity),
+			expected: []string{"Negligible", "Low", "Medium", "High", "Critical"},
+		},
+		{
+			name:     "low is inclusive",
+			min:      severityPointer(vulnerability.LowSeverity),
+			expected: []string{"Low", "Medium", "High", "Critical"},
+		},
+		{
+			name:     "medium is inclusive",
+			min:      severityPointer(vulnerability.MediumSeverity),
+			expected: []string{"Medium", "High", "Critical"},
+		},
+		{
+			name:     "high is inclusive",
+			min:      severityPointer(vulnerability.HighSeverity),
+			expected: []string{"High", "Critical"},
+		},
+		{
+			name:     "critical is inclusive",
+			min:      severityPointer(vulnerability.CriticalSeverity),
+			expected: []string{"Critical"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := newReportFilterTestDocument(t, severities)
+			metadataBefore := documentWithoutVulnerabilities(doc)
+
+			filterDocumentByMinSeverity(&doc, tt.min)
+
+			assert.Equal(t, tt.expected, matchSeverities(doc.Matches))
+			assert.Equal(t, tt.expected, ignoredMatchSeverities(doc.IgnoredMatches))
+			assert.Equal(t, metadataBefore, documentWithoutVulnerabilities(doc))
+
+			for _, ignored := range doc.IgnoredMatches {
+				require.Len(t, ignored.AppliedIgnoreRules, 1)
+				assert.Equal(t, "preserve this rule", ignored.AppliedIgnoreRules[0].Reason)
+			}
+		})
+	}
+}
+
+func TestFilterDocumentByMinSeverityFullyFiltered(t *testing.T) {
+	doc := newReportFilterTestDocument(t, []string{"Unknown", "Low"})
+	metadataBefore := documentWithoutVulnerabilities(doc)
+
+	filterDocumentByMinSeverity(&doc, severityPointer(vulnerability.CriticalSeverity))
+
+	assert.Empty(t, doc.Matches)
+	assert.NotNil(t, doc.Matches)
+	assert.Empty(t, doc.IgnoredMatches)
+	assert.NotNil(t, doc.IgnoredMatches)
+	assert.Equal(t, metadataBefore, documentWithoutVulnerabilities(doc))
+}
+
+func newReportFilterTestDocument(t *testing.T, severities []string) models.Document {
+	t.Helper()
+
+	d := &distro.Distro{
+		Type:    "ubuntu",
+		Version: "22.04",
+		IDLike:  []string{"debian"},
+	}
+	p := pkg.Package{
+		ID:      "package-id",
+		Name:    "package",
+		Version: "1.0.0",
+		Distro:  d,
+	}
+	ctx := pkg.Context{
+		Source: &syftSource.Description{
+			Name:     "test-source",
+			Version:  "1.0.0",
+			Metadata: syftSource.DirectoryMetadata{Path: "/test/source"},
+		},
+		Distro: d,
+	}
+	doc, err := models.NewDocument(
+		clio.Identification{Name: "grype", Version: "test"},
+		[]pkg.Package{p},
+		ctx,
+		match.NewMatches(),
+		nil,
+		nil,
+		map[string]any{"configuration": "preserve"},
+		map[string]any{"database": "preserve"},
+		models.SortByPackage,
+		false,
+		&models.DistroAlertData{EOLDistroPackages: []pkg.Package{p}},
+	)
+	require.NoError(t, err)
+
+	for idx, severity := range severities {
+		m := reportModelMatch(idx, severity)
+		doc.Matches = append(doc.Matches, m)
+		doc.IgnoredMatches = append(doc.IgnoredMatches, models.IgnoredMatch{
+			Match: m,
+			AppliedIgnoreRules: []models.IgnoreRule{
+				{
+					Reason:    "preserve this rule",
+					Namespace: "vex",
+					VexStatus: "not_affected",
+				},
+			},
+		})
+	}
+
+	return doc
+}
+
+func reportModelMatch(idx int, severity string) models.Match {
+	id := fmt.Sprintf("CVE-%d-%s", idx, strings.ToLower(severity))
+	return models.Match{
+		Vulnerability: models.Vulnerability{
+			VulnerabilityMetadata: models.VulnerabilityMetadata{
+				ID:       id,
+				Severity: severity,
+			},
+		},
+		Artifact: models.Package{
+			ID:      fmt.Sprintf("package-%d", idx),
+			Name:    fmt.Sprintf("package-%d", idx),
+			Version: "1.0.0",
+		},
+	}
+}
+
+func matchSeverities(matches []models.Match) []string {
+	result := make([]string, 0, len(matches))
+	for _, m := range matches {
+		result = append(result, m.Vulnerability.Severity)
+	}
+	return result
+}
+
+func ignoredMatchSeverities(matches []models.IgnoredMatch) []string {
+	result := make([]string, 0, len(matches))
+	for _, m := range matches {
+		result = append(result, m.Vulnerability.Severity)
+	}
+	return result
+}
+
+func documentWithoutVulnerabilities(doc models.Document) models.Document {
+	doc.Matches = nil
+	doc.IgnoredMatches = nil
+	return doc
+}
+
+func severityPointer(severity vulnerability.Severity) *vulnerability.Severity {
+	return &severity
+}

--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -262,6 +262,7 @@ func runGrype(ctx context.Context, app clio.Application, opts *options.Grype, us
 	if err != nil {
 		return fmt.Errorf("failed to create document: %w", err)
 	}
+	filterDocumentByMinSeverity(&model, opts.MinSeverityThreshold())
 
 	if err = writer.Write(models.PresenterConfig{
 		ID:       app.ID(),

--- a/cmd/grype/cli/options/grype.go
+++ b/cmd/grype/cli/options/grype.go
@@ -29,6 +29,7 @@ type Grype struct {
 	ExternalSources            externalSources    `yaml:"external-sources" json:"externalSources" mapstructure:"external-sources"`
 	Match                      matchConfig        `yaml:"match" json:"match" mapstructure:"match"`
 	FailOn                     string             `yaml:"fail-on-severity" json:"fail-on-severity" mapstructure:"fail-on-severity"`
+	MinSeverity                string             `yaml:"min-severity" json:"min-severity" mapstructure:"min-severity"`
 	Registry                   registry           `yaml:"registry" json:"registry" mapstructure:"registry"`
 	ShowSuppressed             bool               `yaml:"show-suppressed" json:"show-suppressed" mapstructure:"show-suppressed"`
 	ByCVE                      bool               `yaml:"by-cve" json:"by-cve" mapstructure:"by-cve"` // --by-cve, indicates if the original match vulnerability IDs should be preserved or the CVE should be used instead
@@ -118,6 +119,11 @@ func (o *Grype) AddFlags(flags clio.FlagSet) {
 		fmt.Sprintf("set the return code to 2 if a vulnerability is found with a severity >= the given severity, options=%v", vulnerability.AllSeverities()),
 	)
 
+	flags.StringVarP(&o.MinSeverity,
+		"min-severity", "",
+		fmt.Sprintf("filter the report to vulnerabilities with a severity >= the given severity; unknown severities are excluded; does not affect --fail-on, options=%v", vulnerability.AllSeverities()),
+	)
+
 	flags.BoolVarP(&o.OnlyFixed,
 		"only-fixed", "",
 		"ignore matches for vulnerabilities that are not fixed",
@@ -173,6 +179,12 @@ func (o *Grype) PostLoad() error {
 			return fmt.Errorf("bad --fail-on severity value '%s'", o.FailOn)
 		}
 	}
+
+	if minSeverity := o.MinSeverityThreshold(); minSeverity != nil {
+		if *minSeverity == vulnerability.UnknownSeverity {
+			return fmt.Errorf("bad --min-severity value '%s'", o.MinSeverity)
+		}
+	}
 	return nil
 }
 
@@ -196,6 +208,9 @@ when using template as the output type, you must also provide a value for 'outpu
 	descriptions.Add(&o.Pretty, `pretty-print output`)
 	descriptions.Add(&o.FailOn, `upon scanning, if a severity is found at or above the given severity then the return code will be 1
 default is unset which will skip this validation (options: negligible, low, medium, high, critical)`)
+	descriptions.Add(&o.MinSeverity, `filter report output to vulnerabilities at or above the given severity (options: negligible, low, medium, high, critical)
+unknown-severity vulnerabilities are excluded when this option is configured
+this option controls report visibility only and does not affect --fail-on`)
 	descriptions.Add(&o.Ignore, `A list of vulnerability ignore rules, one or more property may be specified and all matching vulnerabilities will be ignored.
 This is the full set of supported rule fields:
   - vulnerability: CVE-2008-4318
@@ -216,6 +231,14 @@ VEX fields apply when Grype reads vex data:
 
 func (o Grype) FailOnSeverity() *vulnerability.Severity {
 	severity := vulnerability.ParseSeverity(o.FailOn)
+	return &severity
+}
+
+func (o Grype) MinSeverityThreshold() *vulnerability.Severity {
+	if o.MinSeverity == "" {
+		return nil
+	}
+	severity := vulnerability.ParseSeverity(o.MinSeverity)
 	return &severity
 }
 

--- a/cmd/grype/cli/options/grype_test.go
+++ b/cmd/grype/cli/options/grype_test.go
@@ -4,7 +4,52 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/grype/grype/vulnerability"
 )
+
+func TestGrypePostLoadMinSeverity(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected vulnerability.Severity
+		wantErr  string
+	}{
+		{name: "unset"},
+		{name: "negligible", value: "negligible", expected: vulnerability.NegligibleSeverity},
+		{name: "low", value: "low", expected: vulnerability.LowSeverity},
+		{name: "medium", value: "medium", expected: vulnerability.MediumSeverity},
+		{name: "high", value: "high", expected: vulnerability.HighSeverity},
+		{name: "critical", value: "critical", expected: vulnerability.CriticalSeverity},
+		{name: "mixed case", value: "MeDiUm", expected: vulnerability.MediumSeverity},
+		{name: "uppercase", value: "HIGH", expected: vulnerability.HighSeverity},
+		{name: "unknown", value: "unknown", wantErr: "bad --min-severity value 'unknown'"},
+		{name: "invalid", value: "important", wantErr: "bad --min-severity value 'important'"},
+		{name: "whitespace is invalid", value: " high ", wantErr: "bad --min-severity value ' high '"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := Grype{MinSeverity: tt.value}
+
+			err := opts.PostLoad()
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			threshold := opts.MinSeverityThreshold()
+			if tt.value == "" {
+				assert.Nil(t, threshold)
+			} else {
+				require.NotNil(t, threshold)
+				assert.Equal(t, tt.expected, *threshold)
+			}
+		})
+	}
+}
 
 func Test_flatten(t *testing.T) {
 	tests := []struct {

--- a/test/cli/config_test.go
+++ b/test/cli/config_test.go
@@ -169,6 +169,66 @@ func Test_configLoading(t *testing.T) {
 	}
 }
 
+func Test_minSeverityConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		configValue string
+		envValue    string
+		expected    string
+	}{
+		{
+			name: "unset",
+		},
+		{
+			name:        "yaml configuration",
+			configValue: "low",
+			expected:    "low",
+		},
+		{
+			name:     "environment configuration",
+			envValue: "MeDiUm",
+			expected: "MeDiUm",
+		},
+		{
+			name:        "environment overrides YAML",
+			configValue: "low",
+			envValue:    "medium",
+			expected:    "medium",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			cfgPath := filepath.Join(tmpDir, ".grype.yaml")
+			configContents := "check-for-app-update: false\n"
+			if tt.configValue != "" {
+				configContents += "min-severity: " + tt.configValue + "\n"
+			}
+			require.NoError(t, os.WriteFile(cfgPath, []byte(configContents), 0644))
+
+			env := map[string]string{
+				"HOME":            tmpDir,
+				"XDG_CONFIG_HOME": tmpDir,
+			}
+			if tt.envValue != "" {
+				env["GRYPE_MIN_SEVERITY"] = tt.envValue
+			}
+
+			args := []string{"-c", cfgPath, "config", "--load"}
+
+			_, stdout, stderr := runGrype(t, env, args...)
+			require.Empty(t, stderr)
+
+			var got struct {
+				MinSeverity string `yaml:"min-severity"`
+			}
+			require.NoError(t, yaml.NewDecoder(strings.NewReader(stdout)).Decode(&got))
+			assert.Equal(t, tt.expected, got.MinSeverity)
+		})
+	}
+}
+
 func Test_dpkgUseCPEsForEOLEnvVar(t *testing.T) {
 	// Test that GRYPE_MATCH_DPKG_USE_CPES_FOR_EOL env var is properly wired up
 	type matchConfig struct {

--- a/test/cli/min_severity_test.go
+++ b/test/cli/min_severity_test.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/grype/grype/vulnerability"
+)
+
+func TestMinSeverityFailOnRemainsIndependent(t *testing.T) {
+	cmd, stdout, stderr := runGrype(
+		t,
+		nil,
+		"./testdata/sbom-grype-source.json",
+		"--min-severity", "critical",
+		"--fail-on", "high",
+		"--output", "json",
+	)
+
+	require.Equal(t, 2, cmd.ProcessState.ExitCode(), stderr)
+	assert.NotContains(t, stdout, "GHSA-pq64-v7f5-gqh8", "the known High finding should be hidden from the Critical-only report")
+	assertReportSeveritiesAtOrAbove(t, stdout, vulnerability.CriticalSeverity)
+}
+
+func TestMinSeverityRejectsInvalidValuesBeforeScan(t *testing.T) {
+	for _, value := range []string{"unknown", "important", " high "} {
+		t.Run(value, func(t *testing.T) {
+			cmd, _, stderr := runGrype(
+				t,
+				nil,
+				"does-not-exist",
+				"--min-severity", value,
+			)
+
+			require.Equal(t, 1, cmd.ProcessState.ExitCode())
+			assert.Contains(t, stderr, "bad --min-severity value")
+			assert.NotContains(t, stderr, "failed to catalog", "validation should fail before scanning begins")
+		})
+	}
+}
+
+func TestMinSeverityCLIOverridesEnvironmentAndYAML(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), ".grype.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("check-for-app-update: false\nmin-severity: low\n"), 0600))
+
+	cmd, stdout, stderr := runGrype(
+		t,
+		map[string]string{"GRYPE_MIN_SEVERITY": "medium"},
+		"-c", cfgPath,
+		"./testdata/sbom-grype-source.json",
+		"--min-severity", "critical",
+		"--output", "json",
+	)
+
+	require.Equal(t, 0, cmd.ProcessState.ExitCode(), stderr)
+	assert.NotContains(t, stdout, "GHSA-pq64-v7f5-gqh8", "the CLI Critical threshold should override the lower environment and YAML thresholds")
+	report := parseMinSeverityReport(t, stdout)
+	assert.Equal(t, "critical", report.Descriptor.Configuration.MinSeverity)
+	assertReportMatchesAtOrAbove(t, report.Matches, vulnerability.CriticalSeverity)
+	assertReportMatchesAtOrAbove(t, report.IgnoredMatches, vulnerability.CriticalSeverity)
+}
+
+func TestMinSeverityComposesWithFixStateFilters(t *testing.T) {
+	tests := []struct {
+		name          string
+		flag          string
+		activeIsFixed bool
+	}{
+		{
+			name:          "only fixed",
+			flag:          "--only-fixed",
+			activeIsFixed: true,
+		},
+		{
+			name:          "only not fixed",
+			flag:          "--only-notfixed",
+			activeIsFixed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, stdout, stderr := runGrype(
+				t,
+				nil,
+				"./testdata/sbom-grype-source.json",
+				"--min-severity", "high",
+				tt.flag,
+				"--output", "json",
+			)
+
+			require.Equal(t, 0, cmd.ProcessState.ExitCode(), stderr)
+			report := parseMinSeverityReport(t, stdout)
+			require.NotEmpty(t, report.Matches)
+			require.NotEmpty(t, report.IgnoredMatches)
+			assertReportMatchesAtOrAbove(t, report.Matches, vulnerability.HighSeverity)
+			assertReportMatchesAtOrAbove(t, report.IgnoredMatches, vulnerability.HighSeverity)
+			for _, m := range report.Matches {
+				if tt.activeIsFixed {
+					assert.Equal(t, string(vulnerability.FixStateFixed), m.Vulnerability.Fix.State)
+				} else {
+					assert.NotEqual(t, string(vulnerability.FixStateFixed), m.Vulnerability.Fix.State)
+				}
+			}
+		})
+	}
+}
+
+type minSeverityReport struct {
+	Matches        []minSeverityReportMatch `json:"matches"`
+	IgnoredMatches []minSeverityReportMatch `json:"ignoredMatches"`
+	Descriptor     struct {
+		Configuration struct {
+			MinSeverity string `json:"min-severity"`
+		} `json:"configuration"`
+	} `json:"descriptor"`
+}
+
+type minSeverityReportMatch struct {
+	Vulnerability struct {
+		ID       string `json:"id"`
+		Severity string `json:"severity"`
+		Fix      struct {
+			State string `json:"state"`
+		} `json:"fix"`
+	} `json:"vulnerability"`
+}
+
+func parseMinSeverityReport(t *testing.T, output string) minSeverityReport {
+	t.Helper()
+	var report minSeverityReport
+	require.NoError(t, json.Unmarshal([]byte(output), &report))
+	return report
+}
+
+func assertReportSeveritiesAtOrAbove(t *testing.T, output string, min vulnerability.Severity) {
+	t.Helper()
+	report := parseMinSeverityReport(t, output)
+	assertReportMatchesAtOrAbove(t, report.Matches, min)
+	assertReportMatchesAtOrAbove(t, report.IgnoredMatches, min)
+}
+
+func assertReportMatchesAtOrAbove(t *testing.T, matches []minSeverityReportMatch, min vulnerability.Severity) {
+	t.Helper()
+	for _, m := range matches {
+		severity := vulnerability.ParseSeverity(m.Vulnerability.Severity)
+		assert.GreaterOrEqual(t, severity, min, "%s has severity %s", m.Vulnerability.ID, m.Vulnerability.Severity)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a minimum severity filter for Grype report output.

Users can configure the threshold through:

- CLI: `--min-severity <level>`
- YAML: `min-severity`
- Environment: `GRYPE_MIN_SEVERITY`

Supported values are `negligible`, `low`, `medium`, `high`, and `critical`.

## Behavior

- The threshold is inclusive.
- Findings with Unknown severity are excluded when filtering is enabled.
- Both regular and ignored matches are filtered.
- Filtering is applied once before the report is passed to the output presenters, keeping table, JSON, SARIF, template, and CycloneDX output consistent.
- Scanning, ignore/VEX processing, and `--fail-on` behavior remain unchanged.

## Testing

Added coverage for:

- all severity thresholds;
- case-insensitive configuration;
- invalid and Unknown values;
- regular and ignored matches;
- empty filtered reports and metadata preservation;
- YAML, environment, and CLI precedence;
- `--only-fixed` and `--only-notfixed`;
- independent `--fail-on` behavior;
- table, JSON, SARIF, template, and CycloneDX output.

Validation performed:

- `make format`
- `make lint`
- focused unit tests
- compiled-binary CLI tests
- `git diff --check`

Closes #3529
