### PR TITLE
feat(version): add a CPAN/perl version comparator

### DIFF
--- a/grype/version/constraint.go
+++ b/grype/version/constraint.go
@@ -40,6 +40,8 @@ func GetConstraint(constStr string, format Format) (Constraint, error) {
 		c, err = newGenericConstraint(PacmanFormat, constStr)
 	case JVMFormat:
 		c, err = newGenericConstraint(JVMFormat, constStr)
+	case CpanFormat:
+		c, err = newGenericConstraint(CpanFormat, constStr)
 	case UnknownFormat:
 		c, err = newFuzzyConstraint(constStr, "unknown")
 	default:

--- a/grype/version/cpan_version.go
+++ b/grype/version/cpan_version.go
@@ -1,0 +1,194 @@
+package version
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var _ Comparator = (*cpanVersion)(nil)
+
+// cpanVersionMax mirrors VERSION_MAX from perl's vutil.h. perl clamps oversized components
+// instead of failing, which means two absurdly large but distinct versions compare equal.
+// that matches upstream on purpose, it is not a bug to fix.
+const cpanVersionMax int64 = 0x7FFFFFFF
+
+// cpanLaxRegexp is $LAX from perl's lib/version/regex.pm (shipped in the CPAN "version"
+// distribution), anchored. In regex.pm terms the alternatives are, in order:
+//
+//	$LAX_DOTTED_DECIMAL_VERSION = v INT (DOTTED+ ALPHA?)?  |  INT? DOTTED{2,} ALPHA?
+//	$LAX_DECIMAL_VERSION        = INT (FRACTION | \.)? ALPHA?  |  FRACTION ALPHA?
+//
+// lax deliberately allows leading zeros, a leading or trailing decimal point, and more than
+// three dotted components. The literal string "undef" is also a valid lax version and is
+// handled separately below.
+//
+// Two deviations from regex.pm, both to follow prescan_version, which is what actually
+// parses a version and is slightly looser: "v1." is accepted (a trailing "." is only an
+// error once a second "." has been seen) and the underscore checks below are tightened.
+var cpanLaxRegexp = regexp.MustCompile(
+	`^(?:v[0-9]+(?:\.|(?:\.[0-9]+)+(?:_[0-9]+)?)?|[0-9]*(?:\.[0-9]+){2,}(?:_[0-9]+)?|[0-9]+(?:\.[0-9]+|\.)?(?:_[0-9]+)?|\.[0-9]+(?:_[0-9]+)?)$`)
+
+type cpanVersion struct {
+	original   string
+	components []int64
+	// isAlpha records the single-underscore developer-release marker. It is display-only:
+	// Perl_vcmp never reads it, so "1.23_01" sorts above "1.23" purely because its
+	// underscore digits fold into the numeric groups, not because of any pre-release rule.
+	isAlpha bool
+}
+
+// newCpanVersion ports Perl_prescan_version and Perl_scan_version from perl's vutil.c, which
+// is the same code the CPAN "version" distribution ships and therefore what every CPAN
+// toolchain comparison bottoms out in.
+func newCpanVersion(raw string) (*cpanVersion, error) {
+	// prescan_version treats whitespace as a version terminator, an artifact of scanning
+	// versions out of perl source
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return nil, fmt.Errorf("invalid version format (version required)")
+	}
+
+	// $LAX admits the literal string "undef", a concession to ExtUtils::MM->parse_version
+	// returning undef as a string. perl parses it as version 0.
+	if s == "undef" {
+		return &cpanVersion{original: raw, components: []int64{0}}, nil
+	}
+
+	if !cpanLaxRegexp.MatchString(s) {
+		return nil, fmt.Errorf("invalid version format (non-numeric data)")
+	}
+
+	// prescan_version rejects two underscore placements that the lax grammar lets through:
+	// an underscore with no preceding decimal point ("1_2") and one not directly after a
+	// digit ("1._2"). the grammar already caps underscores at one.
+	if i := strings.IndexByte(s, '_'); i >= 0 {
+		if !strings.Contains(s[:i], ".") {
+			return nil, fmt.Errorf("invalid version format (alpha without decimal)")
+		}
+		if s[i-1] < '0' || s[i-1] > '9' {
+			return nil, fmt.Errorf("invalid version format (fractional part required)")
+		}
+	}
+
+	v := cpanVersion{original: raw, isAlpha: strings.Contains(s, "_")}
+	// the underscore is only a marker; its digits belong to the group they sit in, so
+	// "1.23_01" scans as "1.2301" and "v1.2_3" as "v1.23"
+	s = strings.ReplaceAll(s, "_", "")
+
+	// a leading "v" followed by a digit, or a second "." seen while scanning the fractional
+	// part, makes the whole string dotted-decimal. everything else is decimal.
+	qv := strings.HasPrefix(s, "v")
+	if qv {
+		s = s[1:]
+	}
+	if strings.Count(s, ".") > 1 {
+		qv = true
+	}
+
+	if qv {
+		for _, part := range strings.Split(s, ".") {
+			component, overflowed := cpanComponent(part)
+			v.components = append(v.components, component)
+			if overflowed {
+				// scan_version stops consuming once it flags an overflow, so nothing
+				// after the clamped component makes it into the vector
+				break
+			}
+		}
+		// quoted versions always get at least three terms
+		for len(v.components) < 3 {
+			v.components = append(v.components, 0)
+		}
+		return &v, nil
+	}
+
+	intPart, fracPart, hasFraction := strings.Cut(s, ".")
+	intComponent, overflowed := cpanComponent(intPart)
+	v.components = append(v.components, intComponent)
+	if overflowed {
+		// same stop-on-overflow rule as above: the fractional groups are never reached
+		return &v, nil
+	}
+	if hasFraction {
+		// a trailing "." with no digits still contributes one zero component
+		if fracPart == "" {
+			fracPart = "0"
+		}
+		// each fractional group takes at most three digits, evaluated with place values
+		// 100, 10, 1. a short final group is left-aligned, which is the same as
+		// right-padding the fractional digits to a multiple of three.
+		for len(fracPart)%3 != 0 {
+			fracPart += "0"
+		}
+		for i := 0; i < len(fracPart); i += 3 {
+			component, _ := cpanComponent(fracPart[i : i+3])
+			v.components = append(v.components, component)
+		}
+	}
+
+	return &v, nil
+}
+
+// cpanComponent converts one run of digits, clamping at VERSION_MAX the way perl does rather
+// than erroring, and reporting whether it had to. An empty run (from a leading ".") is zero.
+func cpanComponent(digits string) (value int64, overflowed bool) {
+	digits = strings.TrimLeft(digits, "0")
+	if digits == "" {
+		return 0, false
+	}
+	if len(digits) > 10 {
+		return cpanVersionMax, true
+	}
+	value, err := strconv.ParseInt(digits, 10, 64)
+	if err != nil || value > cpanVersionMax {
+		return cpanVersionMax, true
+	}
+	return value, false
+}
+
+func (v *cpanVersion) Compare(other *Version) (int, error) {
+	if other == nil {
+		return -1, ErrNoVersionProvided
+	}
+
+	o, err := newCpanVersion(other.Raw)
+	if err != nil {
+		return 0, invalidFormatError(CpanFormat, other.Raw, err)
+	}
+
+	return v.compare(o), nil
+}
+
+// compare is Perl_vcmp: compare pairwise over the shared prefix, then treat the longer side
+// as equal only if every remaining component is zero, so v1.2 == v1.2.0 == v1.2.0.0. The
+// alpha flag never participates, and neither does a numified float (numify is lossy on long
+// CPAN versions in exactly the cases this comparator exists for).
+func (v *cpanVersion) compare(other *cpanVersion) int {
+	shared := min(len(v.components), len(other.components))
+	for i := range shared {
+		switch {
+		case v.components[i] < other.components[i]:
+			return -1
+		case v.components[i] > other.components[i]:
+			return 1
+		}
+	}
+
+	for _, c := range v.components[shared:] {
+		if c != 0 {
+			return 1
+		}
+	}
+	for _, c := range other.components[shared:] {
+		if c != 0 {
+			return -1
+		}
+	}
+	return 0
+}
+
+func (v *cpanVersion) String() string {
+	return v.original
+}

--- a/grype/version/cpan_version_test.go
+++ b/grype/version/cpan_version_test.go
@@ -1,0 +1,218 @@
+package version
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// vnormal renders a parsed version the way Perl_vnormal does (padding to at least three
+// terms for display only), so the expectations below can be copied verbatim from perl's own
+// output.
+func vnormal(v *cpanVersion) string {
+	parts := make([]string, 0, len(v.components))
+	for _, c := range v.components {
+		parts = append(parts, strconv.FormatInt(c, 10))
+	}
+	for len(parts) < 3 {
+		parts = append(parts, "0")
+	}
+	return "v" + strings.Join(parts, ".")
+}
+
+// TestCpanVersionNormalization is the shared vector table, measured against perl 5. Every
+// entry is also asserted by the vunnel-side port of this algorithm; the two must agree.
+func TestCpanVersionNormalization(t *testing.T) {
+	tests := []struct {
+		input   string
+		normal  string
+		isAlpha bool
+	}{
+		{input: "1.23", normal: "v1.230.0"},
+		{input: "1.2.3", normal: "v1.2.3"},
+		{input: "v1.2.3", normal: "v1.2.3"},
+		{input: "1.230", normal: "v1.230.0"},
+		{input: "1.2", normal: "v1.200.0"},
+		{input: "v1.2", normal: "v1.2.0"},
+		{input: "1.0203", normal: "v1.20.300"},
+		{input: "0.90380906", normal: "v0.903.809.60"},
+		{input: "5.008001", normal: "v5.8.1"},
+		{input: "5.40.0", normal: "v5.40.0"},
+		{input: "1.004008", normal: "v1.4.8"},
+		{input: "1.303", normal: "v1.303.0"},
+		{input: "v1.1.4", normal: "v1.1.4"},
+		{input: "v0.41.0", normal: "v0.41.0"},
+		{input: "2.150013", normal: "v2.150.13"},
+		{input: "0.32", normal: "v0.320.0"},
+		{input: "6.68", normal: "v6.680.0"},
+		{input: "9.31", normal: "v9.310.0"},
+		{input: "1.23_01", normal: "v1.230.100", isAlpha: true},
+		{input: "1.23_1", normal: "v1.231.0", isAlpha: true},
+		{input: "0.999920", normal: "v0.999.920"},
+		{input: "20260726.001", normal: "v20260726.1.0"},
+		{input: "1.9.9", normal: "v1.9.9"},
+		{input: "1.10", normal: "v1.100.0"},
+		{input: "1.9", normal: "v1.900.0"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			v, err := newCpanVersion(test.input)
+			require.NoError(t, err)
+			assert.Equal(t, test.normal, vnormal(v))
+			assert.Equal(t, test.isAlpha, v.isAlpha, "unexpected alpha flag")
+		})
+	}
+}
+
+// TestCpanVersionOrdering is the shared ordering table. Every one of these inverts or breaks
+// under semver rules and they are all correct: perl orders decimal versions by fractional
+// value, not by integer components, and the alpha flag takes no part in ordering.
+func TestCpanVersionOrdering(t *testing.T) {
+	tests := []struct {
+		left     string
+		right    string
+		expected int
+	}{
+		{left: "1.23", right: "1.2.3", expected: 1},
+		{left: "1.23", right: "1.230", expected: 0},
+		{left: "1.2", right: "1.10", expected: 1},
+		{left: "1.9", right: "1.10", expected: 1},
+		{left: "v1.2.3", right: "1.2.3", expected: 0},
+		{left: "1.23", right: "v1.23.0", expected: 1},
+		{left: "1.23", right: "v1.230.0", expected: 0},
+		{left: "5.008001", right: "5.8.1", expected: 0},
+		{left: "v1.1.4", right: "1.1.4", expected: 0},
+		{left: "1.23_01", right: "1.23", expected: 1},
+		{left: "1.23_01", right: "1.24", expected: -1},
+		{left: "0.90380906", right: "0.9038", expected: 1},
+		{left: "1.0", right: "1", expected: 0},
+		{left: "v1.2", right: "v1.2.0", expected: 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.left+"_vs_"+test.right, func(t *testing.T) {
+			left, err := newCpanVersion(test.left)
+			require.NoError(t, err)
+
+			actual, err := left.Compare(New(test.right, CpanFormat))
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, actual)
+
+			// the ordering must be antisymmetric
+			right, err := newCpanVersion(test.right)
+			require.NoError(t, err)
+
+			actual, err = right.Compare(New(test.left, CpanFormat))
+			require.NoError(t, err)
+			assert.Equal(t, -test.expected, actual)
+		})
+	}
+}
+
+// TestCpanVersionParseEdges covers the lax grammar edges, including the forms that perl
+// accepts only in lax mode and the ones prescan_version rejects outright.
+func TestCpanVersionParseEdges(t *testing.T) {
+	tests := []struct {
+		input   string
+		normal  string
+		wantErr string
+	}{
+		{input: "", wantErr: "version required"},
+		{input: "abc", wantErr: "non-numeric data"},
+		{input: "v", wantErr: "dotted-decimal versions require at least three parts"},
+		{input: "1..2", wantErr: "fractional part required"},
+		{input: "1_2", wantErr: "alpha without decimal"},
+		{input: "1.2.3.4.5", normal: "v1.2.3.4.5"},
+		{input: "0", normal: "v0.0.0"},
+		{input: "v0", normal: "v0.0.0"},
+		{input: ".5", normal: "v0.500.0"},
+		{input: "1.", normal: "v1.0.0"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			v, err := newCpanVersion(test.input)
+			if test.wantErr != "" {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.normal, vnormal(v))
+		})
+	}
+}
+
+func TestCpanVersionComponents(t *testing.T) {
+	tests := []struct {
+		input      string
+		components []int64
+	}{
+		// decimal fractional grouping
+		{input: "1.2", components: []int64{1, 200}},
+		{input: "1.23", components: []int64{1, 230}},
+		{input: "1.0203", components: []int64{1, 20, 300}},
+		{input: "0.90380906", components: []int64{0, 903, 809, 60}},
+		// dotted-decimal parsing, padded to at least three components
+		{input: "v1.2", components: []int64{1, 2, 0}},
+		{input: "v1.2.3", components: []int64{1, 2, 3}},
+		{input: "1.2.3", components: []int64{1, 2, 3}},
+		// alpha underscore digits fold into the numeric groups
+		{input: "1.23_01", components: []int64{1, 230, 100}},
+		{input: "v1.2_3", components: []int64{1, 23, 0}},
+		// lax forms
+		{input: ".5", components: []int64{0, 500}},
+		{input: "1.", components: []int64{1, 0}},
+		// a trailing "." is only an error once a second "." has been seen, so "v1." parses
+		// even though $LAX does not admit it
+		{input: "v1.", components: []int64{1, 0, 0}},
+		{input: "0", components: []int64{0}},
+		{input: "v0", components: []int64{0, 0, 0}},
+		{input: "1.2.3.4.5", components: []int64{1, 2, 3, 4, 5}},
+		// leading zeros are legal in lax and always mean decimal, never octal
+		{input: "010", components: []int64{10}},
+		// "undef" is a valid lax version, a concession to ExtUtils::MM->parse_version
+		{input: "undef", components: []int64{0}},
+		// components are clamped at VERSION_MAX rather than erroring
+		{input: "v1.99999999999.0", components: []int64{1, cpanVersionMax, 0}},
+		{input: "v2147483647.2147483648.0", components: []int64{cpanVersionMax, cpanVersionMax, 0}},
+		{input: "2147483647.5", components: []int64{cpanVersionMax, 500}},
+		// an overflowed integer part stops the scan, so the fraction is never reached
+		{input: "99999999999.1", components: []int64{cpanVersionMax}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			v, err := newCpanVersion(test.input)
+			require.NoError(t, err)
+			assert.Equal(t, test.components, v.components)
+		})
+	}
+}
+
+// TestCpanVersionUnparseableDegrades pins the failure mode: an unparseable version surfaces
+// an error from the comparison rather than silently comparing equal. The search layer turns
+// that into "skip this vulnerability" and keeps the package (see
+// grype/search/version_constraint.go), so a bad version never drops a package from matching.
+func TestCpanVersionUnparseableDegrades(t *testing.T) {
+	c, err := GetConstraint("< 1.24", CpanFormat)
+	require.NoError(t, err)
+
+	satisfied, err := c.Satisfied(New("abc", CpanFormat))
+	require.Error(t, err)
+	assert.False(t, satisfied)
+
+	// a package version that does parse still resolves against the same constraint
+	satisfied, err = c.Satisfied(New("1.23_01", CpanFormat))
+	require.NoError(t, err)
+	assert.True(t, satisfied)
+
+	// an unparseable constraint version is an error, not a bogus equality
+	v, err := newCpanVersion("1.23")
+	require.NoError(t, err)
+	_, err = v.Compare(New("not-a-version", CpanFormat))
+	require.Error(t, err)
+}

--- a/grype/version/format.go
+++ b/grype/version/format.go
@@ -22,6 +22,7 @@ const (
 	JVMFormat
 	BitnamiFormat
 	PacmanFormat
+	CpanFormat
 )
 
 type Format int
@@ -41,6 +42,7 @@ var formatStr = []string{
 	"JVM",
 	"Bitnami",
 	"Pacman",
+	"CPAN",
 }
 
 var Formats = []Format{
@@ -57,6 +59,7 @@ var Formats = []Format{
 	JVMFormat,
 	BitnamiFormat,
 	PacmanFormat,
+	CpanFormat,
 }
 
 func ParseFormat(userStr string) Format {
@@ -88,6 +91,9 @@ func ParseFormat(userStr string) Format {
 		return JVMFormat
 	case strings.ToLower(PacmanFormat.String()), "pacman", pkg.AlpmPkg.String():
 		return PacmanFormat
+	// "perl" is the language name that vulnerability data uses, "cpan" the package type
+	case strings.ToLower(CpanFormat.String()), "cpan", "perl":
+		return CpanFormat
 	}
 	return UnknownFormat
 }

--- a/grype/version/format_test.go
+++ b/grype/version/format_test.go
@@ -167,6 +167,19 @@ func TestParseFormat(t *testing.T) {
 			input:  "alpm",
 			format: PacmanFormat,
 		},
+		// CpanFormat cases
+		{
+			input:  "cpan",
+			format: CpanFormat,
+		},
+		{
+			input:  "perl",
+			format: CpanFormat,
+		},
+		{
+			input:  "CPAN",
+			format: CpanFormat,
+		},
 		// UnknownFormat case
 		{
 			input:  "unknown",

--- a/grype/version/version.go
+++ b/grype/version/version.go
@@ -76,6 +76,8 @@ func (v *Version) getComparator(format Format) (Comparator, error) {
 		comparator, err = newJvmVersion(v.Raw)
 	case PacmanFormat:
 		comparator, err = newPacmanVersion(v.Raw)
+	case CpanFormat:
+		comparator, err = newCpanVersion(v.Raw)
 	case UnknownFormat:
 		comparator, err = newFuzzyVersion(v.Raw)
 	default:


### PR DESCRIPTION
Adds `CpanFormat` and a comparator implementing perl's own `version.pm` semantics. `ParseFormat` accepts both `cpan` and `perl`.

Semver is wrong for the most common version shape on CPAN. Under perl's rules a decimal version is a fraction, so `1.2` > `1.10` and `1.23` > `1.2.3`, and a packed decimal equals its dotted form, so `5.008001` and `5.8.1` are the same version. Comparing those as semver gets the ordering backwards.

Follows `Perl_prescan_version`, `Perl_scan_version` and `Perl_vcmp`: qv detection, three-digit fractional grouping, dotted-decimal padding, underscore alpha, and `VERSION_MAX` clamping. Alpha components take no part in ordering, and trailing zeros compare equal.

Correctness was established against real perl rather than by inspection: `version->parse($s)` and `<=>` inside `perl:5.40-slim`, over every distinct version string in the CPANSA database. That turned up three things reading the source alone did not, all of which are handled here:

- the `$LAX` regex rejects a trailing `.` that `prescan_version` accepts
- `1.` really does parse as `[1, 0]`
- overflow **stops the scan**, so `99999999999.1` is `[2147483647]` rather than clamping and continuing

Unparseable input degrades to a no-match rather than dropping the package.