### PR TITLE
fix(db): surface the update error when no DB exists to fall back on

### DIFF
--- a/grype/load_vulnerability_db.go
+++ b/grype/load_vulnerability_db.go
@@ -1,6 +1,7 @@
 package grype
 
 import (
+	"errors"
 	"fmt"
 
 	v6 "github.com/anchore/grype/grype/db/v6"
@@ -20,6 +21,7 @@ func LoadVulnerabilityDB(distCfg v6dist.Config, installCfg v6inst.Config, update
 		return nil, nil, fmt.Errorf("unable to create curator: %w", err)
 	}
 
+	var updateErr error
 	if update {
 		updated, err := c.Update()
 		if err != nil {
@@ -27,6 +29,7 @@ func LoadVulnerabilityDB(distCfg v6dist.Config, installCfg v6inst.Config, update
 				return nil, nil, fmt.Errorf("unable to update db: %w", err)
 			}
 			log.WithFields("error", err).Warn("error updating db")
+			updateErr = err
 		}
 		if !updated {
 			log.Debug("no db update found")
@@ -37,7 +40,7 @@ func LoadVulnerabilityDB(distCfg v6dist.Config, installCfg v6inst.Config, update
 
 	s := c.Status()
 	if s.Error != nil {
-		return nil, nil, s.Error
+		return nil, nil, statusError(s.Error, updateErr)
 	}
 
 	rdr, err := c.Reader()
@@ -46,4 +49,17 @@ func LoadVulnerabilityDB(distCfg v6dist.Config, installCfg v6inst.Config, update
 	}
 
 	return v6.NewVulnerabilityProvider(rdr), &s, nil
+}
+
+// statusError surfaces a prior, non-fatal update error (RequireUpdateCheck is
+// false, so the update failure was only logged as a warning) when the DB
+// status check subsequently fails because there's no DB at all to fall back
+// on. Without this, a first-run update failure is silently discarded and
+// replaced by the much less informative ErrDBDoesNotExist, hiding the actual,
+// actionable cause from anyone not reading debug-level logs.
+func statusError(statusErr, updateErr error) error {
+	if updateErr == nil || !errors.Is(statusErr, v6.ErrDBDoesNotExist) {
+		return statusErr
+	}
+	return fmt.Errorf("%w: %w", statusErr, updateErr)
 }

--- a/grype/load_vulnerability_db_test.go
+++ b/grype/load_vulnerability_db_test.go
@@ -1,0 +1,55 @@
+package grype
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v6 "github.com/anchore/grype/grype/db/v6"
+)
+
+func TestStatusError(t *testing.T) {
+	someOtherErr := errors.New("some other status error")
+
+	tests := []struct {
+		name      string
+		statusErr error
+		updateErr error
+		wantNil   bool
+		wantIs    []error
+	}{
+		{
+			name:      "no update error, DB missing",
+			statusErr: v6.ErrDBDoesNotExist,
+			updateErr: nil,
+			wantIs:    []error{v6.ErrDBDoesNotExist},
+		},
+		{
+			name:      "update error, DB missing -- surfaces the update error",
+			statusErr: v6.ErrDBDoesNotExist,
+			updateErr: errors.New("network timeout while checking for update"),
+			wantIs:    []error{v6.ErrDBDoesNotExist},
+		},
+		{
+			name:      "update error, but status error is unrelated to a missing DB",
+			statusErr: someOtherErr,
+			updateErr: errors.New("network timeout while checking for update"),
+			wantIs:    []error{someOtherErr},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := statusError(tt.statusErr, tt.updateErr)
+			require.Error(t, got)
+			for _, want := range tt.wantIs {
+				assert.ErrorIs(t, got, want)
+			}
+			if tt.updateErr != nil && errors.Is(tt.statusErr, v6.ErrDBDoesNotExist) {
+				assert.ErrorIs(t, got, tt.updateErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- On a first-run scan (no DB downloaded yet), when the update check fails and `RequireUpdateCheck` is false (the default for the scan command), the code only logs the update failure as a `WARN` and falls through to the DB status check.
- Since there's no existing DB to fall back on, `Status()` resolves to the generic `ErrDBDoesNotExist`, and the real, actionable update error is discarded — only visible in a `WARN` log line, not in the final error returned/printed to the user.
- This makes a transient update failure on a fresh install look like an opaque "database does not exist" problem, which is confusing given that a subsequent `grype db update` typically succeeds right after (see #3399).
- Fix: when `Status()` fails specifically because the DB doesn't exist, and there was a prior (warned-but-swallowed) update error, join the two so the underlying cause is part of the returned error instead of being lost.

## Test plan
- [x] Added `TestStatusError` covering: no update error, update error + missing DB (error is surfaced), update error + unrelated status error (update error is not spuriously attached)
- [x] `go test ./grype/...` passes
- [x] `go vet` / `gofmt` clean on changed files

Fixes #3399