### PR TITLE
fix: exclude the distro Go toolchain stdlib module from OS packages

### DIFF
--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -2,9 +2,11 @@ package pkg
 
 import (
 	"fmt"
+	"path"
 	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/anchore/grype/grype/distro"
@@ -256,9 +258,14 @@ func excludePackage(p *Package, parent *Package) bool {
 
 	comprehensiveDistroOwner := distroFeedIsComprehensive(parent.Distro) && isOSPackage(parent)
 
-	// Go module versions describe the embedded modules rather than the owning
-	// distro package, so they cannot be compared to determine ownership.
-	if comprehensiveDistroOwner && p.Type == syftPkg.GoModulePkg {
+	// Go module versions describe the embedded module rather than the owning
+	// distro package, so the version-similarity check below cannot recognize an
+	// owned duplicate. Only treat the module as a duplicate when it appears to
+	// be the distro package's own main module (e.g. the containerd package
+	// owning github.com/containerd/containerd); dependency modules embedded in
+	// the same binaries must stay matchable, since a distro feed does not track
+	// vulnerabilities for a third-party package's vendored dependencies.
+	if comprehensiveDistroOwner && p.Type == syftPkg.GoModulePkg && goModuleIsOwnersMainModule(p.Name, parent.Name) {
 		return true
 	}
 
@@ -320,6 +327,25 @@ var comprehensiveDistros = []distro.Type{
 	distro.Mariner,
 	distro.RedHat,
 	distro.Ubuntu,
+}
+
+// goModuleIsOwnersMainModule indicates whether a Go module found within an OS
+// package's files appears to be that package's own main module rather than an
+// embedded dependency. The comparison is based on the module path's base name
+// (accounting for /vN major-version suffixes), e.g. the "containerd" package
+// matches "github.com/containerd/containerd". The Go standard library
+// ("stdlib") is only considered owned by a distro's Go toolchain package.
+func goModuleIsOwnersMainModule(modulePath, packageName string) bool {
+	if modulePath == "stdlib" {
+		return strings.EqualFold(packageName, "go") || strings.EqualFold(packageName, "golang")
+	}
+	base := path.Base(modulePath)
+	if len(base) > 1 && base[0] == 'v' {
+		if _, err := strconv.Atoi(base[1:]); err == nil {
+			base = path.Base(path.Dir(modulePath))
+		}
+	}
+	return strings.EqualFold(base, packageName)
 }
 
 func isOSPackage(p *Package) bool {

--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -254,6 +254,14 @@ func excludePackage(p *Package, parent *Package) bool {
 	// python      3.9.2      binary
 	// python3.9   3.9.2-1    deb
 
+	comprehensiveDistroOwner := distroFeedIsComprehensive(parent.Distro) && isOSPackage(parent)
+
+	// Go module versions describe the embedded modules rather than the owning
+	// distro package, so they cannot be compared to determine ownership.
+	if comprehensiveDistroOwner && p.Type == syftPkg.GoModulePkg {
+		return true
+	}
+
 	// If the version is not approximately the same, keep both
 	if !strings.HasPrefix(parent.Version, p.Version) && !strings.HasPrefix(p.Version, parent.Version) {
 		return false
@@ -263,7 +271,7 @@ func excludePackage(p *Package, parent *Package) bool {
 	// for distros that have a comprehensive feed. That is, distros that list
 	// vulnerabilities that aren't fixed. Otherwise, the child package might
 	// be needed for matching.
-	if distroFeedIsComprehensive(parent.Distro) && isOSPackage(parent) && !isOSPackage(p) {
+	if comprehensiveDistroOwner && !isOSPackage(p) {
 		return true
 	}
 

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -1523,11 +1523,18 @@ func Test_RemovePackagesByOverlap(t *testing.T) {
 			expectedPackages: []string{"rpm:python3-rpm@4.14.3-26.el8"},
 		},
 		{
-			name: "distro package owns a Go module with a different version",
+			name: "distro package owns its own Go main module with a different version",
 			sbom: withLinuxRelease(catalogWithOverlaps(
 				[]string{"deb:containerd@1.7.24~ds1-4ubuntu1", "go-module:github.com/containerd/containerd@1.7.22"},
 				[]string{"deb:containerd@1.7.24~ds1-4ubuntu1 -> go-module:github.com/containerd/containerd@1.7.22"}), "ubuntu"),
 			expectedPackages: []string{"deb:containerd@1.7.24~ds1-4ubuntu1"},
+		},
+		{
+			name: "distro package keeps embedded dependency Go modules",
+			sbom: withLinuxRelease(catalogWithOverlaps(
+				[]string{"deb:gitlab-ce@15.6.1-ce.0", "go-module:golang.org/x/crypto@v0.0.0-20220525230936-793ad666bf5e"},
+				[]string{"deb:gitlab-ce@15.6.1-ce.0 -> go-module:golang.org/x/crypto@v0.0.0-20220525230936-793ad666bf5e"}), "ubuntu"),
+			expectedPackages: []string{"deb:gitlab-ce@15.6.1-ce.0", "go-module:golang.org/x/crypto@v0.0.0-20220525230936-793ad666bf5e"},
 		},
 		{
 			name: "amzn linux doesn't remove packages in this way",

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -1523,6 +1523,13 @@ func Test_RemovePackagesByOverlap(t *testing.T) {
 			expectedPackages: []string{"rpm:python3-rpm@4.14.3-26.el8"},
 		},
 		{
+			name: "distro package owns a Go module with a different version",
+			sbom: withLinuxRelease(catalogWithOverlaps(
+				[]string{"deb:containerd@1.7.24~ds1-4ubuntu1", "go-module:github.com/containerd/containerd@1.7.22"},
+				[]string{"deb:containerd@1.7.24~ds1-4ubuntu1 -> go-module:github.com/containerd/containerd@1.7.22"}), "ubuntu"),
+			expectedPackages: []string{"deb:containerd@1.7.24~ds1-4ubuntu1"},
+		},
+		{
 			name: "amzn linux doesn't remove packages in this way",
 			sbom: withLinuxRelease(catalogWithOverlaps(
 				[]string{"rpm:python3-rpm@4.14.3-26.el8", "python:rpm@4.14.3"},


### PR DESCRIPTION
## Summary

- exclude an embedded Go module when a comprehensive distro package owns it
- add a regression case for a distro package and Go module whose versions differ

## Why

The overlap relationship already establishes that the distro package owns the embedded Go module. The previous version-prefix check ran before the comprehensive-distro ownership rule, so a legitimate owned module was retained when its module version differed from the distro package version.

This can leave duplicate package representations available for vulnerability matching even though the OS package is the authoritative representation.

## Validation

- `git diff --check`
- `go test ./grype/pkg` was attempted with `golang:1.26.3`; dependency downloads failed with upstream TLS handshake timeouts before the test package could run