### PR TITLE
Add fix date to rhel minor records created from rhsa

### DIFF
--- a/grype/db/v6/build/transformers/os/stream_expansion_test.go
+++ b/grype/db/v6/build/transformers/os/stream_expansion_test.go
@@ -121,6 +121,26 @@ func advisoryIDByMinor(t *testing.T, afs []db.AffectedPackageHandle, pkg string)
 	return out
 }
 
+// fixDateByMinor returns pkg's per-minor fix availability date (YYYY-MM-DD) keyed by OS minor
+// ("" = major fallback); "" when a row carries no fix date. This guards the
+// fail-on-missing-fix-date contract: every fixed row, pinned stream minors included, must
+// carry the date vunnel attached to the source fixedIn.
+func fixDateByMinor(t *testing.T, afs []db.AffectedPackageHandle, pkg string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, h := range afs {
+		if h.Package.Name != pkg {
+			continue
+		}
+		date := ""
+		if r := h.BlobValue.Ranges[0]; r.Fix != nil && r.Fix.Detail != nil && r.Fix.Detail.Available != nil && r.Fix.Detail.Available.Date != nil {
+			date = r.Fix.Detail.Available.Date.UTC().Format("2006-01-02")
+		}
+		out[h.OperatingSystem.MinorVersion] = date
+	}
+	return out
+}
+
 // assertCopiedToAllMinors asserts pkg was fixed at the same evr on every materialized minor
 // row and the major-only fallback -- i.e. a single fix copied verbatim across the whole span.
 func assertCopiedToAllMinors(t *testing.T, afs []db.AffectedPackageHandle, pkg, evr string) {
@@ -221,6 +241,31 @@ func Test_MultiRHSAsAssignedToCorrectMinors(t *testing.T) {
 		ref := h.BlobValue.Ranges[0].Fix.Detail.References[0]
 		assert.Equal(t, "https://access.redhat.com/errata/"+ref.ID, ref.URL)
 		assert.Contains(t, ref.Tags, db.AdvisoryReferenceTag)
+	}
+}
+
+// Test_MultiRHSAFixDateCarriedToAllMinors: the fix date vunnel attaches to a fixedIn must be
+// carried onto EVERY materialized minor row -- including the pinned per-stream minors, which
+// build their own db.Fix during expansion. Before the fix those pinned rows carried only the
+// RHSA reference and no date, so a downstream writer with fail-on-missing-fix-date rejected
+// them ("missing fix date for version ..."). This is the regression guard for that.
+//
+// Real data shape: RHEL 10 CVE-2024-28956 (kernel), a per-minor stream fix on 10.1 with an
+// observed fix date on the source record.
+func Test_MultiRHSAFixDateCarriedToAllMinors(t *testing.T) {
+	fixed := rhelFixed("rhel:9", "kernel", "0:5.14.0-362.8.1.el9_3",
+		streamAdvisory("RHSA-2022:8267", "0:5.14.0-162.6.1.el9_1", 1),
+		streamAdvisory("RHSA-2023:6583", "0:5.14.0-362.8.1.el9_3", 3),
+	)
+	fixed.Vulnerability.FixedIn[0].Available.Date = "2023-11-07"
+
+	afs, _ := getPackages(fixed)
+
+	// every minor -- the two pinned stream minors (1, 3) and every base-fix row -- carries the date.
+	byMinor := fixDateByMinor(t, afs, "kernel")
+	require.NotEmpty(t, byMinor)
+	for minor, date := range byMinor {
+		assert.Equal(t, "2023-11-07", date, "minor %q missing fix date", minor)
 	}
 }
 

--- a/grype/db/v6/build/transformers/os/transform.go
+++ b/grype/db/v6/build/transformers/os/transform.go
@@ -161,9 +161,10 @@ func buildRanges(vuln unmarshal.OSVulnerability, fixedIns []unmarshal.OSFixedIn)
 
 // minorFix pairs a known fix minor with the fix build (Version) shipped for it.
 type minorFix struct {
-	minor    int
-	version  string
-	advisory string // RHSA id that shipped this build ("" when unknown); becomes the fix's reference
+	minor        int
+	version      string
+	advisory     string              // RHSA id that shipped this build ("" when unknown); becomes the fix's reference
+	availability *db.FixAvailability // fix date carried from the source fixedIn (nil when vunnel emitted none)
 }
 
 // expandRHELMinorRows implements the cumulative server-side stream-affinity expansion.
@@ -227,8 +228,17 @@ func expandRHELMinorRows(vuln unmarshal.OSVulnerability, group groupIndex, fixed
 			Version: versionutil.CleanFixedInVersion(maxFix.version),
 			State:   db.FixedStatus,
 		}
+		// carry both the RHSA reference and the source fix date onto the pinned per-minor fix;
+		// without the date, fail-on-missing-fix-date rejects the record at write time.
+		var refs []db.Reference
 		if ref := advisoryReference(maxFix.advisory); ref != nil {
-			fix.Detail = &db.FixDetail{References: []db.Reference{*ref}}
+			refs = []db.Reference{*ref}
+		}
+		if len(refs) > 0 || maxFix.availability != nil {
+			fix.Detail = &db.FixDetail{
+				Available:  maxFix.availability,
+				References: refs,
+			}
 		}
 		return []db.Range{{
 			Version: db.Version{
@@ -342,7 +352,7 @@ func collectKnownMinorFixes(fixedIns []unmarshal.OSFixedIn) ([]minorFix, string)
 			if adv.Minor == nil {
 				continue
 			}
-			knownByMinor[*adv.Minor] = minorFix{minor: *adv.Minor, version: adv.Version, advisory: adv.Advisory}
+			knownByMinor[*adv.Minor] = minorFix{minor: *adv.Minor, version: adv.Version, advisory: adv.Advisory, availability: getFixAvailability(f)}
 			versionFormat = f.VersionFormat
 		}
 	}


### PR DESCRIPTION
This is a fix related to the recent changes with #3542 and #3572, which expand major-only RHEL records to also emit per-minor version records. In the process of emitting these new records, the fix available information that carries fix date information was not carried to the new records. This PR addresses this by preserving the fix available object from the major record to all created records.