### PR TITLE
fix(distro): guard against panic on empty version in parseVersion

### DIFF
--- a/grype/distro/distro.go
+++ b/grype/distro/distro.go
@@ -66,7 +66,7 @@ func parseVersion(version string) (major, minor, remaining, versionWithoutSuffix
 	version = strings.TrimPrefix(version, "v")
 
 	// if starts with a digit, then assume it's a version and extract the major, minor, and remaining versions
-	if version[0] >= '0' && version[0] <= '9' {
+	if len(version) > 0 && version[0] >= '0' && version[0] <= '9' {
 		// extract the major, minor, and remaining versions
 		parts := strings.Split(version, ".")
 		if len(parts) > 0 {

--- a/grype/distro/distro_test.go
+++ b/grype/distro/distro_test.go
@@ -839,3 +839,37 @@ func TestParseDistroString(t *testing.T) {
 		})
 	}
 }
+
+// Test_parseVersion_shortVersionNoPanic guards against a process-crashing panic
+// (index out of range) in parseVersion when a version reduces to an empty string
+// after the "v" prefix is trimmed. Such values are fully attacker-controlled: they
+// arrive from an artifact's /etc/os-release VERSION_ID (dir/image scans) or from the
+// "distro.versionID" field of a syft-JSON SBOM (sbom: input). Because distro
+// construction happens in the pre-match parsing phase, which is not wrapped in a
+// panic recover, an unguarded index panic terminates the whole grype process.
+func Test_parseVersion_shortVersionNoPanic(t *testing.T) {
+	inputs := []string{"v", "V", "v+eus", "v+1", "+", ""}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				_, _, _, _, _ = parseVersion(in)
+			})
+		})
+	}
+}
+
+// Test_NewFromRelease_shortVersionIDNoPanic reproduces the end-to-end reachability:
+// a recognized distro ID with a VERSION_ID that becomes empty after trimming the "v"
+// prefix must not crash the process during distro construction.
+func Test_NewFromRelease_shortVersionIDNoPanic(t *testing.T) {
+	releases := []linux.Release{
+		{ID: "alpine", VersionID: "v"},   // no Version -> fallback selects VersionID="v"
+		{ID: "alpine", VersionID: "v+1"}, // channel suffix leaves an empty core version
+		{ID: "ubuntu", VersionID: "v", Version: "v"},
+	}
+	for _, r := range releases {
+		require.NotPanics(t, func() {
+			_, _ = NewFromRelease(r, testFixChannels())
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3588

## Summary

`parseVersion` indexed `version[0]` immediately after `strings.TrimPrefix(version, "v")`. A version consisting solely of the `v` prefix (e.g. `v`, or `v+<channel>` whose core reduces to empty) trims to `""`, so `version[0]` panics with `index out of range [0] with length 0`.

This value comes from the scanned artifact and is reached in the pre-match parsing phase, which is **not** wrapped in panic recovery (only the matcher phase is, via `callMatcherSafely`), so a malformed value crashes the whole process:

- **dir/image scan:** `/etc/os-release` with `VERSION_ID=v`
- **sbom input:** syft-JSON SBOM with `"distro": {"versionID": "v"}`

Adds the missing length guard and regression tests covering `parseVersion` and the end-to-end `NewFromRelease` path.