### PR TITLE
fix: honor match.rust.using-cpes configuration

### DIFF
--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/anchore/grype/grype/matcher/python"
 	"github.com/anchore/grype/grype/matcher/rpm"
 	"github.com/anchore/grype/grype/matcher/ruby"
+	"github.com/anchore/grype/grype/matcher/rust"
 	"github.com/anchore/grype/grype/matcher/stock"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/presenter/models"
@@ -382,6 +383,7 @@ func getMatcherConfig(opts *options.Grype) matcher.Config {
 			AlwaysUseCPEForStdlib:                  opts.Match.Golang.AlwaysUseCPEForStdlib,
 			AllowMainModulePseudoVersionComparison: opts.Match.Golang.AllowMainModulePseudoVersionComparison,
 		},
+		Rust:  rust.MatcherConfig(opts.Match.Rust),
 		Hex:   hex.MatcherConfig(opts.Match.Hex),
 		Stock: stock.MatcherConfig(opts.Match.Stock),
 		Dpkg: dpkg.MatcherConfig{

--- a/cmd/grype/cli/commands/root_test.go
+++ b/cmd/grype/cli/commands/root_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/anchore/grype/grype/matcher/python"
 	"github.com/anchore/grype/grype/matcher/rpm"
 	"github.com/anchore/grype/grype/matcher/ruby"
+	"github.com/anchore/grype/grype/matcher/rust"
 	"github.com/anchore/grype/grype/matcher/stock"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/version"
@@ -203,6 +204,42 @@ func Test_getMatcherConfig(t *testing.T) {
 				},
 				Dpkg: dpkg.MatcherConfig{
 					MissingEpochStrategy: "auto",
+				},
+			},
+		},
+		{
+			name: "rust using-cpes enabled",
+			opts: func() *options.Grype {
+				opts := options.DefaultGrype(clio.Identification{Name: "test", Version: "1.0"})
+				opts.Match.Rust.UseCPEs = true
+				return opts
+			}(),
+			want: matcher.Config{
+				Java: java.MatcherConfig{
+					ExternalSearchConfig: java.ExternalSearchConfig{
+						SearchMavenUpstream: false,
+						MavenBaseURL:        "https://search.maven.org/solrsearch/select",
+						MavenRateLimit:      300000000,
+					},
+					UseCPEs: false,
+				},
+				Ruby:       ruby.MatcherConfig{},
+				Python:     python.MatcherConfig{},
+				Dotnet:     dotnet.MatcherConfig{},
+				Javascript: javascript.MatcherConfig{},
+				Golang: golang.MatcherConfig{
+					UseCPEs:                                false,
+					AlwaysUseCPEForStdlib:                  false,
+					AllowMainModulePseudoVersionComparison: false,
+				},
+				Rust:  rust.MatcherConfig{UseCPEs: true},
+				Hex:   hex.MatcherConfig{},
+				Stock: stock.MatcherConfig{UseCPEs: true},
+				Rpm: rpm.MatcherConfig{
+					MissingEpochStrategy: "auto",
+				},
+				Dpkg: dpkg.MatcherConfig{
+					MissingEpochStrategy: "zero",
 				},
 			},
 		},


### PR DESCRIPTION
`match.rust.using-cpes` (and `GRYPE_MATCH_RUST_USING_CPES`) currently has no effect.

`matchConfig.Rust` is declared and defaulted in `cmd/grype/cli/options/match.go`, and `matcher.Config.Rust` is consumed by `rust.NewRustMatcher` in `NewDefaultMatchers` — but `getMatcherConfig` never assigns it. The matcher therefore always receives the Go zero value, and Rust CPE matching stays off regardless of configuration.

The default (`using-cpes: false`) coincides with the zero value, so behaviour is only wrong when a user explicitly opts in — and it then fails silently in the direction of *missing* matches rather than extra noise, which is likely why it went unnoticed.

### Reproduction

An SBOM containing a single `rust-crate` package with a CPE:

```json
{
  "name": "openssl",
  "version": "1.0.1f",
  "type": "rust-crate",
  "cpes": ["cpe:2.3:a:openssl:openssl:1.0.1f:*:*:*:*:*:*:*"]
}
```

Scanned with `GRYPE_MATCH_RUST_USING_CPES` toggled:

| | `false` | `true` |
|---|---|---|
| `main` (545d9143) | 0 matches | 0 matches |
| this branch | 0 matches | 74 matches |

### Change

Two lines in `getMatcherConfig`, following the existing `ruby`/`python`/`hex` conversion pattern. Default behaviour is unchanged.

The added `Test_getMatcherConfig` case fails on `main` with:

```
- Rust: rust.MatcherConfig{UseCPEs: true}
+ Rust: rust.MatcherConfig{}
```

The existing cases don't cover it because each `want` literal omits `Rust`, so the assertion compares a zero value against a zero value.

### Unrelated open question

`matchConfig.JVM` is declared in the same struct and defaulted to `using-cpes: true`, but has no corresponding field in `matcher.Config` and no consumer — JVM packages are `BinaryPkg` and fall through to the stock matcher. It traces back to #2114, which added the option and removed the JVM matcher in the same change. Is that intentional scaffolding for a future matcher, or would it be cleaner to drop the option?
