### PR TITLE
feat: add DHI OSV support

### DIFF
--- a/grype/db/v6/build/transformers/osv/testdata/DHI-CVE-2016-2781-coreutils.json
+++ b/grype/db/v6/build/transformers/osv/testdata/DHI-CVE-2016-2781-coreutils.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "1.6.0",
+  "id": "DHI-CVE-2016-2781-coreutils",
+  "modified": "2026-06-30T00:00:00Z",
+  "published": "2026-06-30T00:00:00Z",
+  "summary": "Synthetic DHI advisory fixture for CVE-2016-2781 in coreutils",
+  "details": "Pre-production fixture used to validate DHI OSV routing for an Alpine-family ID=dhi package.",
+  "upstream": ["CVE-2016-2781"],
+  "affected": [{
+    "package": {
+      "ecosystem": "Docker Hardened Images:Alpine:3.24",
+      "name": "coreutils",
+      "purl": "pkg:apk/dhi/coreutils?os_distro=alpine&os_name=dhi&os_version=3.24"
+    },
+    "ranges": [{
+      "type": "ECOSYSTEM",
+      "events": [{"introduced": "0"}, {"fixed": "9.11-r1"}]
+    }]
+  }]
+}

--- a/grype/db/v6/build/transformers/osv/transform.go
+++ b/grype/db/v6/build/transformers/osv/transform.go
@@ -50,4 +50,5 @@ var strategies = []Strategy{
 	govulndbStrategy{},
 	rootioStrategy{},
 	chainguardStrategy{},
+	dhiStrategy{},
 }

--- a/grype/db/v6/build/transformers/osv/transform_dhi.go
+++ b/grype/db/v6/build/transformers/osv/transform_dhi.go
@@ -18,7 +18,11 @@ import (
 	"github.com/anchore/syft/syft/pkg"
 )
 
-const dhiEcosystemPrefix = "Docker Hardened Images:"
+const (
+	dhiEcosystemPrefix = "Docker Hardened Images:"
+	dhiLineageAlpine   = "alpine"
+	dhiLineageDebian   = "debian"
+)
 
 type dhiStrategy struct{}
 
@@ -176,9 +180,9 @@ func parseDHIIdentity(osvPackage osvmodel.Package) (dhiIdentity, error) {
 
 	var packageType pkg.Type
 	switch {
-	case lineage == "alpine" && purl.Type == packageurl.TypeApk:
+	case lineage == dhiLineageAlpine && purl.Type == packageurl.TypeApk:
 		packageType = pkg.ApkPkg
-	case lineage == "debian" && purl.Type == packageurl.TypeDebian:
+	case lineage == dhiLineageDebian && purl.Type == packageurl.TypeDebian:
 		packageType = pkg.DebPkg
 	default:
 		return dhiIdentity{}, fmt.Errorf("ecosystem lineage %q does not agree with PURL type %q", lineage, purl.Type)

--- a/grype/db/v6/build/transformers/osv/transform_dhi.go
+++ b/grype/db/v6/build/transformers/osv/transform_dhi.go
@@ -22,10 +22,12 @@ const dhiEcosystemPrefix = "Docker Hardened Images:"
 
 type dhiStrategy struct{}
 
+// Matches reports whether an OSV record uses the DHI advisory ID prefix.
 func (dhiStrategy) Matches(id string) bool {
 	return strings.HasPrefix(id, "DHI-")
 }
 
+// Transform converts a DHI OSV record into vulnerability and affected-package entries.
 func (dhiStrategy) Transform(vuln unmarshal.OSVVulnerability, state provider.State) ([]data.Entry, error) {
 	affected, err := dhiAffectedPackages(vuln, dhiAliases(vuln))
 	if err != nil {
@@ -70,6 +72,7 @@ func (dhiStrategy) Transform(vuln unmarshal.OSVVulnerability, state provider.Sta
 	return transformers.NewEntries(in...), nil
 }
 
+// dhiAliases combines and deduplicates the aliases and upstream IDs of a DHI advisory.
 func dhiAliases(vuln unmarshal.OSVVulnerability) []string {
 	seen := make(map[string]struct{})
 	var aliases []string
@@ -86,6 +89,7 @@ func dhiAliases(vuln unmarshal.OSVVulnerability) []string {
 	return aliases
 }
 
+// dhiReferences converts OSV references into their Grype database representation.
 func dhiReferences(vuln unmarshal.OSVVulnerability) []db.Reference {
 	refs := make([]db.Reference, 0, len(vuln.References))
 	for _, ref := range vuln.References {
@@ -98,6 +102,7 @@ func dhiReferences(vuln unmarshal.OSVVulnerability) []db.Reference {
 	return refs
 }
 
+// dhiAffectedPackages validates and converts each affected DHI package into a database handle.
 func dhiAffectedPackages(vuln unmarshal.OSVVulnerability, aliases []string) ([]db.AffectedPackageHandle, error) {
 	var handles []db.AffectedPackageHandle
 	for _, affected := range vuln.Affected {
@@ -141,6 +146,7 @@ type dhiIdentity struct {
 	architecture string
 }
 
+// qualifiers returns the package qualifiers used to constrain matching for this identity.
 func (i dhiIdentity) qualifiers() *db.PackageQualifiers {
 	if i.architecture == "" {
 		return nil
@@ -149,6 +155,7 @@ func (i dhiIdentity) qualifiers() *db.PackageQualifiers {
 	return &db.PackageQualifiers{Architecture: &architecture}
 }
 
+// parseDHIIdentity validates and extracts the package lineage, release, type, and architecture.
 func parseDHIIdentity(osvPackage osvmodel.Package) (dhiIdentity, error) {
 	parts := strings.Split(osvPackage.Ecosystem, ":")
 	if len(parts) != 3 || parts[0] != strings.TrimSuffix(dhiEcosystemPrefix, ":") {
@@ -188,6 +195,7 @@ func parseDHIIdentity(osvPackage osvmodel.Package) (dhiIdentity, error) {
 	return dhiIdentity{packageType: packageType, lineage: lineage, release: release, architecture: qualifiers["arch"]}, nil
 }
 
+// validDHIRelease reports whether a release is a numeric major or major-minor version.
 func validDHIRelease(release string) bool {
 	parts := strings.Split(release, ".")
 	if len(parts) == 0 || len(parts) > 2 {
@@ -206,6 +214,7 @@ func validDHIRelease(release string) bool {
 	return true
 }
 
+// dhiOperatingSystem maps a DHI release into Grype's operating-system representation.
 func dhiOperatingSystem(release string) *db.OperatingSystem {
 	parts := strings.SplitN(release, ".", 2)
 	os := &db.OperatingSystem{Name: "dhi", ReleaseID: "dhi", MajorVersion: parts[0]}

--- a/grype/db/v6/build/transformers/osv/transform_dhi.go
+++ b/grype/db/v6/build/transformers/osv/transform_dhi.go
@@ -1,0 +1,216 @@
+package osv
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/anchore/grype/grype/db/data"
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal"
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
+	"github.com/anchore/grype/grype/db/provider"
+	db "github.com/anchore/grype/grype/db/v6"
+	"github.com/anchore/grype/grype/db/v6/build/transformers"
+	"github.com/anchore/grype/grype/db/v6/build/transformers/internal"
+	"github.com/anchore/grype/grype/db/v6/name"
+	"github.com/anchore/packageurl-go"
+	"github.com/anchore/syft/syft/pkg"
+)
+
+const dhiEcosystemPrefix = "Docker Hardened Images:"
+
+type dhiStrategy struct{}
+
+func (dhiStrategy) Matches(id string) bool {
+	return strings.HasPrefix(id, "DHI-")
+}
+
+func (dhiStrategy) Transform(vuln unmarshal.OSVVulnerability, state provider.State) ([]data.Entry, error) {
+	affected, err := dhiAffectedPackages(vuln, dhiAliases(vuln))
+	if err != nil {
+		return nil, err
+	}
+	if len(affected) == 0 {
+		return nil, nil
+	}
+
+	severities, err := getSeverities(vuln)
+	if err != nil {
+		return nil, fmt.Errorf("unable to obtain severities: %w", err)
+	}
+
+	aliases := dhiAliases(vuln)
+	status := db.VulnerabilityActive
+	var withdrawnDate *time.Time
+	if !vuln.Withdrawn.IsZero() {
+		status = db.VulnerabilityRejected
+		withdrawnDate = &vuln.Withdrawn
+	}
+	in := []any{db.VulnerabilityHandle{
+		Name:          vuln.ID,
+		Status:        status,
+		PublishedDate: &vuln.Published,
+		ModifiedDate:  &vuln.Modified,
+		WithdrawnDate: withdrawnDate,
+		ProviderID:    state.Provider,
+		Provider:      provider.Model(state),
+		BlobValue: &db.VulnerabilityBlob{
+			ID:          vuln.ID,
+			Description: vuln.Details,
+			References:  dhiReferences(vuln),
+			Aliases:     aliases,
+			Severities:  severities,
+		},
+	}}
+
+	for _, handle := range affected {
+		in = append(in, handle)
+	}
+	return transformers.NewEntries(in...), nil
+}
+
+func dhiAliases(vuln unmarshal.OSVVulnerability) []string {
+	seen := make(map[string]struct{})
+	var aliases []string
+	for _, alias := range append(append([]string{}, vuln.Aliases...), vuln.Upstream...) {
+		if alias == "" || alias == vuln.ID {
+			continue
+		}
+		if _, ok := seen[alias]; ok {
+			continue
+		}
+		seen[alias] = struct{}{}
+		aliases = append(aliases, alias)
+	}
+	return aliases
+}
+
+func dhiReferences(vuln unmarshal.OSVVulnerability) []db.Reference {
+	refs := make([]db.Reference, 0, len(vuln.References))
+	for _, ref := range vuln.References {
+		refID := ""
+		if ref.Type == osvmodel.ReferenceAdvisory {
+			refID = vuln.ID
+		}
+		refs = append(refs, db.Reference{ID: refID, URL: ref.URL, Tags: []string{string(ref.Type)}})
+	}
+	return refs
+}
+
+func dhiAffectedPackages(vuln unmarshal.OSVVulnerability, aliases []string) ([]db.AffectedPackageHandle, error) {
+	var handles []db.AffectedPackageHandle
+	for _, affected := range vuln.Affected {
+		if len(affected.Versions) > 0 {
+			return nil, fmt.Errorf("invalid DHI affected package in %s: package %s uses explicit versions; DHI OS packages require ECOSYSTEM ranges", vuln.ID, affected.Package.Name)
+		}
+		identity, err := parseDHIIdentity(affected.Package)
+		if err != nil {
+			return nil, fmt.Errorf("invalid DHI affected package in %s: %w", vuln.ID, err)
+		}
+
+		var ranges []db.Range
+		for _, affectedRange := range affected.Ranges {
+			if affectedRange.Type != osvmodel.RangeEcosystem {
+				return nil, fmt.Errorf("package %s uses unsupported %s range; DHI OS packages require ECOSYSTEM ranges", affected.Package.Name, affectedRange.Type)
+			}
+			ranges = append(ranges, getGrypeRangesFromRange(affectedRange, identity.packageType.String())...)
+		}
+
+		handles = append(handles, db.AffectedPackageHandle{
+			OperatingSystem: dhiOperatingSystem(identity.release),
+			Package: &db.Package{
+				Ecosystem: identity.packageType.String(),
+				Name:      name.Normalize(affected.Package.Name, identity.packageType),
+			},
+			BlobValue: &db.PackageBlob{
+				CVEs:       aliases,
+				Ranges:     ranges,
+				Qualifiers: identity.qualifiers(),
+			},
+		})
+	}
+	sort.Sort(internal.ByAffectedPackage(handles))
+	return handles, nil
+}
+
+type dhiIdentity struct {
+	packageType  pkg.Type
+	lineage      string
+	release      string
+	architecture string
+}
+
+func (i dhiIdentity) qualifiers() *db.PackageQualifiers {
+	if i.architecture == "" {
+		return nil
+	}
+	architecture := i.architecture
+	return &db.PackageQualifiers{Architecture: &architecture}
+}
+
+func parseDHIIdentity(osvPackage osvmodel.Package) (dhiIdentity, error) {
+	parts := strings.Split(osvPackage.Ecosystem, ":")
+	if len(parts) != 3 || parts[0] != strings.TrimSuffix(dhiEcosystemPrefix, ":") {
+		return dhiIdentity{}, fmt.Errorf("ecosystem %q must be Docker Hardened Images:<Alpine|Debian>:<release>", osvPackage.Ecosystem)
+	}
+	lineage, release := strings.ToLower(parts[1]), parts[2]
+	if !validDHIRelease(release) {
+		return dhiIdentity{}, fmt.Errorf("ecosystem %q must use a numeric <major> or <major>.<minor> release", osvPackage.Ecosystem)
+	}
+
+	purl, err := packageurl.FromString(osvPackage.Purl)
+	if err != nil {
+		return dhiIdentity{}, fmt.Errorf("invalid PURL %q: %w", osvPackage.Purl, err)
+	}
+	if purl.Namespace != "dhi" || purl.Name != osvPackage.Name || purl.Version != "" {
+		return dhiIdentity{}, fmt.Errorf("PURL %q must be a versionless DHI PURL for package %q", osvPackage.Purl, osvPackage.Name)
+	}
+
+	var packageType pkg.Type
+	switch {
+	case lineage == "alpine" && purl.Type == packageurl.TypeApk:
+		packageType = pkg.ApkPkg
+	case lineage == "debian" && purl.Type == packageurl.TypeDebian:
+		packageType = pkg.DebPkg
+	default:
+		return dhiIdentity{}, fmt.Errorf("ecosystem lineage %q does not agree with PURL type %q", lineage, purl.Type)
+	}
+
+	qualifiers := make(map[string]string)
+	for _, qualifier := range purl.Qualifiers {
+		qualifiers[qualifier.Key] = qualifier.Value
+	}
+	if qualifiers["os_name"] != "dhi" || qualifiers["os_distro"] != lineage || qualifiers["os_version"] != release {
+		return dhiIdentity{}, fmt.Errorf("PURL qualifiers must identify dhi/%s/%s", lineage, release)
+	}
+
+	return dhiIdentity{packageType: packageType, lineage: lineage, release: release, architecture: qualifiers["arch"]}, nil
+}
+
+func validDHIRelease(release string) bool {
+	parts := strings.Split(release, ".")
+	if len(parts) == 0 || len(parts) > 2 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for _, char := range part {
+			if char < '0' || char > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func dhiOperatingSystem(release string) *db.OperatingSystem {
+	parts := strings.SplitN(release, ".", 2)
+	os := &db.OperatingSystem{Name: "dhi", ReleaseID: "dhi", MajorVersion: parts[0]}
+	if len(parts) == 2 {
+		os.MinorVersion = parts[1]
+	}
+	return os
+}

--- a/grype/db/v6/build/transformers/osv/transform_dhi_test.go
+++ b/grype/db/v6/build/transformers/osv/transform_dhi_test.go
@@ -1,0 +1,272 @@
+package osv
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
+	db "github.com/anchore/grype/grype/db/v6"
+	"github.com/anchore/grype/grype/db/v6/build/transformers"
+	"github.com/anchore/syft/syft/pkg"
+)
+
+func TestDHIStrategyMatches(t *testing.T) {
+	tests := map[string]bool{
+		"DHI-CVE-2016-2781-coreutils": true,
+		"DHI-mcwm-2wmc-6hv4":          true,
+		"CVE-2016-2781":               false,
+		"CGA-xcpc-gm23-prj9":          false,
+		"":                            false,
+	}
+	for id, want := range tests {
+		t.Run(id, func(t *testing.T) {
+			require.Equal(t, want, (dhiStrategy{}).Matches(id))
+		})
+	}
+}
+
+func TestDHITransformAlpineFixture(t *testing.T) {
+	vulns := loadFixture(t, "testdata/DHI-CVE-2016-2781-coreutils.json")
+	require.Len(t, vulns, 1)
+
+	entries, err := Transform(vulns[0], inputProviderState())
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	related, ok := entries[0].Data.(transformers.RelatedEntries)
+	require.True(t, ok)
+	require.Equal(t, "DHI-CVE-2016-2781-coreutils", related.VulnerabilityHandle.Name)
+	require.Equal(t, []string{"CVE-2016-2781"}, related.VulnerabilityHandle.BlobValue.Aliases)
+	require.Len(t, related.Related, 1)
+
+	handle, ok := related.Related[0].(db.AffectedPackageHandle)
+	require.True(t, ok)
+	require.Equal(t, &db.OperatingSystem{
+		Name:         "dhi",
+		ReleaseID:    "dhi",
+		MajorVersion: "3",
+		MinorVersion: "24",
+	}, handle.OperatingSystem)
+	require.Equal(t, &db.Package{Ecosystem: "apk", Name: "coreutils"}, handle.Package)
+	require.Equal(t, []db.Range{{
+		Version: db.Version{Type: "apk", Constraint: "< 9.11-r1"},
+		Fix:     &db.Fix{Version: "9.11-r1", State: db.FixedStatus},
+	}}, handle.BlobValue.Ranges)
+}
+
+func TestDHITransformMetadataAndWithdrawal(t *testing.T) {
+	vulns := loadFixture(t, "testdata/DHI-CVE-2016-2781-coreutils.json")
+	vuln := vulns[0]
+	vuln.Aliases = []string{"CVE-2016-2781", "CVE-2016-2781", vuln.ID}
+	vuln.Upstream = []string{"CVE-2016-2781", "GHSA-test-test-test"}
+	vuln.References = []osvmodel.Reference{
+		{Type: osvmodel.ReferenceAdvisory, URL: "https://example.test/advisory"},
+		{Type: osvmodel.ReferenceReport, URL: "https://example.test/report"},
+	}
+	vuln.Withdrawn = time.Date(2026, time.July, 29, 12, 0, 0, 0, time.UTC)
+
+	entries, err := Transform(vuln, inputProviderState())
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	related := entries[0].Data.(transformers.RelatedEntries)
+	handle := related.VulnerabilityHandle
+	require.Equal(t, db.VulnerabilityRejected, handle.Status)
+	require.Equal(t, &vuln.Withdrawn, handle.WithdrawnDate)
+	require.Equal(t, []string{"CVE-2016-2781", "GHSA-test-test-test"}, handle.BlobValue.Aliases)
+	require.Equal(t, []db.Reference{
+		{ID: vuln.ID, URL: "https://example.test/advisory", Tags: []string{"ADVISORY"}},
+		{URL: "https://example.test/report", Tags: []string{"REPORT"}},
+	}, handle.BlobValue.References)
+}
+
+func TestDHITransformSkipsRecordWithoutAffectedPackages(t *testing.T) {
+	vulns := loadFixture(t, "testdata/DHI-CVE-2016-2781-coreutils.json")
+	vulns[0].Affected = nil
+	entries, err := Transform(vulns[0], inputProviderState())
+	require.NoError(t, err)
+	require.Empty(t, entries)
+}
+
+func TestDHITransformRejectsExplicitVersions(t *testing.T) {
+	vulns := loadFixture(t, "testdata/DHI-CVE-2016-2781-coreutils.json")
+	vulns[0].Affected[0].Versions = []string{"9.11-r0"}
+	_, err := Transform(vulns[0], inputProviderState())
+	require.ErrorContains(t, err, "uses explicit versions")
+}
+
+func TestParseDHIIdentity(t *testing.T) {
+	tests := []struct {
+		name string
+		pkg  osvmodel.Package
+		want dhiIdentity
+	}{
+		{
+			name: "Alpine",
+			pkg: osvmodel.Package{
+				Ecosystem: "Docker Hardened Images:Alpine:3.24",
+				Name:      "coreutils",
+				Purl:      "pkg:apk/dhi/coreutils?os_distro=alpine&os_name=dhi&os_version=3.24",
+			},
+			want: dhiIdentity{packageType: pkg.ApkPkg, lineage: "alpine", release: "3.24"},
+		},
+		{
+			name: "Debian",
+			pkg: osvmodel.Package{
+				Ecosystem: "Docker Hardened Images:Debian:13",
+				Name:      "coreutils",
+				Purl:      "pkg:deb/dhi/coreutils?os_distro=debian&os_name=dhi&os_version=13",
+			},
+			want: dhiIdentity{packageType: pkg.DebPkg, lineage: "debian", release: "13"},
+		},
+		{
+			name: "architecture qualifier",
+			pkg: osvmodel.Package{
+				Ecosystem: "Docker Hardened Images:Alpine:3.24",
+				Name:      "coreutils",
+				Purl:      "pkg:apk/dhi/coreutils?arch=aarch64&os_distro=alpine&os_name=dhi&os_version=3.24",
+			},
+			want: dhiIdentity{packageType: pkg.ApkPkg, lineage: "alpine", release: "3.24", architecture: "aarch64"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseDHIIdentity(test.pkg)
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestParseDHIIdentityRejectsInvalidPackageIdentity(t *testing.T) {
+	tests := []struct {
+		name    string
+		pkg     osvmodel.Package
+		wantErr string
+	}{
+		{
+			name: "SemVer-era ecosystem",
+			pkg: osvmodel.Package{
+				Ecosystem: "Docker Hardened Images",
+				Name:      "coreutils",
+				Purl:      "pkg:apk/dhi/coreutils?os_distro=alpine&os_name=dhi&os_version=3.24",
+			},
+			wantErr: "must be Docker Hardened Images:<Alpine|Debian>:<release>",
+		},
+		{
+			name: "lineage and type mismatch",
+			pkg: osvmodel.Package{
+				Ecosystem: "Docker Hardened Images:Debian:13",
+				Name:      "coreutils",
+				Purl:      "pkg:apk/dhi/coreutils?os_distro=debian&os_name=dhi&os_version=13",
+			},
+			wantErr: "does not agree with PURL type",
+		},
+		{
+			name: "upstream namespace",
+			pkg: osvmodel.Package{
+				Ecosystem: "Docker Hardened Images:Alpine:3.24",
+				Name:      "coreutils",
+				Purl:      "pkg:apk/alpine/coreutils?os_distro=alpine&os_name=dhi&os_version=3.24",
+			},
+			wantErr: "must be a versionless DHI PURL",
+		},
+		{
+			name: "versioned advisory PURL",
+			pkg: osvmodel.Package{
+				Ecosystem: "Docker Hardened Images:Alpine:3.24",
+				Name:      "coreutils",
+				Purl:      "pkg:apk/dhi/coreutils@9.11-r0?os_distro=alpine&os_name=dhi&os_version=3.24",
+			},
+			wantErr: "must be a versionless DHI PURL",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parseDHIIdentity(test.pkg)
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+func TestParseDHIIdentityRejectsInvalidRelease(t *testing.T) {
+	tests := []struct {
+		name, ecosystem, purl, wantErr string
+	}{
+		{
+			name:      "release mismatch",
+			ecosystem: "Docker Hardened Images:Alpine:3.24",
+			purl:      "pkg:apk/dhi/coreutils?os_distro=alpine&os_name=dhi&os_version=3.25",
+			wantErr:   "must identify dhi/alpine/3.24",
+		},
+		{
+			name:      "unrepresentable patch release",
+			ecosystem: "Docker Hardened Images:Alpine:3.24.1",
+			purl:      "pkg:apk/dhi/coreutils?os_distro=alpine&os_name=dhi&os_version=3.24.1",
+			wantErr:   "must use a numeric <major> or <major>.<minor> release",
+		},
+		{
+			name:      "nonnumeric release",
+			ecosystem: "Docker Hardened Images:Alpine:edge",
+			purl:      "pkg:apk/dhi/coreutils?os_distro=alpine&os_name=dhi&os_version=edge",
+			wantErr:   "must use a numeric <major> or <major>.<minor> release",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parseDHIIdentity(osvmodel.Package{Ecosystem: test.ecosystem, Name: "coreutils", Purl: test.purl})
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+func TestDHIArchitectureQualifier(t *testing.T) {
+	vulns := loadFixture(t, "testdata/DHI-CVE-2016-2781-coreutils.json")
+	vulns[0].Affected[0].Package.Purl = "pkg:apk/dhi/coreutils?arch=aarch64&os_distro=alpine&os_name=dhi&os_version=3.24"
+
+	entries, err := Transform(vulns[0], inputProviderState())
+	require.NoError(t, err)
+	related := entries[0].Data.(transformers.RelatedEntries)
+	handle := related.Related[0].(db.AffectedPackageHandle)
+	require.NotNil(t, handle.BlobValue.Qualifiers)
+	require.Equal(t, "aarch64", *handle.BlobValue.Qualifiers.Architecture)
+}
+
+func TestDHIRangeFormatByLineage(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		ecosystem  string
+		purl       string
+		fixed      string
+		wantFormat string
+	}{
+		{
+			name:       "APK",
+			ecosystem:  "Docker Hardened Images:Alpine:3.24",
+			purl:       "pkg:apk/dhi/coreutils?os_distro=alpine&os_name=dhi&os_version=3.24",
+			fixed:      "9.11-r1",
+			wantFormat: "apk",
+		},
+		{
+			name:       "dpkg",
+			ecosystem:  "Docker Hardened Images:Debian:13",
+			purl:       "pkg:deb/dhi/coreutils?os_distro=debian&os_name=dhi&os_version=13",
+			fixed:      "9.7-3+dhi4",
+			wantFormat: "deb",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			identity, err := parseDHIIdentity(osvmodel.Package{
+				Ecosystem: test.ecosystem,
+				Name:      "coreutils",
+				Purl:      test.purl,
+			})
+			require.NoError(t, err)
+			ranges := eventsToRanges([]osvmodel.Event{{Introduced: "0"}, {Fixed: test.fixed}}, nil, identity.packageType.String())
+			require.Len(t, ranges, 1)
+			require.Equal(t, test.wantFormat, ranges[0].Version.Type)
+		})
+	}
+}

--- a/grype/db/v6/search_query.go
+++ b/grype/db/v6/search_query.go
@@ -140,8 +140,8 @@ func (b *searchQueryBuilder) handleCPE(c *search.CPECriteria) error {
 
 func (b *searchQueryBuilder) handleDistro(c *search.DistroCriteria) {
 	for _, d := range c.Distros {
-		// DHI advisories are release-specific. Never fall back from a requested
-		// minor release (for example 3.25) to another DHI release's records.
+		// DHI affected-package entries are release-scoped. Never fall back from a
+		// requested release (for example 3.25) to another DHI release's records.
 		disableFallback := d.Type == distro.DHI
 		var foundChannels int
 		for _, channel := range d.Channels {

--- a/grype/db/v6/search_query.go
+++ b/grype/db/v6/search_query.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/anchore/grype/grype/db/v6/name"
+	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/search"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/syft/syft/cpe"
@@ -139,6 +140,9 @@ func (b *searchQueryBuilder) handleCPE(c *search.CPECriteria) error {
 
 func (b *searchQueryBuilder) handleDistro(c *search.DistroCriteria) {
 	for _, d := range c.Distros {
+		// DHI advisories are release-specific. Never fall back from a requested
+		// minor release (for example 3.25) to another DHI release's records.
+		disableFallback := d.Type == distro.DHI
 		var foundChannels int
 		for _, channel := range d.Channels {
 			if channel == "" {
@@ -154,6 +158,7 @@ func (b *searchQueryBuilder) handleDistro(c *search.DistroCriteria) {
 				LabelVersion:     d.LabelVersion(),
 				Channel:          channel,
 				DisableAliasing:  c.Exact,
+				DisableFallback:  disableFallback,
 			})
 		}
 		if foundChannels == 0 {
@@ -164,6 +169,7 @@ func (b *searchQueryBuilder) handleDistro(c *search.DistroCriteria) {
 				RemainingVersion: d.RemainingVersion(),
 				LabelVersion:     d.LabelVersion(),
 				DisableAliasing:  c.Exact,
+				DisableFallback:  disableFallback,
 			})
 		}
 	}

--- a/grype/db/v6/search_query_test.go
+++ b/grype/db/v6/search_query_test.go
@@ -333,6 +333,28 @@ func TestQueryBuilder_ExactDistroCriteria(t *testing.T) {
 				require.Empty(t, remaining)
 			},
 		},
+		{
+			name: "DHI distro criteria disables version fallback",
+			criteria: []vulnerability.Criteria{
+				search.ByDistro(*distro.New(distro.DHI, "3.24", "")),
+			},
+			validate: func(t *testing.T, query *searchQuery, remaining []vulnerability.Criteria) {
+				require.Len(t, query.osSpecs, 1)
+				require.True(t, query.osSpecs[0].DisableFallback)
+				require.Empty(t, remaining)
+			},
+		},
+		{
+			name: "ordinary distro criteria retains version fallback",
+			criteria: []vulnerability.Criteria{
+				search.ByDistro(*distro.New(distro.Alpine, "3.24", "")),
+			},
+			validate: func(t *testing.T, query *searchQuery, remaining []vulnerability.Criteria) {
+				require.Len(t, query.osSpecs, 1)
+				require.False(t, query.osSpecs[0].DisableFallback)
+				require.Empty(t, remaining)
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/grype/distro/distro_test.go
+++ b/grype/distro/distro_test.go
@@ -423,6 +423,11 @@ func Test_NewDistroFromRelease_Coverage(t *testing.T) {
 			Version: "3.11.6",
 		},
 		{
+			Name:    "testdata/os/dhi",
+			Type:    DHI,
+			Version: "3.24",
+		},
+		{
 			Name:    "testdata/os/alpine-edge",
 			Type:    Alpine,
 			Version: "3.22.0_alpha20250108",

--- a/grype/distro/testdata/os/dhi/etc/os-release
+++ b/grype/distro/testdata/os/dhi/etc/os-release
@@ -1,0 +1,5 @@
+NAME="Docker Hardened Images (Alpine)"
+ID=dhi
+ID_LIKE=alpine
+VERSION_ID=3.24
+PRETTY_NAME="Docker Hardened Images (Alpine 3.24)"

--- a/grype/distro/type.go
+++ b/grype/distro/type.go
@@ -38,6 +38,7 @@ const (
 	SecureOS     Type = "secureos"
 	PostmarketOS Type = "postmarketos"
 	Hummingbird  Type = "hummingbird"
+	DHI          Type = "dhi"
 )
 
 // All contains all Linux distribution options
@@ -70,6 +71,7 @@ var All = []Type{
 	SecureOS,
 	PostmarketOS,
 	Hummingbird,
+	DHI,
 }
 
 // IDMapping maps a distro ID from the /etc/os-release (e.g. like "ubuntu") to a Distro type.
@@ -101,6 +103,7 @@ var IDMapping = map[string]Type{
 	"secureos":      SecureOS,
 	"postmarketos":  PostmarketOS,
 	"hummingbird":   Hummingbird,
+	"dhi":           DHI,
 }
 
 // aliasTypes maps common aliases to their corresponding Type.

--- a/grype/distro/type_test.go
+++ b/grype/distro/type_test.go
@@ -16,6 +16,14 @@ func TestTypeFromRelease(t *testing.T) {
 		want    Type
 	}{
 		{
+			name: "DHI ID takes precedence over Alpine lineage",
+			release: linux.Release{
+				ID:     "dhi",
+				IDLike: []string{"alpine"},
+			},
+			want: DHI,
+		},
+		{
 			name: "direct ID mapping",
 			release: linux.Release{
 				ID: "ubuntu",

--- a/grype/matcher/apk/matcher_test.go
+++ b/grype/matcher/apk/matcher_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/version"
@@ -64,6 +65,56 @@ func TestMatcherApk_DirectMatch_Wolfi(t *testing.T) {
 				SelectDetailByType(match.ExactDirectMatch).
 				AsDistroSearch()
 		})
+}
+
+func TestMatcherApk_DirectMatch_DHI(t *testing.T) {
+	dbtest.DBs(t, "dhi-324").Run(func(t *testing.T, db *dbtest.DB) {
+		matcher := Matcher{}
+
+		t.Run("affected DHI package matches", func(t *testing.T) {
+			p := dbtest.NewPackage("coreutils", "9.11-r0", syftPkg.ApkPkg).
+				WithDistro(dbtest.DHI324).
+				WithPURL("pkg:apk/dhi/coreutils@9.11-r0?arch=aarch64&distro=dhi-3.24").
+				Build()
+
+			db.Match(t, &matcher, p).
+				SelectMatch("DHI-CVE-2016-2781-coreutils").
+				SelectDetailByType(match.ExactDirectMatch).
+				AsDistroSearch()
+		})
+
+		t.Run("fixed DHI package does not match", func(t *testing.T) {
+			p := dbtest.NewPackage("coreutils", "9.11-r1", syftPkg.ApkPkg).
+				WithDistro(dbtest.DHI324).
+				Build()
+
+			// Fixed distro packages produce an ownership ignore, rather than a finding.
+			db.Match(t, &matcher, p).Ignores().
+				SelectRelatedPackageIgnores(reasonDistroPackageFixed,
+					"DHI-CVE-2016-2781-coreutils", "CVE-2016-2781")
+		})
+
+		t.Run("different DHI release is isolated", func(t *testing.T) {
+			p := dbtest.NewPackage("coreutils", "9.11-r0", syftPkg.ApkPkg).
+				WithDistro(dbtest.DHI325).
+				Build()
+			db.Match(t, &matcher, p).IsEmpty()
+		})
+
+		t.Run("ordinary Alpine is isolated", func(t *testing.T) {
+			p := dbtest.NewPackage("coreutils", "9.11-r0", syftPkg.ApkPkg).
+				WithDistro(distro.New(distro.Alpine, "3.24", "")).
+				Build()
+			db.Match(t, &matcher, p).IsEmpty()
+		})
+
+		t.Run("withdrawn DHI advisory is ignored", func(t *testing.T) {
+			p := dbtest.NewPackage("withdrawn-only", "1.0-r0", syftPkg.ApkPkg).
+				WithDistro(dbtest.DHI324).
+				Build()
+			db.Match(t, &matcher, p).IsEmpty()
+		})
+	})
 }
 
 // TestMatcherApk_IndirectMatchBySource verifies the upstream/origin

--- a/grype/matcher/apk/testdata/dhi-324/dhi/metadata.json
+++ b/grype/matcher/apk/testdata/dhi-324/dhi/metadata.json
@@ -1,0 +1,17 @@
+{
+  "provider": "dhi",
+  "version": 1,
+  "processor": "vunnel@manual",
+  "schema": {
+    "version": "1.0.3",
+    "url": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/provider-workspace-state/schema-1.0.3.json"
+  },
+  "urls": ["https://dhi.io/security/osv"],
+  "timestamp": "2026-07-29T00:00:00Z",
+  "listing": {
+    "path": "results/listing.xxh64",
+    "digest": "0000000000000000",
+    "algorithm": "xxh64"
+  },
+  "store": "flat-file"
+}

--- a/grype/matcher/apk/testdata/dhi-324/dhi/results/dhi-cve-2016-2781-coreutils.json
+++ b/grype/matcher/apk/testdata/dhi-324/dhi/results/dhi-cve-2016-2781-coreutils.json
@@ -1,0 +1,24 @@
+{
+  "identifier": "DHI-CVE-2016-2781-coreutils",
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.0.json",
+  "item": {
+    "schema_version": "1.6.0",
+    "id": "DHI-CVE-2016-2781-coreutils",
+    "modified": "2026-06-30T00:00:00Z",
+    "published": "2026-06-30T00:00:00Z",
+    "summary": "Synthetic DHI advisory fixture for CVE-2016-2781 in coreutils",
+    "details": "Pre-production fixture used to validate DHI OSV matching for an Alpine-family ID=dhi package.",
+    "upstream": ["CVE-2016-2781"],
+    "affected": [{
+      "package": {
+        "ecosystem": "Docker Hardened Images:Alpine:3.24",
+        "name": "coreutils",
+        "purl": "pkg:apk/dhi/coreutils?os_distro=alpine&os_name=dhi&os_version=3.24"
+      },
+      "ranges": [{
+        "type": "ECOSYSTEM",
+        "events": [{"introduced": "0"}, {"fixed": "9.11-r1"}]
+      }]
+    }]
+  }
+}

--- a/grype/matcher/apk/testdata/dhi-324/dhi/results/dhi-withdrawn-coreutils.json
+++ b/grype/matcher/apk/testdata/dhi-324/dhi/results/dhi-withdrawn-coreutils.json
@@ -1,0 +1,23 @@
+{
+  "identifier": "DHI-WITHDRAWN-coreutils",
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.0.json",
+  "item": {
+    "schema_version": "1.6.0",
+    "id": "DHI-WITHDRAWN-coreutils",
+    "modified": "2026-07-29T00:00:00Z",
+    "published": "2026-07-28T00:00:00Z",
+    "withdrawn": "2026-07-29T00:00:00Z",
+    "summary": "Synthetic withdrawn DHI advisory",
+    "affected": [{
+      "package": {
+        "ecosystem": "Docker Hardened Images:Alpine:3.24",
+        "name": "withdrawn-only",
+        "purl": "pkg:apk/dhi/withdrawn-only?os_distro=alpine&os_name=dhi&os_version=3.24"
+      },
+      "ranges": [{
+        "type": "ECOSYSTEM",
+        "events": [{"introduced": "0"}, {"fixed": "99.0-r0"}]
+      }]
+    }]
+  }
+}

--- a/grype/matcher/dpkg/matcher_test.go
+++ b/grype/matcher/dpkg/matcher_test.go
@@ -3,6 +3,7 @@ package dpkg
 import (
 	"testing"
 
+	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/internal/dbtest"
 	syftPkg "github.com/anchore/syft/syft/pkg"
@@ -23,6 +24,47 @@ func TestMatcherDpkg_DirectMatch(t *testing.T) {
 				SelectDetailByType(match.ExactDirectMatch).
 				AsDistroSearch()
 		})
+}
+
+func TestMatcherDpkg_DirectMatch_DHI(t *testing.T) {
+	dbtest.DBs(t, "dhi-13").Run(func(t *testing.T, db *dbtest.DB) {
+		matcher := Matcher{}
+
+		t.Run("affected DHI package matches", func(t *testing.T) {
+			p := dbtest.NewPackage("coreutils", "9.7-3+dhi3", syftPkg.DebPkg).
+				WithDistro(dbtest.DHI13).
+				WithPURL("pkg:deb/dhi/coreutils@9.7-3%2Bdhi3?arch=arm64&distro=dhi-13").
+				Build()
+
+			db.Match(t, &matcher, p).
+				SelectMatch("DHI-CVE-2017-18018-coreutils").
+				SelectDetailByType(match.ExactDirectMatch).
+				AsDistroSearch()
+		})
+
+		t.Run("fixed DHI package does not match", func(t *testing.T) {
+			p := dbtest.NewPackage("coreutils", "9.7-3+dhi4", syftPkg.DebPkg).
+				WithDistro(dbtest.DHI13).
+				Build()
+			db.Match(t, &matcher, p).Ignores().
+				SelectRelatedPackageIgnores("DistroPackageFixed",
+					"DHI-CVE-2017-18018-coreutils", "CVE-2017-18018")
+		})
+
+		t.Run("different DHI release is isolated", func(t *testing.T) {
+			p := dbtest.NewPackage("coreutils", "9.7-3+dhi3", syftPkg.DebPkg).
+				WithDistro(dbtest.DHI14).
+				Build()
+			db.Match(t, &matcher, p).IsEmpty()
+		})
+
+		t.Run("ordinary Debian is isolated", func(t *testing.T) {
+			p := dbtest.NewPackage("coreutils", "9.7-3+dhi3", syftPkg.DebPkg).
+				WithDistro(distro.New(distro.Debian, "13", "")).
+				Build()
+			db.Match(t, &matcher, p).IsEmpty()
+		})
+	})
 }
 
 func TestMatcherDpkg_IndirectMatch(t *testing.T) {

--- a/grype/matcher/dpkg/testdata/dhi-13/dhi/metadata.json
+++ b/grype/matcher/dpkg/testdata/dhi-13/dhi/metadata.json
@@ -1,0 +1,17 @@
+{
+  "provider": "dhi",
+  "version": 1,
+  "processor": "vunnel@manual",
+  "schema": {
+    "version": "1.0.3",
+    "url": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/provider-workspace-state/schema-1.0.3.json"
+  },
+  "urls": ["https://dhi.io/security/osv"],
+  "timestamp": "2026-07-29T00:00:00Z",
+  "listing": {
+    "path": "results/listing.xxh64",
+    "digest": "0000000000000000",
+    "algorithm": "xxh64"
+  },
+  "store": "flat-file"
+}

--- a/grype/matcher/dpkg/testdata/dhi-13/dhi/results/dhi-cve-2017-18018-coreutils.json
+++ b/grype/matcher/dpkg/testdata/dhi-13/dhi/results/dhi-cve-2017-18018-coreutils.json
@@ -1,0 +1,23 @@
+{
+  "identifier": "DHI-CVE-2017-18018-coreutils",
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.0.json",
+  "item": {
+    "schema_version": "1.6.0",
+    "id": "DHI-CVE-2017-18018-coreutils",
+    "modified": "2026-07-29T00:00:00Z",
+    "published": "2026-07-29T00:00:00Z",
+    "summary": "Synthetic DHI Debian advisory used to validate dpkg matching",
+    "upstream": ["CVE-2017-18018"],
+    "affected": [{
+      "package": {
+        "ecosystem": "Docker Hardened Images:Debian:13",
+        "name": "coreutils",
+        "purl": "pkg:deb/dhi/coreutils?os_distro=debian&os_name=dhi&os_version=13"
+      },
+      "ranges": [{
+        "type": "ECOSYSTEM",
+        "events": [{"introduced": "0"}, {"fixed": "9.7-3+dhi4"}]
+      }]
+    }]
+  }
+}

--- a/grype/matcher/internal/distro.go
+++ b/grype/matcher/internal/distro.go
@@ -55,6 +55,7 @@ func FindResultsByDistro(provider vulnerability.Provider, searchPkg pkg.Package,
 			search.ByPackageName(name),
 			search.ByDistro(*searchPkg.Distro),
 			OnlyQualifiedPackages(searchPkg),
+			OnlyNonWithdrawnVulnerabilities(),
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("matcher failed to fetch distro=%q pkg=%q: %w", searchPkg.Distro, name, err)
@@ -72,6 +73,7 @@ func FindResultsByDistro(provider vulnerability.Provider, searchPkg pkg.Package,
 			search.ByPackageName(name),
 			search.ForUnaffected(),
 			versionCriteria,
+			OnlyNonWithdrawnVulnerabilities(),
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("matcher failed to fetch unaffected distro=%q pkg=%q: %w", searchPkg.Distro, name, err)

--- a/internal/dbtest/package.go
+++ b/internal/dbtest/package.go
@@ -28,6 +28,10 @@ var (
 	Alpine317 = distro.New(distro.Alpine, "3.17", "")
 	Alpine318 = distro.New(distro.Alpine, "3.18", "")
 	Alpine319 = distro.New(distro.Alpine, "3.19", "")
+	DHI324    = distro.New(distro.DHI, "3.24", "")
+	DHI325    = distro.New(distro.DHI, "3.25", "")
+	DHI13     = distro.New(distro.DHI, "13", "")
+	DHI14     = distro.New(distro.DHI, "14", "")
 
 	// Wolfi and Chainguard are both rolling-release apk distros; version is
 	// unused for matching but preserved here for readability at call sites.

--- a/internal/dbtest/package.go
+++ b/internal/dbtest/package.go
@@ -28,10 +28,11 @@ var (
 	Alpine317 = distro.New(distro.Alpine, "3.17", "")
 	Alpine318 = distro.New(distro.Alpine, "3.18", "")
 	Alpine319 = distro.New(distro.Alpine, "3.19", "")
-	DHI324    = distro.New(distro.DHI, "3.24", "")
-	DHI325    = distro.New(distro.DHI, "3.25", "")
-	DHI13     = distro.New(distro.DHI, "13", "")
-	DHI14     = distro.New(distro.DHI, "14", "")
+
+	DHI324 = distro.New(distro.DHI, "3.24", "")
+	DHI325 = distro.New(distro.DHI, "3.25", "")
+	DHI13  = distro.New(distro.DHI, "13", "")
+	DHI14  = distro.New(distro.DHI, "14", "")
 
 	// Wolfi and Chainguard are both rolling-release apk distros; version is
 	// unused for matching but preserved here for readability at call sites.


### PR DESCRIPTION
## Purpose

Add first-class vulnerability matching support for Docker Hardened Images (DHI) that identify themselves with `ID=dhi` and publish DHI OS-package advisories in OSV format.

Without this change, Grype does not recognize `dhi` as a distro and falls back through `ID_LIKE` to Alpine or Debian. This can match DHI-built OS packages against upstream distro advisories even though Syft reports them under the DHI package namespace.

## Changes

- Recognize `dhi` as a first-class distro while preserving `ID_LIKE` as package-manager lineage metadata.
- Add a `DHI-` OSV transformer strategy for release-scoped Alpine/APK and Debian/dpkg affected-package entries.
- Validate the DHI ecosystem, versionless package PURL, lineage, release qualifiers, optional architecture, and ECOSYSTEM ranges.
- Preserve native APK and Debian package version semantics in generated database ranges.
- Store aliases, upstream IDs, references, severity metadata, and withdrawn status.
- Prevent DHI database lookup from falling back across releases or into ordinary Alpine/Debian namespaces.
- Exclude rejected/withdrawn records in the shared distro matcher, matching the existing CPE and language matcher behavior.
- Add transformer, database-query, distro-recognition, APK matcher, and dpkg matcher coverage, including affected, fixed, withdrawn, cross-release, and non-DHI isolation cases.

## Scope

This PR teaches Grype's database builder and runtime matcher how to represent and match DHI advisories. Source ingestion remains a separate Vunnel/grype-db concern; Grype does not fetch advisory sources during a scan.

Provenance-aware routing for OS packages added in customer layers is also outside this PR. Such packages may share the final image's DHI package namespace, and distinguishing them from packages inherited from the DHI base would require broader base-image/layer provenance support.

## Testing

- `go test ./grype/db/v6/build/transformers/osv`
- `go test ./grype/db/v6/...`
- `go test ./grype/distro/...`
- `go test ./grype/matcher/apk ./grype/matcher/dpkg`
- `git diff --check`

The implementation was also exercised through the Grype CLI using synthetic v6 databases against Alpine- and Debian-based DHI fixtures.