### PR TITLE
fix: rhel version streams

### DIFF
--- a/grype/db/v6/build/transformers/os/stream_expansion_test.go
+++ b/grype/db/v6/build/transformers/os/stream_expansion_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/anchore/grype/grype/db/internal/provider/unmarshal"
 	db "github.com/anchore/grype/grype/db/v6"
+	"github.com/anchore/grype/grype/version"
 )
 
 func intRef(i int) *int { return &i }
@@ -26,8 +27,10 @@ func gaAdvisory(id, version string) unmarshal.OSAdvisory {
 }
 
 // rhelFixed builds a single-package RHEL vulnerability. topVersion is the record's canonical
-// fix; advs are the per-stream advisories (pass none for a plain single-stream record).
-func rhelFixed(namespace, pkg, topVersion string, advID, url string, advs ...unmarshal.OSAdvisory) unmarshal.OSVulnerability {
+// fix; advs are the per-stream advisories (pass none for a plain single-stream record). The
+// record's top-level VendorAdvisory is derived from the highest-versioned advisory in advs --
+// mirroring how RHEL records carry the latest build's errata at the top level.
+func rhelFixed(namespace, pkg, topVersion string, advs ...unmarshal.OSAdvisory) unmarshal.OSVulnerability {
 	v := unmarshal.OSVulnerability{}
 	v.Vulnerability.Name = "CVE-TEST-0001"
 	v.Vulnerability.NamespaceName = namespace
@@ -35,18 +38,31 @@ func rhelFixed(namespace, pkg, topVersion string, advID, url string, advs ...unm
 	if len(advs) > 0 {
 		fi.Advisories = advs
 	}
-	// these records also include a top-level fixed in advisory information
-	fi.VendorAdvisory.AdvisorySummary = []struct {
-		ID   string `json:"ID"`
-		Link string `json:"Link"`
-	}{
-		{
-			ID:   advID,
-			Link: url,
-		},
+	if top, ok := highestVersionedAdvisory(advs); ok {
+		fi.VendorAdvisory.AdvisorySummary = []struct {
+			ID   string `json:"ID"`
+			Link string `json:"Link"`
+		}{
+			{ID: top.Advisory, Link: "https://access.redhat.com/errata/" + top.Advisory},
+		}
 	}
 	v.Vulnerability.FixedIn = unmarshal.OSFixedIns{fi}
 	return v
+}
+
+// highestVersionedAdvisory returns the advisory in advs with the highest RPM version, so a
+// fixture's top-level advisory reflects the latest build shipped for the record.
+func highestVersionedAdvisory(advs []unmarshal.OSAdvisory) (best unmarshal.OSAdvisory, found bool) {
+	for _, adv := range advs {
+		if !found {
+			best, found = adv, true
+			continue
+		}
+		if cmp, err := version.New(adv.Version, version.RpmFormat).Compare(version.New(best.Version, version.RpmFormat)); err == nil && cmp > 0 {
+			best = adv
+		}
+	}
+	return best, found
 }
 
 // --- assertion helpers ------------------------------------------------------
@@ -153,7 +169,7 @@ func assertNotAffectedOnAllMinors(t *testing.T, unafs []db.UnaffectedPackageHand
 // Real data: RHEL 9 CVE-2006-20001 (httpd), a single fix 0:2.4.53-7.el9_1.1 shipped by
 // RHSA-2023:0970 with no per-minor Advisories list -- the common single-stream shape.
 func Test_SingleRHSACopiedToAllMinors(t *testing.T) {
-	afs, unafs := getPackages(rhelFixed("rhel:9", "httpd", "0:2.4.53-7.el9_1.1", "", ""))
+	afs, unafs := getPackages(rhelFixed("rhel:9", "httpd", "0:2.4.53-7.el9_1.1"))
 	require.Empty(t, unafs)
 	assertCopiedToAllMinors(t, afs, "httpd", "0:2.4.53-7.el9_1.1")
 }
@@ -170,7 +186,6 @@ func Test_SingleRHSACopiedToAllMinors(t *testing.T) {
 // 0:5.14.0-362.8.1.el9_3 on 9.3 (minor 3). Nothing on 9.2 -> the gap falls to the base fix.
 func Test_MultiRHSAsAssignedToCorrectMinors(t *testing.T) {
 	fixed := rhelFixed("rhel:9", "kernel", "0:5.14.0-362.8.1.el9_3",
-		"RHSA-2023:6583", "https://access.redhat.com/errata/RHSA-2023:6583",
 		streamAdvisory("RHSA-2022:8267", "0:5.14.0-162.6.1.el9_1", 1),
 		streamAdvisory("RHSA-2023:6583", "0:5.14.0-362.8.1.el9_3", 3),
 	)
@@ -219,7 +234,7 @@ func Test_MultiRHSAsAssignedToCorrectMinors(t *testing.T) {
 // null minor. Only 6.9 and 6.10 pin their stream fixes; every other minor takes the base fix
 // (0:2.6.32-754.2.1.el6), and the GA build never appears.
 func Test_SupersededGADropped(t *testing.T) {
-	afs, _ := getPackages(rhelFixed("rhel:6", "kernel", "0:2.6.32-754.2.1.el6", "", "",
+	afs, _ := getPackages(rhelFixed("rhel:6", "kernel", "0:2.6.32-754.2.1.el6",
 		gaAdvisory("RHSA-2018:1854", "0:2.6.32-754.el6"), // lower EVR than the 6.10 fix -> superseded
 		streamAdvisory("RHSA-2018:1651", "0:2.6.32-696.30.1.el6", 9),
 		streamAdvisory("RHSA-2018:2164", "0:2.6.32-754.2.1.el6", 10),
@@ -254,7 +269,7 @@ func Test_SupersededGADropped(t *testing.T) {
 // Real data: RHEL 9 CVE-2002-0059 (zlib) is a real not-affected record -- a single FixedIn with
 // Version "0" and no advisory, i.e. RHEL 9's zlib is not affected.
 func Test_NotAffectedCopiedToAllMinors(t *testing.T) {
-	vuln := rhelFixed("rhel:9", "zlib", "0", "", "") // version "0" => not-affected
+	vuln := rhelFixed("rhel:9", "zlib", "0") // version "0" => not-affected
 	afs, unafs := getPackages(vuln)
 
 	require.Empty(t, afs)
@@ -267,7 +282,7 @@ func Test_NotAffectedCopiedToAllMinors(t *testing.T) {
 // 0:3.9.18-1.module+el8.9.0+20024+793d7211 for the python39:3.9 module stream -- a single
 // module-scoped fix that must keep its module qualifier on every expanded minor row.
 func Test_ModuleQualifierPreservedAcrossMinors(t *testing.T) {
-	vuln := rhelFixed("rhel:8", "python39", "0:3.9.18-1.module+el8.9.0+20024+793d7211", "", "")
+	vuln := rhelFixed("rhel:8", "python39", "0:3.9.18-1.module+el8.9.0+20024+793d7211")
 	vuln.Vulnerability.FixedIn[0].Module = strRef("python39:3.9")
 
 	afs, _ := getPackages(vuln)
@@ -290,7 +305,7 @@ func Test_ModuleQualifierPreservedAcrossMinors(t *testing.T) {
 // disjoint VulnerableRange verbatim, not a single governing fix.
 func Test_MultiUpstreamBase_KeepsDisjointRange(t *testing.T) {
 	const vulnRange = "< 4:20191115-4.20200602.2.el8_2 || >= 4:20210216, < 4:20210216-1.20210608.1.el8_4"
-	vuln := rhelFixed("rhel:8", "microcode_ctl", "4:20210216-1.20210608.1.el8_4", "", "",
+	vuln := rhelFixed("rhel:8", "microcode_ctl", "4:20210216-1.20210608.1.el8_4",
 		streamAdvisory("RHSA-2020:2431", "4:20191115-4.20200602.2.el8_2", 2),
 		streamAdvisory("RHSA-2021:3027", "4:20210216-1.20210608.1.el8_4", 4),
 	)

--- a/grype/db/v6/build/transformers/os/stream_expansion_test.go
+++ b/grype/db/v6/build/transformers/os/stream_expansion_test.go
@@ -1,7 +1,6 @@
 package os
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,21 +19,31 @@ func streamAdvisory(id, version string, minor int) unmarshal.OSAdvisory {
 	return unmarshal.OSAdvisory{Advisory: id, Version: version, Minor: intRef(minor), Channels: []string{"ga"}}
 }
 
-// gaAdvisory is a GA (major-wide) build with no known minor (a bare .elN dist tag). Its
-// minor is inferred from EVR ordering during expansion.
+// gaAdvisory is a GA (major-wide) build with no known minor (a bare .elN dist tag); it is
+// not tied to any specific stream.
 func gaAdvisory(id, version string) unmarshal.OSAdvisory {
 	return unmarshal.OSAdvisory{Advisory: id, Version: version, Minor: nil, Channels: []string{}}
 }
 
 // rhelFixed builds a single-package RHEL vulnerability. topVersion is the record's canonical
 // fix; advs are the per-stream advisories (pass none for a plain single-stream record).
-func rhelFixed(namespace, pkg, topVersion string, advs ...unmarshal.OSAdvisory) unmarshal.OSVulnerability {
+func rhelFixed(namespace, pkg, topVersion string, advID, url string, advs ...unmarshal.OSAdvisory) unmarshal.OSVulnerability {
 	v := unmarshal.OSVulnerability{}
 	v.Vulnerability.Name = "CVE-TEST-0001"
 	v.Vulnerability.NamespaceName = namespace
 	fi := unmarshal.OSFixedIn{Name: pkg, NamespaceName: namespace, Version: topVersion, VersionFormat: "rpm"}
 	if len(advs) > 0 {
 		fi.Advisories = advs
+	}
+	// these records also include a top-level fixed in advisory information
+	fi.VendorAdvisory.AdvisorySummary = []struct {
+		ID   string `json:"ID"`
+		Link string `json:"Link"`
+	}{
+		{
+			ID:   advID,
+			Link: url,
+		},
 	}
 	v.Vulnerability.FixedIn = unmarshal.OSFixedIns{fi}
 	return v
@@ -78,7 +87,7 @@ func constraintByMinor(t *testing.T, afs []db.AffectedPackageHandle, pkg string)
 	return out
 }
 
-// advisoryIDByMinor returns pkg's per-minor governing-fix RHSA id (from the fix's first advisory
+// advisoryIDByMinor returns pkg's per-minor fix RHSA id (from the fix's first advisory
 // reference) keyed by OS minor ("" = major fallback); "" when a row carries no reference.
 func advisoryIDByMinor(t *testing.T, afs []db.AffectedPackageHandle, pkg string) map[string]string {
 	t.Helper()
@@ -144,32 +153,34 @@ func assertNotAffectedOnAllMinors(t *testing.T, unafs []db.UnaffectedPackageHand
 // Real data: RHEL 9 CVE-2006-20001 (httpd), a single fix 0:2.4.53-7.el9_1.1 shipped by
 // RHSA-2023:0970 with no per-minor Advisories list -- the common single-stream shape.
 func Test_SingleRHSACopiedToAllMinors(t *testing.T) {
-	afs, unafs := getPackages(rhelFixed("rhel:9", "httpd", "0:2.4.53-7.el9_1.1"))
-
+	afs, unafs := getPackages(rhelFixed("rhel:9", "httpd", "0:2.4.53-7.el9_1.1", "", ""))
 	require.Empty(t, unafs)
 	assertCopiedToAllMinors(t, afs, "httpd", "0:2.4.53-7.el9_1.1")
 }
 
-// Test_MultiRHSAsAssignedToCorrectMinors: fixes shipped on two streams (9.1 and 9.3, nothing
-// on 9.2) are assigned by rolling FORWARD -- each minor is governed by the lowest fix at or
-// above it (the build that actually reaches a host on that minor). Crucially 9.2, which has
-// no build of its own, is judged against the 9.3 fix (not the 9.1 one): a 9.2 host is only
-// patched once it takes the 9.3 build. Minors past the last fix, and the major-only fallback,
-// take the highest fix.
+// Test_MultiRHSAsAssignedToCorrectMinors: a per-stream RHSA fix is pinned ONLY to the exact
+// minor it targets (9.1 and 9.3 here); it is not rolled onto adjacent minors. Every other
+// minor -- the gaps (9.0, 9.2) and everything past the last stream, plus the major-only
+// fallback -- carries the record's base fix (its canonical top-level version), which here is
+// the 9.3 GA build. So the two stream minors cite their own RHSA and every other row carries
+// the base fix with no per-stream advisory reference.
 //
 // Real data: RHEL 9 CVE-2022-50536 (kernel), same-base multi-minor with no VulnerableRange.
 // RHSA-2022:8267 ships 0:5.14.0-162.6.1.el9_1 on 9.1 (minor 1); RHSA-2023:6583 ships
-// 0:5.14.0-362.8.1.el9_3 on 9.3 (minor 3). Nothing on 9.2 -> the gap exercises roll-forward.
+// 0:5.14.0-362.8.1.el9_3 on 9.3 (minor 3). Nothing on 9.2 -> the gap falls to the base fix.
 func Test_MultiRHSAsAssignedToCorrectMinors(t *testing.T) {
-	afs, _ := getPackages(rhelFixed("rhel:9", "kernel", "0:5.14.0-362.8.1.el9_3",
+	fixed := rhelFixed("rhel:9", "kernel", "0:5.14.0-362.8.1.el9_3",
+		"RHSA-2023:6583", "https://access.redhat.com/errata/RHSA-2023:6583",
 		streamAdvisory("RHSA-2022:8267", "0:5.14.0-162.6.1.el9_1", 1),
 		streamAdvisory("RHSA-2023:6583", "0:5.14.0-362.8.1.el9_3", 3),
-	))
+	)
+
+	afs, _ := getPackages(fixed)
 
 	assertMinorAssignment(t, afs, "kernel", map[string]string{
-		"0":  "0:5.14.0-162.6.1.el9_1", // rolls forward to the earliest fix
+		"0":  "0:5.14.0-362.8.1.el9_3", // no 9.0 stream -> base fix (the 9.3 GA build)
 		"1":  "0:5.14.0-162.6.1.el9_1", // 9.1 stream
-		"2":  "0:5.14.0-362.8.1.el9_3", // no 9.2 build -> the 9.3 build is what reaches it
+		"2":  "0:5.14.0-362.8.1.el9_3", // no 9.2 stream -> base fix
 		"3":  "0:5.14.0-362.8.1.el9_3", // 9.3 stream
 		"4":  "0:5.14.0-362.8.1.el9_3",
 		"5":  "0:5.14.0-362.8.1.el9_3",
@@ -177,14 +188,13 @@ func Test_MultiRHSAsAssignedToCorrectMinors(t *testing.T) {
 		"7":  "0:5.14.0-362.8.1.el9_3",
 		"8":  "0:5.14.0-362.8.1.el9_3",
 		"9":  "0:5.14.0-362.8.1.el9_3",
-		"10": "0:5.14.0-362.8.1.el9_3", // past the last fix -> highest fix
-		"":   "0:5.14.0-362.8.1.el9_3", // major-only fallback -> highest fix
+		"10": "0:5.14.0-362.8.1.el9_3", // past the last stream -> base fix
+		"":   "0:5.14.0-362.8.1.el9_3", // major-only fallback -> base fix
 	})
 
-	// each per-minor row keeps its governing build's RHSA reference (not dropped): the minors
-	// governed by the 9.1 build cite its RHSA, those governed by the 9.3 build cite the other.
+	// a stream minor cites its own RHSA; every base-fix row cites the record's top-level advisory.
 	assert.Equal(t, map[string]string{
-		"0": "RHSA-2022:8267", "1": "RHSA-2022:8267",
+		"0": "RHSA-2023:6583", "1": "RHSA-2022:8267",
 		"2": "RHSA-2023:6583", "3": "RHSA-2023:6583", "4": "RHSA-2023:6583", "5": "RHSA-2023:6583",
 		"6": "RHSA-2023:6583", "7": "RHSA-2023:6583", "8": "RHSA-2023:6583",
 		"9": "RHSA-2023:6583", "10": "RHSA-2023:6583",
@@ -199,69 +209,17 @@ func Test_MultiRHSAsAssignedToCorrectMinors(t *testing.T) {
 	}
 }
 
-// Test_LaterGARebaseInferredAsNextMinor: a GA build (null minor) whose EVR outranks the
-// highest known stream fix is a genuinely-later rebase; it is inferred onto the next minor
-// and governs from there up (including the major fallback), while the known stream minors
-// keep their fixes.
-//
-// Real data: RHEL 9 CVE-2023-4813 (glibc). RHSA-2023:5453 pins 0:2.34-60.el9_2.7 on 9.2
-// (minor 2); RHBA-2024:2413 is a GA rebase 0:2.34-100.el9 with a null minor. The GA EVR
-// (2.34-100.el9) outranks the pinned 9.2 fix (2.34-60.el9_2.7), so it is inferred onto minor
-// 3 and governs from there up (including the major fallback), while 9.0..9.2 keep the pinned
-// fix. This is the only GA-null-minor + pinned-stream rebase in the source data whose GA build
-// outranks the stream fix; the fabricated second "release counter reset" table entry had no
-// real counterpart, so the table is collapsed to this single real case (nothing invented).
-func Test_LaterGARebaseInferredAsNextMinor(t *testing.T) {
-	tests := []struct {
-		name    string
-		vuln    unmarshal.OSVulnerability
-		pkg     string
-		below   string // fix for minors up to and including the known stream
-		knownAt int    // the known stream minor
-		rebase  string // inferred GA fix for minors above the known stream
-	}{
-		{
-			name: "glibc GA higher release",
-			vuln: rhelFixed("rhel:9", "glibc", "0:2.34-100.el9",
-				gaAdvisory("RHBA-2024:2413", "0:2.34-100.el9"),
-				streamAdvisory("RHSA-2023:5453", "0:2.34-60.el9_2.7", 2),
-			),
-			pkg: "glibc", below: "0:2.34-60.el9_2.7", knownAt: 2, rebase: "0:2.34-100.el9",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			afs, _ := getPackages(tt.vuln)
-
-			want := map[string]string{}
-			for m := 0; m <= rhelMinorSpan["9"]; m++ {
-				if m <= tt.knownAt {
-					want[strconv.Itoa(m)] = tt.below
-				} else {
-					want[strconv.Itoa(m)] = tt.rebase // inferred at knownAt+1, governs upward
-				}
-			}
-			want[""] = tt.rebase // major fallback -> highest (the inferred rebase)
-			assertMinorAssignment(t, afs, tt.pkg, want)
-		})
-	}
-}
-
-// Test_SupersededGADropped: a GA build whose EVR is at or below the highest known stream fix is
-// already covered by that fix, so it is dropped rather than inferred onto a new minor. No lower
-// GA build then leaks in as a fix (which would be a false negative); the per-minor rows carry
-// only the pinned stream fixes, rolled forward.
+// Test_SupersededGADropped: a GA build (null minor) never becomes a row's fix -- only the
+// pinned stream minors carry their own fix, and every other minor carries the base fix. A
+// lower GA build must not leak in as a fix (which would be a false negative).
 //
 // Real data: RHEL 6 CVE-2018-3639 (kernel), no VulnerableRange (so it takes the per-minor path).
 // RHSA-2018:1651 pins 0:2.6.32-696.30.1.el6 on 6.9 (minor 9); RHSA-2018:2164 pins
 // 0:2.6.32-754.2.1.el6 on 6.10 (minor 10); RHSA-2018:1854 is a GA build 0:2.6.32-754.el6 with a
-// null minor. The GA EVR (2.6.32-754.el6) is LOWER than the highest pinned fix (2.6.32-754.2.1.el6,
-// the 6.10 build), so the GA is dropped -- it is not inferred onto minor 11 and no host is judged
-// against it. The rows then reflect only the two pinned stream fixes rolled forward: minors up to
-// 9 take the 6.9 fix, and 10+ (plus the major fallback) take the 6.10 fix.
+// null minor. Only 6.9 and 6.10 pin their stream fixes; every other minor takes the base fix
+// (0:2.6.32-754.2.1.el6), and the GA build never appears.
 func Test_SupersededGADropped(t *testing.T) {
-	afs, _ := getPackages(rhelFixed("rhel:6", "kernel", "0:2.6.32-754.2.1.el6",
+	afs, _ := getPackages(rhelFixed("rhel:6", "kernel", "0:2.6.32-754.2.1.el6", "", "",
 		gaAdvisory("RHSA-2018:1854", "0:2.6.32-754.el6"), // lower EVR than the 6.10 fix -> superseded
 		streamAdvisory("RHSA-2018:1651", "0:2.6.32-696.30.1.el6", 9),
 		streamAdvisory("RHSA-2018:2164", "0:2.6.32-754.2.1.el6", 10),
@@ -275,18 +233,18 @@ func Test_SupersededGADropped(t *testing.T) {
 	}
 
 	assertMinorAssignment(t, afs, "kernel", map[string]string{
-		"0":  "0:2.6.32-696.30.1.el6", // rolls forward to the 6.9 fix
-		"1":  "0:2.6.32-696.30.1.el6",
-		"2":  "0:2.6.32-696.30.1.el6",
-		"3":  "0:2.6.32-696.30.1.el6",
-		"4":  "0:2.6.32-696.30.1.el6",
-		"5":  "0:2.6.32-696.30.1.el6",
-		"6":  "0:2.6.32-696.30.1.el6",
-		"7":  "0:2.6.32-696.30.1.el6",
-		"8":  "0:2.6.32-696.30.1.el6",
+		"0":  "0:2.6.32-754.2.1.el6", // no 6.0 stream -> base fix
+		"1":  "0:2.6.32-754.2.1.el6",
+		"2":  "0:2.6.32-754.2.1.el6",
+		"3":  "0:2.6.32-754.2.1.el6",
+		"4":  "0:2.6.32-754.2.1.el6",
+		"5":  "0:2.6.32-754.2.1.el6",
+		"6":  "0:2.6.32-754.2.1.el6",
+		"7":  "0:2.6.32-754.2.1.el6",
+		"8":  "0:2.6.32-754.2.1.el6",
 		"9":  "0:2.6.32-696.30.1.el6", // 6.9 stream
-		"10": "0:2.6.32-754.2.1.el6",  // 6.10 stream (GA superseded, dropped); also the last pinned fix
-		"":   "0:2.6.32-754.2.1.el6",  // major-only fallback -> highest pinned fix
+		"10": "0:2.6.32-754.2.1.el6",  // 6.10 stream
+		"":   "0:2.6.32-754.2.1.el6",  // major-only fallback -> base fix
 	})
 }
 
@@ -296,7 +254,7 @@ func Test_SupersededGADropped(t *testing.T) {
 // Real data: RHEL 9 CVE-2002-0059 (zlib) is a real not-affected record -- a single FixedIn with
 // Version "0" and no advisory, i.e. RHEL 9's zlib is not affected.
 func Test_NotAffectedCopiedToAllMinors(t *testing.T) {
-	vuln := rhelFixed("rhel:9", "zlib", "0") // version "0" => not-affected
+	vuln := rhelFixed("rhel:9", "zlib", "0", "", "") // version "0" => not-affected
 	afs, unafs := getPackages(vuln)
 
 	require.Empty(t, afs)
@@ -309,7 +267,7 @@ func Test_NotAffectedCopiedToAllMinors(t *testing.T) {
 // 0:3.9.18-1.module+el8.9.0+20024+793d7211 for the python39:3.9 module stream -- a single
 // module-scoped fix that must keep its module qualifier on every expanded minor row.
 func Test_ModuleQualifierPreservedAcrossMinors(t *testing.T) {
-	vuln := rhelFixed("rhel:8", "python39", "0:3.9.18-1.module+el8.9.0+20024+793d7211")
+	vuln := rhelFixed("rhel:8", "python39", "0:3.9.18-1.module+el8.9.0+20024+793d7211", "", "")
 	vuln.Vulnerability.FixedIn[0].Module = strRef("python39:3.9")
 
 	afs, _ := getPackages(vuln)
@@ -325,14 +283,14 @@ func Test_ModuleQualifierPreservedAcrossMinors(t *testing.T) {
 // Test_MultiUpstreamBase_KeepsDisjointRange uses real data: RHEL 8 CVE-2020-0543 (microcode_ctl),
 // fixed on two upstream bases -- RHSA-2020:2431 (base 20191115, el8_2) and RHSA-2021:3027 (base
 // 20210216, el8_4) -- which vunnel emits as a disjoint VulnerableRange plus a two-entry Advisories
-// list. The expansion must NOT collapse this to one roll-forward "< fix" per minor (that would flag
+// list. The expansion must NOT collapse this to a single "< fix" per minor (that would flag
 // a host still on the 20191115 base, carrying its own el8_2 fix, against the 20210216 build).
 // Instead it must (a) stay COMPLETE: present on every minor row + major fallback (so a minored host
 // resolving to a per-minor row still sees the package), and (b) stay CORRECT: every row carries the
 // disjoint VulnerableRange verbatim, not a single governing fix.
 func Test_MultiUpstreamBase_KeepsDisjointRange(t *testing.T) {
 	const vulnRange = "< 4:20191115-4.20200602.2.el8_2 || >= 4:20210216, < 4:20210216-1.20210608.1.el8_4"
-	vuln := rhelFixed("rhel:8", "microcode_ctl", "4:20210216-1.20210608.1.el8_4",
+	vuln := rhelFixed("rhel:8", "microcode_ctl", "4:20210216-1.20210608.1.el8_4", "", "",
 		streamAdvisory("RHSA-2020:2431", "4:20191115-4.20200602.2.el8_2", 2),
 		streamAdvisory("RHSA-2021:3027", "4:20210216-1.20210608.1.el8_4", 4),
 	)
@@ -343,6 +301,6 @@ func Test_MultiUpstreamBase_KeepsDisjointRange(t *testing.T) {
 	got := constraintByMinor(t, afs, "microcode_ctl")
 	require.Len(t, got, rhelMinorSpan["8"]+2) // completeness: 8.0..span + major fallback ("")
 	for minor, c := range got {
-		assert.Equalf(t, vulnRange, c, "minor %q must carry the disjoint VulnerableRange, not a collapsed roll-forward fix", minor)
+		assert.Equalf(t, vulnRange, c, "minor %q must carry the disjoint VulnerableRange, not a collapsed single fix", minor)
 	}
 }

--- a/grype/db/v6/build/transformers/os/transform.go
+++ b/grype/db/v6/build/transformers/os/transform.go
@@ -227,7 +227,7 @@ func expandRHELMinorRows(vuln unmarshal.OSVulnerability, group groupIndex, fixed
 		if len(minorFixes) == 0 {
 			return baseRanges
 		}
-		return governingRanges(minorFixes, m, versionFormat, vuln.Vulnerability.Name)
+		return governingRanges(minorFixes, versionFormat, vuln.Vulnerability.Name)
 	}
 
 	out := make([]db.AffectedPackageHandle, 0, len(minors))
@@ -316,8 +316,8 @@ func rhelGAExpansionMinors(group groupIndex) []string {
 // judged against the 9.4 build, not the 9.2 one. Rolling backward there would clear a 9.3
 // host whose version sorts above the 9.2 build but below the (applicable) 9.4 build, a false
 // negative. `fixes` is sorted ascending by minor.
-func governingRanges(fixes []minorFix, m int, versionFormat, vulnID string) []db.Range {
-	gov := fixes[len(fixes)-1] // m past the last fix -> highest known fix
+func governingRanges(minorFixes []minorFix, versionFormat, vulnID string) []db.Range {
+	gov := minorFixes[len(minorFixes)-1] // m past the last fix -> highest known fix
 	fix := &db.Fix{
 		Version: versionutil.CleanFixedInVersion(gov.version),
 		State:   db.FixedStatus,

--- a/grype/db/v6/build/transformers/os/transform.go
+++ b/grype/db/v6/build/transformers/os/transform.go
@@ -115,7 +115,7 @@ func getPackages(vuln unmarshal.OSVulnerability) ([]db.AffectedPackageHandle, []
 		// must appear on EVERY minor row or minored hosts lose coverage; the expansion
 		// is therefore cumulative and uniform across records. Single-stream packages
 		// carry their normal ranges on every minor (verdict unchanged); multi-stream
-		// packages pin the fix governing each minor. Non-RHEL / EUS / already-minored
+		// packages pin each minor's own stream fix. Non-RHEL / EUS / already-minored
 		// groups fall through to the single-handle path unchanged.
 		if expanded := expandRHELMinorRows(vuln, group, fixedIns, qualifiers); expanded != nil {
 			afs = append(afs, expanded...)
@@ -159,7 +159,7 @@ func buildRanges(vuln unmarshal.OSVulnerability, fixedIns []unmarshal.OSFixedIn)
 	return ranges
 }
 
-// minorFix pairs a known fix minor with the fix build (Version) that governs it.
+// minorFix pairs a known fix minor with the fix build (Version) shipped for it.
 type minorFix struct {
 	minor    int
 	version  string
@@ -175,44 +175,38 @@ type minorFix struct {
 // The expansion is result-preserving for the common single-stream package: with no known
 // per-minor fixes, every minor row (and the major fallback) carries the group's normal
 // ranges, so a host on any minor sees the same verdict it does today. It only changes
-// behavior for same-base multi-RHSA packages, where each minor row pins the fix governing
-// that minor by rolling FORWARD to the next reachable fix (see governingRange):
+// behavior for same-base multi-RHSA packages: a minor with its own stream fix pins that
+// fix, and every other minor carries the record's base (canonical top-level) fix:
 //
-//	fixes at 9.2="Alpha", 9.4="Bravo" (nothing on 9.3):
-//	  minors 9.0, 9.1, 9.2  -> "< Alpha"   (lowest known fix-minor >= m)
-//	  minor  9.3            -> "< Bravo"   (no 9.3 build -> the 9.4 build reaches it)
-//	  minor  9.4 .. span    -> "< Bravo"
-//	  major-only (9, "")    -> "< Bravo"   (highest known fix; unknown/rolled-forward host)
-//
-// A GA null-minor (.elN) advisory cannot be placed on a minor directly; inferGAMinors
-// folds it in by EVR ordering (a build newer than every pinnable fix becomes the next
-// minor's fix; an older/superseded one is dropped, which is safe since the pinnable fix
-// already covers it).
+//	stream fixes at 9.2="Alpha", 9.4="Bravo" (base/top-level = "Base"):
+//	  minor 9.2         -> "< Alpha"
+//	  minor 9.4         -> "< Bravo"
+//	  every other minor -> "< Base"   (gaps, minors past the streams, and major-only "")
 func expandRHELMinorRows(vuln unmarshal.OSVulnerability, group groupIndex, fixedIns []unmarshal.OSFixedIn, qualifiers *db.PackageQualifiers) []db.AffectedPackageHandle {
 	minors := rhelGAExpansionMinors(group)
 	if minors == nil {
 		return nil
 	}
 
-	// known per-minor governing fixes (empty for the common single-stream case).
+	// known per-minor stream fixes (empty for the common single-stream case).
 	fixes, versionFormat := collectKnownMinorFixes(fixedIns)
 
-	// Per-minor governing pins one "< fix" per minor. That is correct for same-base multi-minor
-	// RHSAs, but a MULTI-UPSTREAM-BASE group carries a disjoint VulnerableRange that a single
-	// constraint cannot represent -- roll-forward would pick the higher base's fix and flag a host
-	// still on the lower base that already carries its own base's fix (a false positive). For those,
-	// fall back to the group's normal ranges (which honor VulnerableRange) replicated on every row,
-	// exactly as single-stream groups are handled. We still expand across the span so the multi-base
-	// package stays present on every minor row (completeness), it just carries the disjoint range.
+	// Per-minor pinning is correct for same-base multi-minor RHSAs, but a MULTI-UPSTREAM-BASE
+	// group carries a disjoint VulnerableRange that a single per-minor "< fix" cannot represent
+	// (it would flag a host still on the lower base that already carries its own base's fix -- a
+	// false positive). Those fall back to the group's normal ranges (which honor VulnerableRange)
+	// on every row, exactly as single-stream groups do; we still expand across the span so the
+	// package stays present on every minor row (completeness), just carrying the disjoint range.
 	perMinor := len(fixes) > 0 && !hasVulnerableRange(fixedIns)
 
-	// baseRanges is the group's normal per-fix range set (honors VulnerableRange, wont-fix, etc.);
-	// used verbatim on every row for single-stream and multi-upstream-base groups.
+	// baseRanges is the group's normal per-fix range set (honors VulnerableRange, wont-fix, and
+	// the record's top-level advisory); carried on every non-per-minor row and every per-minor
+	// row that has no stream fix of its own.
 	baseRanges := buildRanges(vuln, fixedIns)
 
 	// rangesFor returns the ranges for a given minor row (minor=="" is the major fallback).
-	// Non-per-minor groups carry baseRanges on every row; per-minor groups pin the fix governing
-	// that minor (the major fallback rolls higher-minor hosts forward to the highest known fix).
+	// Non-per-minor groups carry baseRanges on every row; per-minor groups pin a minor's own
+	// stream fix and fall back to baseRanges for every other minor.
 	rangesFor := func(minor string) []db.Range {
 		if !perMinor || minor == "" {
 			return baseRanges
@@ -227,7 +221,22 @@ func expandRHELMinorRows(vuln unmarshal.OSVulnerability, group groupIndex, fixed
 		if len(minorFixes) == 0 {
 			return baseRanges
 		}
-		return governingRanges(minorFixes, versionFormat, vuln.Vulnerability.Name)
+
+		maxFix := minorFixes[len(minorFixes)-1] // highest fix targeting this minor
+		fix := &db.Fix{
+			Version: versionutil.CleanFixedInVersion(maxFix.version),
+			State:   db.FixedStatus,
+		}
+		if ref := advisoryReference(maxFix.advisory); ref != nil {
+			fix.Detail = &db.FixDetail{References: []db.Reference{*ref}}
+		}
+		return []db.Range{{
+			Version: db.Version{
+				Type:       versionFormat,
+				Constraint: deriveConstraintFromFix(versionutil.CleanConstraint(maxFix.version), vuln.Vulnerability.Name),
+			},
+			Fix: fix,
+		}}
 	}
 
 	out := make([]db.AffectedPackageHandle, 0, len(minors))
@@ -307,34 +316,6 @@ func rhelGAExpansionMinors(group groupIndex) []string {
 		minors = append(minors, strconv.Itoa(m))
 	}
 	return append(minors, "") // major-only fallback row
-}
-
-// governingRange builds the single fixed-version range for a host at minor m by rolling
-// FORWARD: the fix at the lowest known fix-minor >= m, or (when m is past the last fix) the
-// highest known fix. A minor with no fix of its own is judged against the next minor's fix
-// -- the build that actually reaches it -- e.g. a 9.3 host with fixes on 9.2 and 9.4 is
-// judged against the 9.4 build, not the 9.2 one. Rolling backward there would clear a 9.3
-// host whose version sorts above the 9.2 build but below the (applicable) 9.4 build, a false
-// negative. `fixes` is sorted ascending by minor.
-func governingRanges(minorFixes []minorFix, versionFormat, vulnID string) []db.Range {
-	gov := minorFixes[len(minorFixes)-1] // m past the last fix -> highest known fix
-	fix := &db.Fix{
-		Version: versionutil.CleanFixedInVersion(gov.version),
-		State:   db.FixedStatus,
-	}
-	// carry the governing build's RHSA reference so a multi-RHSA per-minor match shows the same
-	// errata link a single-stream match does (single-stream refs come from getFix; this is the
-	// multi-stream equivalent).
-	if ref := advisoryReference(gov.advisory); ref != nil {
-		fix.Detail = &db.FixDetail{References: []db.Reference{*ref}}
-	}
-	return []db.Range{{
-		Version: db.Version{
-			Type:       versionFormat,
-			Constraint: deriveConstraintFromFix(versionutil.CleanConstraint(gov.version), vulnID),
-		},
-		Fix: fix,
-	}}
 }
 
 // advisoryReference builds a fix Detail reference from an RHSA id, deriving the canonical Red Hat

--- a/grype/db/v6/build/transformers/os/transform.go
+++ b/grype/db/v6/build/transformers/os/transform.go
@@ -2,7 +2,6 @@ package os // nolint:revive
 
 import (
 	"fmt"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -19,15 +18,9 @@ import (
 	"github.com/anchore/grype/grype/db/v6/build/transformers/internal"
 	"github.com/anchore/grype/grype/db/v6/name"
 	"github.com/anchore/grype/grype/distro"
-	"github.com/anchore/grype/grype/version"
 	"github.com/anchore/grype/internal/log"
 	"github.com/anchore/syft/syft/pkg"
 )
-
-// bareGARelease matches an RPM release suffix that is a bare GA .elN dist tag
-// (e.g. ".el9") but NOT a z-stream/modular one (".el9_2", ".el9_2.3"). The negative
-// lookahead is emulated below since Go's regexp lacks lookahead.
-var bareGARelease = regexp.MustCompile(`\.el\d+($|[^_\d])`)
 
 // advisoryKey is an internal struct used for sorting and deduplicating advisories
 // that have both a link and ID from the vunnel results data
@@ -212,9 +205,6 @@ func expandRHELMinorRows(vuln unmarshal.OSVulnerability, group groupIndex, fixed
 	// exactly as single-stream groups are handled. We still expand across the span so the multi-base
 	// package stays present on every minor row (completeness), it just carries the disjoint range.
 	perMinor := len(fixes) > 0 && !hasVulnerableRange(fixedIns)
-	if perMinor {
-		fixes = inferGAMinors(fixes, collectNullMinorGABuilds(fixedIns))
-	}
 
 	// baseRanges is the group's normal per-fix range set (honors VulnerableRange, wont-fix, etc.);
 	// used verbatim on every row for single-stream and multi-upstream-base groups.
@@ -224,14 +214,20 @@ func expandRHELMinorRows(vuln unmarshal.OSVulnerability, group groupIndex, fixed
 	// Non-per-minor groups carry baseRanges on every row; per-minor groups pin the fix governing
 	// that minor (the major fallback rolls higher-minor hosts forward to the highest known fix).
 	rangesFor := func(minor string) []db.Range {
-		if !perMinor {
+		if !perMinor || minor == "" {
 			return baseRanges
 		}
-		m := fixes[len(fixes)-1].minor // major fallback -> highest known fix
-		if minor != "" {
-			m, _ = strconv.Atoi(minor)
+		m, _ := strconv.Atoi(minor)
+		var minorFixes []minorFix
+		for _, fix := range fixes {
+			if fix.minor == m {
+				minorFixes = append(minorFixes, fix)
+			}
 		}
-		return []db.Range{governingRange(fixes, m, versionFormat, vuln.Vulnerability.Name)}
+		if len(minorFixes) == 0 {
+			return baseRanges
+		}
+		return governingRanges(minorFixes, m, versionFormat, vuln.Vulnerability.Name)
 	}
 
 	out := make([]db.AffectedPackageHandle, 0, len(minors))
@@ -320,14 +316,8 @@ func rhelGAExpansionMinors(group groupIndex) []string {
 // judged against the 9.4 build, not the 9.2 one. Rolling backward there would clear a 9.3
 // host whose version sorts above the 9.2 build but below the (applicable) 9.4 build, a false
 // negative. `fixes` is sorted ascending by minor.
-func governingRange(fixes []minorFix, m int, versionFormat, vulnID string) db.Range {
+func governingRanges(fixes []minorFix, m int, versionFormat, vulnID string) []db.Range {
 	gov := fixes[len(fixes)-1] // m past the last fix -> highest known fix
-	for _, f := range fixes {
-		if f.minor >= m {
-			gov = f // lowest fix-minor >= m (fixes ascending)
-			break
-		}
-	}
 	fix := &db.Fix{
 		Version: versionutil.CleanFixedInVersion(gov.version),
 		State:   db.FixedStatus,
@@ -338,13 +328,13 @@ func governingRange(fixes []minorFix, m int, versionFormat, vulnID string) db.Ra
 	if ref := advisoryReference(gov.advisory); ref != nil {
 		fix.Detail = &db.FixDetail{References: []db.Reference{*ref}}
 	}
-	return db.Range{
+	return []db.Range{{
 		Version: db.Version{
 			Type:       versionFormat,
 			Constraint: deriveConstraintFromFix(versionutil.CleanConstraint(gov.version), vulnID),
 		},
 		Fix: fix,
-	}
+	}}
 }
 
 // advisoryReference builds a fix Detail reference from an RHSA id, deriving the canonical Red Hat
@@ -385,27 +375,6 @@ func collectKnownMinorFixes(fixedIns []unmarshal.OSFixedIn) ([]minorFix, string)
 	return fixes, versionFormat
 }
 
-// collectNullMinorGABuilds returns advisories whose Minor is null AND whose Version is a bare GA
-// .elN build (not a z-stream .elN_M), carrying the RHSA id so inferGAMinors keeps the reference
-// when it places the build on an inferred minor.
-func collectNullMinorGABuilds(fixedIns []unmarshal.OSFixedIn) []minorFix {
-	var out []minorFix
-	for _, f := range fixedIns {
-		for _, adv := range f.Advisories {
-			if adv.Minor == nil && isBareGABuild(adv.Version) {
-				out = append(out, minorFix{version: adv.Version, advisory: adv.Advisory})
-			}
-		}
-	}
-	return out
-}
-
-// isBareGABuild reports whether an RPM EVR carries a bare GA .elN dist tag (e.g.
-// 0:2.34-100.el9) rather than a z-stream/modular one (0:2.34-60.el9_2.7).
-func isBareGABuild(evr string) bool {
-	return bareGARelease.MatchString(evr)
-}
-
 // hasVulnerableRange reports whether any fixedIn carries a VulnerableRange, which vunnel emits for
 // multi-upstream-base groups (disjoint per-base vulnerable ranges). Such groups must not be
 // collapsed to a single per-minor governing fix.
@@ -416,36 +385,6 @@ func hasVulnerableRange(fixedIns []unmarshal.OSFixedIn) bool {
 		}
 	}
 	return false
-}
-
-// inferGAMinors folds each GA null-minor build into the sorted per-minor fixes by EVR
-// ordering: a GA build whose full EVR exceeds the current max pinnable EVR is inferred
-// to fix minor (maxMinor+1) and appended (governing that minor and up, and becoming the
-// new highest fix); a GA build at or below some pinnable EVR is superseded and dropped.
-// Comparison is version-first RPM EVR (epoch->version->release), NOT a release-int
-// compare, so an upstream rebase whose release counter reset (e.g. 2.40.5-1.el9 vs a
-// pinned 2.38.5-1.el9_2.3) still orders correctly by version.
-func inferGAMinors(fixes []minorFix, gaBuilds []minorFix) []minorFix {
-	// ascending EVR so successively-higher GA builds land on successive minors.
-	sort.Slice(gaBuilds, func(i, j int) bool { return compareRPMEVR(gaBuilds[i].version, gaBuilds[j].version) < 0 })
-	for _, ga := range gaBuilds {
-		maxFix := fixes[len(fixes)-1]
-		if compareRPMEVR(ga.version, maxFix.version) > 0 {
-			fixes = append(fixes, minorFix{minor: maxFix.minor + 1, version: ga.version, advisory: ga.advisory})
-		}
-	}
-	return fixes
-}
-
-// compareRPMEVR compares two RPM EVR strings, returning -1/0/1. On a parse/compare
-// error it returns 0 (treated as "not greater" by callers -> conservative drop).
-func compareRPMEVR(a, b string) int {
-	cmp, err := version.New(a, version.RpmFormat).Compare(version.New(b, version.RpmFormat))
-	if err != nil {
-		log.WithFields("a", a, "b", b, "error", err).Trace("unable to compare RPM EVRs for GA-minor inference")
-		return 0
-	}
-	return cmp
 }
 
 func getFix(fixedInEntry unmarshal.OSFixedIn) *db.Fix {

--- a/grype/matcher/rpm/rhel_multi_rhsa_test.go
+++ b/grype/matcher/rpm/rhel_multi_rhsa_test.go
@@ -277,9 +277,13 @@ func TestRpmNotAffected_MinoredHostGetsSuppressingIgnore(t *testing.T) {
 // transformer's non-per-minor groups are forced back to the single major-only handle, while
 // the multi-stream glibc case keeps matching - exactly the sparse-row shadow FN.
 func TestRpmCumulativeCompleteness_MinoredHostSeesBothPackages(t *testing.T) {
+	rhel91 := distro.New(distro.RedHat, "9.1", "")
+	rhel92 := distro.New(distro.RedHat, "9.2", "")
+	rhel93 := distro.New(distro.RedHat, "9.3", "")
+
 	dbtest.DBs(t, "rhel-multi-rhsa").
+		SelectOnly("CVE-2017-17095").
 		Run(func(t *testing.T, db *dbtest.DB) {
-			rhel92 := distro.New(distro.RedHat, "9.2", "")
 
 			t.Run("single-stream libtiff seen at the minor row", func(t *testing.T) {
 				// below the GA fix 0:4.4.0-10.el9; only visible on rhel 9.2 if the
@@ -292,7 +296,11 @@ func TestRpmCumulativeCompleteness_MinoredHostSeesBothPackages(t *testing.T) {
 					SelectDetailByType(match.ExactDirectMatch).
 					AsDistroSearch()
 			})
+		})
 
+	dbtest.DBs(t, "rhel-multi-rhsa").
+		SelectOnly("CVE-2023-4813").
+		Run(func(t *testing.T, db *dbtest.DB) {
 			t.Run("multi-stream glibc seen at the same minor row", func(t *testing.T) {
 				// the record that caused rhel 9.2 to exist; below its 9.2 stream fix.
 				version := "0:2.34-60.el9_2.1"
@@ -302,6 +310,51 @@ func TestRpmCumulativeCompleteness_MinoredHostSeesBothPackages(t *testing.T) {
 					SelectMatch("CVE-2023-4813").
 					SelectDetailByType(match.ExactDirectMatch).
 					AsDistroSearch()
+			})
+
+			t.Run("later builds on same stream not vulnerable", func(t *testing.T) {
+				version := "0:2.34-70.el9_2.8"
+				matcher := Matcher{}
+				p := rhelStreamHost("glibc", rhel92, version, pkg.ID("glibc-"+version))
+				db.Match(t, &matcher, p).
+					DoesNotHaveAnyVulnerabilities("CVE-2023-4813").
+					Ignores().SelectRelatedPackageIgnore(IgnoreReasonDistroNotVulnerable, "CVE-2023-4813")
+			})
+
+			t.Run("later builds on previous stream still vulnerable", func(t *testing.T) {
+				version := "0:2.34-70.el9"
+				matcher := Matcher{}
+				p := rhelStreamHost("glibc", rhel91, version, pkg.ID("glibc-"+version))
+				db.Match(t, &matcher, p).
+					SelectMatch("CVE-2023-4813").
+					SelectDetailByType(match.ExactDirectMatch).
+					AsDistroSearch()
+			})
+
+			t.Run("later builds on next stream still vulnerable", func(t *testing.T) {
+				version := "0:2.34-70.el9"
+				matcher := Matcher{}
+				p := rhelStreamHost("glibc", rhel93, version, pkg.ID("glibc-"+version))
+				db.Match(t, &matcher, p).
+					SelectMatch("CVE-2023-4813").
+					SelectDetailByType(match.ExactDirectMatch).
+					AsDistroSearch()
+			})
+		})
+
+	dbtest.DBs(t, "rhel-multi-rhsa").
+		SelectOnly("CVE-2023-4813", "CVE-2026-5450").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			t.Run("different glibc vulnerability seen when minor row records exist", func(t *testing.T) {
+				version := "0:2.34-60.el9_2.7"
+				matcher := Matcher{}
+				p := rhelStreamHost("glibc", rhel92, version, pkg.ID("glibc-"+version))
+				m := db.Match(t, &matcher, p)
+				m.SelectMatch("CVE-2026-5450").
+					SelectDetailByType(match.ExactDirectMatch).
+					AsDistroSearch()
+				m.OnlyHasVulnerabilities("CVE-2026-5450").
+					Ignores().SelectRelatedPackageIgnore(IgnoreReasonDistroNotVulnerable, "CVE-2023-4813")
 			})
 		})
 }
@@ -418,6 +471,7 @@ func TestRpmPerMinorExpansion_KernelRollForwardGap(t *testing.T) { //nolint:funl
 // and crucially NOT against the GA -100.el9 build.
 func TestRpmPerMinorExpansion_GlibcMinorNull(t *testing.T) {
 	dbtest.DBs(t, "rhel-multi-rhsa").
+		SelectOnly("CVE-2023-4813").
 		Run(func(t *testing.T, db *dbtest.DB) {
 			rhel92 := distro.New(distro.RedHat, "9.2", "")
 
@@ -471,6 +525,7 @@ func TestRpmPerMinorExpansion_GlibcMinorNull(t *testing.T) {
 // rhel:9.2 row, so an EUS host is judged against its own stream's fix exactly like a GA host.
 func TestRpmPerMinorExpansion_SameBaseUnderEUS(t *testing.T) {
 	dbtest.DBs(t, "rhel-multi-rhsa").
+		SelectOnly("CVE-2023-4813").
 		Run(func(t *testing.T, db *dbtest.DB) {
 			eus92 := newEUSDistro("9.2")
 

--- a/grype/matcher/rpm/testdata/rhel-multi-rhsa/rhel/results/rhel@9/cve-2023-4813.json
+++ b/grype/matcher/rpm/testdata/rhel-multi-rhsa/rhel/results/rhel@9/cve-2023-4813.json
@@ -1,11 +1,26 @@
 {
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json",
   "identifier": "rhel:9/cve-2023-4813",
   "item": {
     "Vulnerability": {
-      "CVSS": [],
-      "Description": "glibc real-shape record: a GA RHBA -100.el9 with Minor=null plus a 9.2 stream RHSA -60.el9_2.7 with Minor=2. Only one known minor, so the GA null-minor build must NOT become a cross-minor false positive for a 9.2 host past its stream fix.",
+      "Severity": "Medium",
+      "NamespaceName": "rhel:9",
       "FixedIn": [
         {
+          "Name": "glibc",
+          "Version": "0:2.34-100.el9",
+          "Module": null,
+          "VersionFormat": "rpm",
+          "NamespaceName": "rhel:9",
+          "VendorAdvisory": {
+            "NoAdvisory": false,
+            "AdvisorySummary": [
+              {
+                "ID": "RHBA-2024:2413",
+                "Link": "https://access.redhat.com/errata/RHBA-2024:2413"
+              }
+            ]
+          },
           "Advisories": [
             {
               "Advisory": "RHBA-2024:2413",
@@ -17,35 +32,32 @@
               "Advisory": "RHSA-2023:5453",
               "Version": "0:2.34-60.el9_2.7",
               "Minor": 2,
-              "Channels": ["ga"]
+              "Channels": []
             }
           ],
-          "Module": null,
-          "Name": "glibc",
-          "NamespaceName": "rhel:9",
-          "VendorAdvisory": {
-            "AdvisorySummary": [
-              {
-                "ID": "RHBA-2024:2413",
-                "Link": "https://access.redhat.com/errata/RHBA-2024:2413"
-              },
-              {
-                "ID": "RHSA-2023:5453",
-                "Link": "https://access.redhat.com/errata/RHSA-2023:5453"
-              }
-            ],
-            "NoAdvisory": false
-          },
-          "Version": "0:2.34-100.el9",
-          "VersionFormat": "rpm"
+          "Available": {
+            "date": "2025-05-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-4813",
+      "Description": "A flaw has been identified in glibc. In an uncommon situation, the gaih_inet function may use memory that has been freed, resulting in an application crash. This issue is only exploitable when the getaddrinfo function is called and the hosts database in /etc/nsswitch.conf is configured with SUCCESS=continue or SUCCESS=merge.",
       "Metadata": {},
       "Name": "CVE-2023-4813",
-      "NamespaceName": "rhel:9",
-      "Severity": "Medium"
+      "CVSS": [
+        {
+          "version": "3.1",
+          "status": "verified",
+          "vector_string": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "base_metrics": {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "base_severity": "Medium"
+          }
+        }
+      ]
     }
-  },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  }
 }

--- a/grype/matcher/rpm/testdata/rhel-multi-rhsa/rhel/results/rhel@9/cve-2026-5450.json
+++ b/grype/matcher/rpm/testdata/rhel-multi-rhsa/rhel/results/rhel@9/cve-2026-5450.json
@@ -1,0 +1,49 @@
+{
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json",
+  "identifier": "rhel:9/cve-2026-5450",
+  "item": {
+    "Vulnerability": {
+      "Severity": "Medium",
+      "NamespaceName": "rhel:9",
+      "FixedIn": [
+        {
+          "Name": "glibc",
+          "Version": "0:2.34-272.el9_8",
+          "Module": null,
+          "VersionFormat": "rpm",
+          "NamespaceName": "rhel:9",
+          "VendorAdvisory": {
+            "NoAdvisory": false,
+            "AdvisorySummary": [
+              {
+                "ID": "RHSA-2026:33226",
+                "Link": "https://access.redhat.com/errata/RHSA-2026:33226"
+              }
+            ]
+          },
+          "Available": {
+            "date": "2026-07-13",
+            "kind": "first-observed"
+          }
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2026-5450",
+      "Description": "A flaw was found in glibc (GNU C Library). This vulnerability occurs when an application uses the `scanf` family of functions with a `%mc` format specifier, which is used for dynamically allocating memory for character input, and provides an explicit width greater than 1024. This specific combination can lead to a one-byte heap buffer overflow, potentially allowing an attacker to corrupt memory.",
+      "Metadata": {},
+      "Name": "CVE-2026-5450",
+      "CVSS": [
+        {
+          "version": "3.1",
+          "status": "verified",
+          "vector_string": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:N/I:L/A:H",
+          "base_metrics": {
+            "base_score": 5.0,
+            "exploitability_score": 0.8,
+            "impact_score": 4.2,
+            "base_severity": "Medium"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR adjusts the redhat stream fixes to be applied only to the specific minor version. For example:
A fix for CVE-2023-4813 issued in RHSA-2023:5453 was published in a 9_2.7 release, but this was after later builds were likely available on the main branch. The development branches and main EL9 fix landed in `0:2.34-100.el9` noted in RHBA-2024:2413 whereas the 9.2 stream fix landed in: `0:2.34-60.el9_2.7`. A user who is on 9.0 as I understand it will be able to get a mainline fix but not the 9_2 stream fix, so including the 9_2 fixed version range needs to only apply to RHEL 9.2, previously the fix was showing up in all prior versions. With this change, it looks like: 
```
CVE-2023-4813  glibc         rpm        redhat@9        < 0:2.34-100.el9      
CVE-2023-4813  glibc         rpm        redhat@9.0      < 0:2.34-100.el9   
CVE-2023-4813  glibc         rpm        redhat@9.1      < 0:2.34-100.el9   
CVE-2023-4813  glibc         rpm        redhat@9.10     < 0:2.34-100.el9      
CVE-2023-4813  glibc         rpm        redhat@9.2      < 0:2.34-60.el9_2.7   
CVE-2023-4813  glibc         rpm        redhat@9.3      < 0:2.34-100.el9      
CVE-2023-4813  glibc         rpm        redhat@9.4      < 0:2.34-100.el9      
CVE-2023-4813  glibc         rpm        redhat@9.5      < 0:2.34-100.el9      
CVE-2023-4813  glibc         rpm        redhat@9.6      < 0:2.34-100.el9      
CVE-2023-4813  glibc         rpm        redhat@9.7      < 0:2.34-100.el9      
CVE-2023-4813  glibc         rpm        redhat@9.8      < 0:2.34-100.el9      
CVE-2023-4813  glibc         rpm        redhat@9.9      < 0:2.34-100.el9
```
