### PR TITLE
fix(java): match explicitly declared CPEs

### DIFF
--- a/grype/matcher/java/matcher.go
+++ b/grype/matcher/java/matcher.go
@@ -12,6 +12,7 @@ import (
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal/log"
+	"github.com/anchore/syft/syft/cpe"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
@@ -76,7 +77,38 @@ func (m *Matcher) Match(store vulnerability.Provider, p pkg.Package) ([]match.Ma
 	matches = append(matches, criteriaMatches...)
 	ignores = append(ignores, ignored...)
 
+	if !m.cfg.UseCPEs {
+		declaredMatches, declaredIgnores, err := m.matchDeclaredCPEs(store, p)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to match by declared CPE: %w", err)
+		}
+		matches = append(matches, declaredMatches...)
+		ignores = append(ignores, declaredIgnores...)
+	}
+
 	return matches, ignores, nil
+}
+
+// matchDeclaredCPEs preserves Java's default protection against false positives
+// from generated CPEs while honoring CPEs explicitly supplied by an input SBOM.
+func (m *Matcher) matchDeclaredCPEs(store vulnerability.Provider, p pkg.Package) ([]match.Match, []match.IgnoreFilter, error) {
+	var declared []cpe.CPE
+	for _, candidate := range p.CPEs {
+		if candidate.Source == cpe.DeclaredSource {
+			declared = append(declared, candidate)
+		}
+	}
+	if len(declared) == 0 {
+		return nil, nil, nil
+	}
+
+	originalPackage := p
+	p.CPEs = declared
+	matches, ignores, err := internal.MatchPackageByCPEs(store, p, m.Type())
+	for i := range matches {
+		matches[i].Package = originalPackage
+	}
+	return matches, ignores, err
 }
 
 func (m *Matcher) matchUpstreamMavenPackages(store vulnerability.Provider, p pkg.Package) ([]match.Match, []match.IgnoreFilter, error) {

--- a/grype/matcher/java/matcher_test.go
+++ b/grype/matcher/java/matcher_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/internal/dbtest"
+	"github.com/anchore/syft/syft/cpe"
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
@@ -20,6 +21,61 @@ func springPackage(metadata pkg.JavaMetadata) pkg.Package {
 		WithLanguage(syftPkg.Java).
 		WithMetadata(metadata).
 		Build()
+}
+
+func TestMatcherJava_DeclaredCPEs(t *testing.T) {
+	const opensslCPE = "cpe:2.3:a:openssl:openssl:1.1.1k:*:*:*:*:*:*:*"
+
+	tests := []struct {
+		name          string
+		source        cpe.Source
+		useCPEs       bool
+		expectMatches bool
+	}{
+		{
+			name:          "declared CPE is honored by default",
+			source:        cpe.DeclaredSource,
+			expectMatches: true,
+		},
+		{
+			name:   "generated CPE remains disabled by default",
+			source: cpe.GeneratedSource,
+		},
+		{
+			name:          "generated CPE is honored when CPE matching is enabled",
+			source:        cpe.GeneratedSource,
+			useCPEs:       true,
+			expectMatches: true,
+		},
+	}
+
+	dbtest.SharedDBs(t, "all").
+		SelectOnly("CVE-2024-0727").
+		Run(func(t *testing.T, db *dbtest.DB) {
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					p := dbtest.NewPackage("org.openssl.openssl", "1.1.1k", syftPkg.JavaPkg).
+						WithLanguage(syftPkg.Java).
+						WithPURL("pkg:maven/org.openssl/openssl@1.1.1k").
+						WithMetadata(pkg.JavaMetadata{
+							PomArtifactID: "openssl",
+							PomGroupID:    "org.openssl",
+						}).
+						Build()
+					p.CPEs = []cpe.CPE{cpe.Must(opensslCPE, test.source)}
+
+					findings := db.Match(t, NewJavaMatcher(MatcherConfig{UseCPEs: test.useCPEs}), p)
+					if !test.expectMatches {
+						findings.IsEmpty()
+						return
+					}
+					findings.
+						SelectMatch("CVE-2024-0727").
+						SelectDetailByType(match.CPEMatch).
+						AsCPESearch()
+				})
+			}
+		})
 }
 
 // TestMatcherJava_matchUpstreamMavenPackage exercises the


### PR DESCRIPTION
## Summary

- honor CPEs explicitly declared by an input SBOM when matching Java/Maven packages
- keep generated CPE matching disabled by default for Java to preserve the existing false-positive protection
- preserve the full original package in emitted matches

This fixes the gap where a CycloneDX Maven component could contain an authoritative cpe field, but Grype skipped the NVD lookup solely because Java CPE matching defaults to off. The fallback filters by cpe.DeclaredSource, so Syft-generated CPEs still require match.java.using-cpes: true.

Fixes #3594

## Testing

- go test ./grype/matcher/java -count=1
- go test ./grype/matcher/internal ./grype/matcher/java -count=1
- regression coverage verifies declared CPEs match by default, generated CPEs do not, and generated CPEs still match when explicitly enabled
