### PR TITLE
fix(version): do not cache a comparator that failed to build

### DIFF
--- a/grype/version/version.go
+++ b/grype/version/version.go
@@ -82,9 +82,15 @@ func (v *Version) getComparator(format Format) (Comparator, error) {
 		err = fmt.Errorf("no comparator available for format %q", v.Format)
 	}
 
+	if err != nil {
+		// do not cache a comparator that failed to build; a cached broken
+		// comparator would be returned with a nil error on the next lookup
+		// and then panic (or compare incorrectly) when used.
+		return comparator, err
+	}
 	v.comparators[format] = comparator
 
-	return comparator, err
+	return comparator, nil
 }
 func (v Version) String() string {
 	return fmt.Sprintf("%s (%s)", v.Raw, v.Format)

--- a/grype/version/version_comparator_cache_test.go
+++ b/grype/version/version_comparator_cache_test.go
@@ -1,0 +1,19 @@
+package version
+
+import "testing"
+
+func TestGetComparatorDoesNotCacheParseFailure(t *testing.T) {
+	// "3.e" is not a valid semantic version; the comparator fails to build.
+	// It must not be cached, otherwise a later lookup returns it with a nil
+	// error and then panics (nil *hashiVer.Version) when used.
+	v := New("3.e", SemanticFormat)
+	other := New("1.0", SemanticFormat)
+
+	if _, err := v.Is(LT, other); err == nil {
+		t.Fatal("expected an error comparing an unparseable version, got nil")
+	}
+	// second call must behave the same (surface the error), not panic.
+	if _, err := v.Is(LT, other); err == nil {
+		t.Fatal("expected an error on the repeated comparison, got nil (broken comparator was cached)")
+	}
+}

--- a/grype/version/version_comparator_cache_test.go
+++ b/grype/version/version_comparator_cache_test.go
@@ -1,19 +1,65 @@
 package version
 
-import "testing"
+import (
+	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// a failed comparator build must never be cached: a cached broken comparator is
+// returned with a nil error on the next lookup, which then panics (formats with a
+// nil *hashiVer.Version) or silently compares against an empty version (value
+// formats) when used.
 func TestGetComparatorDoesNotCacheParseFailure(t *testing.T) {
-	// "3.e" is not a valid semantic version; the comparator fails to build.
-	// It must not be cached, otherwise a later lookup returns it with a nil
-	// error and then panics (nil *hashiVer.Version) when used.
-	v := New("3.e", SemanticFormat)
-	other := New("1.0", SemanticFormat)
+	cases := []struct {
+		name    string
+		format  Format
+		badRaw  string
+		goodRaw string
+	}{
+		// formats whose zero-value comparator holds a nil pointer -> panic on use
+		{"semantic", SemanticFormat, "3.e", "1.0"},
+		{"jvm", JVMFormat, "abc", "1.0"},
+		{"bitnami", BitnamiFormat, "abc", "1.0.0"},
+		// value-receiver format whose zero-value silently compares as empty -> false negative
+		{"deb", DebFormat, "abc", "1.0"},
+	}
 
-	if _, err := v.Is(LT, other); err == nil {
-		t.Fatal("expected an error comparing an unparseable version, got nil")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := New(tc.badRaw, tc.format)
+
+			_, err := v.getComparator(tc.format)
+			require.Error(t, err, "expected the failed build to surface an error")
+			assert.NotContains(t, v.comparators, tc.format, "failed comparator must not be cached")
+
+			// a repeated lookup must re-attempt and surface the error again, not
+			// hand back a cached broken comparator with a nil error.
+			_, err = v.getComparator(tc.format)
+			require.Error(t, err, "repeated lookup must still error, not return a cached broken comparator")
+
+			// end-to-end: repeated comparison via Is (mirrors matcher/rpm/rhel_eus.go
+			// neededFixes looping v.Is on the same *Version) must error, not panic.
+			other := New(tc.goodRaw, tc.format)
+			_, err = v.Is(LT, other)
+			require.Error(t, err)
+			_, err = v.Is(LT, other)
+			require.Error(t, err, "repeated Is must still error (broken comparator was cached)")
+		})
 	}
-	// second call must behave the same (surface the error), not panic.
-	if _, err := v.Is(LT, other); err == nil {
-		t.Fatal("expected an error on the repeated comparison, got nil (broken comparator was cached)")
-	}
+}
+
+// a successful build is cached for reuse on repeated lookups.
+func TestGetComparatorCachesSuccess(t *testing.T) {
+	v := New("1.2.3", SemanticFormat)
+
+	first, err := v.getComparator(SemanticFormat)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	assert.Contains(t, v.comparators, SemanticFormat, "successful comparator should be cached")
+
+	second, err := v.getComparator(SemanticFormat)
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
 }


### PR DESCRIPTION
`getComparator` caches the constructed comparator in `v.comparators[format]` unconditionally, including when construction returned an error:

```go
comparator, err = newSemanticVersion(v.Raw, false) // may return a broken comparator + err
...
v.comparators[format] = comparator
return comparator, err
```

On a parse failure the constructor returns a zero-value comparator (for Semantic/JVM/Bitnami its internal `*hashiVer.Version` is nil) together with an error. Caching it means the next lookup for that format hits the cache and returns it with a `nil` error, so the caller proceeds to `Compare`, which dereferences the nil version and panics. For formats without a pointer it silently compares against an empty version, i.e. a false negative in matching.

The map persists across calls once a pointer-receiver entry point (`Is` / `Validate`) populates it, so a repeated comparison on the same `*Version` triggers it. In-tree this is reachable from `matcher/rpm/rhel_eus.go` `neededFixes`, which calls `v.Is(LT, ...)` in a loop on the same package version.

Repro:

```go
v := New("3.e", SemanticFormat)
other := New("1.0", SemanticFormat)
v.Is(LT, other) // caches the broken comparator; error is logged/handled
v.Is(LT, other) // cache hit: nil error, then panic in Compare
```

The fix returns early on a build error so the broken comparator is never cached, and the error surfaces consistently instead. Added a regression test. `go test ./grype/version/` passes.