### PR TITLE
fix: normalize "u" update shorthand in pre-JEP 223 JVM versions

### DIFF
--- a/grype/version/jvm_version.go
+++ b/grype/version/jvm_version.go
@@ -15,7 +15,7 @@ var _ interface {
 } = (*jvmVersion)(nil)
 
 var (
-	preJep223VersionPattern = regexp.MustCompile(`^1\.(?P<major>\d+)(\.(?P<minor>\d+)([_-](update)?(_)?(?P<patch>\d+))?(-(?P<prerelease>[^b][^-]+))?(-b(?P<build>\d+))?)?`)
+	preJep223VersionPattern = regexp.MustCompile(`^1\.(?P<major>\d+)(\.(?P<minor>\d+)([_u-](update)?(_)?(?P<patch>\d+))?(-(?P<prerelease>[^b][^-]+))?(-b(?P<build>\d+))?)?`)
 	nonCompliantSemverIsh   = regexp.MustCompile(`^(?P<major>\d+)(\.(?P<minor>\d+)(\.(?P<patch>\d+))?([_-](update)?(_)?(?P<update>\d+))?(-(?P<prerelease>[^b][^-]+))?(-b(?P<build>\d+))?)?`)
 )
 

--- a/grype/version/jvm_version_test.go
+++ b/grype/version/jvm_version_test.go
@@ -119,6 +119,13 @@ func TestJVMVersion_Compare(t *testing.T) {
 		// invalid but we should work with these
 		{"1.8.0_131", "1.8.0-update131-b02", 0},
 		{"1.8.0_131", "1.8.0-update_131-b02", 0},
+
+		// the "u" update shorthand (e.g. 1.6.0u141) is equivalent to the underscore form
+		{"1.6.0u141", "1.6.0_141", 0},
+		{"1.6.0u141", "6.0.141", 0},
+		{"1.6.0u141", "1.6.0u142", -1},
+		{"1.6.0u141", "1.6.0", 1},
+		{"1.8.0u131-b11", "1.8.0_131", 0},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Pre-JEP-223 JVM versions using the "u" update shorthand (e.g. 1.6.0u141) were normalized to 6.0.0, dropping the update number, so they compared unequal to 1.6.0_141 / 6.0.141. Accept "u" in the update separator class of preJep223VersionPattern so 1.6.0u141 normalizes to 6.0.141 like 1.6.0_141.

Fixes #2701