### PR TITLE
fix: replace panic with error return in range.go Satisfied method

### DIFF
--- a/grype/version/range.go
+++ b/grype/version/range.go
@@ -70,20 +70,20 @@ func trimQuotes(s string) (string, error) {
 	}
 }
 
-func (c *rangeUnit) Satisfied(comparison int) bool {
+func (c *rangeUnit) Satisfied(comparison int) (bool, error) {
 	switch c.Operator {
 	case EQ:
-		return comparison == 0
+		return comparison == 0, nil
 	case GT:
-		return comparison > 0
+		return comparison > 0, nil
 	case GTE:
-		return comparison >= 0
+		return comparison >= 0, nil
 	case LT:
-		return comparison < 0
+		return comparison < 0, nil
 	case LTE:
-		return comparison <= 0
+		return comparison <= 0, nil
 	default:
-		panic(fmt.Errorf("unknown operator: %s", c.Operator))
+		return false, fmt.Errorf("unknown operator: %s", c.Operator)
 	}
 }
 

--- a/grype/version/range_expression.go
+++ b/grype/version/range_expression.go
@@ -74,7 +74,11 @@ func (c *simpleRangeExpression) satisfiedWithConfig(format Format, version *Vers
 			}
 			unit := c.Units[i][j]
 
-			if !unit.Satisfied(result) {
+			satisfied, err := unit.Satisfied(result)
+			if err != nil {
+				return false, fmt.Errorf("unable to evaluate satisfaction for %q: %w", andUnit.Version, err)
+			}
+			if !satisfied {
 				allSatisfied = false
 			}
 		}


### PR DESCRIPTION
## Summary

Replace \panic\ call in \angeUnit.Satisfied()\ with proper error return to prevent potential crashes when encountering unknown operators.

## Changes

- Modified \angeUnit.Satisfied()\ to return \(bool, error)\ instead of \ool\
- Replaced \panic(fmt.Errorf(...))\ with \eturn false, fmt.Errorf(...)\
- Updated caller in \ange_expression.go\ to handle the error gracefully

## Impact

This change prevents potential application crashes when the version constraint system encounters an unexpected operator. Instead of panicking, the error is now propagated up the call stack where it can be handled appropriately.

## Testing

Local environment limitations prevent full dynamic testing; relying on CI/CD automated tests for verification.