### PR TITLE
feat(db): transform CPANSA advisories into cpan package entries

### DIFF
--- a/grype/db/v6/build/transformers/osv/testdata/CPANSA-DBD-SQLite-2018-8740-sqlite.json
+++ b/grype/db/v6/build/transformers/osv/testdata/CPANSA-DBD-SQLite-2018-8740-sqlite.json
@@ -1,0 +1,123 @@
+{
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "CPAN",
+        "name": "DBD-SQLite"
+      },
+      "ranges": [
+        {
+          "database_specific": {
+            "anchore": {
+              "fixes": [
+                {
+                  "date": "2018-03-17",
+                  "kind": "advisory",
+                  "version": "1.35"
+                },
+                {
+                  "date": "2018-03-17",
+                  "kind": "advisory",
+                  "version": "1.47_04"
+                },
+                {
+                  "date": "2018-03-17",
+                  "kind": "advisory",
+                  "version": "1.59_01"
+                }
+              ]
+            }
+          },
+          "events": [
+            {
+              "introduced": "1.00"
+            },
+            {
+              "fixed": "1.35"
+            },
+            {
+              "introduced": "1.36_01"
+            },
+            {
+              "fixed": "1.47_04"
+            },
+            {
+              "introduced": "1.47_05"
+            },
+            {
+              "fixed": "1.59_01"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    }
+  ],
+  "aliases": [
+    "CVE-2018-8740"
+  ],
+  "database_specific": {
+    "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+    "cpansa_generated": "Sun Jul 26 06:23:50 2026",
+    "severity": "high"
+  },
+  "details": "In SQLite through 3.22.0, databases whose schema is corrupted using a CREATE TABLE AS statement could cause a NULL pointer dereference, related to build.c and prepare.c.",
+  "id": "CPANSA-DBD-SQLite-2018-8740-sqlite",
+  "modified": "2026-07-26T06:23:50Z",
+  "published": "2018-03-17T00:00:00Z",
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.sqlite.org/cgi/src/timeline?r=corrupt-schema"
+    },
+    {
+      "type": "WEB",
+      "url": "https://bugs.launchpad.net/ubuntu/+source/sqlite3/+bug/1756349"
+    },
+    {
+      "type": "WEB",
+      "url": "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=6964"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.sqlite.org/cgi/src/vdiff?from=1774f1c3baf0bc3d&to=d75e67654aa9620b"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.securityfocus.com/bid/103466"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2019/01/msg00009.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://lists.opensuse.org/opensuse-security-announce/2019-05/msg00050.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PU4NZ6DDU4BEM3ACM3FM6GLEPX56ZQXK/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://usn.ubuntu.com/4205-1/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://usn.ubuntu.com/4394-1/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2020/08/msg00037.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4@%3Cissues.bookkeeper.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b@%3Cissues.bookkeeper.apache.org%3E"
+    }
+  ],
+  "schema_version": "1.6.1"
+}

--- a/grype/db/v6/build/transformers/osv/testdata/CPANSA-ExtUtils-ParseXS-2016-1238.json
+++ b/grype/db/v6/build/transformers/osv/testdata/CPANSA-ExtUtils-ParseXS-2016-1238.json
@@ -1,0 +1,143 @@
+{
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "CPAN",
+        "name": "ExtUtils-ParseXS"
+      },
+      "ranges": [
+        {
+          "database_specific": {
+            "anchore": {
+              "fixes": [
+                {
+                  "date": "2016-08-02",
+                  "kind": "advisory",
+                  "version": "3.35"
+                }
+              ]
+            }
+          },
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.35"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "CPAN",
+        "name": "perl"
+      },
+      "ranges": [
+        {
+          "database_specific": {
+            "anchore": {
+              "fixes": [
+                {
+                  "date": "2016-08-02",
+                  "kind": "advisory",
+                  "version": "5.024001"
+                }
+              ]
+            }
+          },
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.024001"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    }
+  ],
+  "aliases": [
+    "CVE-2016-1238"
+  ],
+  "database_specific": {
+    "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+    "cpansa_generated": "Sun Jul 26 06:23:50 2026",
+    "severity": "high"
+  },
+  "details": "(1) cpan/Archive-Tar/bin/ptar, (2) cpan/Archive-Tar/bin/ptardiff, (3) cpan/Archive-Tar/bin/ptargrep, (4) cpan/CPAN/scripts/cpan, (5) cpan/Digest-SHA/shasum, (6) cpan/Encode/bin/enc2xs, (7) cpan/Encode/bin/encguess, (8) cpan/Encode/bin/piconv, (9) cpan/Encode/bin/ucmlint, (10) cpan/Encode/bin/unidump, (11) cpan/ExtUtils-MakeMaker/bin/instmodsh, (12) cpan/IO-Compress/bin/zipdetails, (13) cpan/JSON-PP/bin/json_pp, (14) cpan/Test-Harness/bin/prove, (15) dist/ExtUtils-ParseXS/lib/ExtUtils/xsubpp, (16) dist/Module-CoreList/corelist, (17) ext/Pod-Html/bin/pod2html, (18) utils/c2ph.PL, (19) utils/h2ph.PL, (20) utils/h2xs.PL, (21) utils/libnetcfg.PL, (22) utils/perlbug.PL, (23) utils/perldoc.PL, (24) utils/perlivp.PL, and (25) utils/splain.PL in Perl 5.x before 5.22.3-RC2 and 5.24 before 5.24.1-RC2 do not properly remove . (period) characters from the end of the includes directory array, which might allow local users to gain privileges via a Trojan horse module under the current working directory.",
+  "id": "CPANSA-ExtUtils-ParseXS-2016-1238",
+  "modified": "2026-07-26T06:23:50Z",
+  "published": "2016-08-02T00:00:00Z",
+  "references": [
+    {
+      "type": "WEB",
+      "url": "http://lists.opensuse.org/opensuse-security-announce/2019-08/msg00002.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://perl5.git.perl.org/perl.git/commit/cee96d52c39b1e7b36e1c62d38bcd8d86e9a41ab"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.debian.org/security/2016/dsa-3628"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.nntp.perl.org/group/perl.perl5.porters/2016/07/msg238271.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.securityfocus.com/bid/92136"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.securitytracker.com/id/1036440"
+    },
+    {
+      "type": "WEB",
+      "url": "https://h20566.www2.hpe.com/portal/site/hpsc/public/kb/docDisplay?docId=emr_na-c05240731"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/7f6a16bc0fd0fd5e67c7fd95bd655069a2ac7d1f88e42d3c853e601c%40%3Cannounce.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2018/11/msg00016.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/2FBQOCV3GBAN2EYZUM3CFDJ4ECA3GZOK/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/DOFRQWJRP2NQJEYEWOMECVW3HAMD5SYN/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/TZBNQH3DMI7HDELJAZ4TFJJANHXOEDWH/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://rt.perl.org/Public/Bug/Display.html?id=127834"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.gentoo.org/glsa/201701-75"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.gentoo.org/glsa/201812-07"
+    },
+    {
+      "type": "WEB",
+      "url": "https://perldoc.perl.org/5.24.1/perldelta"
+    }
+  ],
+  "schema_version": "1.6.1"
+}

--- a/grype/db/v6/build/transformers/osv/testdata/CPANSA-Mojolicious-2022-03.json
+++ b/grype/db/v6/build/transformers/osv/testdata/CPANSA-Mojolicious-2022-03.json
@@ -1,0 +1,58 @@
+{
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "CPAN",
+        "name": "Mojolicious"
+      },
+      "ranges": [
+        {
+          "database_specific": {
+            "anchore": {
+              "fixes": [
+                {
+                  "date": "2022-12-10",
+                  "kind": "advisory",
+                  "version": "9.31"
+                }
+              ]
+            }
+          },
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "9.31"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    }
+  ],
+  "aliases": [],
+  "database_specific": {
+    "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+    "cpansa_generated": "Sun Jul 26 06:23:50 2026"
+  },
+  "details": "Mojo::DOM did not correctly parse <script> tags.",
+  "id": "CPANSA-Mojolicious-2022-03",
+  "modified": "2026-07-26T06:23:50Z",
+  "published": "2022-12-10T00:00:00Z",
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://github.com/mojolicious/mojo/commit/6f195d85db6756022d3599f7d2634975688c9550"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mojolicious/mojo/issues/2014"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mojolicious/mojo/issues/2015"
+    }
+  ],
+  "schema_version": "1.6.1"
+}

--- a/grype/db/v6/build/transformers/osv/testdata/CPANSA-libwww-perl-1995-01-no-affected.json
+++ b/grype/db/v6/build/transformers/osv/testdata/CPANSA-libwww-perl-1995-01-no-affected.json
@@ -1,0 +1,19 @@
+{
+  "affected": [],
+  "aliases": [],
+  "database_specific": {
+    "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+    "cpansa_generated": "Sun Jul 26 06:23:50 2026"
+  },
+  "details": "There is a security hole with the implementation of getBasicCredentials().",
+  "id": "CPANSA-libwww-perl-1995-01",
+  "modified": "2026-07-26T06:23:50Z",
+  "published": "1995-09-06T00:00:00Z",
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://metacpan.org/dist/libwww-perl/changes"
+    }
+  ],
+  "schema_version": "1.6.1"
+}

--- a/grype/db/v6/build/transformers/osv/transform.go
+++ b/grype/db/v6/build/transformers/osv/transform.go
@@ -47,6 +47,7 @@ type Strategy interface {
 var strategies = []Strategy{
 	almaStrategy{},
 	bitnamiStrategy{},
+	cpansaStrategy{},
 	govulndbStrategy{},
 	rootioStrategy{},
 	chainguardStrategy{},

--- a/grype/db/v6/build/transformers/osv/transform_cpansa.go
+++ b/grype/db/v6/build/transformers/osv/transform_cpansa.go
@@ -1,0 +1,134 @@
+package osv
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/anchore/grype/grype/db/data"
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal"
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
+	"github.com/anchore/grype/grype/db/provider"
+	db "github.com/anchore/grype/grype/db/v6"
+	"github.com/anchore/grype/grype/db/v6/build/transformers"
+	"github.com/anchore/grype/grype/db/v6/build/transformers/internal"
+)
+
+// cpanEcosystem is both the syft package type and the grype version-format
+// string for Perl distributions.
+//
+// TODO: use string(pkg.CpanPkg) once the syft release carrying it is vendored.
+const cpanEcosystem = "cpan"
+
+// cpansaStrategy handles CPANSA-* records from the CPAN Security Advisory
+// database (github.com/briandfoy/cpan-security-advisory), shaped into OSV by
+// vunnel's `cpan` provider. CPANSA specifics:
+//   - the advisory subject is a CPAN *distribution* ("DBD-SQLite", "libwww-perl",
+//     and "perl" itself), never a module, so names map straight onto the syft
+//     `cpan` package type.
+//   - distribution names are case sensitive and are used verbatim: no
+//     name.Normalize call here, and no resolver is registered for `cpan` in
+//     grype/db/v6/name. `JSON-MaybeXS` must not match `json-maybexs`.
+//   - CPANSA's freeform range strings are resolved against each distribution's
+//     published release list at provider time, so what arrives here is ordinary
+//     bounded OSV windows. Ranges are tagged "cpan" so the Perl comparator
+//     evaluates them; Perl version ordering is decimal-fraction based
+//     (1.2 > 1.10) and no other format gets it right.
+//   - aliases hold CVEs when one exists. Many advisories have none at all and
+//     are only ever reachable under their CPANSA id.
+//   - references pass through with the OSV type as the tag; CPANSA emits only
+//     WEB references, so there is no ADVISORY reference to key a refID off of.
+//   - CPANSA has no withdrawal concept, so every record is emitted active.
+type cpansaStrategy struct{}
+
+func (cpansaStrategy) Matches(id string) bool {
+	return strings.HasPrefix(id, "CPANSA-")
+}
+
+func (cpansaStrategy) Transform(vuln unmarshal.OSVVulnerability, state provider.State) ([]data.Entry, error) {
+	affected := cpansaAffectedPackages(vuln)
+	if len(affected) == 0 {
+		// no affected packages: emitting just the vulnerability handle would write
+		// an orphaned record that can never match a package, so skip the advisory.
+		return nil, nil
+	}
+
+	severities, err := getSeverities(vuln)
+	if err != nil {
+		return nil, fmt.Errorf("unable to obtain severities: %w", err)
+	}
+
+	in := []any{
+		db.VulnerabilityHandle{
+			Name:          vuln.ID,
+			ProviderID:    state.Provider,
+			Provider:      provider.Model(state),
+			Status:        db.VulnerabilityActive,
+			ModifiedDate:  &vuln.Modified,
+			PublishedDate: &vuln.Published,
+			BlobValue: &db.VulnerabilityBlob{
+				ID:          vuln.ID,
+				Description: vuln.Details,
+				References:  cpansaReferences(vuln),
+				Aliases:     vuln.Aliases,
+				Severities:  severities,
+			},
+		},
+	}
+
+	for _, aph := range affected {
+		in = append(in, aph)
+	}
+	return transformers.NewEntries(in...), nil
+}
+
+func cpansaReferences(vuln unmarshal.OSVVulnerability) []db.Reference {
+	var refs []db.Reference
+	for _, ref := range vuln.References {
+		refs = append(refs, db.Reference{
+			URL:  ref.URL,
+			Tags: []string{string(ref.Type)},
+		})
+	}
+	return refs
+}
+
+// cpansaAffectedPackages builds one handle per affected distribution. A single
+// CPANSA id can span several distributions (CPANSA-ExtUtils-ParseXS-2016-1238
+// covers both ExtUtils-ParseXS and perl), and upstream also collapses dozens of
+// separate version windows under one id, which arrive as multiple windows on one
+// distribution rather than as duplicate handles.
+func cpansaAffectedPackages(vuln unmarshal.OSVVulnerability) []db.AffectedPackageHandle {
+	var aphs []db.AffectedPackageHandle
+	for _, affected := range vuln.Affected {
+		aphs = append(aphs, db.AffectedPackageHandle{
+			Package: cpansaPackage(affected.Package),
+			BlobValue: &db.PackageBlob{
+				CVEs:   vuln.Aliases,
+				Ranges: cpansaRanges(affected.Ranges),
+			},
+		})
+	}
+	sort.Sort(internal.ByAffectedPackage(aphs))
+	return aphs
+}
+
+// cpansaPackage maps an OSV package onto the syft `cpan` type, keeping the
+// distribution name exactly as CPANSA wrote it.
+func cpansaPackage(p osvmodel.Package) *db.Package {
+	return &db.Package{
+		Ecosystem: cpanEcosystem,
+		Name:      p.Name,
+	}
+}
+
+func cpansaRanges(ranges []osvmodel.Range) []db.Range {
+	var out []db.Range
+	for _, r := range ranges {
+		// range type is always ECOSYSTEM from this provider, and "ecosystem" as a
+		// grype format string parses to UnknownFormat, whose fuzzy comparison
+		// mis-orders Perl decimal versions. Tag "cpan" unconditionally.
+		out = append(out, getGrypeRangesFromRange(r, cpanEcosystem)...)
+	}
+	return out
+}

--- a/grype/db/v6/build/transformers/osv/transform_cpansa_test.go
+++ b/grype/db/v6/build/transformers/osv/transform_cpansa_test.go
@@ -1,0 +1,234 @@
+package osv
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/grype/grype/db/internal/provider/unmarshal/osvmodel"
+	db "github.com/anchore/grype/grype/db/v6"
+	"github.com/anchore/grype/grype/db/v6/build/transformers"
+	"github.com/anchore/grype/grype/db/v6/name"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+func cpanFix(version string, date time.Time) *db.Fix {
+	return &db.Fix{
+		Version: version,
+		State:   db.FixedStatus,
+		Detail: &db.FixDetail{
+			Available: &db.FixAvailability{
+				Date: timeRef(date),
+				Kind: "advisory",
+			},
+		},
+	}
+}
+
+// TestCpansaTransform exercises the CPANSA strategy end-to-end against real
+// records emitted by vunnel's cpan provider.
+//
+//   - CPANSA-Mojolicious-2022-03: no CVE alias at all. The advisory is only ever
+//     reachable under its CPANSA id, so a pipeline that keys on CVEs loses it.
+//   - CPANSA-DBD-SQLite-2018-8740-sqlite: upstream collapses dozens of separate
+//     version windows under one id. They arrive as one affected entry with three
+//     windows and three fix dates, and must stay one advisory. Also carries
+//     underscore alpha versions (1.47_04), which are ordinary CPAN versions and
+//     must not be mangled into semver pre-releases.
+//   - CPANSA-ExtUtils-ParseXS-2016-1238: one id spanning two distributions, one
+//     of which is the perl interpreter itself. Both names are used verbatim.
+//   - CPANSA-libwww-perl-1995-01 with its affected list emptied by hand: an
+//     advisory whose ranges resolved to nothing must produce no entries at all.
+func TestCpansaTransform(t *testing.T) {
+	fixDate2016 := time.Date(2016, time.August, 2, 0, 0, 0, 0, time.UTC)
+
+	tests := []transformCase{
+		{
+			name:        "no CVE alias",
+			fixturePath: "testdata/CPANSA-Mojolicious-2022-03.json",
+			want: []transformers.RelatedEntries{{
+				VulnerabilityHandle: &db.VulnerabilityHandle{
+					Name:          "CPANSA-Mojolicious-2022-03",
+					Status:        db.VulnerabilityActive,
+					ProviderID:    "osv",
+					Provider:      expectedProvider(),
+					ModifiedDate:  timeRef(time.Date(2026, time.July, 26, 6, 23, 50, 0, time.UTC)),
+					PublishedDate: timeRef(time.Date(2022, time.December, 10, 0, 0, 0, 0, time.UTC)),
+					BlobValue: &db.VulnerabilityBlob{
+						ID:          "CPANSA-Mojolicious-2022-03",
+						Description: "Mojo::DOM did not correctly parse <script> tags.",
+						References: []db.Reference{{
+							URL:  "https://github.com/mojolicious/mojo/commit/6f195d85db6756022d3599f7d2634975688c9550",
+							Tags: []string{"WEB"},
+						}, {
+							URL:  "https://github.com/mojolicious/mojo/issues/2014",
+							Tags: []string{"WEB"},
+						}, {
+							URL:  "https://github.com/mojolicious/mojo/issues/2015",
+							Tags: []string{"WEB"},
+						}},
+						Aliases: []string{},
+					},
+				},
+				Related: affectedPkgSlice(db.AffectedPackageHandle{
+					Package: &db.Package{Name: "Mojolicious", Ecosystem: "cpan"},
+					BlobValue: &db.PackageBlob{
+						CVEs: []string{},
+						Ranges: []db.Range{{
+							Version: db.Version{Type: "cpan", Constraint: "< 9.31"},
+							Fix:     cpanFix("9.31", time.Date(2022, time.December, 10, 0, 0, 0, 0, time.UTC)),
+						}},
+					},
+				}),
+			}},
+		},
+		{
+			name:        "many entries collapsed under one id",
+			fixturePath: "testdata/CPANSA-DBD-SQLite-2018-8740-sqlite.json",
+			want: []transformers.RelatedEntries{{
+				VulnerabilityHandle: &db.VulnerabilityHandle{
+					Name:          "CPANSA-DBD-SQLite-2018-8740-sqlite",
+					Status:        db.VulnerabilityActive,
+					ProviderID:    "osv",
+					Provider:      expectedProvider(),
+					ModifiedDate:  timeRef(time.Date(2026, time.July, 26, 6, 23, 50, 0, time.UTC)),
+					PublishedDate: timeRef(time.Date(2018, time.March, 17, 0, 0, 0, 0, time.UTC)),
+					BlobValue: &db.VulnerabilityBlob{
+						ID:          "CPANSA-DBD-SQLite-2018-8740-sqlite",
+						Description: "In SQLite through 3.22.0, databases whose schema is corrupted using a CREATE TABLE AS statement could cause a NULL pointer dereference, related to build.c and prepare.c.",
+						References:  dbdSQLiteReferences(),
+						Aliases:     []string{"CVE-2018-8740"},
+					},
+				},
+				Related: affectedPkgSlice(db.AffectedPackageHandle{
+					Package: &db.Package{Name: "DBD-SQLite", Ecosystem: "cpan"},
+					BlobValue: &db.PackageBlob{
+						CVEs: []string{"CVE-2018-8740"},
+						Ranges: []db.Range{{
+							Version: db.Version{Type: "cpan", Constraint: ">= 1.00 < 1.35"},
+							Fix:     cpanFix("1.35", time.Date(2018, time.March, 17, 0, 0, 0, 0, time.UTC)),
+						}, {
+							Version: db.Version{Type: "cpan", Constraint: ">= 1.36_01 < 1.47_04"},
+							Fix:     cpanFix("1.47_04", time.Date(2018, time.March, 17, 0, 0, 0, 0, time.UTC)),
+						}, {
+							Version: db.Version{Type: "cpan", Constraint: ">= 1.47_05 < 1.59_01"},
+							Fix:     cpanFix("1.59_01", time.Date(2018, time.March, 17, 0, 0, 0, 0, time.UTC)),
+						}},
+					},
+				}),
+			}},
+		},
+		{
+			name:        "one id spanning two distributions, including the interpreter",
+			fixturePath: "testdata/CPANSA-ExtUtils-ParseXS-2016-1238.json",
+			want: []transformers.RelatedEntries{{
+				VulnerabilityHandle: &db.VulnerabilityHandle{
+					Name:          "CPANSA-ExtUtils-ParseXS-2016-1238",
+					Status:        db.VulnerabilityActive,
+					ProviderID:    "osv",
+					Provider:      expectedProvider(),
+					ModifiedDate:  timeRef(time.Date(2026, time.July, 26, 6, 23, 50, 0, time.UTC)),
+					PublishedDate: timeRef(fixDate2016),
+					BlobValue: &db.VulnerabilityBlob{
+						ID:          "CPANSA-ExtUtils-ParseXS-2016-1238",
+						Description: extUtilsParseXSDescription,
+						References:  extUtilsParseXSReferences(),
+						Aliases:     []string{"CVE-2016-1238"},
+					},
+				},
+				Related: affectedPkgSlice(
+					db.AffectedPackageHandle{
+						Package: &db.Package{Name: "ExtUtils-ParseXS", Ecosystem: "cpan"},
+						BlobValue: &db.PackageBlob{
+							CVEs: []string{"CVE-2016-1238"},
+							Ranges: []db.Range{{
+								Version: db.Version{Type: "cpan", Constraint: "< 3.35"},
+								Fix:     cpanFix("3.35", fixDate2016),
+							}},
+						},
+					},
+					db.AffectedPackageHandle{
+						Package: &db.Package{Name: "perl", Ecosystem: "cpan"},
+						BlobValue: &db.PackageBlob{
+							CVEs: []string{"CVE-2016-1238"},
+							Ranges: []db.Range{{
+								Version: db.Version{Type: "cpan", Constraint: "< 5.024001"},
+								Fix:     cpanFix("5.024001", fixDate2016),
+							}},
+						},
+					},
+				),
+			}},
+		},
+		{
+			name:        "advisory with no affected packages is not emitted",
+			fixturePath: "testdata/CPANSA-libwww-perl-1995-01-no-affected.json",
+			want:        nil,
+		},
+	}
+
+	runTransformCases(t, tests)
+}
+
+// TestCpansaPackageNameIsVerbatim guards the case-sensitivity requirement: CPAN
+// distribution names are case sensitive, CPANSA keys match CPAN casing exactly,
+// and no resolver may be registered for the cpan type that would fold case.
+func TestCpansaPackageNameIsVerbatim(t *testing.T) {
+	for _, n := range []string{"JSON-MaybeXS", "libwww-perl", "perl", "CPAN-02Packages-Search"} {
+		p := cpansaPackage(osvmodel.Package{Ecosystem: "CPAN", Name: n})
+		assert.Equal(t, n, p.Name)
+		assert.Equal(t, "cpan", p.Ecosystem)
+	}
+
+	assert.Nil(t, name.FromType(syftPkg.Type("cpan")), "no name resolver may be registered for cpan")
+}
+
+const extUtilsParseXSDescription = "(1) cpan/Archive-Tar/bin/ptar, (2) cpan/Archive-Tar/bin/ptardiff, (3) cpan/Archive-Tar/bin/ptargrep, (4) cpan/CPAN/scripts/cpan, (5) cpan/Digest-SHA/shasum, (6) cpan/Encode/bin/enc2xs, (7) cpan/Encode/bin/encguess, (8) cpan/Encode/bin/piconv, (9) cpan/Encode/bin/ucmlint, (10) cpan/Encode/bin/unidump, (11) cpan/ExtUtils-MakeMaker/bin/instmodsh, (12) cpan/IO-Compress/bin/zipdetails, (13) cpan/JSON-PP/bin/json_pp, (14) cpan/Test-Harness/bin/prove, (15) dist/ExtUtils-ParseXS/lib/ExtUtils/xsubpp, (16) dist/Module-CoreList/corelist, (17) ext/Pod-Html/bin/pod2html, (18) utils/c2ph.PL, (19) utils/h2ph.PL, (20) utils/h2xs.PL, (21) utils/libnetcfg.PL, (22) utils/perlbug.PL, (23) utils/perldoc.PL, (24) utils/perlivp.PL, and (25) utils/splain.PL in Perl 5.x before 5.22.3-RC2 and 5.24 before 5.24.1-RC2 do not properly remove . (period) characters from the end of the includes directory array, which might allow local users to gain privileges via a Trojan horse module under the current working directory."
+
+func webRefs(urls ...string) []db.Reference {
+	refs := make([]db.Reference, 0, len(urls))
+	for _, u := range urls {
+		refs = append(refs, db.Reference{URL: u, Tags: []string{"WEB"}})
+	}
+	return refs
+}
+
+func dbdSQLiteReferences() []db.Reference {
+	return webRefs(
+		"https://www.sqlite.org/cgi/src/timeline?r=corrupt-schema",
+		"https://bugs.launchpad.net/ubuntu/+source/sqlite3/+bug/1756349",
+		"https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=6964",
+		"https://www.sqlite.org/cgi/src/vdiff?from=1774f1c3baf0bc3d&to=d75e67654aa9620b",
+		"http://www.securityfocus.com/bid/103466",
+		"https://lists.debian.org/debian-lts-announce/2019/01/msg00009.html",
+		"http://lists.opensuse.org/opensuse-security-announce/2019-05/msg00050.html",
+		"https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PU4NZ6DDU4BEM3ACM3FM6GLEPX56ZQXK/",
+		"https://usn.ubuntu.com/4205-1/",
+		"https://usn.ubuntu.com/4394-1/",
+		"https://lists.debian.org/debian-lts-announce/2020/08/msg00037.html",
+		"https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4@%3Cissues.bookkeeper.apache.org%3E",
+		"https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b@%3Cissues.bookkeeper.apache.org%3E",
+	)
+}
+
+func extUtilsParseXSReferences() []db.Reference {
+	return webRefs(
+		"http://lists.opensuse.org/opensuse-security-announce/2019-08/msg00002.html",
+		"http://perl5.git.perl.org/perl.git/commit/cee96d52c39b1e7b36e1c62d38bcd8d86e9a41ab",
+		"http://www.debian.org/security/2016/dsa-3628",
+		"http://www.nntp.perl.org/group/perl.perl5.porters/2016/07/msg238271.html",
+		"http://www.securityfocus.com/bid/92136",
+		"http://www.securitytracker.com/id/1036440",
+		"https://h20566.www2.hpe.com/portal/site/hpsc/public/kb/docDisplay?docId=emr_na-c05240731",
+		"https://lists.apache.org/thread.html/7f6a16bc0fd0fd5e67c7fd95bd655069a2ac7d1f88e42d3c853e601c%40%3Cannounce.apache.org%3E",
+		"https://lists.debian.org/debian-lts-announce/2018/11/msg00016.html",
+		"https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/2FBQOCV3GBAN2EYZUM3CFDJ4ECA3GZOK/",
+		"https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/DOFRQWJRP2NQJEYEWOMECVW3HAMD5SYN/",
+		"https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/TZBNQH3DMI7HDELJAZ4TFJJANHXOEDWH/",
+		"https://rt.perl.org/Public/Bug/Display.html?id=127834",
+		"https://security.gentoo.org/glsa/201701-75",
+		"https://security.gentoo.org/glsa/201812-07",
+		"https://perldoc.perl.org/5.24.1/perldelta",
+	)
+}

--- a/grype/db/v6/data.go
+++ b/grype/db/v6/data.go
@@ -120,6 +120,8 @@ func KnownPackageSpecifierOverrides() []PackageSpecifierOverride {
 		{Ecosystem: pkg.JavaScript.String(), ReplacementEcosystem: ptr(string(pkg.NpmPkg))},
 		{Ecosystem: pkg.Lua.String(), ReplacementEcosystem: ptr(string(pkg.LuaRocksPkg))},
 		{Ecosystem: pkg.OCaml.String(), ReplacementEcosystem: ptr(string(pkg.OpamPkg))},
+		// TODO: use pkg.Perl.String() / string(pkg.CpanPkg) once the syft release carrying them is vendored
+		{Ecosystem: "perl", ReplacementEcosystem: ptr("cpan")},
 		{Ecosystem: pkg.PHP.String(), ReplacementEcosystem: ptr(string(pkg.PhpComposerPkg))},
 		{Ecosystem: pkg.Python.String(), ReplacementEcosystem: ptr(string(pkg.PythonPkg))},
 		{Ecosystem: pkg.R.String(), ReplacementEcosystem: ptr(string(pkg.Rpkg))},

--- a/grype/db/v6/vulnerability.go
+++ b/grype/db/v6/vulnerability.go
@@ -292,6 +292,9 @@ func mimicV5GithubNamespace(provider, language string) string {
 		language = "php"
 	case "cargo", string(pkg.RustPkg):
 		language = "rust"
+	// TODO: use string(pkg.CpanPkg) once the syft release carrying it is vendored
+	case "cpan":
+		language = "perl"
 	case "pub", string(pkg.DartPubPkg):
 		language = "dart"
 	case "nuget", string(pkg.DotnetPkg):


### PR DESCRIPTION
Adds `cpansaStrategy` to the OSV transformers, so perl advisories land in the v6 database.

- distribution names are used verbatim, with no `name.Normalize` call and no name resolver registered for `cpan`. CPAN distribution names are case- and punctuation-significant, and normalizing them loses matches.
- emitted ranges are tagged with the `cpan` version format so the perl comparator is what evaluates them.
- `perl` maps to the `cpan` package type through `KnownPackageSpecifierOverrides`.

The `"perl"` and `"cpan"` strings are deliberately literals rather than the syft constants. CI builds against the released syft, which does not have them yet; they can be swapped after the next vendor bump.

Builds on the perl version comparator branch, and needs the cpan provider on the data side to produce anything.