### PR TITLE
Ensure channel parsing is consistent

### DIFF
--- a/grype/distro/distro.go
+++ b/grype/distro/distro.go
@@ -131,12 +131,23 @@ func ParseDistroString(s string) (name, version string) {
 
 // NewFromNameVersion creates a new Distro object derived from the provided name and version
 func NewFromNameVersion(name, version string) *Distro {
+	// separate any channel suffix before the codename heuristic below. Without this a value like
+	// "jammy+esm" is swallowed whole into the codename, which matches no OS record and silently
+	// yields zero results.
+	base, channels, hasChannels := strings.Cut(version, "+")
+
 	var codename string
 
 	// if there are no digits in the version, it is likely a codename
-	if !strings.ContainsAny(version, "0123456789") {
-		codename = version
-		version = ""
+	if !strings.ContainsAny(base, "0123456789") {
+		codename = base
+		base = ""
+	}
+
+	if hasChannels {
+		// re-attach the suffix so that channel splitting stays in parseVersion alone. When the base
+		// was a codename this leaves a bare "+esm", which parseVersion handles as an empty version.
+		base += "+" + channels
 	}
 
 	typ := IDMapping[name]
@@ -144,7 +155,7 @@ func NewFromNameVersion(name, version string) *Distro {
 		typ = Type(name)
 	}
 
-	return New(typ, version, codename, string(typ))
+	return New(typ, base, codename, string(typ))
 }
 
 // FromRelease attempts to get a distro from the linux release, only logging any errors

--- a/grype/distro/distro_test.go
+++ b/grype/distro/distro_test.go
@@ -873,3 +873,91 @@ func Test_NewFromRelease_shortVersionIDNoPanic(t *testing.T) {
 		})
 	}
 }
+
+// Test_NewFromNameVersion_channels covers the user-supplied distro string forms that reach this
+// constructor: the --distro flag, the purl "distro" qualifier, and grype db search --distro. A
+// channel suffix must survive regardless of whether the version part is a number or a codename.
+func Test_NewFromNameVersion_channels(t *testing.T) {
+	tests := []struct {
+		name             string
+		distroName       string
+		version          string
+		expectedVersion  string
+		expectedCodename string
+		expectedChannels []string
+	}{
+		{
+			name:            "version only",
+			distroName:      "ubuntu",
+			version:         "22.04",
+			expectedVersion: "22.04",
+		},
+		{
+			name:             "version with channel",
+			distroName:       "ubuntu",
+			version:          "22.04+esm",
+			expectedVersion:  "22.04",
+			expectedChannels: []string{"esm"},
+		},
+		{
+			name:             "codename only",
+			distroName:       "ubuntu",
+			version:          "jammy",
+			expectedCodename: "jammy",
+		},
+		{
+			// the regression: "jammy+esm" used to become the codename verbatim, dropping the channel
+			// and matching no OS record at all
+			name:             "codename with channel",
+			distroName:       "ubuntu",
+			version:          "jammy+esm",
+			expectedCodename: "jammy",
+			expectedChannels: []string{"esm"},
+		},
+		{
+			name:             "codename with multiple channels",
+			distroName:       "ubuntu",
+			version:          "jammy+esm,other",
+			expectedCodename: "jammy",
+			expectedChannels: []string{"esm", "other"},
+		},
+		{
+			name:             "version with multiple channels",
+			distroName:       "ubuntu",
+			version:          "22.04+esm+other",
+			expectedVersion:  "22.04",
+			expectedChannels: []string{"esm", "other"},
+		},
+		{
+			name:             "rhel eus",
+			distroName:       "rhel",
+			version:          "9+eus",
+			expectedVersion:  "9",
+			expectedChannels: []string{"eus"},
+		},
+		{
+			name:             "bare channel with no version",
+			distroName:       "ubuntu",
+			version:          "+esm",
+			expectedChannels: []string{"esm"},
+		},
+		{
+			name:       "empty version",
+			distroName: "ubuntu",
+			version:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewFromNameVersion(tt.distroName, tt.version)
+
+			require.NotNil(t, d)
+			assert.Equal(t, tt.expectedVersion, d.Version, "unexpected version")
+			assert.Equal(t, tt.expectedCodename, d.Codename, "unexpected codename")
+			if d := cmp.Diff(tt.expectedChannels, d.Channels, cmpopts.EquateEmpty()); d != "" {
+				assert.Fail(t, "unexpected channels", d)
+			}
+		})
+	}
+}

--- a/grype/distro/fix_channel.go
+++ b/grype/distro/fix_channel.go
@@ -113,11 +113,17 @@ func applyChannels(release linux.Release, ver *version.Version, existingChannels
 				log.WithFields("error", err, "constraint", channel.Versions).Debugf("unable to determine if channel %q is applicable for distro %q with version %q", channel.Name, release.ID, ver)
 				continue
 			}
-			if isApplicable {
-				log.Debugf("using channel %q for distro %q with version %q", channel.Name, release.ID, ver)
-				addResult(channel.Name, extendedSupport, channel.Apply)
+			if !isApplicable {
+				// the channel has a version window and this distro falls outside it, so the channel
+				// does not apply. Falling through here would add it anyway, contradicting the same
+				// check in pkg.applyChannelsToDistro.
+				log.Debugf("skipping channel %q for distro %q with version %q, outside the channel version window", channel.Name, release.ID, ver)
 				continue
 			}
+
+			log.Debugf("using channel %q for distro %q with version %q", channel.Name, release.ID, ver)
+			addResult(channel.Name, extendedSupport, channel.Apply)
+			continue
 		}
 		log.Debugf("using channel %q for distro %q", channel.Name, release.ID)
 		addResult(channel.Name, extendedSupport, channel.Apply)

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -1645,7 +1645,7 @@ func Test_ExcludeRetainsCorrectRelationships(t *testing.T) {
 
 	d := distro.FromRelease(s.Artifacts.LinuxDistribution, nil)
 	pkgs := FromCollection(s.Artifacts.Packages, s.Relationships, SynthesisConfig{},
-		setDistroFromPURL(func(d *distro.Distro) bool { return true }),
+		setDistroFromPURL(func(d *distro.Distro) {}),
 		func(out *Package, _ packageurl.PackageURL, _ syftPkg.Package) {
 			if out.Type == syftPkg.ApkPkg {
 				out.Distro = d

--- a/grype/pkg/provider.go
+++ b/grype/pkg/provider.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v2"
@@ -169,28 +170,62 @@ func buildChannelIndex(channels []distro.FixChannel) map[string]distro.FixChanne
 	return idx
 }
 
-func getDistroChannelApplier(channels []distro.FixChannel) func(d *distro.Distro) bool {
+func getDistroChannelApplier(channels []distro.FixChannel) func(d *distro.Distro) {
 	idx := buildChannelIndex(channels)
 
-	return func(d *distro.Distro) bool {
+	return func(d *distro.Distro) {
 		if d == nil {
-			return false
+			return
 		}
 
 		id := strings.ToLower(d.ID())
 		channels, ok := idx[id]
 		if !ok {
-			return false
+			// no channels are configured for this distro, so any channel it carries (e.g. from a
+			// user-supplied --distro string) cannot be honored. Leaving it in place would send an
+			// unsatisfiable channel into the search, which returns nothing and reads like a clean scan.
+			warnRejectedChannels(d, channelSet(d.Channels), nil)
+			d.Channels = nil
+			return
 		}
 
-		return applyChannelsToDistro(d, channels)
+		applyChannelsToDistro(d, channels)
 	}
 }
 
+// channelSet normalizes channel names into a set for comparison. Channel names are matched
+// case-insensitively, consistent with the matchers (see dpkg.shouldUseUbuntuESMMatching) and with
+// distro.FixChannels.Get.
+func channelSet(channels []string) *strset.Set {
+	s := strset.New()
+	for _, c := range channels {
+		if n := strings.ToLower(strings.TrimSpace(c)); n != "" {
+			s.Add(n)
+		}
+	}
+	return s
+}
+
+// warnRejectedChannels reports any fix channel that was requested but will not be applied. A request
+// grype cannot honor must never be silently ignored: the result is always fewer vulnerabilities than
+// reality, which is the one direction a scanner cannot afford to be quiet about.
+func warnRejectedChannels(d *distro.Distro, requested *strset.Set, applied []string) {
+	rejected := strset.Difference(requested, channelSet(applied))
+	if rejected.IsEmpty() {
+		return
+	}
+
+	names := rejected.List()
+	sort.Strings(names)
+
+	log.WithFields("distro", d.Type, "channels", strings.Join(names, ", ")).
+		Warn("ignoring requested fix channel(s) that are unavailable or disabled for this distro")
+}
+
 // applyChannelsToDistro applies fix channels to a distro based on channel configuration
-func applyChannelsToDistro(d *distro.Distro, channels distro.FixChannels) bool {
+func applyChannelsToDistro(d *distro.Distro, channels distro.FixChannels) {
 	var result []string
-	existing := strset.New(d.Channels...)
+	existing := channelSet(d.Channels)
 	ver := version.New(d.Version, version.SemanticFormat)
 
 	shouldReview := func(channel distro.FixChannel) bool {
@@ -205,7 +240,6 @@ func applyChannelsToDistro(d *distro.Distro, channels distro.FixChannels) bool {
 		return true
 	}
 
-	var modified bool
 	for _, channel := range channels {
 		if channel.Name == "" {
 			continue
@@ -218,27 +252,25 @@ func applyChannelsToDistro(d *distro.Distro, channels distro.FixChannels) bool {
 
 		switch channel.Apply {
 		case distro.ChannelNeverEnabled:
-			if existing.Has(channel.Name) {
-				modified = true
-			}
+			// never applied, regardless of what was requested
 		case distro.ChannelAlwaysEnabled:
 			result = append(result, channel.Name)
-			if !existing.Has(channel.Name) {
-				modified = true
-			}
 		case distro.ChannelConditionallyEnabled:
-			if existing.Has(channel.Name) {
+			if existing.Has(strings.ToLower(channel.Name)) {
+				// note: the configured spelling is kept, not the requested one, so that a request
+				// like "+ESM" is normalized to "esm" for the search and for display
 				result = append(result, channel.Name)
 			}
 		}
 	}
 
+	warnRejectedChannels(d, existing, result)
+
 	d.Channels = result
-	return modified
 }
 
 // Provide a set of packages and context metadata describing where they were sourced from.
-func provide(userInput string, config ProviderConfig, applyChannel func(d *distro.Distro) bool) ([]*Package, Context, *sbom.SBOM, error) {
+func provide(userInput string, config ProviderConfig, applyChannel func(d *distro.Distro)) ([]*Package, Context, *sbom.SBOM, error) {
 	packages, ctx, s, err := purlProvider(userInput, config, applyChannel)
 	if !errors.Is(err, errDoesNotProvide) {
 		log.WithFields("input", userInput).Trace("interpreting input as one or more PURLs")

--- a/grype/pkg/provider_test.go
+++ b/grype/pkg/provider_test.go
@@ -386,6 +386,43 @@ func Test_getDistroChannelApplier(t *testing.T) {
 			distro: defaultOSGen,
 			want:   nil,
 		},
+		{
+			// a distro with no configured channels means no channel is valid for it. Leaving a
+			// requested channel in place would reach the OS specifier, match no record, and silently
+			// report zero vulnerabilities.
+			name:     "channel on a distro with no configured channels is cleared",
+			channels: distro.DefaultFixChannels(),
+			distro: func() *distro.Distro {
+				return distro.NewFromNameVersion("debian", "11+esm")
+			},
+			want: nil,
+		},
+		{
+			name:     "arbitrary channel on an unconfigured distro is cleared",
+			channels: distro.DefaultFixChannels(),
+			distro: func() *distro.Distro {
+				return distro.NewFromNameVersion("alpine", "3.20+anything")
+			},
+			want: nil,
+		},
+		{
+			// centos is not in the EUS channel's IDs, but it aliases toward RHEL data at search time,
+			// so a surviving channel here yields a partial result set rather than an obvious zero
+			name:     "eus on centos is cleared",
+			channels: distro.DefaultFixChannels(),
+			distro: func() *distro.Distro {
+				return distro.NewFromNameVersion("centos", "9+eus")
+			},
+			want: nil,
+		},
+		{
+			name:     "ubuntu esm on a codename survives",
+			channels: distro.DefaultFixChannels(),
+			distro: func() *distro.Distro {
+				return distro.NewFromNameVersion("ubuntu", "jammy+esm")
+			},
+			want: []string{"esm"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -404,11 +441,10 @@ func Test_getDistroChannelApplier(t *testing.T) {
 
 func Test_applyChannelsToDistro(t *testing.T) {
 	tests := []struct {
-		name             string
-		distro           func() *distro.Distro
-		channels         distro.FixChannels
-		expectedResult   []string
-		expectedModified bool
+		name           string
+		distro         func() *distro.Distro
+		channels       distro.FixChannels
+		expectedResult []string
 	}{
 		{
 			name:   "always enabled channel adds new channel",
@@ -419,8 +455,7 @@ func Test_applyChannelsToDistro(t *testing.T) {
 					Apply: distro.ChannelAlwaysEnabled,
 				},
 			},
-			expectedResult:   []string{"eus"},
-			expectedModified: true,
+			expectedResult: []string{"eus"},
 		},
 		{
 			name: "always enabled channel keeps existing channel",
@@ -435,8 +470,7 @@ func Test_applyChannelsToDistro(t *testing.T) {
 					Apply: distro.ChannelAlwaysEnabled,
 				},
 			},
-			expectedResult:   []string{"eus"},
-			expectedModified: false,
+			expectedResult: []string{"eus"},
 		},
 		{
 			name: "conditionally enabled channel keeps existing channel",
@@ -451,8 +485,7 @@ func Test_applyChannelsToDistro(t *testing.T) {
 					Apply: distro.ChannelConditionallyEnabled,
 				},
 			},
-			expectedResult:   []string{"eus"},
-			expectedModified: false,
+			expectedResult: []string{"eus"},
 		},
 		{
 			name:   "conditionally enabled channel does not add missing channel",
@@ -463,8 +496,7 @@ func Test_applyChannelsToDistro(t *testing.T) {
 					Apply: distro.ChannelConditionallyEnabled,
 				},
 			},
-			expectedResult:   []string{},
-			expectedModified: false,
+			expectedResult: []string{},
 		},
 		{
 			name: "never enabled channel removes existing channel",
@@ -479,8 +511,7 @@ func Test_applyChannelsToDistro(t *testing.T) {
 					Apply: distro.ChannelNeverEnabled,
 				},
 			},
-			expectedResult:   []string{},
-			expectedModified: true,
+			expectedResult: []string{},
 		},
 		{
 			name:   "never enabled channel with no existing channel",
@@ -491,8 +522,7 @@ func Test_applyChannelsToDistro(t *testing.T) {
 					Apply: distro.ChannelNeverEnabled,
 				},
 			},
-			expectedResult:   []string{},
-			expectedModified: false,
+			expectedResult: []string{},
 		},
 		{
 			name:   "empty channel name is skipped",
@@ -507,8 +537,7 @@ func Test_applyChannelsToDistro(t *testing.T) {
 					Apply: distro.ChannelAlwaysEnabled,
 				},
 			},
-			expectedResult:   []string{"eus"},
-			expectedModified: true,
+			expectedResult: []string{"eus"},
 		},
 		{
 			name:   "version constraint allows channel",
@@ -520,8 +549,7 @@ func Test_applyChannelsToDistro(t *testing.T) {
 					Versions: version.MustGetConstraint(">= 8.0", version.SemanticFormat),
 				},
 			},
-			expectedResult:   []string{"eus"},
-			expectedModified: true,
+			expectedResult: []string{"eus"},
 		},
 		{
 			name:   "version constraint blocks channel",
@@ -533,8 +561,7 @@ func Test_applyChannelsToDistro(t *testing.T) {
 					Versions: version.MustGetConstraint(">= 8.0", version.SemanticFormat),
 				},
 			},
-			expectedResult:   []string{},
-			expectedModified: false,
+			expectedResult: []string{},
 		},
 		{
 			name: "multiple channels with different behaviors",
@@ -557,8 +584,7 @@ func Test_applyChannelsToDistro(t *testing.T) {
 					Apply: distro.ChannelNeverEnabled,
 				},
 			},
-			expectedResult:   []string{"eus", "main"},
-			expectedModified: true,
+			expectedResult: []string{"eus", "main"},
 		},
 		{
 			name:   "invalid version string defaults to allowing channel",
@@ -570,8 +596,68 @@ func Test_applyChannelsToDistro(t *testing.T) {
 					Versions: version.MustGetConstraint(">= 8.0", version.SemanticFormat),
 				},
 			},
-			expectedResult:   []string{"eus"},
-			expectedModified: true,
+			expectedResult: []string{"eus"},
+		},
+		{
+			// channel names are matched case-insensitively, consistent with the matchers; the
+			// configured spelling wins so the search and the output both see "eus"
+			name:   "requested channel matches configured name regardless of case",
+			distro: func() *distro.Distro { return distro.NewFromNameVersion("rhel", "9+EUS") },
+			channels: distro.FixChannels{
+				{
+					Name:  "eus",
+					Apply: distro.ChannelConditionallyEnabled,
+				},
+			},
+			expectedResult: []string{"eus"},
+		},
+		{
+			name:   "requested channel with surrounding whitespace is matched",
+			distro: func() *distro.Distro { return distro.NewFromNameVersion("rhel", "9+ eus ") },
+			channels: distro.FixChannels{
+				{
+					Name:  "eus",
+					Apply: distro.ChannelConditionallyEnabled,
+				},
+			},
+			expectedResult: []string{"eus"},
+		},
+		{
+			name:   "unrecognized channel is dropped",
+			distro: func() *distro.Distro { return distro.NewFromNameVersion("rhel", "9+bogus") },
+			channels: distro.FixChannels{
+				{
+					Name:  "eus",
+					Apply: distro.ChannelConditionallyEnabled,
+				},
+			},
+			expectedResult: []string{},
+		},
+		{
+			// a channel that is real but belongs to a different distro must not leak through
+			name:   "channel from another distro is dropped",
+			distro: func() *distro.Distro { return distro.NewFromNameVersion("ubuntu", "16.04+eus") },
+			channels: distro.FixChannels{
+				{
+					Name:  "esm",
+					Apply: distro.ChannelConditionallyEnabled,
+				},
+			},
+			expectedResult: []string{},
+		},
+		{
+			// requesting a channel outside its version window drops it, rather than passing an
+			// unsatisfiable channel into the search
+			name:   "requested channel outside the version window is dropped",
+			distro: func() *distro.Distro { return distro.NewFromNameVersion("rhel", "7+eus") },
+			channels: distro.FixChannels{
+				{
+					Name:     "eus",
+					Apply:    distro.ChannelConditionallyEnabled,
+					Versions: version.MustGetConstraint(">= 8.0", version.SemanticFormat),
+				},
+			},
+			expectedResult: []string{},
 		},
 	}
 
@@ -579,12 +665,11 @@ func Test_applyChannelsToDistro(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			d := tt.distro()
 
-			modified := applyChannelsToDistro(d, tt.channels)
+			applyChannelsToDistro(d, tt.channels)
 
 			if d := cmp.Diff(tt.expectedResult, d.Channels, cmpopts.EquateEmpty()); d != "" {
 				t.Errorf("applyChannelsToDistro() mismatch (-want +got):\n%s", d)
 			}
-			assert.Equal(t, tt.expectedModified, modified)
 		})
 	}
 }

--- a/grype/pkg/purl_provider.go
+++ b/grype/pkg/purl_provider.go
@@ -23,11 +23,11 @@ type PURLLiteralMetadata struct {
 	PURL string
 }
 
-func purlEnhancers(applyChannel func(*distro.Distro) bool) []Enhancer {
+func purlEnhancers(applyChannel func(*distro.Distro)) []Enhancer {
 	return []Enhancer{setUpstreamsFromPURL, setDistroFromPURL(applyChannel)}
 }
 
-func purlProvider(userInput string, config ProviderConfig, applyChannel func(*distro.Distro) bool) ([]*Package, Context, *sbom.SBOM, error) {
+func purlProvider(userInput string, config ProviderConfig, applyChannel func(*distro.Distro)) ([]*Package, Context, *sbom.SBOM, error) {
 	reader, ctx, err := getPurlReader(userInput)
 	if err != nil {
 		return nil, Context{}, nil, err
@@ -74,7 +74,7 @@ func upstreamsFromPURL(purl packageurl.PackageURL, pkgType syftPkg.Type) (upstre
 	return upstreams
 }
 
-func setDistroFromPURL(applyChannel func(*distro.Distro) bool) func(out *Package, purl packageurl.PackageURL, _ syftPkg.Package) {
+func setDistroFromPURL(applyChannel func(*distro.Distro)) func(out *Package, purl packageurl.PackageURL, _ syftPkg.Package) {
 	return func(out *Package, purl packageurl.PackageURL, _ syftPkg.Package) {
 		if out.Distro == nil {
 			out.Distro = distroFromPURL(purl)

--- a/grype/pkg/syft_provider.go
+++ b/grype/pkg/syft_provider.go
@@ -15,7 +15,7 @@ import (
 	"github.com/anchore/syft/syft/source/sourceproviders"
 )
 
-func syftProvider(userInput string, config ProviderConfig, applyChannel func(*distro.Distro) bool) ([]*Package, Context, *sbom.SBOM, error) {
+func syftProvider(userInput string, config ProviderConfig, applyChannel func(*distro.Distro)) ([]*Package, Context, *sbom.SBOM, error) {
 	src, err := getSource(userInput, config)
 	if err != nil {
 		return nil, Context{}, nil, err
@@ -45,7 +45,7 @@ func syftProvider(userInput string, config ProviderConfig, applyChannel func(*di
 	return packages, pkgCtx, s, nil
 }
 
-func distroFromSBOM(s *sbom.SBOM, config ProviderConfig, applyChannel func(*distro.Distro) bool) (d *distro.Distro, detectionFailed bool) {
+func distroFromSBOM(s *sbom.SBOM, config ProviderConfig, applyChannel func(*distro.Distro)) (d *distro.Distro, detectionFailed bool) {
 	if config.Distro.Override != nil {
 		d = config.Distro.Override
 	} else {

--- a/grype/pkg/syft_sbom_provider.go
+++ b/grype/pkg/syft_sbom_provider.go
@@ -23,7 +23,7 @@ type SBOMFileMetadata struct {
 	Path string
 }
 
-func syftSBOMProvider(userInput string, config ProviderConfig, applyChannel func(*distro.Distro) bool) ([]*Package, Context, *sbom.SBOM, error) {
+func syftSBOMProvider(userInput string, config ProviderConfig, applyChannel func(*distro.Distro)) ([]*Package, Context, *sbom.SBOM, error) {
 	s, fmtID, path, err := getSBOM(userInput)
 	if err != nil {
 		return nil, Context{}, nil, err
@@ -50,7 +50,7 @@ func syftSBOMProvider(userInput string, config ProviderConfig, applyChannel func
 	}, s, nil
 }
 
-func syftSBOMProviderFromReader(reader io.ReadSeeker, config ProviderConfig, applyChannel func(*distro.Distro) bool) ([]*Package, Context, *sbom.SBOM, error) {
+func syftSBOMProviderFromReader(reader io.ReadSeeker, config ProviderConfig, applyChannel func(*distro.Distro)) ([]*Package, Context, *sbom.SBOM, error) {
 	s, fmtID, err := readSBOM(reader)
 	if err != nil {
 		return nil, Context{}, nil, err

--- a/grype/pkg/zarf_provider.go
+++ b/grype/pkg/zarf_provider.go
@@ -39,7 +39,7 @@ type ZarfPackageMetadata struct {
 	Path string
 }
 
-func zarfProvider(userInput string, config ProviderConfig, applyChannel func(*distro.Distro) bool) ([]*Package, Context, *sbom.SBOM, error) {
+func zarfProvider(userInput string, config ProviderConfig, applyChannel func(*distro.Distro)) ([]*Package, Context, *sbom.SBOM, error) {
 	if !strings.HasPrefix(userInput, zarfInputPrefix) {
 		return nil, Context{}, nil, errDoesNotProvide
 	}
@@ -64,7 +64,7 @@ func zarfProvider(userInput string, config ProviderConfig, applyChannel func(*di
 
 // readZarfPackage opens a Zarf .tar.zst archive, locates sboms.tar within it,
 // and decodes each SBOM entry into a merged package list.
-func readZarfPackage(archivePath string, config ProviderConfig, applyChannel func(*distro.Distro) bool) ([]*Package, *sbom.SBOM, error) {
+func readZarfPackage(archivePath string, config ProviderConfig, applyChannel func(*distro.Distro)) ([]*Package, *sbom.SBOM, error) {
 	f, err := os.Open(archivePath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to open Zarf package %s: %w", archivePath, err)
@@ -103,7 +103,7 @@ func readZarfPackage(archivePath string, config ProviderConfig, applyChannel fun
 
 // readSBOMsFromTar iterates over entries in sboms.tar, decoding each SBOM
 // and merging all packages into a single result set.
-func readSBOMsFromTar(r io.Reader, config ProviderConfig, applyChannel func(*distro.Distro) bool) ([]*Package, *sbom.SBOM, error) {
+func readSBOMsFromTar(r io.Reader, config ProviderConfig, applyChannel func(*distro.Distro)) ([]*Package, *sbom.SBOM, error) {
 	sbomTar := tar.NewReader(r)
 
 	var allPackages []*Package


### PR DESCRIPTION
Fixes a handful of ways a requested fix channel could get silently dropped, or silently passed through to a search that matches nothing:

- `--distro ubuntu:jammy+esm` returned zero matches. `NewFromNameVersion` decided "this looks like a codename" before splitting off the channel suffix, so the whole `jammy+esm` string became the codename and the channel was lost. Hits any codename, and applies equally to the purl `?distro=` qualifier and `grype db search`.

- `--distro debian:11+esm` returned zero matches, and `centos:9+eus` returned 16 instead of 72. Distros with no configured channels were skipping channel normalization entirely, so an unusable channel rode all the way into the OS specifier. Those channels now get cleared.

- `+ESM` and `+EUS` were silently ignored. The configured spelling now wins, so `+ESM` normalizes to `esm` for the search and for display.

- When a channel can't be honored grype now says so rather than quietly returning fewer results:
  `WARN ignoring requested fix channel(s) that are unavailable or disabled for this distro channels=esm distro=debian`

Also drops the `bool` return from the channel applier since it was ignored at every call site, and fixes a fall-through in `distro.applyChannels` that added a channel even when the distro fell outside that channel's version window, which contradicted the same check in `applyChannelsToDistro`.