### PR TITLE
ci: let a failed SBOM step fail the release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,7 +102,6 @@ jobs:
           GITHUB_BREW_TOKEN: ${{ secrets.ANCHOREOPS_GITHUB_OSS_WRITE_TOKEN }}
 
       - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-        continue-on-error: true
         with:
           artifact-name: sbom.spdx.json
 


### PR DESCRIPTION
Hi, and thanks for Grype.

In `.github/workflows/release.yaml`, the SBOM step at the end of the `release` job is marked `continue-on-error: true`:

```yaml
      - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
        continue-on-error: true
        with:
          artifact-name: sbom.spdx.json
```

It runs after the release itself has been created, so if it fails the release is already published — and the run stays green. The result is a release without `sbom.spdx.json` attached, with nothing in the workflow saying so. You would find out by looking at the release assets afterwards.

I am conscious that you know this ground far better than I do, and that removing the flag is a trade-off rather than an obvious win: if the step has been flaky, blocking a release on it may well be worse than shipping and re-attaching the SBOM by hand. This PR takes the simple option — deleting the one line so a failed SBOM fails the job — but if you would rather keep the resilience, a small alternative is to leave `continue-on-error` in place and add a check afterwards that emits `::warning::` (or fails) when the expected asset is missing, so at least the gap is visible in the run. Happy to switch this PR to that shape instead.

Single deleted line; nothing else in the workflow is touched.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the release job myself.
