### PR TITLE
Add match details to CycloneDX vulnerabilities

### DIFF
--- a/grype/presenter/cyclonedx/testdata/snapshot/TestCycloneDxPresenterDir.golden
+++ b/grype/presenter/cyclonedx/testdata/snapshot/TestCycloneDxPresenterDir.golden
@@ -118,6 +118,12 @@
         {
           "ref": "a246fd2054833c93"
         }
+      ],
+      "properties": [
+        {
+          "name": "grype:match:details",
+          "value": "[{\"type\":\"exact-direct-match\",\"matcher\":\"dpkg-matcher\",\"searchedBy\":{\"distro\":{\"type\":\"ubuntu\",\"version\":\"20.04\"}},\"found\":{\"constraint\":\"\\u003e= 20\"},\"fix\":{\"suggestedVersion\":\"1.2.1\"}}]"
+        }
       ]
     },
     {
@@ -158,6 +164,12 @@
       "affects": [
         {
           "ref": "pkg:deb/package-2@2.2.2?package-id=74378afe15713625"
+        }
+      ],
+      "properties": [
+        {
+          "name": "grype:match:details",
+          "value": "[{\"type\":\"exact-indirect-match\",\"matcher\":\"dpkg-matcher\",\"searchedBy\":{\"cpe\":\"somecpe\"},\"found\":{\"constraint\":\"somecpe\"}}]"
         }
       ]
     }

--- a/grype/presenter/cyclonedx/testdata/snapshot/TestCycloneDxPresenterImage.golden
+++ b/grype/presenter/cyclonedx/testdata/snapshot/TestCycloneDxPresenterImage.golden
@@ -119,6 +119,12 @@
         {
           "ref": "a246fd2054833c93"
         }
+      ],
+      "properties": [
+        {
+          "name": "grype:match:details",
+          "value": "[{\"type\":\"exact-direct-match\",\"matcher\":\"dpkg-matcher\",\"searchedBy\":{\"distro\":{\"type\":\"ubuntu\",\"version\":\"20.04\"}},\"found\":{\"constraint\":\"\\u003e= 20\"},\"fix\":{\"suggestedVersion\":\"1.2.1\"}}]"
+        }
       ]
     },
     {
@@ -159,6 +165,12 @@
       "affects": [
         {
           "ref": "pkg:deb/package-2@2.2.2?package-id=74378afe15713625"
+        }
+      ],
+      "properties": [
+        {
+          "name": "grype:match:details",
+          "value": "[{\"type\":\"exact-indirect-match\",\"matcher\":\"dpkg-matcher\",\"searchedBy\":{\"cpe\":\"somecpe\"},\"found\":{\"constraint\":\"somecpe\"}}]"
         }
       ]
     }

--- a/grype/presenter/cyclonedx/vulnerability.go
+++ b/grype/presenter/cyclonedx/vulnerability.go
@@ -1,6 +1,8 @@
 package cyclonedx
 
 import (
+	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -38,6 +40,11 @@ func NewVulnerability(m models.Match) (v cyclonedx.Vulnerability, err error) {
 		})
 	}
 
+	properties, err := generateCDXProperties(m.MatchDetails)
+	if err != nil {
+		return cyclonedx.Vulnerability{}, err
+	}
+
 	// Note: if a field isn't captured here it's usually because the resulting
 	// reference link contains that information for the consumer
 	return cyclonedx.Vulnerability{
@@ -71,7 +78,25 @@ func NewVulnerability(m models.Match) (v cyclonedx.Vulnerability, err error) {
 		Tools: nil,
 		// TODO:  we do not leverage the following fields in our model
 		Analysis:   nil,
-		Properties: nil,
+		Properties: properties,
+	}, nil
+}
+
+func generateCDXProperties(matchDetails []models.MatchDetails) (*[]cyclonedx.Property, error) {
+	if len(matchDetails) == 0 {
+		return nil, nil
+	}
+
+	value, err := json.Marshal(matchDetails)
+	if err != nil {
+		return nil, fmt.Errorf("unable to encode match details as a CycloneDX property: %w", err)
+	}
+
+	return &[]cyclonedx.Property{
+		{
+			Name:  "grype:match:details",
+			Value: string(value),
+		},
 	}, nil
 }
 

--- a/grype/presenter/cyclonedx/vulnerability_test.go
+++ b/grype/presenter/cyclonedx/vulnerability_test.go
@@ -1,6 +1,8 @@
 package cyclonedx
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/CycloneDX/cyclonedx-go"
@@ -190,4 +192,151 @@ func TestNewVulnerability_IncludesEPSSAndKEV(t *testing.T) {
 	}
 	assert.True(t, foundEPSS, "should include EPSS rating")
 	assert.True(t, foundKEV, "should include KEV rating")
+}
+
+func TestNewVulnerability_IncludesMatchDetailsProperty(t *testing.T) {
+	match := models.Match{
+		Vulnerability: models.Vulnerability{
+			VulnerabilityMetadata: models.VulnerabilityMetadata{
+				ID:       "CVE-2026-0001",
+				Severity: "High",
+			},
+		},
+		Artifact: models.Package{
+			ID:      "package-id",
+			Name:    "example-package",
+			Version: "1.2.3",
+		},
+		MatchDetails: []models.MatchDetails{
+			{
+				Type:    "exact-direct-match",
+				Matcher: "stock-matcher",
+				SearchedBy: map[string]any{
+					"package": map[string]any{
+						"name":    "example-package",
+						"version": "1.2.3",
+					},
+				},
+				Found: map[string]any{
+					"vulnerabilityID":   "CVE-2026-0001",
+					"versionConstraint": "< 1.2.4",
+				},
+				Fix: &models.FixDetails{SuggestedVersion: "1.2.4"},
+			},
+			{
+				Type:    "exact-indirect-match",
+				Matcher: "rpm-matcher",
+				SearchedBy: map[string]any{
+					"namespace": "fedora:distro:fedora:42",
+					"package": map[string]any{
+						"name":    "upstream-package",
+						"version": "1.2.3-1.fc42",
+					},
+				},
+				Found: map[string]any{
+					"vulnerabilityID":   "CVE-2026-0001",
+					"versionConstraint": "< 1.2.4-1.fc42 (rpm)",
+				},
+			},
+		},
+	}
+
+	vuln, err := NewVulnerability(match)
+	require.NoError(t, err)
+	require.NotNil(t, vuln.Properties)
+	require.Len(t, *vuln.Properties, 1)
+
+	property := (*vuln.Properties)[0]
+	assert.Equal(t, "grype:match:details", property.Name)
+
+	expected, err := json.Marshal(match.MatchDetails)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(expected), property.Value)
+}
+
+func TestNewVulnerability_OmitsMatchDetailsPropertyWhenEmpty(t *testing.T) {
+	vuln, err := NewVulnerability(models.Match{
+		Vulnerability: models.Vulnerability{
+			VulnerabilityMetadata: models.VulnerabilityMetadata{
+				ID:       "CVE-2026-0002",
+				Severity: "Medium",
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Nil(t, vuln.Properties)
+}
+
+func TestNewVulnerability_MatchDetailsPropertySerializesInCycloneDXFormats(t *testing.T) {
+	match := models.Match{
+		Vulnerability: models.Vulnerability{
+			VulnerabilityMetadata: models.VulnerabilityMetadata{
+				ID:       "CVE-2026-0003",
+				Severity: "Low",
+			},
+		},
+		MatchDetails: []models.MatchDetails{
+			{
+				Type:       "exact-direct-match",
+				Matcher:    "stock-matcher",
+				SearchedBy: map[string]any{"language": "go"},
+				Found:      map[string]any{"vulnerabilityID": "CVE-2026-0003"},
+			},
+		},
+	}
+
+	vuln, err := NewVulnerability(match)
+	require.NoError(t, err)
+
+	formats := []struct {
+		name   string
+		format cyclonedx.BOMFileFormat
+	}{
+		{name: "json", format: cyclonedx.BOMFileFormatJSON},
+		{name: "xml", format: cyclonedx.BOMFileFormatXML},
+	}
+	for _, tc := range formats {
+		t.Run(tc.name, func(t *testing.T) {
+			bom := cyclonedx.NewBOM()
+			bom.Vulnerabilities = &[]cyclonedx.Vulnerability{vuln}
+
+			var encoded bytes.Buffer
+			err := cyclonedx.NewBOMEncoder(&encoded, tc.format).EncodeVersion(bom, cyclonedx.SpecVersion1_6)
+			require.NoError(t, err)
+
+			var decoded cyclonedx.BOM
+			err = cyclonedx.NewBOMDecoder(&encoded, tc.format).Decode(&decoded)
+			require.NoError(t, err)
+			require.NotNil(t, decoded.Vulnerabilities)
+			require.Len(t, *decoded.Vulnerabilities, 1)
+			require.NotNil(t, (*decoded.Vulnerabilities)[0].Properties)
+			require.Len(t, *(*decoded.Vulnerabilities)[0].Properties, 1)
+
+			property := (*(*decoded.Vulnerabilities)[0].Properties)[0]
+			assert.Equal(t, "grype:match:details", property.Name)
+			expected, err := json.Marshal(match.MatchDetails)
+			require.NoError(t, err)
+			assert.JSONEq(t, string(expected), property.Value)
+		})
+	}
+}
+
+func TestNewVulnerability_ReturnsErrorForUnencodableMatchDetails(t *testing.T) {
+	_, err := NewVulnerability(models.Match{
+		Vulnerability: models.Vulnerability{
+			VulnerabilityMetadata: models.VulnerabilityMetadata{
+				ID: "CVE-2026-0004",
+			},
+		},
+		MatchDetails: []models.MatchDetails{
+			{
+				Type:       "exact-direct-match",
+				Matcher:    "stock-matcher",
+				SearchedBy: make(chan struct{}),
+			},
+		},
+	})
+
+	require.ErrorContains(t, err, "unable to encode match details as a CycloneDX property")
 }


### PR DESCRIPTION
## Summary

Include Grype match details in CycloneDX vulnerability entries as a custom property.

Each vulnerability with match details now has a `grype:match:details` property whose value is the complete `matchDetails` array encoded as JSON. Vulnerabilities without match details do not receive the property.

## Motivation

CycloneDX output currently omits the evidence that explains how Grype matched a vulnerability. Consumers need that information to distinguish direct and indirect matches and make better-informed triage decisions.

## Approach

- Serialize the existing `models.MatchDetails` collection without changing its shape.
- Use one `grype:match:details` property so the complete ordered collection survives both CycloneDX JSON and XML output.
- Propagate serialization errors instead of silently dropping match evidence.
- Update CycloneDX presenter snapshots.

The issue confirms that CycloneDX properties are the intended extension point, but it does not prescribe the exact property name or whether the data should be flattened. This draft uses a single JSON-valued property to preserve nested match evidence losslessly. Maintainer feedback on that representation is welcome before this is marked ready.

## Testing

- `go test ./grype/presenter/cyclonedx -count=1`
- `make static-analysis`
- `git diff --check`

Tests cover direct and indirect match details, omission for empty details, JSON and XML round trips, and serialization errors.

Closes #3513

## AI assistance

AI-assisted tools were used during implementation and test development. I reviewed the resulting diff, verified the behavior locally, and take responsibility for the contribution.
