### PR TITLE
fix(db search): reconstruct namespaced package names from PURLs

### DIFF
--- a/cmd/grype/cli/options/database_search_packages.go
+++ b/cmd/grype/cli/options/database_search_packages.go
@@ -62,8 +62,9 @@ func (o *DBSearchPackages) PostLoad() error {
 				log.Warnf("ignoring version and qualifiers for package URL %q", purl)
 			}
 
-			o.PkgSpecs = append(o.PkgSpecs, &v6.PackageSpecifier{Name: purl.Name, Ecosystem: purl.Type})
-			o.CPESpecs = append(o.CPESpecs, &v6.PackageSpecifier{CPE: &cpe.Attributes{Part: "a", Product: purl.Name, TargetSW: purl.Type}})
+			name := packageNameFromPURL(purl)
+			o.PkgSpecs = append(o.PkgSpecs, &v6.PackageSpecifier{Name: name, Ecosystem: purl.Type})
+			o.CPESpecs = append(o.CPESpecs, &v6.PackageSpecifier{CPE: &cpe.Attributes{Part: "a", Product: name, TargetSW: purl.Type}})
 
 		default:
 			o.PkgSpecs = append(o.PkgSpecs, &v6.PackageSpecifier{Name: p, Ecosystem: o.Ecosystem})
@@ -81,4 +82,24 @@ func (o *DBSearchPackages) PostLoad() error {
 	}
 
 	return nil
+}
+
+// packageNameFromPURL reconstructs the package name in the form the grype DB
+// stores it in for the package's ecosystem. Most ecosystems are flat-namespaced
+// and use purl.Name directly. Namespaced ecosystems like golang (module paths,
+// e.g. "github.com/gin-gonic/gin") and npm (scoped packages, e.g. "@scope/name")
+// split the namespace out of the name during PURL parsing, so it must be
+// rejoined to match how the DB stores these names. Maven (java) packages are
+// stored as "groupId:artifactId" by the DB build pipeline.
+func packageNameFromPURL(purl packageurl.PackageURL) string {
+	if purl.Namespace == "" {
+		return purl.Name
+	}
+	switch purl.Type {
+	case packageurl.TypeMaven:
+		return purl.Namespace + ":" + purl.Name
+	case packageurl.TypeGolang, packageurl.TypeNPM:
+		return purl.Namespace + "/" + purl.Name
+	}
+	return purl.Name
 }

--- a/cmd/grype/cli/options/database_search_packages_test.go
+++ b/cmd/grype/cli/options/database_search_packages_test.go
@@ -43,6 +43,42 @@ func TestDBSearchPackagesPostLoad(t *testing.T) {
 			},
 		},
 		{
+			name: "valid golang PURL with module path",
+			input: DBSearchPackages{
+				Packages: []string{"pkg:golang/github.com/gin-gonic/gin@v1.9.0"},
+			},
+			expectedPkg: v6.PackageSpecifiers{
+				{Name: "github.com/gin-gonic/gin", Ecosystem: "golang"},
+			},
+			expectedCPE: v6.PackageSpecifiers{
+				{CPE: &cpe.Attributes{Part: "a", Product: "github.com/gin-gonic/gin", TargetSW: "golang"}},
+			},
+		},
+		{
+			name: "valid npm PURL with scope",
+			input: DBSearchPackages{
+				Packages: []string{"pkg:npm/%40angular/core@1.0.0"},
+			},
+			expectedPkg: v6.PackageSpecifiers{
+				{Name: "@angular/core", Ecosystem: "npm"},
+			},
+			expectedCPE: v6.PackageSpecifiers{
+				{CPE: &cpe.Attributes{Part: "a", Product: "@angular/core", TargetSW: "npm"}},
+			},
+		},
+		{
+			name: "valid maven PURL with group id",
+			input: DBSearchPackages{
+				Packages: []string{"pkg:maven/org.springframework/spring-core@5.3.0"},
+			},
+			expectedPkg: v6.PackageSpecifiers{
+				{Name: "org.springframework:spring-core", Ecosystem: "maven"},
+			},
+			expectedCPE: v6.PackageSpecifiers{
+				{CPE: &cpe.Attributes{Part: "a", Product: "org.springframework:spring-core", TargetSW: "maven"}},
+			},
+		},
+		{
 			name: "plain package name",
 			input: DBSearchPackages{
 				Packages: []string{"package-name"},


### PR DESCRIPTION
## Summary
- `grype db search --pkg` with a namespaced PURL (golang module paths, npm scoped packages, maven group:artifact) was searching by the bare `Name` field only, dropping the `Namespace` that `packageurl-go` splits out during parsing.
- For golang this meant `pkg:golang/github.com/gin-gonic/gin@v1.9.0` searched for `gin` instead of `github.com/gin-gonic/gin`, always returning no results.
- Reconstructs the full name per-ecosystem: `namespace/name` for golang and npm, `namespace:name` for maven (matching how the DB already stores Maven coordinates elsewhere in the build pipeline).

## Test plan
- [x] Added unit test cases for golang, npm-scoped, and maven PURLs in `database_search_packages_test.go`
- [x] `go test ./cmd/grype/cli/options/...` passes
- [x] `go vet` and `gofmt` clean

Fixes #3508