### PR TITLE
fix: cpan advisories could not match anything

### DIFF
--- a/grype/db/internal/versionutil/constraint.go
+++ b/grype/db/internal/versionutil/constraint.go
@@ -13,7 +13,10 @@ import (
 // > 5.0.0
 // >=5
 // <6
-var forceSemVerPattern = regexp.MustCompile(`[><=]+\s*[^<>=]+`)
+// the comma exclusion matters: clauses arrive both space separated and already comma
+// separated (GHSA ranges are written ">= 1.0, < 2.0"), and without it the trailing comma is
+// captured as part of the clause and the rejoin below emits ">=1.0,,<2.0".
+var forceSemVerPattern = regexp.MustCompile(`[><=]+\s*[^<>=,]+`)
 
 func EnforceSemVerConstraint(constraint string) string {
 	constraint = CleanConstraint(constraint)

--- a/grype/db/internal/versionutil/constraint_test.go
+++ b/grype/db/internal/versionutil/constraint_test.go
@@ -12,6 +12,12 @@ func TestEnforceSemVerConstraint(t *testing.T) {
 			expected: ">=5.0.0,<7.1",
 		},
 		{
+			// already comma separated, which is how GHSA writes ranges. Without excluding
+			// commas from the clause pattern this comes back as ">=1.0.0,,<2.0.0".
+			value:    ">= 1.0.0, < 2.0.0",
+			expected: ">=1.0.0,<2.0.0",
+		},
+		{
 			value:    "None",
 			expected: "",
 		},

--- a/grype/db/v6/build/transformers/osv/helpers.go
+++ b/grype/db/v6/build/transformers/osv/helpers.go
@@ -82,7 +82,13 @@ func eventsToRanges(events []osvmodel.Event, fixes map[string]db.FixAvailability
 		if constraint == "" {
 			constraint = c
 		} else {
-			constraint = versionutil.AndConstraints(constraint, c)
+			// comma, not space: grype's range expression parser only splits AND clauses on
+			// commas, and a space-joined ">= 1.00 < 1.35" fails to parse for every format
+			// that does not go through EnforceSemVerConstraint below (cpan, apk). The
+			// constraint then matches nothing, silently, so any window opened by a non-zero
+			// `introduced` disappears. Semver-ish formats are unaffected either way, since
+			// EnforceSemVerConstraint re-joins on commas regardless of the input separator.
+			constraint = strings.Join([]string{constraint, c}, ", ")
 		}
 	}
 	emit := func(fix *db.Fix) {

--- a/grype/db/v6/build/transformers/osv/testdata/CPANSA-libwww-perl-1995-01-empty-ranges.json
+++ b/grype/db/v6/build/transformers/osv/testdata/CPANSA-libwww-perl-1995-01-empty-ranges.json
@@ -1,0 +1,27 @@
+{
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "CPAN",
+        "name": "libwww-perl"
+      },
+      "ranges": []
+    }
+  ],
+  "aliases": [],
+  "database_specific": {
+    "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+    "cpansa_generated": "Sun Jul 26 06:23:50 2026"
+  },
+  "details": "There is a security hole with the implementation of getBasicCredentials().",
+  "id": "CPANSA-libwww-perl-1995-01",
+  "modified": "2026-07-26T06:23:50Z",
+  "published": "1995-09-06T00:00:00Z",
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://metacpan.org/dist/libwww-perl/changes"
+    }
+  ],
+  "schema_version": "1.6.1"
+}

--- a/grype/db/v6/build/transformers/osv/transform_cpansa.go
+++ b/grype/db/v6/build/transformers/osv/transform_cpansa.go
@@ -101,11 +101,20 @@ func cpansaReferences(vuln unmarshal.OSVVulnerability) []db.Reference {
 func cpansaAffectedPackages(vuln unmarshal.OSVVulnerability) []db.AffectedPackageHandle {
 	var aphs []db.AffectedPackageHandle
 	for _, affected := range vuln.Affected {
+		ranges := cpansaRanges(affected.Ranges)
+		if len(ranges) == 0 {
+			// the provider emits an affected entry with no ranges when an advisory's version
+			// strings resolve against nothing in the distribution's release list, which real
+			// data does (CPANSA-libwww-perl-1995-01 predates any recorded release). An entry
+			// with no ranges is not harmlessly orphaned: an empty constraint is satisfied by
+			// every version, so it would report against every install of the distribution.
+			continue
+		}
 		aphs = append(aphs, db.AffectedPackageHandle{
 			Package: cpansaPackage(affected.Package),
 			BlobValue: &db.PackageBlob{
 				CVEs:   vuln.Aliases,
-				Ranges: cpansaRanges(affected.Ranges),
+				Ranges: ranges,
 			},
 		})
 	}

--- a/grype/db/v6/build/transformers/osv/transform_cpansa_test.go
+++ b/grype/db/v6/build/transformers/osv/transform_cpansa_test.go
@@ -106,13 +106,13 @@ func TestCpansaTransform(t *testing.T) {
 					BlobValue: &db.PackageBlob{
 						CVEs: []string{"CVE-2018-8740"},
 						Ranges: []db.Range{{
-							Version: db.Version{Type: "cpan", Constraint: ">= 1.00 < 1.35"},
+							Version: db.Version{Type: "cpan", Constraint: ">= 1.00, < 1.35"},
 							Fix:     cpanFix("1.35", time.Date(2018, time.March, 17, 0, 0, 0, 0, time.UTC)),
 						}, {
-							Version: db.Version{Type: "cpan", Constraint: ">= 1.36_01 < 1.47_04"},
+							Version: db.Version{Type: "cpan", Constraint: ">= 1.36_01, < 1.47_04"},
 							Fix:     cpanFix("1.47_04", time.Date(2018, time.March, 17, 0, 0, 0, 0, time.UTC)),
 						}, {
-							Version: db.Version{Type: "cpan", Constraint: ">= 1.47_05 < 1.59_01"},
+							Version: db.Version{Type: "cpan", Constraint: ">= 1.47_05, < 1.59_01"},
 							Fix:     cpanFix("1.59_01", time.Date(2018, time.March, 17, 0, 0, 0, 0, time.UTC)),
 						}},
 					},
@@ -164,6 +164,15 @@ func TestCpansaTransform(t *testing.T) {
 		{
 			name:        "advisory with no affected packages is not emitted",
 			fixturePath: "testdata/CPANSA-libwww-perl-1995-01-no-affected.json",
+			want:        nil,
+		},
+		{
+			// the shape upstream actually produces: an affected entry is present but its
+			// ranges resolved to nothing, because the advisory predates any release CPANSA
+			// records. Emitting it would write an empty constraint, and an empty constraint is
+			// satisfied by every version, so this would report against every install.
+			name:        "affected package whose ranges resolved to nothing is not emitted",
+			fixturePath: "testdata/CPANSA-libwww-perl-1995-01-empty-ranges.json",
 			want:        nil,
 		},
 	}

--- a/grype/matcher/stock/cpan_test.go
+++ b/grype/matcher/stock/cpan_test.go
@@ -1,0 +1,450 @@
+package stock
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/search"
+	"github.com/anchore/grype/internal/dbtest"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+// TestMatcherStock_CPAN drives the whole grype-side Perl path against a real database built
+// from the CPANSA records vunnel's `cpan` provider emits: OSV record -> CPANSA transformer ->
+// v6 database -> matcher. The transformer tests stop at the entry and the version tests stop
+// at the comparator, so this is the only place the pieces are checked together.
+//
+// CPAN packages have no dedicated matcher; they fall through to stock, which searches by
+// ecosystem and package name. What makes them interesting is entirely in the data:
+//
+//   - Perl version ordering. 4.09 > 4.10 is wrong everywhere else and right here, and perl
+//     writes its own version three different ways (5.22.1, 5.022001, v5.22.1) which all have
+//     to resolve to the same point on a range.
+//   - Advisories with no CVE at all. CPANSA ids are the primary key; a pipeline that assumes
+//     a CVE exists loses roughly two thirds of the database.
+//   - One id carrying many disjoint version windows, because upstream files one entry per
+//     slice of the affected range.
+//   - Distribution names, not module names, and case sensitively.
+func TestMatcherStock_CPAN(t *testing.T) { //nolint:funlen // table-driven CPAN version and naming cases
+	tests := []struct {
+		name       string
+		pkgName    string
+		pkgVersion string
+		expect     []string
+	}{
+		{
+			// ordinary bounded range carrying a CVE alias, plus the later Mojolicious advisory
+			name: "Mojolicious below both fixes", pkgName: "Mojolicious", pkgVersion: "9.10",
+			expect: []string{"CPANSA-Mojolicious-2021-01", "CPANSA-Mojolicious-2022-03"},
+		},
+		{
+			// the fixed bound is exclusive, so 9.11 clears the 2021 advisory exactly
+			name: "Mojolicious at the 2021 fix", pkgName: "Mojolicious", pkgVersion: "9.11",
+			expect: []string{"CPANSA-Mojolicious-2022-03"},
+		},
+		{
+			// CPANSA-Mojolicious-2022-03 has `cves: []` and is only ever reachable under its
+			// CPANSA id
+			name: "advisory with no CVE at all", pkgName: "Mojolicious", pkgVersion: "9.30",
+			expect: []string{"CPANSA-Mojolicious-2022-03"},
+		},
+		{
+			name: "Mojolicious above every fix", pkgName: "Mojolicious", pkgVersion: "9.31",
+		},
+		{
+			// the perl interpreter is an ordinary CPAN distribution to CPANSA. CPANSA writes
+			// perl's release history in decimal form and its advisories in dotted form, so
+			// these two rows are the same version and both have to land the same way. A string
+			// compare finds neither; a semver compare finds the wrong set.
+			//
+			// CPANSA-perl-2026-57432 rides along on every perl row below: its lowest window is
+			// open at the bottom (0 -> 5.040005), so every perl the fixture knows about is
+			// inside it.
+			name: "perl interpreter, decimal form", pkgName: "perl", pkgVersion: "5.022001",
+			expect: []string{"CPANSA-ExtUtils-ParseXS-2016-1238", "CPANSA-perl-2015-8608", "CPANSA-perl-2016-6185", "CPANSA-perl-2026-57432"},
+		},
+		{
+			name: "perl interpreter, dotted form", pkgName: "perl", pkgVersion: "5.22.1",
+			expect: []string{"CPANSA-ExtUtils-ParseXS-2016-1238", "CPANSA-perl-2015-8608", "CPANSA-perl-2016-6185", "CPANSA-perl-2026-57432"},
+		},
+		{
+			// CPANSA starts CVE-2016-6185 at 5.22.0 where NVD starts it at 5.23.0. That is a
+			// data disagreement between the two sources, not a matching bug.
+			name: "perl interpreter at the 2016-6185 fix", pkgName: "perl", pkgVersion: "5.024000",
+			expect: []string{"CPANSA-ExtUtils-ParseXS-2016-1238", "CPANSA-perl-2026-57432"},
+		},
+		{
+			// CPANSA-perl-2015-8608 carries two disjoint affected windows upstream, but its
+			// fixed_versions of ">=5.22.2" subtracts the whole second one. That is what
+			// CPAN::Audit itself computes, so the emitted record has a single 0 -> 5.022002
+			// window and a 5.23.x perl is genuinely not affected by it.
+			name: "perl 5.023001 sits outside the 2015-8608 window", pkgName: "perl", pkgVersion: "5.023001",
+			expect: []string{"CPANSA-ExtUtils-ParseXS-2016-1238", "CPANSA-perl-2016-6185", "CPANSA-perl-2026-57432"},
+		},
+		{
+			// 65 upstream entries under one id, unioned into three windows. One advisory, not 65.
+			name: "one id, many windows: inside the first", pkgName: "DBD-SQLite", pkgVersion: "1.20_01",
+			expect: []string{"CPANSA-DBD-SQLite-2018-8740-sqlite"},
+		},
+		{
+			// the `=1.05` entry, a form upstream's own range regex fails to match
+			name: "one id, many windows: the single-equals entry", pkgName: "DBD-SQLite", pkgVersion: "1.05",
+			expect: []string{"CPANSA-DBD-SQLite-2018-8740-sqlite"},
+		},
+		{
+			// an underscore version is an ordinary CPAN version, not a semver pre-release, and
+			// 1.59_01 is the exclusive upper bound of the last window
+			name: "one id, many windows: at the alpha upper bound", pkgName: "DBD-SQLite", pkgVersion: "1.59_01",
+		},
+		{
+			name: "one id, many windows: in the gap between two", pkgName: "DBD-SQLite", pkgVersion: "1.35",
+		},
+		{
+			// NVD records CVE-2011-0633 under vendor `gisle_aas` with versions enumerated one
+			// CPE at a time, so the CPE path cannot reach it. CPANSA expresses it as a range.
+			name: "libwww-perl the CPE path misses", pkgName: "libwww-perl", pkgVersion: "5.836",
+			expect: []string{"CPANSA-libwww-perl-2011-01", "CPANSA-libwww-perl-2017-01", "CPANSA-libwww-perl-2026-8368"},
+		},
+		{
+			name: "libwww-perl as debian bookworm ships it", pkgName: "libwww-perl", pkgVersion: "6.68",
+			expect: []string{"CPANSA-libwww-perl-2026-8368"},
+		},
+		{
+			// 4.09 is v4.90.0 and 4.10 is v4.100.0 under perl rules, so 4.09 really is the
+			// lower version. Every other ecosystem grype knows orders these the other way.
+			name: "decimal ordering at a real boundary", pkgName: "CGI-Session", pkgVersion: "4.09",
+			expect: []string{"CPANSA-CGI-Session-2006-01", "CPANSA-CGI-Session-2006-1279", "CPANSA-CGI-Session-2026-56016"},
+		},
+		{
+			name: "decimal ordering, one past the boundary", pkgName: "CGI-Session", pkgVersion: "4.10",
+			expect: []string{"CPANSA-CGI-Session-2006-01", "CPANSA-CGI-Session-2026-56016"},
+		},
+		{
+			// CPAN distribution names are case sensitive, and this does NOT hold: the v6
+			// package name index is declared `collate:NOCASE` for every ecosystem
+			// (grype/db/v6/models.go), so the lookup folds case before the cpan strategy ever
+			// sees it. Registering no name normalizer for `cpan` is necessary but not
+			// sufficient. Pinned here as the real behavior so a change to it is deliberate.
+			name:    "wrong case still matches, because v6 name lookup is NOCASE",
+			pkgName: "mojolicious", pkgVersion: "9.10",
+			expect: []string{"CPANSA-Mojolicious-2021-01", "CPANSA-Mojolicious-2022-03"},
+		},
+		{
+			// LWP is libwww-perl's main module, and a CPAN.pm install lands at
+			// auto/LWP/.packlist, so LWP is the only name syft has to report. The advisory
+			// data carries an alias for exactly this case; see
+			// TestMatcherStock_CPAN_MainModuleAlias.
+			name: "main module name matches through the alias", pkgName: "LWP", pkgVersion: "5.836",
+			expect: []string{"CPANSA-libwww-perl-2011-01", "CPANSA-libwww-perl-2017-01", "CPANSA-libwww-perl-2026-8368"},
+		},
+	}
+
+	dbtest.DBs(t, "cpansa").Run(func(t *testing.T, db *dbtest.DB) {
+		matcher := NewStockMatcher(MatcherConfig{})
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				p := newCpanPackage(tt.pkgName, tt.pkgVersion)
+
+				// SkipCompleteness: these rows assert the whole result set by id rather than
+				// drilling into each match's details, which is what the completeness check
+				// wants to see.
+				findings := db.Match(t, matcher, p).SkipCompleteness()
+				if len(tt.expect) == 0 {
+					findings.IsEmpty()
+					return
+				}
+				findings.OnlyHasVulnerabilities(tt.expect...)
+			})
+		}
+	})
+}
+
+// TestMatcherStock_CPAN_FromImageSBOM closes the loop TestMatcherStock_CPAN leaves open. Those
+// rows hand-build grype packages, so they assert what syft is *assumed* to report: the name, the
+// version string, the `cpan` type and the `perl` language are all typed in by the test. This one
+// starts from a real syft SBOM of the `cpan-fixture` image instead, so the same database is driven
+// by whatever the cataloger actually emits.
+//
+// That covers the seam between the two, which nothing else does:
+//
+//   - distributions, not modules. `libwww-perl` installs `LWP.pm`, and an SBOM that named the
+//     module would match nothing here while looking perfectly healthy.
+//   - the perl interpreter arrives as a `cpan` package from the binary classifier rather than a
+//     `binary` one, which is what makes its 46 CPANSA advisories reachable at all.
+//   - the version strings are the ones on disk (`5.836`, `4.09`, `v1.1.4`), not ones chosen to
+//     exercise a comparator.
+//
+// The fixture is `syft scan cpan-fixture:latest -o syft-json` filtered to the `cpan` artifacts and
+// the relationships among them. The image's 158 deb packages and the whole file catalog are
+// dropped: no CPANSA advisory can reach them, and they were 97% of the bytes.
+func TestMatcherStock_CPAN_FromImageSBOM(t *testing.T) {
+	// every finding the image is expected to produce against the cpansa fixture database. The 47
+	// other cpan packages in the SBOM must produce nothing; CPANSA covers 388 of CPAN's ~44,000
+	// distributions, so that is the normal outcome and not a broken matcher.
+	expected := map[string][]string{
+		"CGI-Session@4.09": {
+			"CPANSA-CGI-Session-2006-01",
+			"CPANSA-CGI-Session-2006-1279",
+			"CPANSA-CGI-Session-2026-56016",
+		},
+		"Mojolicious@9.10": {
+			"CPANSA-Mojolicious-2021-01",
+			"CPANSA-Mojolicious-2022-03",
+		},
+		"libwww-perl@5.836": {
+			"CPANSA-libwww-perl-2011-01",
+			"CPANSA-libwww-perl-2017-01",
+			"CPANSA-libwww-perl-2026-8368",
+		},
+		// the interpreter, all the way through. Identity and matching used to be split across two
+		// tests: this one proved perl arrives as a cpan package, and TestMatcherStock_CPAN proved a
+		// perl version could match, but only for a hand-typed 5.022001. Nothing drove the real
+		// binary-classifier output against a real advisory until CPANSA-perl-2026-57432 (still open
+		// below 5.40.5) was added to the fixture, which the shipped 5.40.4 is inside.
+		"perl@5.40.4": {
+			"CPANSA-perl-2026-57432",
+		},
+	}
+
+	cpanPkgs := cpanPackagesFromImageSBOM(t)
+
+	names := make(map[string]struct{}, len(cpanPkgs))
+	for _, p := range cpanPkgs {
+		names[p.Name] = struct{}{}
+	}
+	// the two guards worth keeping on the syft side of the seam. `libwww-perl` was installed with
+	// cpanm, which writes an install.json, so syft has the real distribution name and must use it
+	// rather than falling back to the packlist path. The advisory-side alias covers installs where
+	// only the packlist exists (TestMatcherStock_CPAN_MainModuleAlias); it is a safety net, not a
+	// licence for syft to report module names. A missing `perl` means the interpreter went back to
+	// being a `binary` package.
+	require.NotContains(t, names, "LWP")
+	require.Contains(t, names, "perl")
+
+	dbtest.DBs(t, "cpansa").Run(func(t *testing.T, db *dbtest.DB) {
+		matcher := NewStockMatcher(MatcherConfig{})
+
+		for _, p := range cpanPkgs {
+			key := p.Name + "@" + p.Version
+			t.Run(key, func(t *testing.T) {
+				findings := db.Match(t, matcher, p).SkipCompleteness()
+				if expect, ok := expected[key]; ok {
+					findings.OnlyHasVulnerabilities(expect...)
+					return
+				}
+				findings.IsEmpty()
+			})
+		}
+	})
+}
+
+// TestMatcherStock_CPAN_CPANSAAndNVDOnTheSameCVE pins what happens when both halves of the stock
+// matcher reach the same underlying vulnerability for the same cpan package.
+//
+// The fixture database carries CPANSA-perl-2026-57432 under the `cpan` provider and NVD's
+// CVE-2026-57432 (which the CPANSA record lists as its only alias) under `nvd`. Both cover the
+// interpreter the `cpan-fixture` image ships: the CPANSA record's lowest window is open below
+// 5.40.5, and NVD's single CPE is `cpe:2.3:a:perl:perl:*` up to and including 5.43.10. The package
+// is the real SBOM one, so the CPE the NVD path matches on is the one the nvd-cpe-dictionary
+// assigned perl, not one typed in here.
+//
+// The result is two findings, not one, and that is the real behavior rather than the desired one.
+// Deduplication is keyed on vulnerability ID, namespace and package (grype/match/fingerprint.go),
+// and `CPANSA-perl-2026-57432` in `cpan` is not `CVE-2026-57432` in `nvd:cpe` on any of the three.
+// Collapsing the two requires normalizeByCVE (grype/vulnerability_matcher.go), which only runs
+// under `--by-cve` and sits above every matcher. So the duplicate is structural to CPANSA using its
+// own ids: all 46 of perl's CPANSA advisories carry a CVE alias, and each one is a second row on any
+// perl that NVD also covers.
+func TestMatcherStock_CPAN_CPANSAAndNVDOnTheSameCVE(t *testing.T) {
+	var perl pkg.Package
+	for _, p := range cpanPackagesFromImageSBOM(t) {
+		if p.Name == "perl" {
+			perl = p
+		}
+	}
+	require.Equal(t, "5.40.4", perl.Version)
+	require.NotEmpty(t, perl.CPEs, "the CPE path cannot fire without a CPE on the package")
+
+	dbtest.DBs(t, "cpansa").Run(func(t *testing.T, db *dbtest.DB) {
+		// UseCPEs is what grype runs the stock matcher with in production
+		// (grype/vulnerability_matcher.go), and it is the only way the nvd rows are reachable
+		matcher := NewStockMatcher(MatcherConfig{UseCPEs: true})
+
+		matches, ignores, err := matcher.Match(db, perl)
+		require.NoError(t, err)
+		require.Empty(t, ignores)
+
+		// the matcher only concatenates its two result sets; deduplication happens when they land
+		// in match.Matches, so assert on the far side of that rather than on the raw slice
+		deduped := match.NewMatches(matches...)
+		require.Equal(t, len(matches), deduped.Count(), "matches merged unexpectedly")
+
+		findings := dbtest.AssertFindings(t, deduped.Sorted(), perl)
+		findings.SelectMatch("CPANSA-perl-2026-57432").
+			// the same CVE the other finding is keyed by, which is what makes these duplicates
+			HasRelatedVulnerabilities("CVE-2026-57432").
+			SelectDetailByEcosystem("perl")
+		findings.SelectMatch("CVE-2026-57432").
+			SelectDetailByCPE("cpe:2.3:a:perl:perl:5.40.4:*:*:*:*:*:*:*").
+			FoundCPEs("cpe:2.3:a:perl:perl:*:*:*:*:*:*:*:*")
+	})
+}
+
+// TestMatcherStock_CPAN_MainModuleAlias covers the naming problem that can make a whole
+// distribution's advisories unreachable, and the deliberately narrow fix for it.
+//
+// A CPAN.pm install of libwww-perl lands at `auto/LWP/.packlist`, because the packlist path is
+// built from the builder's NAME and libwww-perl's Makefile.PL overrides that to `LWP`. CPAN.pm
+// writes no install.json, so a packlist is all syft has to go on and the package is reported as
+// `LWP`. CPANSA keys every advisory by distribution, so `LWP` matches nothing, and libwww-perl's
+// advisories are unreachable on exactly the install layout that produces the name.
+//
+// The advisory data carries the fix rather than syft: each advisory gets an extra affected package
+// named for the distribution's `main_module` with `::` replaced by `-`, carrying the same resolved
+// ranges. That is sound only because every version syft emits for a cpan package is a distribution
+// version, so `LWP@5.836` really does mean libwww-perl 5.836.
+//
+// What this pins:
+//
+//   - the alias is reachable, at the same constraint as the distribution it came from.
+//   - it is the data doing the work. No name resolver is registered for `cpan`, so nothing on
+//     grype's side could turn `LWP` into `libwww-perl`.
+//   - it is `main_module` only. Aliasing every entry of CPANSA's module2dist table instead would
+//     emit names no installer ever writes (`LWP-UserAgent`, or `URI-Escape` for the URI
+//     distribution), multiplying records and widening the name-collision surface without covering
+//     one additional real install.
+//   - it adds nothing when the main module round-trips, which is the common case. Only 15 of
+//     CPANSA's 409 distributions dash out to a different name.
+func TestMatcherStock_CPAN_MainModuleAlias(t *testing.T) { //nolint:funlen // one row per advisory in the fixture
+	// every advisory in the fixture, and the exact set of cpan package names it is filed against.
+	// Asserting the whole set rather than probing for `LWP` is what pins the narrowing: aliasing
+	// the module table would show up here as extra names on Mojolicious, DBD-SQLite and perl.
+	//
+	// The two empty entries are advisories the transformer drops whole because every affected
+	// entry resolved to no ranges, alias included.
+	affectedNames := map[string][]string{
+		// main module `CGI::Session` dashes back to the distribution name, so no alias
+		"CPANSA-CGI-Session-2006-01":          {"CGI-Session"},
+		"CPANSA-CGI-Session-2006-1279":        {"CGI-Session"},
+		"CPANSA-CGI-Session-2026-56016":       {"CGI-Session"},
+		"CPANSA-Data-FormValidator-2011-2201": {"Data-FormValidator"},
+		"CPANSA-DBD-SQLite-2018-8740-sqlite":  {"DBD-SQLite"},
+		// two distributions on one id, and neither is an alias of the other
+		"CPANSA-ExtUtils-ParseXS-2016-1238": {"ExtUtils-ParseXS", "perl"},
+		"CPANSA-libwww-perl-1995-01":        nil,
+		"CPANSA-libwww-perl-2001-01":        {"libwww-perl", "LWP"},
+		"CPANSA-libwww-perl-2010-01":        {"libwww-perl", "LWP"},
+		"CPANSA-libwww-perl-2011-01":        {"libwww-perl", "LWP"},
+		"CPANSA-libwww-perl-2017-01":        {"libwww-perl", "LWP"},
+		"CPANSA-libwww-perl-2026-8368":      {"libwww-perl", "LWP"},
+		// main module is identical to the distribution name
+		"CPANSA-Mojolicious-2021-01": {"Mojolicious"},
+		"CPANSA-Mojolicious-2022-03": {"Mojolicious"},
+		// perl's own main module is `perl`, so it round-trips. An earlier survey of this using
+		// MetaCPAN's main_module as a stand-in reported perl aliasing to `less`; CPANSA's own
+		// field, which is the one being read, says otherwise.
+		"CPANSA-perl-2015-8608":  {"perl"},
+		"CPANSA-perl-2016-6185":  {"perl"},
+		"CPANSA-perl-2026-57432": {"perl"},
+		// empty main_module, so nothing is guessed
+		"CPANSA-urxvt-bgdsl-2022-4170": nil,
+	}
+
+	dbtest.DBs(t, "cpansa").Run(func(t *testing.T, db *dbtest.DB) {
+		matcher := NewStockMatcher(MatcherConfig{})
+
+		t.Run("only main modules are aliased", func(t *testing.T) {
+			for id, want := range affectedNames {
+				vulns, err := db.FindVulnerabilities(search.ByID(id))
+				require.NoError(t, err)
+
+				var got []string
+				for _, v := range vulns {
+					got = append(got, v.PackageName)
+				}
+				assert.ElementsMatch(t, want, got, "unexpected affected packages for %s", id)
+			}
+		})
+
+		t.Run("the alias carries the distribution's ranges", func(t *testing.T) {
+			for id, names := range affectedNames {
+				if !slices.Contains(names, "LWP") {
+					continue
+				}
+				vulns, err := db.FindVulnerabilities(search.ByID(id))
+				require.NoError(t, err)
+				require.Len(t, vulns, 2, "%s should carry the distribution and its alias", id)
+
+				constraints := make(map[string]string, len(vulns))
+				for _, v := range vulns {
+					constraints[v.PackageName] = v.Constraint.String()
+				}
+				// identical, not merely overlapping: the alias is the same advisory seen under a
+				// second name, so any divergence here is a provider bug
+				assert.Equal(t, constraints["libwww-perl"], constraints["LWP"], "ranges diverged on %s", id)
+			}
+		})
+
+		t.Run("the packlist name matches, without any name rewriting", func(t *testing.T) {
+			alias := newCpanPackage("LWP", "5.836")
+
+			// no resolver is registered for `cpan` in grype/db/v6/name, so the name searched for
+			// is the one syft reported. If this ever grows a second entry the match below stops
+			// saying anything about the alias.
+			require.Equal(t, []string{"LWP"}, db.PackageSearchNames(alias))
+
+			expect := []string{"CPANSA-libwww-perl-2011-01", "CPANSA-libwww-perl-2017-01", "CPANSA-libwww-perl-2026-8368"}
+			db.Match(t, matcher, alias).SkipCompleteness().OnlyHasVulnerabilities(expect...)
+			db.Match(t, matcher, newCpanPackage("libwww-perl", "5.836")).SkipCompleteness().OnlyHasVulnerabilities(expect...)
+
+			// the alias is bounded the same way the distribution is, so it clears the fixes at
+			// the same versions rather than reporting forever
+			db.Match(t, matcher, newCpanPackage("LWP", "6.83")).SkipCompleteness().IsEmpty()
+		})
+
+		t.Run("other modules of an affected distribution find nothing", func(t *testing.T) {
+			// both are modules libwww-perl provides, so both are entries in CPANSA's module2dist
+			// table, and neither is a name a CPAN client ever writes to disk
+			for _, name := range []string{"LWP-UserAgent", "LWP-Simple"} {
+				db.Match(t, matcher, newCpanPackage(name, "5.836")).SkipCompleteness().IsEmpty()
+			}
+		})
+	})
+}
+
+// newCpanPackage builds the grype package syft reports for an installed CPAN distribution.
+func newCpanPackage(name, version string) pkg.Package {
+	// TODO: use syftPkg.CpanPkg / syftPkg.Perl once the syft release carrying them is vendored
+	return dbtest.NewPackage(name, version, syftPkg.Type("cpan")).
+		WithLanguage(syftPkg.Language("perl")).
+		Build()
+}
+
+// cpanPackagesFromImageSBOM returns the cpan packages of the `cpan-fixture` image SBOM as grype's
+// own package provider hands them to a matcher, so callers get whatever the syft cataloger emitted
+// rather than a hand-built approximation of it.
+func cpanPackagesFromImageSBOM(t *testing.T) []pkg.Package {
+	t.Helper()
+
+	pkgs, _, _, err := pkg.Provide("sbom:testdata/cpan-fixture-sbom.json", pkg.ProviderConfig{})
+	require.NoError(t, err)
+
+	var cpanPkgs []pkg.Package
+	for _, p := range pkgs {
+		// TODO: use syftPkg.CpanPkg / syftPkg.Perl once the syft release carrying them is vendored
+		if p.Type != syftPkg.Type("cpan") {
+			continue
+		}
+		require.Equal(t, syftPkg.Language("perl"), p.Language, "%s lost its language crossing into grype", p.Name)
+		cpanPkgs = append(cpanPkgs, p)
+	}
+	require.NotEmpty(t, cpanPkgs)
+
+	return cpanPkgs
+}

--- a/grype/matcher/stock/testdata/cpan-fixture-sbom.json
+++ b/grype/matcher/stock/testdata/cpan-fixture-sbom.json
@@ -1,0 +1,6417 @@
+{
+  "artifacts": [
+    {
+      "id": "bb74316c5f4e4cd6",
+      "name": "App-cpanminus",
+      "version": "1.7049",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/App/cpanminus/.packlist",
+          "layerID": "sha256:14bcd9a672ad733050fe1b4b4761a7d2981daaa6cf689055efea1dd5a0e80a06",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/App/cpanminus/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/App/cpanminus.pm",
+          "layerID": "sha256:14bcd9a672ad733050fe1b4b4761a7d2981daaa6cf689055efea1dd5a0e80a06",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/App/cpanminus.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:App-cpanminus:App-cpanminus:1.7049:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:App-cpanminus:App_cpanminus:1.7049:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:App_cpanminus:App-cpanminus:1.7049:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:App_cpanminus:App_cpanminus:1.7049:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:App:App-cpanminus:1.7049:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:App:App_cpanminus:1.7049:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/App-cpanminus@1.7049",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {}
+    },
+    {
+      "id": "b25087da29b9d8fa",
+      "name": "App-cpm",
+      "version": "v1.1.4",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/App-cpm-v1.1.4/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/App-cpm-v1.1.4/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/App/cpm/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/App/cpm/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/App/cpm.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/App/cpm.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/App-cpm-v1.1.4/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/App-cpm-v1.1.4/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/App-cpm-v1.1.4/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/App-cpm-v1.1.4/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:App-cpm:App-cpm:v1.1.4:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:App-cpm:App_cpm:v1.1.4:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:App_cpm:App-cpm:v1.1.4:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:App_cpm:App_cpm:v1.1.4:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:App:App-cpm:v1.1.4:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:App:App_cpm:v1.1.4:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/App-cpm@v1.1.4?author=SKAJI",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "SKAJI",
+        "path": "S/SK/SKAJI/App-cpm-v1.1.4.tar.gz",
+        "modules": [
+          {
+            "name": "App::cpm",
+            "version": "v1.1.4"
+          },
+          {
+            "name": "App::cpm::Builder::Base"
+          },
+          {
+            "name": "App::cpm::Builder::EUMM"
+          },
+          {
+            "name": "App::cpm::Builder::MB"
+          },
+          {
+            "name": "App::cpm::Builder::Prebuilt"
+          },
+          {
+            "name": "App::cpm::Builder::Static"
+          },
+          {
+            "name": "App::cpm::CLI"
+          },
+          {
+            "name": "App::cpm::CircularDependency"
+          },
+          {
+            "name": "App::cpm::Context"
+          },
+          {
+            "name": "App::cpm::DistNotation"
+          },
+          {
+            "name": "App::cpm::Distribution"
+          },
+          {
+            "name": "App::cpm::HTTP"
+          },
+          {
+            "name": "App::cpm::Installer::Unpacker"
+          },
+          {
+            "name": "App::cpm::Logger"
+          },
+          {
+            "name": "App::cpm::Logger::File"
+          },
+          {
+            "name": "App::cpm::Logger::Terminal"
+          },
+          {
+            "name": "App::cpm::Master"
+          },
+          {
+            "name": "App::cpm::Requirement"
+          },
+          {
+            "name": "App::cpm::Resolver"
+          },
+          {
+            "name": "App::cpm::Resolver::02Packages"
+          },
+          {
+            "name": "App::cpm::Resolver::Cascade"
+          },
+          {
+            "name": "App::cpm::Resolver::Custom"
+          },
+          {
+            "name": "App::cpm::Resolver::Fixed"
+          },
+          {
+            "name": "App::cpm::Resolver::MetaCPAN"
+          },
+          {
+            "name": "App::cpm::Resolver::MetaDB"
+          },
+          {
+            "name": "App::cpm::Resolver::Snapshot"
+          },
+          {
+            "name": "App::cpm::Task"
+          },
+          {
+            "name": "App::cpm::Tutorial"
+          },
+          {
+            "name": "App::cpm::Util"
+          },
+          {
+            "name": "App::cpm::Worker"
+          },
+          {
+            "name": "App::cpm::Worker::Installer"
+          },
+          {
+            "name": "App::cpm::Worker::Installer::Custom"
+          },
+          {
+            "name": "App::cpm::Worker::Resolver"
+          },
+          {
+            "name": "App::cpm::version"
+          }
+        ]
+      }
+    },
+    {
+      "id": "9e32cc3f6d012a0d",
+      "name": "CGI-Session",
+      "version": "4.09",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CGI-Session-4.09/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CGI-Session-4.09/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/CGI/Session/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/CGI/Session/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/CGI/Session.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/CGI/Session.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CGI-Session-4.09/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CGI-Session-4.09/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "unknown",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CGI-Session-4.09/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CGI-Session-4.09/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:CGI-Session:CGI-Session:4.09:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CGI-Session:CGI_Session:4.09:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CGI_Session:CGI-Session:4.09:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CGI_Session:CGI_Session:4.09:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CGI:CGI-Session:4.09:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CGI:CGI_Session:4.09:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/CGI-Session@4.09?author=SHERZODR",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "SHERZODR",
+        "path": "S/SH/SHERZODR/CGI-Session-4.09.tar.gz",
+        "modules": [
+          {
+            "name": "CGI::Session",
+            "version": "4.09"
+          },
+          {
+            "name": "CGI::Session::Driver",
+            "version": "4.04"
+          },
+          {
+            "name": "CGI::Session::Driver::DBI",
+            "version": "1.4"
+          },
+          {
+            "name": "CGI::Session::Driver::db_file",
+            "version": "1.6"
+          },
+          {
+            "name": "CGI::Session::Driver::file",
+            "version": "3.7"
+          },
+          {
+            "name": "CGI::Session::Driver::mysql",
+            "version": "2.03"
+          },
+          {
+            "name": "CGI::Session::Driver::postgresql",
+            "version": "2.4"
+          },
+          {
+            "name": "CGI::Session::Driver::sqlite",
+            "version": "1.4"
+          },
+          {
+            "name": "CGI::Session::ErrorHandler",
+            "version": "4.04"
+          },
+          {
+            "name": "CGI::Session::ID::incr",
+            "version": "1.6"
+          },
+          {
+            "name": "CGI::Session::ID::md5",
+            "version": "1.5"
+          },
+          {
+            "name": "CGI::Session::ID::static",
+            "version": "1.7"
+          },
+          {
+            "name": "CGI::Session::Query"
+          },
+          {
+            "name": "CGI::Session::Serialize::default",
+            "version": "1.7"
+          },
+          {
+            "name": "CGI::Session::Serialize::freezethaw",
+            "version": "1.7"
+          },
+          {
+            "name": "CGI::Session::Serialize::json",
+            "version": "1.02"
+          },
+          {
+            "name": "CGI::Session::Serialize::storable",
+            "version": "1.6"
+          },
+          {
+            "name": "CGI::Session::Serialize::yaml",
+            "version": "1.02"
+          },
+          {
+            "name": "CGI::Session::Test::Default",
+            "version": "1.54"
+          },
+          {
+            "name": "CGI::Session::Tutorial",
+            "version": "3.42"
+          },
+          {
+            "name": "OverloadedObjectClass",
+            "version": "1.54"
+          },
+          {
+            "name": "SimpleObjectClass",
+            "version": "1.54"
+          }
+        ]
+      }
+    },
+    {
+      "id": "eb766bfb3050c6f5",
+      "name": "CPAN-02Packages-Search",
+      "version": "v1.0.0",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CPAN-02Packages-Search-v1.0.0/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CPAN-02Packages-Search-v1.0.0/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/CPAN/02Packages/Search/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/CPAN/02Packages/Search/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/CPAN/02Packages/Search.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/CPAN/02Packages/Search.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CPAN-02Packages-Search-v1.0.0/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CPAN-02Packages-Search-v1.0.0/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CPAN-02Packages-Search-v1.0.0/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CPAN-02Packages-Search-v1.0.0/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:CPAN-02Packages-Search:CPAN-02Packages-Search:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CPAN-02Packages-Search:CPAN_02Packages_Search:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CPAN_02Packages_Search:CPAN-02Packages-Search:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CPAN_02Packages_Search:CPAN_02Packages_Search:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CPAN-02Packages:CPAN-02Packages-Search:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CPAN-02Packages:CPAN_02Packages_Search:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CPAN_02Packages:CPAN-02Packages-Search:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CPAN_02Packages:CPAN_02Packages_Search:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CPAN:CPAN-02Packages-Search:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CPAN:CPAN_02Packages_Search:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/CPAN-02Packages-Search@v1.0.0?author=SKAJI",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "SKAJI",
+        "path": "S/SK/SKAJI/CPAN-02Packages-Search-v1.0.0.tar.gz",
+        "modules": [
+          {
+            "name": "CPAN::02Packages::Search",
+            "version": "v1.0.0"
+          }
+        ]
+      }
+    },
+    {
+      "id": "87025f0b83211a62",
+      "name": "CPAN-DistnameInfo",
+      "version": "0.12",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CPAN-DistnameInfo-0.12/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CPAN-DistnameInfo-0.12/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/CPAN/DistnameInfo/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/CPAN/DistnameInfo/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/CPAN/DistnameInfo.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/CPAN/DistnameInfo.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CPAN-DistnameInfo-0.12/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CPAN-DistnameInfo-0.12/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CPAN-DistnameInfo-0.12/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/CPAN-DistnameInfo-0.12/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:CPAN-DistnameInfo:CPAN-DistnameInfo:0.12:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CPAN-DistnameInfo:CPAN_DistnameInfo:0.12:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CPAN_DistnameInfo:CPAN-DistnameInfo:0.12:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CPAN_DistnameInfo:CPAN_DistnameInfo:0.12:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CPAN:CPAN-DistnameInfo:0.12:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:CPAN:CPAN_DistnameInfo:0.12:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/CPAN-DistnameInfo@0.12?author=GBARR",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "GBARR",
+        "path": "G/GB/GBARR/CPAN-DistnameInfo-0.12.tar.gz",
+        "modules": [
+          {
+            "name": "CPAN::DistnameInfo",
+            "version": "0.12"
+          }
+        ]
+      }
+    },
+    {
+      "id": "d03572fa2a145dae",
+      "name": "Capture-Tiny",
+      "version": "0.50",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Capture-Tiny-0.50/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Capture-Tiny-0.50/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Capture/Tiny/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Capture/Tiny/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/Capture/Tiny.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/Capture/Tiny.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Capture-Tiny-0.50/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Capture-Tiny-0.50/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "apache_2_0",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Capture-Tiny-0.50/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Capture-Tiny-0.50/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Capture-Tiny:Capture-Tiny:0.50:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Capture-Tiny:Capture_Tiny:0.50:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Capture_Tiny:Capture-Tiny:0.50:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Capture_Tiny:Capture_Tiny:0.50:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Capture:Capture-Tiny:0.50:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Capture:Capture_Tiny:0.50:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Capture-Tiny@0.50?author=DAGOLDEN",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "DAGOLDEN",
+        "path": "D/DA/DAGOLDEN/Capture-Tiny-0.50.tar.gz",
+        "modules": [
+          {
+            "name": "Capture::Tiny",
+            "version": "0.50"
+          }
+        ]
+      }
+    },
+    {
+      "id": "4f0772ea05d9d9e8",
+      "name": "Clone",
+      "version": "0.50",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Clone-0.50/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Clone-0.50/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Clone/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Clone/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Clone-0.50/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Clone-0.50/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/Clone.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/Clone.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Clone-0.50/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Clone-0.50/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Clone:Clone:0.50:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Clone@0.50?author=ATOOMIC",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "ATOOMIC",
+        "path": "A/AT/ATOOMIC/Clone-0.50.tar.gz",
+        "modules": [
+          {
+            "name": "Clone",
+            "version": "0.50"
+          }
+        ]
+      }
+    },
+    {
+      "id": "7f7aa973aea28c3b",
+      "name": "Command-Runner",
+      "version": "v1.0.0",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Command-Runner-v1.0.0/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Command-Runner-v1.0.0/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Command/Runner/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Command/Runner/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/Command/Runner.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/Command/Runner.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Command-Runner-v1.0.0/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Command-Runner-v1.0.0/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Command-Runner-v1.0.0/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Command-Runner-v1.0.0/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Command-Runner:Command-Runner:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Command-Runner:Command_Runner:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Command_Runner:Command-Runner:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Command_Runner:Command_Runner:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Command:Command-Runner:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Command:Command_Runner:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Command-Runner@v1.0.0?author=SKAJI",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "SKAJI",
+        "path": "S/SK/SKAJI/Command-Runner-v1.0.0.tar.gz",
+        "modules": [
+          {
+            "name": "Command::Runner",
+            "version": "v1.0.0"
+          },
+          {
+            "name": "Command::Runner::LineBuffer"
+          },
+          {
+            "name": "Command::Runner::Quote"
+          },
+          {
+            "name": "Command::Runner::Timeout"
+          }
+        ]
+      }
+    },
+    {
+      "id": "f9c4718f9f3450b3",
+      "name": "Darwin-InitObjC",
+      "version": "v1.0.0",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Darwin-InitObjC-v1.0.0/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Darwin-InitObjC-v1.0.0/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Darwin/InitObjC/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Darwin/InitObjC/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/Darwin/InitObjC.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/Darwin/InitObjC.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Darwin-InitObjC-v1.0.0/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Darwin-InitObjC-v1.0.0/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Darwin-InitObjC-v1.0.0/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Darwin-InitObjC-v1.0.0/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Darwin-InitObjC:Darwin-InitObjC:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Darwin-InitObjC:Darwin_InitObjC:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Darwin_InitObjC:Darwin-InitObjC:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Darwin_InitObjC:Darwin_InitObjC:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Darwin:Darwin-InitObjC:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Darwin:Darwin_InitObjC:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Darwin-InitObjC@v1.0.0?author=SKAJI",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "SKAJI",
+        "path": "S/SK/SKAJI/Darwin-InitObjC-v1.0.0.tar.gz",
+        "modules": [
+          {
+            "name": "Darwin::InitObjC",
+            "version": "v1.0.0"
+          }
+        ]
+      }
+    },
+    {
+      "id": "71ffcee2ab338b03",
+      "name": "Encode",
+      "version": "UNKNOWN",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Encode/.packlist",
+          "layerID": "sha256:884e6725555efab47868e5e1d279636f1996316c023a371de1ebe590dc79e43b",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Encode/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/Encode.pm",
+          "layerID": "sha256:884e6725555efab47868e5e1d279636f1996316c023a371de1ebe590dc79e43b",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/Encode.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Encode:Encode:*:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Encode",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {}
+    },
+    {
+      "id": "545ae1bf296ac30c",
+      "name": "Encode-Locale",
+      "version": "1.05",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Encode-Locale-1.05/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Encode-Locale-1.05/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Encode/Locale/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Encode/Locale/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/Encode/Locale.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/Encode/Locale.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Encode-Locale-1.05/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Encode-Locale-1.05/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Encode-Locale-1.05/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Encode-Locale-1.05/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Encode-Locale:Encode-Locale:1.05:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Encode-Locale:Encode_Locale:1.05:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Encode_Locale:Encode-Locale:1.05:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Encode_Locale:Encode_Locale:1.05:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Encode:Encode-Locale:1.05:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Encode:Encode_Locale:1.05:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Encode-Locale@1.05?author=GAAS",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "GAAS",
+        "path": "G/GA/GAAS/Encode-Locale-1.05.tar.gz",
+        "modules": [
+          {
+            "name": "Encode::Locale",
+            "version": "1.05"
+          }
+        ]
+      }
+    },
+    {
+      "id": "873a36702f9b5c66",
+      "name": "ExtUtils-Config",
+      "version": "0.010",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-Config-0.010/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-Config-0.010/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/ExtUtils/Config/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/ExtUtils/Config/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/ExtUtils/Config.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/ExtUtils/Config.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-Config-0.010/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-Config-0.010/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-Config-0.010/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-Config-0.010/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:ExtUtils-Config:ExtUtils-Config:0.010:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils-Config:ExtUtils_Config:0.010:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils_Config:ExtUtils-Config:0.010:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils_Config:ExtUtils_Config:0.010:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils:ExtUtils-Config:0.010:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils:ExtUtils_Config:0.010:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/ExtUtils-Config@0.010?author=LEONT",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "LEONT",
+        "path": "L/LE/LEONT/ExtUtils-Config-0.010.tar.gz",
+        "modules": [
+          {
+            "name": "ExtUtils::Config",
+            "version": "0.010"
+          },
+          {
+            "name": "ExtUtils::Config::MakeMaker",
+            "version": "0.010"
+          }
+        ]
+      }
+    },
+    {
+      "id": "94047903cfc5f703",
+      "name": "ExtUtils-Helpers",
+      "version": "0.028",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-Helpers-0.028/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-Helpers-0.028/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/ExtUtils/Helpers/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/ExtUtils/Helpers/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/ExtUtils/Helpers.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/ExtUtils/Helpers.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-Helpers-0.028/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-Helpers-0.028/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-Helpers-0.028/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-Helpers-0.028/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:ExtUtils-Helpers:ExtUtils-Helpers:0.028:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils-Helpers:ExtUtils_Helpers:0.028:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils_Helpers:ExtUtils-Helpers:0.028:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils_Helpers:ExtUtils_Helpers:0.028:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils:ExtUtils-Helpers:0.028:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils:ExtUtils_Helpers:0.028:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/ExtUtils-Helpers@0.028?author=LEONT",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "LEONT",
+        "path": "L/LE/LEONT/ExtUtils-Helpers-0.028.tar.gz",
+        "modules": [
+          {
+            "name": "ExtUtils::Helpers",
+            "version": "0.028"
+          },
+          {
+            "name": "ExtUtils::Helpers::Unix",
+            "version": "0.028"
+          },
+          {
+            "name": "ExtUtils::Helpers::VMS",
+            "version": "0.028"
+          },
+          {
+            "name": "ExtUtils::Helpers::Windows",
+            "version": "0.028"
+          }
+        ]
+      }
+    },
+    {
+      "id": "59d9fff802d1ddcc",
+      "name": "ExtUtils-InstallPaths",
+      "version": "0.015",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-InstallPaths-0.015/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-InstallPaths-0.015/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/ExtUtils/InstallPaths/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/ExtUtils/InstallPaths/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/ExtUtils/InstallPaths.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/ExtUtils/InstallPaths.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-InstallPaths-0.015/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-InstallPaths-0.015/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-InstallPaths-0.015/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-InstallPaths-0.015/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:ExtUtils-InstallPaths:ExtUtils-InstallPaths:0.015:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils-InstallPaths:ExtUtils_InstallPaths:0.015:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils_InstallPaths:ExtUtils-InstallPaths:0.015:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils_InstallPaths:ExtUtils_InstallPaths:0.015:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils:ExtUtils-InstallPaths:0.015:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils:ExtUtils_InstallPaths:0.015:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/ExtUtils-InstallPaths@0.015?author=LEONT",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "LEONT",
+        "path": "L/LE/LEONT/ExtUtils-InstallPaths-0.015.tar.gz",
+        "modules": [
+          {
+            "name": "ExtUtils::InstallPaths",
+            "version": "0.015"
+          }
+        ]
+      }
+    },
+    {
+      "id": "59412e62a7e9e0c0",
+      "name": "ExtUtils-MakeMaker-CPANfile",
+      "version": "0.11",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-MakeMaker-CPANfile-0.11/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-MakeMaker-CPANfile-0.11/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/ExtUtils/MakeMaker/CPANfile/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/ExtUtils/MakeMaker/CPANfile/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/ExtUtils/MakeMaker/CPANfile.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/ExtUtils/MakeMaker/CPANfile.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-MakeMaker-CPANfile-0.11/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-MakeMaker-CPANfile-0.11/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-MakeMaker-CPANfile-0.11/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/ExtUtils-MakeMaker-CPANfile-0.11/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:ExtUtils-MakeMaker-CPANfile:ExtUtils-MakeMaker-CPANfile:0.11:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils-MakeMaker-CPANfile:ExtUtils_MakeMaker_CPANfile:0.11:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils_MakeMaker_CPANfile:ExtUtils-MakeMaker-CPANfile:0.11:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils_MakeMaker_CPANfile:ExtUtils_MakeMaker_CPANfile:0.11:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils-MakeMaker:ExtUtils-MakeMaker-CPANfile:0.11:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils-MakeMaker:ExtUtils_MakeMaker_CPANfile:0.11:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils_MakeMaker:ExtUtils-MakeMaker-CPANfile:0.11:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils_MakeMaker:ExtUtils_MakeMaker_CPANfile:0.11:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils:ExtUtils-MakeMaker-CPANfile:0.11:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:ExtUtils:ExtUtils_MakeMaker_CPANfile:0.11:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/ExtUtils-MakeMaker-CPANfile@0.11?author=ISHIGAKI",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "ISHIGAKI",
+        "path": "I/IS/ISHIGAKI/ExtUtils-MakeMaker-CPANfile-0.11.tar.gz",
+        "modules": [
+          {
+            "name": "ExtUtils::MakeMaker::CPANfile",
+            "version": "0.11"
+          }
+        ]
+      }
+    },
+    {
+      "id": "0589888b3ac40086",
+      "name": "File-Copy-Recursive",
+      "version": "0.45",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-Copy-Recursive-0.45/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-Copy-Recursive-0.45/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/File/Copy/Recursive/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/File/Copy/Recursive/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/File/Copy/Recursive.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/File/Copy/Recursive.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-Copy-Recursive-0.45/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-Copy-Recursive-0.45/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-Copy-Recursive-0.45/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-Copy-Recursive-0.45/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:File-Copy-Recursive:File-Copy-Recursive:0.45:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File-Copy-Recursive:File_Copy_Recursive:0.45:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File_Copy_Recursive:File-Copy-Recursive:0.45:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File_Copy_Recursive:File_Copy_Recursive:0.45:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File-Copy:File-Copy-Recursive:0.45:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File-Copy:File_Copy_Recursive:0.45:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File_Copy:File-Copy-Recursive:0.45:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File_Copy:File_Copy_Recursive:0.45:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File:File-Copy-Recursive:0.45:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File:File_Copy_Recursive:0.45:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/File-Copy-Recursive@0.45?author=DMUEY",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "DMUEY",
+        "path": "D/DM/DMUEY/File-Copy-Recursive-0.45.tar.gz",
+        "modules": [
+          {
+            "name": "File::Copy::Recursive",
+            "version": "0.45"
+          }
+        ]
+      }
+    },
+    {
+      "id": "abd175f7aeb7c55a",
+      "name": "File-Which",
+      "version": "1.27",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-Which-1.27/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-Which-1.27/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/File/Which/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/File/Which/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/File/Which.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/File/Which.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-Which-1.27/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-Which-1.27/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-Which-1.27/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-Which-1.27/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:File-Which:File-Which:1.27:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File-Which:File_Which:1.27:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File_Which:File-Which:1.27:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File_Which:File_Which:1.27:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File:File-Which:1.27:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File:File_Which:1.27:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/File-Which@1.27?author=PLICEASE",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "PLICEASE",
+        "path": "P/PL/PLICEASE/File-Which-1.27.tar.gz",
+        "modules": [
+          {
+            "name": "File::Which",
+            "version": "1.27"
+          }
+        ]
+      }
+    },
+    {
+      "id": "6a6393b110c49dea",
+      "name": "File-pushd",
+      "version": "1.016",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-pushd-1.016/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-pushd-1.016/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/File/pushd/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/File/pushd/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/File/pushd.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/File/pushd.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-pushd-1.016/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-pushd-1.016/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "apache_2_0",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-pushd-1.016/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/File-pushd-1.016/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:File-pushd:File-pushd:1.016:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File-pushd:File_pushd:1.016:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File_pushd:File-pushd:1.016:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File_pushd:File_pushd:1.016:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File:File-pushd:1.016:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:File:File_pushd:1.016:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/File-pushd@1.016?author=DAGOLDEN",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "DAGOLDEN",
+        "path": "D/DA/DAGOLDEN/File-pushd-1.016.tar.gz",
+        "modules": [
+          {
+            "name": "File::pushd",
+            "version": "1.016"
+          }
+        ]
+      }
+    },
+    {
+      "id": "7f78ab91d22fa93a",
+      "name": "HTML-Parser",
+      "version": "3.85",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTML-Parser-3.85/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTML-Parser-3.85/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/HTML/Parser/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/HTML/Parser/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTML-Parser-3.85/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTML-Parser-3.85/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/HTML/Parser.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/HTML/Parser.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTML-Parser-3.85/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTML-Parser-3.85/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:HTML-Parser:HTML-Parser:3.85:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTML-Parser:HTML_Parser:3.85:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTML_Parser:HTML-Parser:3.85:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTML_Parser:HTML_Parser:3.85:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTML:HTML-Parser:3.85:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTML:HTML_Parser:3.85:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/HTML-Parser@3.85?author=OALDERS",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "OALDERS",
+        "path": "O/OA/OALDERS/HTML-Parser-3.85.tar.gz",
+        "modules": [
+          {
+            "name": "HTML::Entities",
+            "version": "3.85"
+          },
+          {
+            "name": "HTML::Filter",
+            "version": "3.85"
+          },
+          {
+            "name": "HTML::HeadParser",
+            "version": "3.85"
+          },
+          {
+            "name": "HTML::LinkExtor",
+            "version": "3.85"
+          },
+          {
+            "name": "HTML::Parser",
+            "version": "3.85"
+          },
+          {
+            "name": "HTML::PullParser",
+            "version": "3.85"
+          },
+          {
+            "name": "HTML::TokeParser",
+            "version": "3.85"
+          }
+        ]
+      }
+    },
+    {
+      "id": "0582d016697cd605",
+      "name": "HTML-Tagset",
+      "version": "3.24",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTML-Tagset-3.24/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTML-Tagset-3.24/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/HTML/Tagset/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/HTML/Tagset/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/HTML/Tagset.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/HTML/Tagset.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTML-Tagset-3.24/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTML-Tagset-3.24/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "artistic_2",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTML-Tagset-3.24/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTML-Tagset-3.24/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:HTML-Tagset:HTML-Tagset:3.24:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTML-Tagset:HTML_Tagset:3.24:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTML_Tagset:HTML-Tagset:3.24:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTML_Tagset:HTML_Tagset:3.24:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTML:HTML-Tagset:3.24:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTML:HTML_Tagset:3.24:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/HTML-Tagset@3.24?author=PETDANCE",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "PETDANCE",
+        "path": "P/PE/PETDANCE/HTML-Tagset-3.24.tar.gz",
+        "modules": [
+          {
+            "name": "HTML::Tagset",
+            "version": "3.24"
+          }
+        ]
+      }
+    },
+    {
+      "id": "db696fc8b23dc6dc",
+      "name": "HTTP-Date",
+      "version": "5.831",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/HTTP/Date/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/HTTP/Date/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/HTTP/Date.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/HTTP/Date.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:HTTP-Date:HTTP-Date:5.831:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP-Date:HTTP_Date:5.831:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP_Date:HTTP-Date:5.831:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP_Date:HTTP_Date:5.831:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP:HTTP-Date:5.831:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP:HTTP_Date:5.831:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/HTTP-Date@5.831",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {}
+    },
+    {
+      "id": "089bcadfe951629d",
+      "name": "HTTP-Date",
+      "version": "6.08",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Date-6.08/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Date-6.08/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Date-6.08/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Date-6.08/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Date-6.08/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Date-6.08/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:HTTP-Date:HTTP-Date:6.08:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP-Date:HTTP_Date:6.08:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP_Date:HTTP-Date:6.08:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP_Date:HTTP_Date:6.08:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP:HTTP-Date:6.08:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP:HTTP_Date:6.08:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/HTTP-Date@6.08?author=OALDERS",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "OALDERS",
+        "path": "O/OA/OALDERS/HTTP-Date-6.08.tar.gz",
+        "modules": [
+          {
+            "name": "HTTP::Date",
+            "version": "6.08"
+          }
+        ]
+      }
+    },
+    {
+      "id": "8d7176ad454e95ac",
+      "name": "HTTP-Message",
+      "version": "5.835",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/HTTP/Message/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/HTTP/Message/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/HTTP/Message.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/HTTP/Message.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:HTTP-Message:HTTP-Message:5.835:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP-Message:HTTP_Message:5.835:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP_Message:HTTP-Message:5.835:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP_Message:HTTP_Message:5.835:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP:HTTP-Message:5.835:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP:HTTP_Message:5.835:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/HTTP-Message@5.835",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {}
+    },
+    {
+      "id": "f8cdae3dbaab0918",
+      "name": "HTTP-Message",
+      "version": "7.04",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Message-7.04/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Message-7.04/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Message-7.04/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Message-7.04/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Message-7.04/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Message-7.04/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:HTTP-Message:HTTP-Message:7.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP-Message:HTTP_Message:7.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP_Message:HTTP-Message:7.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP_Message:HTTP_Message:7.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP:HTTP-Message:7.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP:HTTP_Message:7.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/HTTP-Message@7.04?author=OALDERS",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "OALDERS",
+        "path": "O/OA/OALDERS/HTTP-Message-7.04.tar.gz",
+        "modules": [
+          {
+            "name": "HTTP::Config",
+            "version": "7.04"
+          },
+          {
+            "name": "HTTP::Headers",
+            "version": "7.04"
+          },
+          {
+            "name": "HTTP::Headers::Auth",
+            "version": "7.04"
+          },
+          {
+            "name": "HTTP::Headers::ETag",
+            "version": "7.04"
+          },
+          {
+            "name": "HTTP::Headers::Util",
+            "version": "7.04"
+          },
+          {
+            "name": "HTTP::Message",
+            "version": "7.04"
+          },
+          {
+            "name": "HTTP::Request",
+            "version": "7.04"
+          },
+          {
+            "name": "HTTP::Request::Common",
+            "version": "7.04"
+          },
+          {
+            "name": "HTTP::Response",
+            "version": "7.04"
+          },
+          {
+            "name": "HTTP::Status",
+            "version": "7.04"
+          }
+        ]
+      }
+    },
+    {
+      "id": "d34e68e22577cfa0",
+      "name": "HTTP-Tinyish",
+      "version": "0.20",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Tinyish-0.20/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Tinyish-0.20/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/HTTP/Tinyish/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/HTTP/Tinyish/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/HTTP/Tinyish.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/HTTP/Tinyish.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Tinyish-0.20/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Tinyish-0.20/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Tinyish-0.20/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/HTTP-Tinyish-0.20/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:HTTP-Tinyish:HTTP-Tinyish:0.20:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP-Tinyish:HTTP_Tinyish:0.20:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP_Tinyish:HTTP-Tinyish:0.20:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP_Tinyish:HTTP_Tinyish:0.20:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP:HTTP-Tinyish:0.20:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:HTTP:HTTP_Tinyish:0.20:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/HTTP-Tinyish@0.20?author=MIYAGAWA",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "MIYAGAWA",
+        "path": "M/MI/MIYAGAWA/HTTP-Tinyish-0.20.tar.gz",
+        "modules": [
+          {
+            "name": "HTTP::Tinyish",
+            "version": "0.20"
+          },
+          {
+            "name": "HTTP::Tinyish::Base"
+          },
+          {
+            "name": "HTTP::Tinyish::Curl"
+          },
+          {
+            "name": "HTTP::Tinyish::HTTPTiny"
+          },
+          {
+            "name": "HTTP::Tinyish::LWP"
+          },
+          {
+            "name": "HTTP::Tinyish::Wget"
+          }
+        ]
+      }
+    },
+    {
+      "id": "feb479095394ec01",
+      "name": "IO-HTML",
+      "version": "1.004",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/IO-HTML-1.004/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/IO-HTML-1.004/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/IO/HTML/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/IO/HTML/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/IO/HTML.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/IO/HTML.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/IO-HTML-1.004/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/IO-HTML-1.004/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/IO-HTML-1.004/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/IO-HTML-1.004/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:IO-HTML:IO-HTML:1.004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IO-HTML:IO_HTML:1.004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IO_HTML:IO-HTML:1.004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IO_HTML:IO_HTML:1.004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IO:IO-HTML:1.004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IO:IO_HTML:1.004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/IO-HTML@1.004?author=CJM",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "CJM",
+        "path": "C/CJ/CJM/IO-HTML-1.004.tar.gz",
+        "modules": [
+          {
+            "name": "IO::HTML",
+            "version": "1.004"
+          }
+        ]
+      }
+    },
+    {
+      "id": "5d8c0a1dd9cb2ef2",
+      "name": "IO-Socket-SSL",
+      "version": "2.099",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/IO/Socket/SSL/.packlist",
+          "layerID": "sha256:14bcd9a672ad733050fe1b4b4761a7d2981daaa6cf689055efea1dd5a0e80a06",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/IO/Socket/SSL/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/IO/Socket/SSL.pm",
+          "layerID": "sha256:14bcd9a672ad733050fe1b4b4761a7d2981daaa6cf689055efea1dd5a0e80a06",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/IO/Socket/SSL.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:IO-Socket-SSL:IO-Socket-SSL:2.099:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IO-Socket-SSL:IO_Socket_SSL:2.099:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IO_Socket_SSL:IO-Socket-SSL:2.099:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IO_Socket_SSL:IO_Socket_SSL:2.099:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IO-Socket:IO-Socket-SSL:2.099:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IO-Socket:IO_Socket_SSL:2.099:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IO_Socket:IO-Socket-SSL:2.099:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IO_Socket:IO_Socket_SSL:2.099:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IO:IO-Socket-SSL:2.099:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IO:IO_Socket_SSL:2.099:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/IO-Socket-SSL@2.099",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {}
+    },
+    {
+      "id": "bdb0cf8826342ba3",
+      "name": "IPC-Run3",
+      "version": "0.049",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/IPC-Run3-0.049/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/IPC-Run3-0.049/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/IPC/Run3/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/IPC/Run3/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/IPC/Run3.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/IPC/Run3.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/IPC-Run3-0.049/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/IPC-Run3-0.049/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "open_source",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/IPC-Run3-0.049/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/IPC-Run3-0.049/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:IPC-Run3:IPC-Run3:0.049:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IPC-Run3:IPC_Run3:0.049:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IPC_Run3:IPC-Run3:0.049:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IPC_Run3:IPC_Run3:0.049:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IPC:IPC-Run3:0.049:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:IPC:IPC_Run3:0.049:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/IPC-Run3@0.049?author=RJBS",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "RJBS",
+        "path": "R/RJ/RJBS/IPC-Run3-0.049.tar.gz",
+        "modules": [
+          {
+            "name": "IPC::Run3",
+            "version": "0.049"
+          }
+        ]
+      }
+    },
+    {
+      "id": "377ab6dc1a8109a9",
+      "name": "LWP-MediaTypes",
+      "version": "5.835",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/LWP/MediaTypes/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/LWP/MediaTypes/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/LWP/MediaTypes.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/LWP/MediaTypes.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:LWP-MediaTypes:LWP-MediaTypes:5.835:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:LWP-MediaTypes:LWP_MediaTypes:5.835:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:LWP_MediaTypes:LWP-MediaTypes:5.835:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:LWP_MediaTypes:LWP_MediaTypes:5.835:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:LWP:LWP-MediaTypes:5.835:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:LWP:LWP_MediaTypes:5.835:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/LWP-MediaTypes@5.835",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {}
+    },
+    {
+      "id": "cadf46a943e80169",
+      "name": "LWP-MediaTypes",
+      "version": "6.04",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/LWP-MediaTypes-6.04/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/LWP-MediaTypes-6.04/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/LWP-MediaTypes-6.04/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/LWP-MediaTypes-6.04/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/LWP-MediaTypes-6.04/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/LWP-MediaTypes-6.04/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:LWP-MediaTypes:LWP-MediaTypes:6.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:LWP-MediaTypes:LWP_MediaTypes:6.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:LWP_MediaTypes:LWP-MediaTypes:6.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:LWP_MediaTypes:LWP_MediaTypes:6.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:LWP:LWP-MediaTypes:6.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:LWP:LWP_MediaTypes:6.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/LWP-MediaTypes@6.04?author=OALDERS",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "OALDERS",
+        "path": "O/OA/OALDERS/LWP-MediaTypes-6.04.tar.gz",
+        "modules": [
+          {
+            "name": "LWP::MediaTypes",
+            "version": "6.04"
+          }
+        ]
+      }
+    },
+    {
+      "id": "90b62328409b9ff5",
+      "name": "MIME-Base32",
+      "version": "1.303",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/MIME-Base32-1.303/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/MIME-Base32-1.303/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/MIME/Base32/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/MIME/Base32/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/MIME/Base32.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/MIME/Base32.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/MIME-Base32-1.303/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/MIME-Base32-1.303/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/MIME-Base32-1.303/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/MIME-Base32-1.303/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:MIME-Base32:MIME-Base32:1.303:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:MIME-Base32:MIME_Base32:1.303:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:MIME_Base32:MIME-Base32:1.303:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:MIME_Base32:MIME_Base32:1.303:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:MIME:MIME-Base32:1.303:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:MIME:MIME_Base32:1.303:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/MIME-Base32@1.303?author=REHSACK",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "REHSACK",
+        "path": "R/RE/REHSACK/MIME-Base32-1.303.tar.gz",
+        "modules": [
+          {
+            "name": "MIME::Base32",
+            "version": "1.303"
+          }
+        ]
+      }
+    },
+    {
+      "id": "bd56847d8ef6cef4",
+      "name": "Module-Build-Tiny",
+      "version": "0.053",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-Build-Tiny-0.053/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-Build-Tiny-0.053/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Module/Build/Tiny/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Module/Build/Tiny/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/Module/Build/Tiny.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/Module/Build/Tiny.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-Build-Tiny-0.053/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-Build-Tiny-0.053/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-Build-Tiny-0.053/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-Build-Tiny-0.053/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Module-Build-Tiny:Module-Build-Tiny:0.053:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module-Build-Tiny:Module_Build_Tiny:0.053:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module_Build_Tiny:Module-Build-Tiny:0.053:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module_Build_Tiny:Module_Build_Tiny:0.053:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module-Build:Module-Build-Tiny:0.053:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module-Build:Module_Build_Tiny:0.053:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module_Build:Module-Build-Tiny:0.053:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module_Build:Module_Build_Tiny:0.053:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module:Module-Build-Tiny:0.053:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module:Module_Build_Tiny:0.053:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Module-Build-Tiny@0.053?author=LEONT",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "LEONT",
+        "path": "L/LE/LEONT/Module-Build-Tiny-0.053.tar.gz",
+        "modules": [
+          {
+            "name": "Module::Build::Tiny",
+            "version": "0.053"
+          }
+        ]
+      }
+    },
+    {
+      "id": "12fb3228bb385c16",
+      "name": "Module-CPANfile",
+      "version": "1.1004",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-CPANfile-1.1004/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-CPANfile-1.1004/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Module/CPANfile/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Module/CPANfile/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/Module/CPANfile.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/Module/CPANfile.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-CPANfile-1.1004/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-CPANfile-1.1004/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-CPANfile-1.1004/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-CPANfile-1.1004/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Module-CPANfile:Module-CPANfile:1.1004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module-CPANfile:Module_CPANfile:1.1004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module_CPANfile:Module-CPANfile:1.1004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module_CPANfile:Module_CPANfile:1.1004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module:Module-CPANfile:1.1004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module:Module_CPANfile:1.1004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Module-CPANfile@1.1004?author=MIYAGAWA",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "MIYAGAWA",
+        "path": "M/MI/MIYAGAWA/Module-CPANfile-1.1004.tar.gz",
+        "modules": [
+          {
+            "name": "Module::CPANfile",
+            "version": "1.1004"
+          },
+          {
+            "name": "Module::CPANfile::Environment"
+          },
+          {
+            "name": "Module::CPANfile::Prereq"
+          },
+          {
+            "name": "Module::CPANfile::Prereqs"
+          },
+          {
+            "name": "Module::CPANfile::Requirement"
+          }
+        ]
+      }
+    },
+    {
+      "id": "e2cccb5a4dfb1991",
+      "name": "Module-cpmfile",
+      "version": "v1.0.0",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-cpmfile-v1.0.0/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-cpmfile-v1.0.0/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Module/cpmfile/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Module/cpmfile/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/Module/cpmfile.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/Module/cpmfile.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-cpmfile-v1.0.0/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-cpmfile-v1.0.0/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-cpmfile-v1.0.0/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Module-cpmfile-v1.0.0/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Module-cpmfile:Module-cpmfile:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module-cpmfile:Module_cpmfile:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module_cpmfile:Module-cpmfile:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module_cpmfile:Module_cpmfile:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module:Module-cpmfile:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Module:Module_cpmfile:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Module-cpmfile@v1.0.0?author=SKAJI",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "SKAJI",
+        "path": "S/SK/SKAJI/Module-cpmfile-v1.0.0.tar.gz",
+        "modules": [
+          {
+            "name": "Module::cpmfile",
+            "version": "v1.0.0"
+          },
+          {
+            "name": "Module::cpmfile::Prereqs"
+          },
+          {
+            "name": "Module::cpmfile::Util"
+          }
+        ]
+      }
+    },
+    {
+      "id": "53c21cecc6795208",
+      "name": "Mojolicious",
+      "version": "9.10",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Mojolicious-9.10/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Mojolicious-9.10/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Mojolicious/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Mojolicious/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/Mojolicious.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/Mojolicious.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Mojolicious-9.10/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Mojolicious-9.10/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "artistic_2",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Mojolicious-9.10/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Mojolicious-9.10/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Mojolicious:Mojolicious:9.10:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Mojolicious@9.10?author=SRI",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "SRI",
+        "path": "S/SR/SRI/Mojolicious-9.10.tar.gz",
+        "modules": [
+          {
+            "name": "Mojo"
+          },
+          {
+            "name": "Mojo::Asset"
+          },
+          {
+            "name": "Mojo::Asset::File"
+          },
+          {
+            "name": "Mojo::Asset::Memory"
+          },
+          {
+            "name": "Mojo::Base"
+          },
+          {
+            "name": "Mojo::ByteStream"
+          },
+          {
+            "name": "Mojo::Cache"
+          },
+          {
+            "name": "Mojo::Collection"
+          },
+          {
+            "name": "Mojo::Content"
+          },
+          {
+            "name": "Mojo::Content::MultiPart"
+          },
+          {
+            "name": "Mojo::Content::Single"
+          },
+          {
+            "name": "Mojo::Cookie"
+          },
+          {
+            "name": "Mojo::Cookie::Request"
+          },
+          {
+            "name": "Mojo::Cookie::Response"
+          },
+          {
+            "name": "Mojo::DOM"
+          },
+          {
+            "name": "Mojo::DOM::CSS"
+          },
+          {
+            "name": "Mojo::DOM::HTML"
+          },
+          {
+            "name": "Mojo::Date"
+          },
+          {
+            "name": "Mojo::DynamicMethods"
+          },
+          {
+            "name": "Mojo::EventEmitter"
+          },
+          {
+            "name": "Mojo::Exception"
+          },
+          {
+            "name": "Mojo::File"
+          },
+          {
+            "name": "Mojo::Headers"
+          },
+          {
+            "name": "Mojo::HelloWorld"
+          },
+          {
+            "name": "Mojo::Home"
+          },
+          {
+            "name": "Mojo::IOLoop"
+          },
+          {
+            "name": "Mojo::IOLoop::Client"
+          },
+          {
+            "name": "Mojo::IOLoop::Server"
+          },
+          {
+            "name": "Mojo::IOLoop::Stream"
+          },
+          {
+            "name": "Mojo::IOLoop::Subprocess"
+          },
+          {
+            "name": "Mojo::IOLoop::TLS"
+          },
+          {
+            "name": "Mojo::JSON"
+          },
+          {
+            "name": "Mojo::JSON::Pointer"
+          },
+          {
+            "name": "Mojo::Loader"
+          },
+          {
+            "name": "Mojo::Log"
+          },
+          {
+            "name": "Mojo::Message"
+          },
+          {
+            "name": "Mojo::Message::Request"
+          },
+          {
+            "name": "Mojo::Message::Response"
+          },
+          {
+            "name": "Mojo::Parameters"
+          },
+          {
+            "name": "Mojo::Path"
+          },
+          {
+            "name": "Mojo::Promise"
+          },
+          {
+            "name": "Mojo::Reactor"
+          },
+          {
+            "name": "Mojo::Reactor::EV"
+          },
+          {
+            "name": "Mojo::Reactor::Poll"
+          },
+          {
+            "name": "Mojo::Server"
+          },
+          {
+            "name": "Mojo::Server::CGI"
+          },
+          {
+            "name": "Mojo::Server::Daemon"
+          },
+          {
+            "name": "Mojo::Server::Hypnotoad"
+          },
+          {
+            "name": "Mojo::Server::Morbo"
+          },
+          {
+            "name": "Mojo::Server::Morbo::Backend"
+          },
+          {
+            "name": "Mojo::Server::Morbo::Backend::Poll"
+          },
+          {
+            "name": "Mojo::Server::PSGI"
+          },
+          {
+            "name": "Mojo::Server::Prefork"
+          },
+          {
+            "name": "Mojo::Template"
+          },
+          {
+            "name": "Mojo::Transaction"
+          },
+          {
+            "name": "Mojo::Transaction::HTTP"
+          },
+          {
+            "name": "Mojo::Transaction::WebSocket"
+          },
+          {
+            "name": "Mojo::URL"
+          },
+          {
+            "name": "Mojo::Upload"
+          },
+          {
+            "name": "Mojo::UserAgent"
+          },
+          {
+            "name": "Mojo::UserAgent::CookieJar"
+          },
+          {
+            "name": "Mojo::UserAgent::Proxy"
+          },
+          {
+            "name": "Mojo::UserAgent::Server"
+          },
+          {
+            "name": "Mojo::UserAgent::Transactor"
+          },
+          {
+            "name": "Mojo::Util"
+          },
+          {
+            "name": "Mojo::WebSocket"
+          },
+          {
+            "name": "Mojolicious",
+            "version": "9.10"
+          },
+          {
+            "name": "Mojolicious::Command"
+          },
+          {
+            "name": "Mojolicious::Command::Author::cpanify"
+          },
+          {
+            "name": "Mojolicious::Command::Author::generate"
+          },
+          {
+            "name": "Mojolicious::Command::Author::generate::app"
+          },
+          {
+            "name": "Mojolicious::Command::Author::generate::dockerfile"
+          },
+          {
+            "name": "Mojolicious::Command::Author::generate::lite_app"
+          },
+          {
+            "name": "Mojolicious::Command::Author::generate::makefile"
+          },
+          {
+            "name": "Mojolicious::Command::Author::generate::plugin"
+          },
+          {
+            "name": "Mojolicious::Command::Author::inflate"
+          },
+          {
+            "name": "Mojolicious::Command::cgi"
+          },
+          {
+            "name": "Mojolicious::Command::daemon"
+          },
+          {
+            "name": "Mojolicious::Command::eval"
+          },
+          {
+            "name": "Mojolicious::Command::get"
+          },
+          {
+            "name": "Mojolicious::Command::prefork"
+          },
+          {
+            "name": "Mojolicious::Command::psgi"
+          },
+          {
+            "name": "Mojolicious::Command::routes"
+          },
+          {
+            "name": "Mojolicious::Command::version"
+          },
+          {
+            "name": "Mojolicious::Commands"
+          },
+          {
+            "name": "Mojolicious::Controller"
+          },
+          {
+            "name": "Mojolicious::Lite"
+          },
+          {
+            "name": "Mojolicious::Plugin"
+          },
+          {
+            "name": "Mojolicious::Plugin::Config"
+          },
+          {
+            "name": "Mojolicious::Plugin::Config::Sandbox"
+          },
+          {
+            "name": "Mojolicious::Plugin::DefaultHelpers"
+          },
+          {
+            "name": "Mojolicious::Plugin::EPLRenderer"
+          },
+          {
+            "name": "Mojolicious::Plugin::EPRenderer"
+          },
+          {
+            "name": "Mojolicious::Plugin::HeaderCondition"
+          },
+          {
+            "name": "Mojolicious::Plugin::JSONConfig"
+          },
+          {
+            "name": "Mojolicious::Plugin::Mount"
+          },
+          {
+            "name": "Mojolicious::Plugin::NotYAMLConfig"
+          },
+          {
+            "name": "Mojolicious::Plugin::TagHelpers"
+          },
+          {
+            "name": "Mojolicious::Plugins"
+          },
+          {
+            "name": "Mojolicious::Renderer"
+          },
+          {
+            "name": "Mojolicious::Routes"
+          },
+          {
+            "name": "Mojolicious::Routes::Match"
+          },
+          {
+            "name": "Mojolicious::Routes::Pattern"
+          },
+          {
+            "name": "Mojolicious::Routes::Route"
+          },
+          {
+            "name": "Mojolicious::Sessions"
+          },
+          {
+            "name": "Mojolicious::Static"
+          },
+          {
+            "name": "Mojolicious::Types"
+          },
+          {
+            "name": "Mojolicious::Validator"
+          },
+          {
+            "name": "Mojolicious::Validator::Validation"
+          },
+          {
+            "name": "Test::Mojo"
+          },
+          {
+            "name": "ojo"
+          }
+        ]
+      }
+    },
+    {
+      "id": "016bd3f97a08555e",
+      "name": "Net-SSLeay",
+      "version": "1.96",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Net/SSLeay/.packlist",
+          "layerID": "sha256:14bcd9a672ad733050fe1b4b4761a7d2981daaa6cf689055efea1dd5a0e80a06",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Net/SSLeay/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/Net/SSLeay.pm",
+          "layerID": "sha256:14bcd9a672ad733050fe1b4b4761a7d2981daaa6cf689055efea1dd5a0e80a06",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/Net/SSLeay.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Net-SSLeay:Net-SSLeay:1.96:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Net-SSLeay:Net_SSLeay:1.96:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Net_SSLeay:Net-SSLeay:1.96:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Net_SSLeay:Net_SSLeay:1.96:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Net:Net-SSLeay:1.96:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Net:Net_SSLeay:1.96:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Net-SSLeay@1.96",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {}
+    },
+    {
+      "id": "f6fb2ec77617e601",
+      "name": "Parallel-Pipes",
+      "version": "v1.0.0",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parallel-Pipes-v1.0.0/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parallel-Pipes-v1.0.0/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Parallel/Pipes/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Parallel/Pipes/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/Parallel/Pipes.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/Parallel/Pipes.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parallel-Pipes-v1.0.0/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parallel-Pipes-v1.0.0/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parallel-Pipes-v1.0.0/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parallel-Pipes-v1.0.0/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Parallel-Pipes:Parallel-Pipes:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Parallel-Pipes:Parallel_Pipes:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Parallel_Pipes:Parallel-Pipes:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Parallel_Pipes:Parallel_Pipes:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Parallel:Parallel-Pipes:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Parallel:Parallel_Pipes:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Parallel-Pipes@v1.0.0?author=SKAJI",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "SKAJI",
+        "path": "S/SK/SKAJI/Parallel-Pipes-v1.0.0.tar.gz",
+        "modules": [
+          {
+            "name": "Parallel::Pipes",
+            "version": "v1.0.0"
+          },
+          {
+            "name": "Parallel::Pipes::App",
+            "version": "v1.0.0"
+          }
+        ]
+      }
+    },
+    {
+      "id": "66847f483c63b78e",
+      "name": "Parse-LocalDistribution",
+      "version": "0.21",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parse-LocalDistribution-0.21/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parse-LocalDistribution-0.21/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Parse/LocalDistribution/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Parse/LocalDistribution/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/Parse/LocalDistribution.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/Parse/LocalDistribution.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parse-LocalDistribution-0.21/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parse-LocalDistribution-0.21/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parse-LocalDistribution-0.21/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parse-LocalDistribution-0.21/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Parse-LocalDistribution:Parse-LocalDistribution:0.21:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Parse-LocalDistribution:Parse_LocalDistribution:0.21:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Parse_LocalDistribution:Parse-LocalDistribution:0.21:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Parse_LocalDistribution:Parse_LocalDistribution:0.21:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Parse:Parse-LocalDistribution:0.21:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Parse:Parse_LocalDistribution:0.21:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Parse-LocalDistribution@0.21?author=ISHIGAKI",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "ISHIGAKI",
+        "path": "I/IS/ISHIGAKI/Parse-LocalDistribution-0.21.tar.gz",
+        "modules": [
+          {
+            "name": "Parse::LocalDistribution",
+            "version": "0.21"
+          }
+        ]
+      }
+    },
+    {
+      "id": "9eb91d6f7b3bf90c",
+      "name": "Parse-PMFile",
+      "version": "0.48",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parse-PMFile-0.48/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parse-PMFile-0.48/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Parse/PMFile/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Parse/PMFile/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/Parse/PMFile.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/Parse/PMFile.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parse-PMFile-0.48/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parse-PMFile-0.48/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parse-PMFile-0.48/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Parse-PMFile-0.48/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Parse-PMFile:Parse-PMFile:0.48:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Parse-PMFile:Parse_PMFile:0.48:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Parse_PMFile:Parse-PMFile:0.48:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Parse_PMFile:Parse_PMFile:0.48:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Parse:Parse-PMFile:0.48:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Parse:Parse_PMFile:0.48:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Parse-PMFile@0.48?author=ISHIGAKI",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "ISHIGAKI",
+        "path": "I/IS/ISHIGAKI/Parse-PMFile-0.48.tar.gz",
+        "modules": [
+          {
+            "name": "Parse::PMFile",
+            "version": "0.48"
+          }
+        ]
+      }
+    },
+    {
+      "id": "da88153dc0cb5d4d",
+      "name": "Proc-ForkSafe",
+      "version": "v1.0.0",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Proc-ForkSafe-v1.0.0/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Proc-ForkSafe-v1.0.0/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Proc/ForkSafe/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Proc/ForkSafe/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/Proc/ForkSafe.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/Proc/ForkSafe.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Proc-ForkSafe-v1.0.0/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Proc-ForkSafe-v1.0.0/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Proc-ForkSafe-v1.0.0/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Proc-ForkSafe-v1.0.0/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Proc-ForkSafe:Proc-ForkSafe:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Proc-ForkSafe:Proc_ForkSafe:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Proc_ForkSafe:Proc-ForkSafe:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Proc_ForkSafe:Proc_ForkSafe:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Proc:Proc-ForkSafe:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Proc:Proc_ForkSafe:v1.0.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Proc-ForkSafe@v1.0.0?author=SKAJI",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "SKAJI",
+        "path": "S/SK/SKAJI/Proc-ForkSafe-v1.0.0.tar.gz",
+        "modules": [
+          {
+            "name": "Proc::ForkSafe",
+            "version": "v1.0.0"
+          }
+        ]
+      }
+    },
+    {
+      "id": "6145b9e87993a43e",
+      "name": "String-ShellQuote",
+      "version": "1.04",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/String-ShellQuote-1.04/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/String-ShellQuote-1.04/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/String/ShellQuote/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/String/ShellQuote/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/String/ShellQuote.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/String/ShellQuote.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/String-ShellQuote-1.04/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/String-ShellQuote-1.04/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "unknown",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/String-ShellQuote-1.04/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/String-ShellQuote-1.04/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:String-ShellQuote:String-ShellQuote:1.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:String-ShellQuote:String_ShellQuote:1.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:String_ShellQuote:String-ShellQuote:1.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:String_ShellQuote:String_ShellQuote:1.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:String:String-ShellQuote:1.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:String:String_ShellQuote:1.04:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/String-ShellQuote@1.04?author=ROSCH",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "ROSCH",
+        "path": "R/RO/ROSCH/String-ShellQuote-1.04.tar.gz",
+        "modules": [
+          {
+            "name": "String::ShellQuote",
+            "version": "1.04"
+          }
+        ]
+      }
+    },
+    {
+      "id": "74fae5132cfcafee",
+      "name": "Text-CSV",
+      "version": "2.06",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Text/CSV/.packlist",
+          "layerID": "sha256:884e6725555efab47868e5e1d279636f1996316c023a371de1ebe590dc79e43b",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Text/CSV/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/Text/CSV.pm",
+          "layerID": "sha256:884e6725555efab47868e5e1d279636f1996316c023a371de1ebe590dc79e43b",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/Text/CSV.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Text-CSV:Text-CSV:2.06:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text-CSV:Text_CSV:2.06:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text_CSV:Text-CSV:2.06:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text_CSV:Text_CSV:2.06:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text:Text-CSV:2.06:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text:Text_CSV:2.06:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Text-CSV@2.06",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {}
+    },
+    {
+      "id": "26858b0577b7166c",
+      "name": "Text-CSV_XS",
+      "version": "1.64",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Text/CSV_XS/.packlist",
+          "layerID": "sha256:884e6725555efab47868e5e1d279636f1996316c023a371de1ebe590dc79e43b",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Text/CSV_XS/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/Text/CSV_XS.pm",
+          "layerID": "sha256:884e6725555efab47868e5e1d279636f1996316c023a371de1ebe590dc79e43b",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/Text/CSV_XS.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Text-CSV-XS:Text-CSV-XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text-CSV-XS:Text-CSV_XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text-CSV-XS:Text_CSV_XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text-CSV_XS:Text-CSV-XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text-CSV_XS:Text-CSV_XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text-CSV_XS:Text_CSV_XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text_CSV_XS:Text-CSV-XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text_CSV_XS:Text-CSV_XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text_CSV_XS:Text_CSV_XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text-CSV:Text-CSV-XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text-CSV:Text-CSV_XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text-CSV:Text_CSV_XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text_CSV:Text-CSV-XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text_CSV:Text-CSV_XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text_CSV:Text_CSV_XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text:Text-CSV-XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text:Text-CSV_XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Text:Text_CSV_XS:1.64:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Text-CSV_XS@1.64",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {}
+    },
+    {
+      "id": "194e0bb8fb4ce000",
+      "name": "Tie-Handle-Offset",
+      "version": "0.004",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Tie-Handle-Offset-0.004/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Tie-Handle-Offset-0.004/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Tie/Handle/Offset/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Tie/Handle/Offset/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/Tie/Handle/Offset.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/Tie/Handle/Offset.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Tie-Handle-Offset-0.004/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Tie-Handle-Offset-0.004/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "apache_2_0",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Tie-Handle-Offset-0.004/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Tie-Handle-Offset-0.004/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Tie-Handle-Offset:Tie-Handle-Offset:0.004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Tie-Handle-Offset:Tie_Handle_Offset:0.004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Tie_Handle_Offset:Tie-Handle-Offset:0.004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Tie_Handle_Offset:Tie_Handle_Offset:0.004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Tie-Handle:Tie-Handle-Offset:0.004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Tie-Handle:Tie_Handle_Offset:0.004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Tie_Handle:Tie-Handle-Offset:0.004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Tie_Handle:Tie_Handle_Offset:0.004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Tie:Tie-Handle-Offset:0.004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Tie:Tie_Handle_Offset:0.004:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Tie-Handle-Offset@0.004?author=DAGOLDEN",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "DAGOLDEN",
+        "path": "D/DA/DAGOLDEN/Tie-Handle-Offset-0.004.tar.gz",
+        "modules": [
+          {
+            "name": "Tie::Handle::Offset",
+            "version": "0.004"
+          },
+          {
+            "name": "Tie::Handle::SkipHeader",
+            "version": "0.004"
+          }
+        ]
+      }
+    },
+    {
+      "id": "45a7fce35517b51f",
+      "name": "TimeDate",
+      "version": "2.35",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/TimeDate-2.35/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/TimeDate-2.35/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/TimeDate/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/TimeDate/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/TimeDate.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/TimeDate.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/TimeDate-2.35/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/TimeDate-2.35/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/TimeDate-2.35/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/TimeDate-2.35/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:TimeDate:TimeDate:2.35:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/TimeDate@2.35?author=ATOOMIC",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "ATOOMIC",
+        "path": "A/AT/ATOOMIC/TimeDate-2.35.tar.gz",
+        "modules": [
+          {
+            "name": "Date::Format",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Format::Generic",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Afar",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Amharic",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Arabic",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Austrian",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Brazilian",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Bulgarian",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Chinese",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Chinese_GB",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Czech",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Danish",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Dutch",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::English",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Finnish",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::French",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Gedeo",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::German",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Greek",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Hungarian",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Icelandic",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Italian",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Norwegian",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Occitan",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Oromo",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Portuguese",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Romanian",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Russian",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Russian_cp1251",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Russian_koi8r",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Sidama",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Somali",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Spanish",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Swedish",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Tigrinya",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::TigrinyaEritrean",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::TigrinyaEthiopian",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Language::Turkish",
+            "version": "2.35"
+          },
+          {
+            "name": "Date::Parse",
+            "version": "2.35"
+          },
+          {
+            "name": "Time::Zone",
+            "version": "2.35"
+          },
+          {
+            "name": "TimeDate",
+            "version": "2.35"
+          }
+        ]
+      }
+    },
+    {
+      "id": "28c0dd69be851b17",
+      "name": "URI",
+      "version": "5.35",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/URI-5.35/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/URI-5.35/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/URI/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/URI/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/URI.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/URI.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/URI-5.35/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/URI-5.35/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/URI-5.35/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/URI-5.35/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:URI:URI:5.35:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/URI@5.35?author=OALDERS",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "OALDERS",
+        "path": "O/OA/OALDERS/URI-5.35.tar.gz",
+        "modules": [
+          {
+            "name": "URI",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::Escape",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::Heuristic",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::IRI",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::QueryParam",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::Split",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::URL",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::WithBase",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::data",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::file",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::file::Base",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::file::FAT",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::file::Mac",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::file::OS2",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::file::QNX",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::file::Unix",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::file::Win32",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::ftp",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::ftpes",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::ftps",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::geo",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::gopher",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::http",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::https",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::icap",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::icaps",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::irc",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::ircs",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::ldap",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::ldapi",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::ldaps",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::mailto",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::mms",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::news",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::nntp",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::nntps",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::otpauth",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::pop",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::rlogin",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::rsync",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::rtsp",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::rtspu",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::scp",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::sftp",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::sip",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::sips",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::smb",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::smtp",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::snews",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::ssh",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::telnet",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::tn3270",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::urn",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::urn::isbn",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::urn::oid",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::ws",
+            "version": "5.35"
+          },
+          {
+            "name": "URI::wss",
+            "version": "5.35"
+          }
+        ]
+      }
+    },
+    {
+      "id": "dc2afc0f0032685f",
+      "name": "Win32-ShellQuote",
+      "version": "0.003001",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Win32-ShellQuote-0.003001/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Win32-ShellQuote-0.003001/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Win32/ShellQuote/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/Win32/ShellQuote/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/Win32/ShellQuote.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/Win32/ShellQuote.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Win32-ShellQuote-0.003001/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Win32-ShellQuote-0.003001/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Win32-ShellQuote-0.003001/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/Win32-ShellQuote-0.003001/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:Win32-ShellQuote:Win32-ShellQuote:0.003001:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Win32-ShellQuote:Win32_ShellQuote:0.003001:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Win32_ShellQuote:Win32-ShellQuote:0.003001:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Win32_ShellQuote:Win32_ShellQuote:0.003001:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Win32:Win32-ShellQuote:0.003001:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:Win32:Win32_ShellQuote:0.003001:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/Win32-ShellQuote@0.003001?author=HAARG",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "HAARG",
+        "path": "H/HA/HAARG/Win32-ShellQuote-0.003001.tar.gz",
+        "modules": [
+          {
+            "name": "Win32::ShellQuote",
+            "version": "0.003001"
+          }
+        ]
+      }
+    },
+    {
+      "id": "37e29db8c10746e5",
+      "name": "YAML-PP",
+      "version": "v0.41.0",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/YAML-PP-v0.41.0/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/YAML-PP-v0.41.0/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/YAML/PP/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/YAML/PP/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/YAML/PP.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/YAML/PP.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/YAML-PP-v0.41.0/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/YAML-PP-v0.41.0/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/YAML-PP-v0.41.0/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/YAML-PP-v0.41.0/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:YAML-PP:YAML-PP:v0.41.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:YAML-PP:YAML_PP:v0.41.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:YAML_PP:YAML-PP:v0.41.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:YAML_PP:YAML_PP:v0.41.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:YAML:YAML-PP:v0.41.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:YAML:YAML_PP:v0.41.0:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/YAML-PP@v0.41.0?author=TINITA",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "TINITA",
+        "path": "T/TI/TINITA/YAML-PP-v0.41.0.tar.gz",
+        "modules": [
+          {
+            "name": "YAML::PP",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Common",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Constructor",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Dumper",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Emitter",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Exception",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Grammar",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Highlight",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Lexer",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Loader",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Parser",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Perl",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Preserve::Array",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Preserve::Hash",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Preserve::Scalar",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Reader",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Reader::File",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Render",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Representer",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Schema",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Schema::Binary",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Schema::Catchall",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Schema::Core",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Schema::Failsafe",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Schema::Include",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Schema::JSON",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Schema::Merge",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Schema::Perl",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Schema::Tie::IxHash",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Schema::YAML1_1",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Type::MergeKey",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Writer",
+            "version": "v0.41.0"
+          },
+          {
+            "name": "YAML::PP::Writer::File",
+            "version": "v0.41.0"
+          }
+        ]
+      }
+    },
+    {
+      "id": "36a74ffb763cab92",
+      "name": "libwww-perl",
+      "version": "5.836",
+      "type": "cpan",
+      "foundBy": "perl-cpan-installed-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/libwww-perl-5.836/install.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/libwww-perl-5.836/install.json",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/LWP/.packlist",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/auto/LWP/.packlist",
+          "annotations": {
+            "evidence": "primary"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/LWP.pm",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/LWP.pm",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        },
+        {
+          "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/libwww-perl-5.836/MYMETA.json",
+          "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/libwww-perl-5.836/MYMETA.json",
+          "annotations": {
+            "evidence": "supporting"
+          }
+        }
+      ],
+      "licenses": [
+        {
+          "value": "perl_5",
+          "spdxExpression": "",
+          "type": "declared",
+          "urls": [],
+          "locations": [
+            {
+              "path": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/libwww-perl-5.836/MYMETA.json",
+              "layerID": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+              "accessPath": "/usr/local/lib/perl5/site_perl/5.40.4/aarch64-linux-gnu/.meta/libwww-perl-5.836/MYMETA.json",
+              "annotations": {
+                "evidence": "supporting"
+              }
+            }
+          ]
+        }
+      ],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:libwww-perl:libwww-perl:5.836:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:libwww-perl:libwww_perl:5.836:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:libwww_perl:libwww-perl:5.836:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:libwww_perl:libwww_perl:5.836:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:libwww:libwww-perl:5.836:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        },
+        {
+          "cpe": "cpe:2.3:a:libwww:libwww_perl:5.836:*:*:*:*:perl:*:*",
+          "source": "syft-generated"
+        }
+      ],
+      "purl": "pkg:cpan/libwww-perl@5.836?author=GAAS",
+      "metadataType": "cpan-distribution-entry",
+      "metadata": {
+        "author": "GAAS",
+        "path": "G/GA/GAAS/libwww-perl-5.836.tar.gz",
+        "modules": [
+          {
+            "name": "Bundle::LWP",
+            "version": "5.835"
+          },
+          {
+            "name": "File::Listing",
+            "version": "5.814"
+          },
+          {
+            "name": "File::Listing::apache",
+            "version": "5.814"
+          },
+          {
+            "name": "File::Listing::dosftp",
+            "version": "5.814"
+          },
+          {
+            "name": "File::Listing::netware",
+            "version": "5.814"
+          },
+          {
+            "name": "File::Listing::unix",
+            "version": "5.814"
+          },
+          {
+            "name": "File::Listing::vms",
+            "version": "5.814"
+          },
+          {
+            "name": "HTML::Form",
+            "version": "5.829"
+          },
+          {
+            "name": "HTML::Form::FileInput",
+            "version": "5.829"
+          },
+          {
+            "name": "HTML::Form::IgnoreInput",
+            "version": "5.829"
+          },
+          {
+            "name": "HTML::Form::ImageInput",
+            "version": "5.829"
+          },
+          {
+            "name": "HTML::Form::Input",
+            "version": "5.829"
+          },
+          {
+            "name": "HTML::Form::KeygenInput",
+            "version": "5.829"
+          },
+          {
+            "name": "HTML::Form::ListInput",
+            "version": "5.829"
+          },
+          {
+            "name": "HTML::Form::SubmitInput",
+            "version": "5.829"
+          },
+          {
+            "name": "HTML::Form::TextInput",
+            "version": "5.829"
+          },
+          {
+            "name": "HTTP::Config",
+            "version": "5.835"
+          },
+          {
+            "name": "HTTP::Cookies",
+            "version": "5.833"
+          },
+          {
+            "name": "HTTP::Cookies::Microsoft",
+            "version": "5.821"
+          },
+          {
+            "name": "HTTP::Cookies::Netscape",
+            "version": "5.832"
+          },
+          {
+            "name": "HTTP::Daemon",
+            "version": "5.827"
+          },
+          {
+            "name": "HTTP::Daemon::ClientConn",
+            "version": "5.827"
+          },
+          {
+            "name": "HTTP::Date",
+            "version": "5.831"
+          },
+          {
+            "name": "HTTP::Headers",
+            "version": "5.835"
+          },
+          {
+            "name": "HTTP::Headers::Auth",
+            "version": "5.817"
+          },
+          {
+            "name": "HTTP::Headers::ETag",
+            "version": "5.810"
+          },
+          {
+            "name": "HTTP::Headers::Util",
+            "version": "5.817"
+          },
+          {
+            "name": "HTTP::Message",
+            "version": "5.835"
+          },
+          {
+            "name": "HTTP::Negotiate",
+            "version": "5.835"
+          },
+          {
+            "name": "HTTP::Request",
+            "version": "5.827"
+          },
+          {
+            "name": "HTTP::Request::Common",
+            "version": "5.824"
+          },
+          {
+            "name": "HTTP::Response",
+            "version": "5.836"
+          },
+          {
+            "name": "HTTP::Status",
+            "version": "5.817"
+          },
+          {
+            "name": "LWP",
+            "version": "5.836"
+          },
+          {
+            "name": "LWP::Authen::Basic"
+          },
+          {
+            "name": "LWP::Authen::Digest"
+          },
+          {
+            "name": "LWP::Authen::Ntlm",
+            "version": "5.835"
+          },
+          {
+            "name": "LWP::ConnCache",
+            "version": "5.810"
+          },
+          {
+            "name": "LWP::Debug"
+          },
+          {
+            "name": "LWP::DebugFile"
+          },
+          {
+            "name": "LWP::MediaTypes",
+            "version": "5.835"
+          },
+          {
+            "name": "LWP::MemberMixin"
+          },
+          {
+            "name": "LWP::Protocol",
+            "version": "5.829"
+          },
+          {
+            "name": "LWP::Protocol::GHTTP"
+          },
+          {
+            "name": "LWP::Protocol::MyFTP"
+          },
+          {
+            "name": "LWP::Protocol::cpan"
+          },
+          {
+            "name": "LWP::Protocol::data"
+          },
+          {
+            "name": "LWP::Protocol::file"
+          },
+          {
+            "name": "LWP::Protocol::ftp"
+          },
+          {
+            "name": "LWP::Protocol::gopher"
+          },
+          {
+            "name": "LWP::Protocol::http"
+          },
+          {
+            "name": "LWP::Protocol::http10"
+          },
+          {
+            "name": "LWP::Protocol::http::Socket"
+          },
+          {
+            "name": "LWP::Protocol::http::SocketMethods"
+          },
+          {
+            "name": "LWP::Protocol::https"
+          },
+          {
+            "name": "LWP::Protocol::https10"
+          },
+          {
+            "name": "LWP::Protocol::https::Socket"
+          },
+          {
+            "name": "LWP::Protocol::loopback"
+          },
+          {
+            "name": "LWP::Protocol::mailto"
+          },
+          {
+            "name": "LWP::Protocol::nntp"
+          },
+          {
+            "name": "LWP::Protocol::nogo"
+          },
+          {
+            "name": "LWP::RobotUA",
+            "version": "5.835"
+          },
+          {
+            "name": "LWP::Simple",
+            "version": "5.835"
+          },
+          {
+            "name": "LWP::UserAgent",
+            "version": "5.835"
+          },
+          {
+            "name": "Net::HTTP",
+            "version": "5.834"
+          },
+          {
+            "name": "Net::HTTP::Methods",
+            "version": "5.834"
+          },
+          {
+            "name": "Net::HTTP::NB",
+            "version": "5.810"
+          },
+          {
+            "name": "Net::HTTPS",
+            "version": "5.819"
+          },
+          {
+            "name": "WWW::RobotRules",
+            "version": "5.832"
+          },
+          {
+            "name": "WWW::RobotRules::AnyDBM_File",
+            "version": "5.835"
+          },
+          {
+            "name": "WWW::RobotRules::InCore",
+            "version": "5.832"
+          }
+        ]
+      }
+    },
+    {
+      "id": "c9e85a8572e279db",
+      "name": "perl",
+      "version": "5.40.4",
+      "type": "cpan",
+      "foundBy": "binary-classifier-cataloger",
+      "locations": [
+        {
+          "path": "/usr/local/bin/perl",
+          "layerID": "sha256:14bcd9a672ad733050fe1b4b4761a7d2981daaa6cf689055efea1dd5a0e80a06",
+          "accessPath": "/usr/local/bin/perl",
+          "annotations": {
+            "evidence": "primary"
+          }
+        }
+      ],
+      "licenses": [],
+      "language": "perl",
+      "cpes": [
+        {
+          "cpe": "cpe:2.3:a:perl:perl:5.40.4:*:*:*:*:*:*:*",
+          "source": "nvd-cpe-dictionary"
+        }
+      ],
+      "purl": "pkg:cpan/perl@5.40.4",
+      "metadataType": "binary-signature",
+      "metadata": {
+        "matches": [
+          {
+            "classifier": "perl-binary",
+            "location": {
+              "path": "/usr/local/bin/perl",
+              "layerID": "sha256:14bcd9a672ad733050fe1b4b4761a7d2981daaa6cf689055efea1dd5a0e80a06",
+              "accessPath": "/usr/local/bin/perl",
+              "annotations": {
+                "evidence": "primary"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "artifactRelationships": [
+    {
+      "parent": "0582d016697cd605",
+      "child": "36a74ffb763cab92",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "0582d016697cd605",
+      "child": "7f78ab91d22fa93a",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "0589888b3ac40086",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "089bcadfe951629d",
+      "child": "f8cdae3dbaab0918",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "12fb3228bb385c16",
+      "child": "59412e62a7e9e0c0",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "12fb3228bb385c16",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "194e0bb8fb4ce000",
+      "child": "eb766bfb3050c6f5",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "28c0dd69be851b17",
+      "child": "36a74ffb763cab92",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "28c0dd69be851b17",
+      "child": "7f78ab91d22fa93a",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "28c0dd69be851b17",
+      "child": "f8cdae3dbaab0918",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "36a74ffb763cab92",
+      "child": "7f78ab91d22fa93a",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "36a74ffb763cab92",
+      "child": "f8cdae3dbaab0918",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "37e29db8c10746e5",
+      "child": "e2cccb5a4dfb1991",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "45a7fce35517b51f",
+      "child": "089bcadfe951629d",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "4f0772ea05d9d9e8",
+      "child": "f8cdae3dbaab0918",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "545ae1bf296ac30c",
+      "child": "f8cdae3dbaab0918",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "59d9fff802d1ddcc",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "59d9fff802d1ddcc",
+      "child": "bd56847d8ef6cef4",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "6145b9e87993a43e",
+      "child": "7f7aa973aea28c3b",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "66847f483c63b78e",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "6a6393b110c49dea",
+      "child": "7f7aa973aea28c3b",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "6a6393b110c49dea",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "7f78ab91d22fa93a",
+      "child": "36a74ffb763cab92",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "7f7aa973aea28c3b",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "87025f0b83211a62",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "873a36702f9b5c66",
+      "child": "59d9fff802d1ddcc",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "873a36702f9b5c66",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "873a36702f9b5c66",
+      "child": "bd56847d8ef6cef4",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "90b62328409b9ff5",
+      "child": "28c0dd69be851b17",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "94047903cfc5f703",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "94047903cfc5f703",
+      "child": "bd56847d8ef6cef4",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "9eb91d6f7b3bf90c",
+      "child": "66847f483c63b78e",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "abd175f7aeb7c55a",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "abd175f7aeb7c55a",
+      "child": "d34e68e22577cfa0",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "bdb0cf8826342ba3",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "bdb0cf8826342ba3",
+      "child": "d34e68e22577cfa0",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "cadf46a943e80169",
+      "child": "f8cdae3dbaab0918",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "d03572fa2a145dae",
+      "child": "7f7aa973aea28c3b",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "d34e68e22577cfa0",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "da88153dc0cb5d4d",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "dc2afc0f0032685f",
+      "child": "7f7aa973aea28c3b",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "e2cccb5a4dfb1991",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "eb766bfb3050c6f5",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "f6fb2ec77617e601",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "f8cdae3dbaab0918",
+      "child": "7f78ab91d22fa93a",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "f9c4718f9f3450b3",
+      "child": "b25087da29b9d8fa",
+      "type": "dependency-of"
+    },
+    {
+      "parent": "feb479095394ec01",
+      "child": "f8cdae3dbaab0918",
+      "type": "dependency-of"
+    }
+  ],
+  "source": {
+    "id": "32f218b0de793254e71484ce159597c5307bf7c21a22d806bb8e36ee638691c0",
+    "name": "cpan-fixture",
+    "version": "sha256:32f218b0de793254e71484ce159597c5307bf7c21a22d806bb8e36ee638691c0",
+    "type": "image",
+    "metadata": {
+      "userInput": "cpan-fixture:latest",
+      "imageID": "sha256:402ea303019b5b7e30711f0185119c12c0d1aa66b40ba04b2da8aa0388400636",
+      "manifestDigest": "sha256:32f218b0de793254e71484ce159597c5307bf7c21a22d806bb8e36ee638691c0",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "tags": [
+        "cpan-fixture:latest"
+      ],
+      "imageSize": 632297198,
+      "layers": [
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:4e6fee325600a0377566ca159a4da9833f6e35e04eaa4194c47dd3b2fe901717",
+          "size": 100492096
+        },
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:091f4a1e10d82f7b58e1fca36ee09b14f9b8212205263afcf0cd8832eb8a4535",
+          "size": 413
+        },
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
+          "size": 0
+        },
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:14bcd9a672ad733050fe1b4b4761a7d2981daaa6cf689055efea1dd5a0e80a06",
+          "size": 117324265
+        },
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:464e0c3c34e5055ef8679bc2e550a337e4190f3f86643116b7e8a7ac43f6eaaf",
+          "size": 0
+        },
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:f5364fbf1e2a51c4ba6fc1fabd99d5eec019bb6c5b3e6fb3e0c5811a295bab3b",
+          "size": 274028859
+        },
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:b228a5511e13c1a5367f2034178b94254cf948215591ed922c1098a943ae0364",
+          "size": 32931100
+        },
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:884e6725555efab47868e5e1d279636f1996316c023a371de1ebe590dc79e43b",
+          "size": 107520465
+        }
+      ],
+      "manifest": "eyJzY2hlbWFWZXJzaW9uIjoyLCJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwiY29uZmlnIjp7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuY29udGFpbmVyLmltYWdlLnYxK2pzb24iLCJzaXplIjo1OTc3LCJkaWdlc3QiOiJzaGEyNTY6NDAyZWEzMDMwMTliNWI3ZTMwNzExZjAxODUxMTljMTJjMGQxYWE2NmI0MGJhMDRiMmRhOGFhMDM4ODQwMDYzNiJ9LCJsYXllcnMiOlt7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuaW1hZ2Uucm9vdGZzLmRpZmYudGFyLmd6aXAiLCJzaXplIjozMDE0MzcwNSwiZGlnZXN0Ijoic2hhMjU2OjRlNmZlZTMyNTYwMGEwMzc3NTY2Y2ExNTlhNGRhOTgzM2Y2ZTM1ZTA0ZWFhNDE5NGM0N2RkM2IyZmU5MDE3MTcifSx7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuaW1hZ2Uucm9vdGZzLmRpZmYudGFyLmd6aXAiLCJzaXplIjo0MzksImRpZ2VzdCI6InNoYTI1NjowOTFmNGExZTEwZDgyZjdiNThlMWZjYTM2ZWUwOWIxNGY5YjgyMTIyMDUyNjNhZmNmMGNkODgzMmViOGE0NTM1In0seyJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmltYWdlLnJvb3Rmcy5kaWZmLnRhci5nemlwIiwic2l6ZSI6MzIsImRpZ2VzdCI6InNoYTI1Njo1ZjcwYmYxOGEwODYwMDcwMTZlOTQ4YjA0YWVkM2I4MjEwM2EzNmJlYTQxNzU1YjZjZGRmYWYxMGFjZTNjNmVmIn0seyJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmltYWdlLnJvb3Rmcy5kaWZmLnRhci5nemlwIiwic2l6ZSI6MzE0NzE0MTIsImRpZ2VzdCI6InNoYTI1NjoxNGJjZDlhNjcyYWQ3MzMwNTBmZTFiNGI0NzYxYTdkMjk4MWRhYWE2Y2Y2ODkwNTVlZmVhMWRkNWEwZTgwYTA2In0seyJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmltYWdlLnJvb3Rmcy5kaWZmLnRhci5nemlwIiwic2l6ZSI6MTMzLCJkaWdlc3QiOiJzaGEyNTY6NDY0ZTBjM2MzNGU1MDU1ZWY4Njc5YmMyZTU1MGEzMzdlNDE5MGYzZjg2NjQzMTE2YjdlOGE3YWM0M2Y2ZWFhZiJ9LHsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIsInNpemUiOjkzODQ0MzU2LCJkaWdlc3QiOiJzaGEyNTY6ZjUzNjRmYmYxZTJhNTFjNGJhNmZjMWZhYmQ5OWQ1ZWVjMDE5YmI2YzViM2U2ZmIzZTBjNTgxMWEyOTViYWIzYiJ9LHsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIsInNpemUiOjEzNTc4NjgzLCJkaWdlc3QiOiJzaGEyNTY6YjIyOGE1NTExZTEzYzFhNTM2N2YyMDM0MTc4Yjk0MjU0Y2Y5NDgyMTU1OTFlZDkyMmMxMDk4YTk0M2FlMDM2NCJ9LHsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIsInNpemUiOjI5NjEwMzEzLCJkaWdlc3QiOiJzaGEyNTY6ODg0ZTY3MjU1NTVlZmFiNDc4NjhlNWUxZDI3OTYzNmYxOTk2MzE2YzAyM2EzNzFkZTFlYmU1OTBkYzc5ZTQzYiJ9XX0=",
+      "config": "eyJhcmNoaXRlY3R1cmUiOiJhcm02NCIsImNvbmZpZyI6eyJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iXSwiQ21kIjpbInBlcmw1LjQwLjQiLCItZGUwIl0sIldvcmtpbmdEaXIiOiIvdXNyL3NyYy9hcHAifSwiY3JlYXRlZCI6IjIwMjYtMDctMjlUMTk6MTM6NTEuMzI3MDg2MTI2WiIsImhpc3RvcnkiOlt7ImNyZWF0ZWQiOiIyMDI2LTA3LTEzVDAwOjAwOjAwWiIsImNyZWF0ZWRfYnkiOiIjIGRlYmlhbi5zaCAtLWFyY2ggJ2FybTY0JyBvdXQvICd0cml4aWUnICdAMTc4MzkwMDgwMCciLCJjb21tZW50IjoiZGVidWVycmVvdHlwZSAwLjE3In0seyJjcmVhdGVkIjoiMjAyNi0wNy0yMlQxODozNTo0Mi4wNDU2NjI0MjVaIiwiY3JlYXRlZF9ieSI6IkNPUFkgKi5wYXRjaCAvdXNyL3NyYy9wZXJsLyAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifSx7ImNyZWF0ZWQiOiIyMDI2LTA3LTIyVDE4OjM1OjQyLjA3MDM4MTExMloiLCJjcmVhdGVkX2J5IjoiV09SS0RJUiAvdXNyL3NyYy9wZXJsIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifSx7ImNyZWF0ZWQiOiIyMDI2LTA3LTIyVDE4OjQwOjE4LjEzNzkxNTA5M1oiLCJjcmVhdGVkX2J5IjoiUlVOIC9iaW4vc2ggLWMgYXB0LWdldCB1cGRhdGUgICAgIFx1MDAyNlx1MDAyNiBhcHQtZ2V0IGluc3RhbGwgLXkgLS1uby1pbnN0YWxsLXJlY29tbWVuZHMgICAgICAgIGJ6aXAyICAgICAgICBjYS1jZXJ0aWZpY2F0ZXMgICAgICAgIGN1cmwgICAgICAgIGRwa2ctZGV2ICAgICAgICBnY2MgICAgICAgIGxpYmM2LWRldiAgICAgICAgbWFrZSAgICAgICAgbmV0YmFzZSAgICAgICAgcGF0Y2ggICAgICAgIHpsaWIxZy1kZXYgICAgICAgIHh6LXV0aWxzICAgICAgICBsaWJzc2wtZGV2ICAgICBcdTAwMjZcdTAwMjYgY3VybCAtZkwgaHR0cHM6Ly9jcGFuLm1ldGFjcGFuLm9yZy9hdXRob3JzL2lkL1MvU0gvU0hBWS9wZXJsLTUuNDAuNC50YXIuZ3ogLW8gcGVybC01LjQwLjQudGFyLmd6ICAgICBcdTAwMjZcdTAwMjYgZWNobyAnMzI1ODU2NGI2NDRkYzkxMmY3MzY3YzRmNDlkNmRmNzdhODU1Y2RlZjkzMDVjNTA4MDFlMDNkMDlkMzkzODFhZiAqcGVybC01LjQwLjQudGFyLmd6JyB8IHNoYTI1NnN1bSAtLXN0cmljdCAtLWNoZWNrIC0gICAgIFx1MDAyNlx1MDAyNiB0YXIgLS1zdHJpcC1jb21wb25lbnRzPTEgLXhhZiBwZXJsLTUuNDAuNC50YXIuZ3ogLUMgL3Vzci9zcmMvcGVybCAgICAgXHUwMDI2XHUwMDI2IHJtIHBlcmwtNS40MC40LnRhci5neiAgICAgXHUwMDI2XHUwMDI2IGNhdCAqLnBhdGNoIHwgcGF0Y2ggLXAxICAgICBcdTAwMjZcdTAwMjYgZ251QXJjaD1cIiQoZHBrZy1hcmNoaXRlY3R1cmUgLS1xdWVyeSBERUJfQlVJTERfR05VX1RZUEUpXCIgICAgIFx1MDAyNlx1MDAyNiBhcmNoQml0cz1cIiQoZHBrZy1hcmNoaXRlY3R1cmUgLS1xdWVyeSBERUJfQlVJTERfQVJDSF9CSVRTKVwiICAgICBcdTAwMjZcdTAwMjYgYXJjaEZsYWc9XCIkKFsgXCIkYXJjaEJpdHNcIiA9ICc2NCcgXSBcdTAwMjZcdTAwMjYgZWNobyAnLUR1c2U2NGJpdGFsbCcgfHwgZWNobyAnLUR1c2U2NGJpdGludCcpXCIgICAgIFx1MDAyNlx1MDAyNiAuL0NvbmZpZ3VyZSAtRGFyY2huYW1lPVwiJGdudUFyY2hcIiBcIiRhcmNoRmxhZ1wiIC1EdXNlc2hycGxpYiAtRHZlbmRvcnByZWZpeD0vdXNyL2xvY2FsICAtZGVzICAgICBcdTAwMjZcdTAwMjYgbWFrZSAtaiQobnByb2MpICAgICBcdTAwMjZcdTAwMjYgVEVTVF9KT0JTPSQobnByb2MpIG1ha2UgdGVzdF9oYXJuZXNzICAgICBcdTAwMjZcdTAwMjYgbWFrZSBpbnN0YWxsICAgICBcdTAwMjZcdTAwMjYgY2QgL3Vzci9zcmMgICAgIFx1MDAyNlx1MDAyNiBjdXJsIC1mTE8gaHR0cHM6Ly93d3cuY3Bhbi5vcmcvYXV0aG9ycy9pZC9NL01JL01JWUFHQVdBL0FwcC1jcGFubWludXMtMS43MDQ5LnRhci5neiAgICAgXHUwMDI2XHUwMDI2IGVjaG8gJ2I5ZmZiODhlNjJhMDZhYTkxYmQ3ZDVhMjhlZjZiZGJiOTQyNjA4YWVhOTBlMzk2OWFhMjliMzM2NDAwMzUyMTQgKkFwcC1jcGFubWludXMtMS43MDQ5LnRhci5neicgfCBzaGEyNTZzdW0gLS1zdHJpY3QgLS1jaGVjayAtICAgICBcdTAwMjZcdTAwMjYgdGFyIC14emYgQXBwLWNwYW5taW51cy0xLjcwNDkudGFyLmd6IFx1MDAyNlx1MDAyNiBjZCBBcHAtY3Bhbm1pbnVzLTEuNzA0OSAgICAgXHUwMDI2XHUwMDI2IHBlcmwgLXBpIC1FICdze2h0dHA6Ly8od3d3XFwuY3BhblxcLm9yZ3xiYWNrcGFuXFwucGVybFxcLm9yZ3xjcGFuXFwubWV0YWNwYW5cXC5vcmd8ZmFzdGFwaVxcLm1ldGFjcGFuXFwub3JnfGNwYW5tZXRhZGJcXC5wbGFja3BlcmxcXC5vcmcpfXtodHRwczovLyQxfWcnIGJpbi9jcGFubSAgICAgXHUwMDI2XHUwMDI2IHBlcmwgLXBpIC1FICdze3RyeV9sd3A9XHUwMDNlMX17dHJ5X2x3cD1cdTAwM2UwfWcnIGJpbi9jcGFubSAgICAgXHUwMDI2XHUwMDI2IHBlcmwgYmluL2NwYW5tIC4gXHUwMDI2XHUwMDI2IGNkIC9yb290ICAgICBcdTAwMjZcdTAwMjYgY3VybCAtZkxPICdodHRwczovL3d3dy5jcGFuLm9yZy9hdXRob3JzL2lkL0MvQ0gvQ0hSSVNOL05ldC1TU0xlYXktMS45Ni50YXIuZ3onICAgICBcdTAwMjZcdTAwMjYgZWNobyAnYWIyMTM2OTE2ODVmYjJhNTc2YzY2OWNiYzhkOTI2NmY4MTY1YTMxNTYzYWQxNWI3YzQwMzBiOTRhZGZjMDc1MyAqTmV0LVNTTGVheS0xLjk2LnRhci5neicgfCBzaGEyNTZzdW0gLS1zdHJpY3QgLS1jaGVjayAtICAgICBcdTAwMjZcdTAwMjYgY3Bhbm0gLS1ub3Rlc3QgLS1mcm9tICRQV0QgTmV0LVNTTGVheS0xLjk2LnRhci5neiAgICAgXHUwMDI2XHUwMDI2IGN1cmwgLWZMTyAnaHR0cHM6Ly93d3cuY3Bhbi5vcmcvYXV0aG9ycy9pZC9TL1NVL1NVTExSL0lPLVNvY2tldC1TU0wtMi4wOTkudGFyLmd6JyAgICAgXHUwMDI2XHUwMDI2IGVjaG8gJ2EwYmU4MDBmZjQ4NTJiMTU2N2VlNTUwMGU3NzI0MTdhZDdhMzYwYWJmZjgwYzAxYjViODc1YzE1ZDQ0YmU4MzIgKklPLVNvY2tldC1TU0wtMi4wOTkudGFyLmd6JyB8IHNoYTI1NnN1bSAtLXN0cmljdCAtLWNoZWNrIC0gICAgIFx1MDAyNlx1MDAyNiBTU0xfQ0VSVF9ESVI9L2V0Yy9zc2wvY2VydHMgY3Bhbm0gLS1mcm9tICRQV0QgSU8tU29ja2V0LVNTTC0yLjA5OS50YXIuZ3ogICAgIFx1MDAyNlx1MDAyNiBjdXJsIC1mTCBodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20vc2thamkvY3BtL3YxLjEuNC9jcG0gLW8gL3Vzci9sb2NhbC9iaW4vY3BtICAgICBcdTAwMjZcdTAwMjYgZWNobyAnNmY1YWU2ZDBlMjViYTIwZjc2OGI4ODU2ZWE2MTQ4MWRhOWQxNDJhMDQ2MjlkNjU4MDI1MDExYzc2ZDNiYmMzZiAqL3Vzci9sb2NhbC9iaW4vY3BtJyB8IHNoYTI1NnN1bSAtLXN0cmljdCAtLWNoZWNrIC0gICAgIFx1MDAyNlx1MDAyNiBjaG1vZCAreCAvdXNyL2xvY2FsL2Jpbi9jcG0gICAgIFx1MDAyNlx1MDAyNiBzYXZlZFBhY2thZ2VzPVwiY2EtY2VydGlmaWNhdGVzIGN1cmwgbWFrZSBuZXRiYXNlIHpsaWIxZy1kZXYgbGlic3NsLWRldlwiICAgICBcdTAwMjZcdTAwMjYgYXB0LW1hcmsgYXV0byAnLionIFx1MDAzZSAvZGV2L251bGwgICAgIFx1MDAyNlx1MDAyNiBhcHQtbWFyayBtYW51YWwgJHNhdmVkUGFja2FnZXMgICAgIFx1MDAyNlx1MDAyNiBhcHQtZ2V0IHB1cmdlIC15IC0tYXV0by1yZW1vdmUgLW8gQVBUOjpBdXRvUmVtb3ZlOjpSZWNvbW1lbmRzSW1wb3J0YW50PWZhbHNlICAgICBcdTAwMjZcdTAwMjYgcm0gLWZyIC92YXIvY2FjaGUvYXB0LyogL3Zhci9saWIvYXB0L2xpc3RzLyogICAgIFx1MDAyNlx1MDAyNiBybSAtZnIgL3Jvb3QvLmNwYW5tIC9yb290L05ldC1TU0xlYXktMS45NiogL3Jvb3QvSU8tU29ja2V0LVNTTC0yLjA5OSogL3Vzci9zcmMvcGVybCAvdXNyL3NyYy9BcHAtY3Bhbm1pbnVzLTEuNzA0OSogL3RtcC8qICAgICBcdTAwMjZcdTAwMjYgY3Bhbm0gLS12ZXJzaW9uIFx1MDAyNlx1MDAyNiBjcG0gLS12ZXJzaW9uICMgYnVpbGRraXQiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCJ9LHsiY3JlYXRlZCI6IjIwMjYtMDctMjJUMTg6NDA6MTguMTg2NDk2MTY2WiIsImNyZWF0ZWRfYnkiOiJXT1JLRElSIC91c3Ivc3JjL2FwcCIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIn0seyJjcmVhdGVkIjoiMjAyNi0wNy0yMlQxODo0MDoxOC4xODY0OTYxNjZaIiwiY3JlYXRlZF9ieSI6IkNNRCBbXCJwZXJsNS40MC40XCIgXCItZGUwXCJdIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkIjoiMjAyNi0wNy0yOVQxOToxMDo0OS4yNTkxMTcyNVoiLCJjcmVhdGVkX2J5IjoiUlVOIC9iaW4vc2ggLWMgYXB0LWdldCB1cGRhdGUgXHUwMDI2XHUwMDI2IGFwdC1nZXQgaW5zdGFsbCAteSAtLW5vLWluc3RhbGwtcmVjb21tZW5kcyBidWlsZC1lc3NlbnRpYWwgXHUwMDI2XHUwMDI2IHJtIC1yZiAvdmFyL2xpYi9hcHQvbGlzdHMvKiAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifSx7ImNyZWF0ZWQiOiIyMDI2LTA3LTI5VDE5OjEyOjQ1LjQ5NTI1OTAxM1oiLCJjcmVhdGVkX2J5IjoiUlVOIC9iaW4vc2ggLWMgY3Bhbm0gLS1ub3Rlc3QgLS1mb3JjZSAgICAgICBodHRwczovL2JhY2twYW4ucGVybC5vcmcvYXV0aG9ycy9pZC9TL1NSL1NSSS9Nb2pvbGljaW91cy05LjEwLnRhci5neiAgICAgICBodHRwczovL2JhY2twYW4ucGVybC5vcmcvYXV0aG9ycy9pZC9TL1NIL1NIRVJaT0RSL0NHSS1TZXNzaW9uLTQuMDkudGFyLmd6ICAgICAgIGh0dHBzOi8vYmFja3Bhbi5wZXJsLm9yZy9hdXRob3JzL2lkL00vTUEvTUFSS1NUT1MvQ0dJLnBtLTMuNDkudGFyLmd6ICAgICAgIGh0dHBzOi8vYmFja3Bhbi5wZXJsLm9yZy9hdXRob3JzL2lkL0cvR0EvR0FBUy9saWJ3d3ctcGVybC01LjgzNi50YXIuZ3ogICAgICAgaHR0cHM6Ly9iYWNrcGFuLnBlcmwub3JnL2F1dGhvcnMvaWQvSS9JUy9JU0hJR0FLSS9EQkQtU1FMaXRlLTEuNTUudGFyLmd6ICAgICAgIE9BTERFUlMvVVJJLTUuMzUudGFyLmd6ICAgICAgIEFwcDo6Y3BtICAgICA7IHRydWUgIyBidWlsZGtpdCIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIn0seyJjcmVhdGVkIjoiMjAyNi0wNy0yOVQxOToxMzo1MS4zMjcwODYxMjZaIiwiY3JlYXRlZF9ieSI6IlJVTiAvYmluL3NoIC1jIFBFUkxfTU1fVVNFX0RFRkFVTFQ9MSBjcGFuIC1pIFRleHQ6OkNTViA7IHRydWUgIyBidWlsZGtpdCIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIn1dLCJvcyI6ImxpbnV4Iiwicm9vdGZzIjp7InR5cGUiOiJsYXllcnMiLCJkaWZmX2lkcyI6WyJzaGEyNTY6NGU2ZmVlMzI1NjAwYTAzNzc1NjZjYTE1OWE0ZGE5ODMzZjZlMzVlMDRlYWE0MTk0YzQ3ZGQzYjJmZTkwMTcxNyIsInNoYTI1NjowOTFmNGExZTEwZDgyZjdiNThlMWZjYTM2ZWUwOWIxNGY5YjgyMTIyMDUyNjNhZmNmMGNkODgzMmViOGE0NTM1Iiwic2hhMjU2OjVmNzBiZjE4YTA4NjAwNzAxNmU5NDhiMDRhZWQzYjgyMTAzYTM2YmVhNDE3NTViNmNkZGZhZjEwYWNlM2M2ZWYiLCJzaGEyNTY6MTRiY2Q5YTY3MmFkNzMzMDUwZmUxYjRiNDc2MWE3ZDI5ODFkYWFhNmNmNjg5MDU1ZWZlYTFkZDVhMGU4MGEwNiIsInNoYTI1Njo0NjRlMGMzYzM0ZTUwNTVlZjg2NzliYzJlNTUwYTMzN2U0MTkwZjNmODY2NDMxMTZiN2U4YTdhYzQzZjZlYWFmIiwic2hhMjU2OmY1MzY0ZmJmMWUyYTUxYzRiYTZmYzFmYWJkOTlkNWVlYzAxOWJiNmM1YjNlNmZiM2UwYzU4MTFhMjk1YmFiM2IiLCJzaGEyNTY6YjIyOGE1NTExZTEzYzFhNTM2N2YyMDM0MTc4Yjk0MjU0Y2Y5NDgyMTU1OTFlZDkyMmMxMDk4YTk0M2FlMDM2NCIsInNoYTI1Njo4ODRlNjcyNTU1NWVmYWI0Nzg2OGU1ZTFkMjc5NjM2ZjE5OTYzMTZjMDIzYTM3MWRlMWViZTU5MGRjNzllNDNiIl19fQ==",
+      "repoDigests": [
+        "cpan-fixture@sha256:5436f9bac9942c04e76e0506f83aa5e7370a311ff84d54763da13180cf4dbe94"
+      ],
+      "architecture": "arm64",
+      "os": "linux"
+    }
+  },
+  "distro": {
+    "prettyName": "Debian GNU/Linux 13 (trixie)",
+    "name": "Debian GNU/Linux",
+    "id": "debian",
+    "version": "13 (trixie)",
+    "versionID": "13.6",
+    "versionCodename": "trixie",
+    "homeURL": "https://www.debian.org/",
+    "supportURL": "https://www.debian.org/support",
+    "bugReportURL": "https://bugs.debian.org/"
+  },
+  "descriptor": {
+    "name": "syft",
+    "version": "[not provided]",
+    "configuration": {
+      "catalogers": {
+        "requested": {
+          "default": [
+            "image",
+            "file"
+          ]
+        },
+        "used": [
+          "alpm-db-cataloger",
+          "apk-db-cataloger",
+          "apple-app-bundle-cataloger",
+          "binary-classifier-cataloger",
+          "bitnami-cataloger",
+          "cargo-auditable-binary-cataloger",
+          "conan-info-cataloger",
+          "dotnet-deps-binary-cataloger",
+          "dotnet-packages-lock-cataloger",
+          "dpkg-db-cataloger",
+          "elf-binary-package-cataloger",
+          "file-content-cataloger",
+          "file-digest-cataloger",
+          "file-executable-cataloger",
+          "file-metadata-cataloger",
+          "gguf-cataloger",
+          "go-module-binary-cataloger",
+          "graalvm-native-image-cataloger",
+          "homebrew-cataloger",
+          "java-archive-cataloger",
+          "java-jvm-cataloger",
+          "javascript-package-cataloger",
+          "linux-kernel-cataloger",
+          "lua-rock-cataloger",
+          "nix-cataloger",
+          "pe-binary-package-cataloger",
+          "perl-cpan-installed-cataloger",
+          "php-composer-installed-cataloger",
+          "php-interpreter-cataloger",
+          "php-pear-serialized-cataloger",
+          "portage-cataloger",
+          "python-installed-package-cataloger",
+          "r-package-cataloger",
+          "rpm-db-cataloger",
+          "ruby-installed-gemspec-cataloger",
+          "safetensors-cataloger",
+          "snap-cataloger",
+          "wordpress-plugins-cataloger"
+        ]
+      },
+      "data-generation": {
+        "generate-cpes": true
+      },
+      "files": {
+        "content": {
+          "globs": null,
+          "skip-files-above-size": 0
+        },
+        "hashers": [
+          "sha-1",
+          "sha-256"
+        ],
+        "selection": "owned-by-package"
+      },
+      "licenses": {
+        "coverage": 75,
+        "include-content": "none"
+      },
+      "packages": {
+        "binary": [
+          "python-binary",
+          "python-binary-lib",
+          "pypy-binary-lib",
+          "go-binary",
+          "julia-binary",
+          "julia-binary",
+          "helm",
+          "redis-binary",
+          "valkey-binary",
+          "nodejs-binary",
+          "busybox-binary",
+          "util-linux-binary",
+          "haproxy-binary",
+          "perl-binary",
+          "php-composer-binary",
+          "httpd-binary",
+          "memcached-binary",
+          "traefik-binary",
+          "arangodb-binary",
+          "postgresql-binary",
+          "mysql-binary",
+          "mysql-binary",
+          "mysql-binary",
+          "mysqld-mysql-cluster-legacy-binary",
+          "mysqld-binary",
+          "ndbd-binary",
+          "ndbmtd-binary",
+          "ndb_mgmd-binary",
+          "xtrabackup-binary",
+          "mariadb-binary",
+          "rust-standard-library-linux",
+          "rust-standard-library-macos",
+          "ruby-binary",
+          "erlang-binary",
+          "erlang-alpine-binary",
+          "erlang-library",
+          "swipl-binary",
+          "dart-binary",
+          "deno-binary",
+          "bun-binary",
+          "haskell-ghc-binary",
+          "haskell-cabal-binary",
+          "haskell-stack-binary",
+          "consul-binary",
+          "hashicorp-vault-binary",
+          "nginx-binary",
+          "bash-binary",
+          "openssl-binary",
+          "openldap-search-binary",
+          "qt-qtbase-lib",
+          "gcc-binary",
+          "fluent-bit-binary",
+          "wordpress-cli-binary",
+          "curl-binary",
+          "lighttpd-binary",
+          "proftpd-binary",
+          "zstd-binary",
+          "xz-binary",
+          "gzip-binary",
+          "sqlcipher-binary",
+          "jq-binary",
+          "chrome-binary",
+          "firefox-binary",
+          "ffmpeg-binary",
+          "ffmpeg-library",
+          "ffmpeg-library",
+          "elixir-binary",
+          "elixir-library",
+          "istio-binary",
+          "istio-binary",
+          "grafana-binary",
+          "grafana-binary",
+          "envoy-binary",
+          "mongodb-binary",
+          "ingress-nginx-binary",
+          "filebeat-binary",
+          "metricbeat-binary",
+          "heartbeat-binary",
+          "packetbeat-binary",
+          "auditbeat-binary",
+          "elastic-agent-binary",
+          "krb5-library",
+          "heimdal-krb5-library",
+          "java-binary",
+          "java-jdb-binary"
+        ],
+        "cpp": {
+          "vcpkg-allow-git-clone": false
+        },
+        "dotnet": {
+          "dep-packages-must-claim-dll": true,
+          "dep-packages-must-have-dll": false,
+          "exclude-project-references": true,
+          "propagate-dll-claims-to-parents": true,
+          "relax-dll-claims-when-bundling-detected": true
+        },
+        "golang": {
+          "capture-symbols": "none",
+          "local-mod-cache-dir": "/Users/wagoodman/go/pkg/mod",
+          "local-vendor-dir": "",
+          "main-module-version": {
+            "from-build-settings": true,
+            "from-contents": false,
+            "from-ld-flags": true
+          },
+          "proxies": [
+            "https://proxy.golang.org",
+            "direct"
+          ],
+          "search-local-mod-cache-licenses": false,
+          "search-local-vendor-licenses": false,
+          "search-remote-licenses": false,
+          "use-packages-lib": true
+        },
+        "java-archive": {
+          "include-indexed-archives": true,
+          "include-unindexed-archives": false,
+          "maven-base-url": "https://repo1.maven.org/maven2",
+          "maven-localrepository-dir": "/Users/wagoodman/.m2/repository",
+          "max-parent-recursive-depth": 0,
+          "resolve-transitive-dependencies": false,
+          "use-maven-localrepository": false,
+          "use-network": false
+        },
+        "javascript": {
+          "include-dev-dependencies": false,
+          "npm-base-url": "https://registry.npmjs.org",
+          "search-remote-licenses": false
+        },
+        "linux-kernel": {
+          "catalog-modules": true
+        },
+        "nix": {
+          "capture-owned-files": false
+        },
+        "python": {
+          "guess-unpinned-requirements": false,
+          "pypi-base-url": "https://pypi.org/pypi",
+          "search-remote-licenses": false
+        }
+      },
+      "relationships": {
+        "exclude-binary-packages-with-file-ownership-overlap": true,
+        "package-file-ownership": true,
+        "package-file-ownership-overlap": true
+      },
+      "search": {
+        "scope": "squashed"
+      }
+    }
+  },
+  "schema": {
+    "version": "16.1.11",
+    "url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-16.1.11.json"
+  }
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/metadata.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/metadata.json
@@ -1,0 +1,19 @@
+{
+  "provider": "cpan",
+  "version": 1,
+  "processor": "vunnel@0.59.0",
+  "schema": {
+    "version": "1.0.3",
+    "url": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/provider-workspace-state/schema-1.0.3.json"
+  },
+  "urls": [
+    "https://raw.githubusercontent.com/briandfoy/cpan-security-advisory/master/cpan-security-advisory.json"
+  ],
+  "timestamp": "2026-07-26T06:23:50Z",
+  "listing": {
+    "path": "results/listing.xxh64",
+    "digest": "0000000000000000",
+    "algorithm": "xxh64"
+  },
+  "store": "flat-file"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-cgi-session-2006-01.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-cgi-session-2006-01.json
@@ -1,0 +1,54 @@
+{
+  "identifier": "cpansa-cgi-session-2006-01",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "CGI-Session"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2006-04-06",
+                    "kind": "advisory",
+                    "version": "4.12"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "4.12"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      }
+    ],
+    "aliases": [],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026"
+    },
+    "details": "possible SQL injection attack",
+    "id": "CPANSA-CGI-Session-2006-01",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "2006-04-06T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "https://rt.cpan.org/Public/Bug/Display.html?id=18578"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-cgi-session-2006-1279.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-cgi-session-2006-1279.json
@@ -1,0 +1,76 @@
+{
+  "identifier": "cpansa-cgi-session-2006-1279",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "CGI-Session"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2006-03-19",
+                    "kind": "advisory",
+                    "version": "4.10"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "4.10"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      }
+    ],
+    "aliases": [
+      "CVE-2006-1279"
+    ],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026"
+    },
+    "details": "CGI::Session 4.03-1 allows local users to overwrite arbitrary files via a symlink attack on temporary files used by (1) Driver::File, (2) Driver::db_file, and possibly (3) Driver::sqlite.",
+    "id": "CPANSA-CGI-Session-2006-1279",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "2006-03-19T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=356555"
+      },
+      {
+        "type": "WEB",
+        "url": "http://secunia.com/advisories/19211"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.securityfocus.com/bid/17177"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.osvdb.org/23865"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.vupen.com/english/advisories/2006/0946"
+      },
+      {
+        "type": "WEB",
+        "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/25285"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-cgi-session-2026-56016.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-cgi-session-2026-56016.json
@@ -1,0 +1,64 @@
+{
+  "identifier": "cpansa-cgi-session-2026-56016",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "CGI-Session"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2026-07-01",
+                    "kind": "advisory",
+                    "version": "4.49"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "4.49"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      }
+    ],
+    "aliases": [
+      "CVE-2026-56016"
+    ],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026"
+    },
+    "details": "CGI::Session::ID::md5 versions before 4.49 for Perl generate predictable session ids from low-entropy sources.  The generate_id method builds the session id from a MD5 digest of the process id, the epoch time, and the built-in rand() function. All three are predictable, low-entropy sources: the PID is drawn from a small range, the epoch time can be guessed or read from the HTTP Date header, and Perl's rand() is unsuitable for security purposes because it is predictable and reversible.  An attacker who predicts a session id can impersonate the corresponding session and bypass authentication.",
+    "id": "CPANSA-CGI-Session-2026-56016",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "2026-07-01T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "https://metacpan.org/release/MARKSTOS/CGI-Session-4.49/changes"
+      },
+      {
+        "type": "WEB",
+        "url": "https://metacpan.org/release/MARKSTOS/CGI-Session-4.49/source/lib/CGI/Session/ID/md5.pm"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.openwall.com/lists/oss-security/2026/07/01/6"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-data-formvalidator-2011-2201.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-data-formvalidator-2011-2201.json
@@ -1,0 +1,84 @@
+{
+  "identifier": "cpansa-data-formvalidator-2011-2201",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "Data-FormValidator"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2011-09-14",
+                    "kind": "advisory",
+                    "version": "4.67"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "4.67"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      }
+    ],
+    "aliases": [
+      "CVE-2011-2201"
+    ],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026"
+    },
+    "details": "The Data::FormValidator module 4.66 and earlier for Perl, when untaint_all_constraints is enabled, does not properly preserve the taint attribute of data, which might allow remote attackers to bypass the taint protection mechanism via form input.",
+    "id": "CPANSA-Data-FormValidator-2011-2201",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "2011-09-14T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=629511"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.openwall.com/lists/oss-security/2011/06/13/13"
+      },
+      {
+        "type": "WEB",
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=712694"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.openwall.com/lists/oss-security/2011/06/12/3"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.securityfocus.com/bid/48167"
+      },
+      {
+        "type": "WEB",
+        "url": "https://rt.cpan.org/Public/Bug/Display.html?id=61792"
+      },
+      {
+        "type": "WEB",
+        "url": "http://lists.fedoraproject.org/pipermail/package-announce/2011-September/065416.html"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.openwall.com/lists/oss-security/2011/06/13/5"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-dbd-sqlite-2018-8740-sqlite.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-dbd-sqlite-2018-8740-sqlite.json
@@ -1,0 +1,127 @@
+{
+  "identifier": "cpansa-dbd-sqlite-2018-8740-sqlite",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "DBD-SQLite"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2018-03-17",
+                    "kind": "advisory",
+                    "version": "1.35"
+                  },
+                  {
+                    "date": "2018-03-17",
+                    "kind": "advisory",
+                    "version": "1.47_04"
+                  },
+                  {
+                    "date": "2018-03-17",
+                    "kind": "advisory",
+                    "version": "1.59_01"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "1.00"
+              },
+              {
+                "fixed": "1.35"
+              },
+              {
+                "introduced": "1.36_01"
+              },
+              {
+                "fixed": "1.47_04"
+              },
+              {
+                "introduced": "1.47_05"
+              },
+              {
+                "fixed": "1.59_01"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      }
+    ],
+    "aliases": [
+      "CVE-2018-8740"
+    ],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026",
+      "severity": "high"
+    },
+    "details": "In SQLite through 3.22.0, databases whose schema is corrupted using a CREATE TABLE AS statement could cause a NULL pointer dereference, related to build.c and prepare.c.",
+    "id": "CPANSA-DBD-SQLite-2018-8740-sqlite",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "2018-03-17T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "https://www.sqlite.org/cgi/src/timeline?r=corrupt-schema"
+      },
+      {
+        "type": "WEB",
+        "url": "https://bugs.launchpad.net/ubuntu/+source/sqlite3/+bug/1756349"
+      },
+      {
+        "type": "WEB",
+        "url": "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=6964"
+      },
+      {
+        "type": "WEB",
+        "url": "https://www.sqlite.org/cgi/src/vdiff?from=1774f1c3baf0bc3d&to=d75e67654aa9620b"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.securityfocus.com/bid/103466"
+      },
+      {
+        "type": "WEB",
+        "url": "https://lists.debian.org/debian-lts-announce/2019/01/msg00009.html"
+      },
+      {
+        "type": "WEB",
+        "url": "http://lists.opensuse.org/opensuse-security-announce/2019-05/msg00050.html"
+      },
+      {
+        "type": "WEB",
+        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PU4NZ6DDU4BEM3ACM3FM6GLEPX56ZQXK/"
+      },
+      {
+        "type": "WEB",
+        "url": "https://usn.ubuntu.com/4205-1/"
+      },
+      {
+        "type": "WEB",
+        "url": "https://usn.ubuntu.com/4394-1/"
+      },
+      {
+        "type": "WEB",
+        "url": "https://lists.debian.org/debian-lts-announce/2020/08/msg00037.html"
+      },
+      {
+        "type": "WEB",
+        "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4@%3Cissues.bookkeeper.apache.org%3E"
+      },
+      {
+        "type": "WEB",
+        "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b@%3Cissues.bookkeeper.apache.org%3E"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-extutils-parsexs-2016-1238.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-extutils-parsexs-2016-1238.json
@@ -1,0 +1,147 @@
+{
+  "identifier": "cpansa-extutils-parsexs-2016-1238",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "ExtUtils-ParseXS"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2016-08-02",
+                    "kind": "advisory",
+                    "version": "3.35"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "3.35"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      },
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "perl"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2016-08-02",
+                    "kind": "advisory",
+                    "version": "5.024001"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "5.024001"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      }
+    ],
+    "aliases": [
+      "CVE-2016-1238"
+    ],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026",
+      "severity": "high"
+    },
+    "details": "(1) cpan/Archive-Tar/bin/ptar, (2) cpan/Archive-Tar/bin/ptardiff, (3) cpan/Archive-Tar/bin/ptargrep, (4) cpan/CPAN/scripts/cpan, (5) cpan/Digest-SHA/shasum, (6) cpan/Encode/bin/enc2xs, (7) cpan/Encode/bin/encguess, (8) cpan/Encode/bin/piconv, (9) cpan/Encode/bin/ucmlint, (10) cpan/Encode/bin/unidump, (11) cpan/ExtUtils-MakeMaker/bin/instmodsh, (12) cpan/IO-Compress/bin/zipdetails, (13) cpan/JSON-PP/bin/json_pp, (14) cpan/Test-Harness/bin/prove, (15) dist/ExtUtils-ParseXS/lib/ExtUtils/xsubpp, (16) dist/Module-CoreList/corelist, (17) ext/Pod-Html/bin/pod2html, (18) utils/c2ph.PL, (19) utils/h2ph.PL, (20) utils/h2xs.PL, (21) utils/libnetcfg.PL, (22) utils/perlbug.PL, (23) utils/perldoc.PL, (24) utils/perlivp.PL, and (25) utils/splain.PL in Perl 5.x before 5.22.3-RC2 and 5.24 before 5.24.1-RC2 do not properly remove . (period) characters from the end of the includes directory array, which might allow local users to gain privileges via a Trojan horse module under the current working directory.",
+    "id": "CPANSA-ExtUtils-ParseXS-2016-1238",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "2016-08-02T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "http://lists.opensuse.org/opensuse-security-announce/2019-08/msg00002.html"
+      },
+      {
+        "type": "WEB",
+        "url": "http://perl5.git.perl.org/perl.git/commit/cee96d52c39b1e7b36e1c62d38bcd8d86e9a41ab"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.debian.org/security/2016/dsa-3628"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.nntp.perl.org/group/perl.perl5.porters/2016/07/msg238271.html"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.securityfocus.com/bid/92136"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.securitytracker.com/id/1036440"
+      },
+      {
+        "type": "WEB",
+        "url": "https://h20566.www2.hpe.com/portal/site/hpsc/public/kb/docDisplay?docId=emr_na-c05240731"
+      },
+      {
+        "type": "WEB",
+        "url": "https://lists.apache.org/thread.html/7f6a16bc0fd0fd5e67c7fd95bd655069a2ac7d1f88e42d3c853e601c%40%3Cannounce.apache.org%3E"
+      },
+      {
+        "type": "WEB",
+        "url": "https://lists.debian.org/debian-lts-announce/2018/11/msg00016.html"
+      },
+      {
+        "type": "WEB",
+        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/2FBQOCV3GBAN2EYZUM3CFDJ4ECA3GZOK/"
+      },
+      {
+        "type": "WEB",
+        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/DOFRQWJRP2NQJEYEWOMECVW3HAMD5SYN/"
+      },
+      {
+        "type": "WEB",
+        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/TZBNQH3DMI7HDELJAZ4TFJJANHXOEDWH/"
+      },
+      {
+        "type": "WEB",
+        "url": "https://rt.perl.org/Public/Bug/Display.html?id=127834"
+      },
+      {
+        "type": "WEB",
+        "url": "https://security.gentoo.org/glsa/201701-75"
+      },
+      {
+        "type": "WEB",
+        "url": "https://security.gentoo.org/glsa/201812-07"
+      },
+      {
+        "type": "WEB",
+        "url": "https://perldoc.perl.org/5.24.1/perldelta"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-libwww-perl-1995-01.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-libwww-perl-1995-01.json
@@ -1,0 +1,38 @@
+{
+  "identifier": "cpansa-libwww-perl-1995-01",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "libwww-perl"
+        },
+        "ranges": []
+      },
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "LWP"
+        },
+        "ranges": []
+      }
+    ],
+    "aliases": [],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026"
+    },
+    "details": "There is a security hole with the implementation of getBasicCredentials().",
+    "id": "CPANSA-libwww-perl-1995-01",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "1995-09-06T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "https://metacpan.org/dist/libwww-perl/changes"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-libwww-perl-2001-01.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-libwww-perl-2001-01.json
@@ -1,0 +1,79 @@
+{
+  "identifier": "cpansa-libwww-perl-2001-01",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "libwww-perl"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2001-03-14",
+                    "kind": "advisory",
+                    "version": "5.51"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "5.51"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      },
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "LWP"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2001-03-14",
+                    "kind": "advisory",
+                    "version": "5.51"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "5.51"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      }
+    ],
+    "aliases": [],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026"
+    },
+    "details": "If LWP::UserAgent::env_proxy is called in a CGI environment, the case-insensitivity when looking for \"http_proxy\" permits \"HTTP_PROXY\" to be found, but this can be trivially set by the web client using the \"Proxy:\" header.",
+    "id": "CPANSA-libwww-perl-2001-01",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "2001-03-14T00:00:00Z",
+    "references": [],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-libwww-perl-2010-01.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-libwww-perl-2010-01.json
@@ -1,0 +1,90 @@
+{
+  "identifier": "cpansa-libwww-perl-2010-01",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "libwww-perl"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2010-07-06",
+                    "kind": "advisory",
+                    "version": "5.835"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "5.835"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      },
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "LWP"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2010-07-06",
+                    "kind": "advisory",
+                    "version": "5.835"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "5.835"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      }
+    ],
+    "aliases": [
+      "CVE-2010-2253"
+    ],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026"
+    },
+    "details": "lwp-download in libwww-perl before 5.835 does not reject downloads to filenames that begin with a . (dot) character, which allows remote servers to create or overwrite files via (1) a 3xx redirect to a URL with a crafted filename or (2) a Content-Disposition header that suggests a crafted filename, and possibly execute arbitrary code as a consequence of writing to a dotfile in a home directory.",
+    "id": "CPANSA-libwww-perl-2010-01",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "2010-07-06T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "http://vttynotes.blogspot.com/2010/12/man-in-middle-fun-with-perl-lwp.html"
+      },
+      {
+        "type": "WEB",
+        "url": "http://vttynotes.blogspot.com/2011/03/quick-note-on-lwp-and-perl-security-cve.html"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-libwww-perl-2011-01.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-libwww-perl-2011-01.json
@@ -1,0 +1,90 @@
+{
+  "identifier": "cpansa-libwww-perl-2011-01",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "libwww-perl"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2011-01-20",
+                    "kind": "advisory",
+                    "version": "6.00"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "6.00"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      },
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "LWP"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2011-01-20",
+                    "kind": "advisory",
+                    "version": "6.00"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "6.00"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      }
+    ],
+    "aliases": [
+      "CVE-2011-0633"
+    ],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026"
+    },
+    "details": "The Net::HTTPS module in libwww-perl (LWP) before 6.00, as used in WWW::Mechanize, LWP::UserAgent, and other products, when running in environments that do not set the If-SSL-Cert-Subject header, does not enable full validation of SSL certificates by default, which allows remote attackers to spoof servers via man-in-the-middle (MITM) attacks involving hostnames that are not properly validated.",
+    "id": "CPANSA-libwww-perl-2011-01",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "2011-01-20T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "http://vttynotes.blogspot.com/2010/12/man-in-middle-fun-with-perl-lwp.html"
+      },
+      {
+        "type": "WEB",
+        "url": "http://vttynotes.blogspot.com/2011/03/quick-note-on-lwp-and-perl-security-cve.html"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-libwww-perl-2017-01.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-libwww-perl-2017-01.json
@@ -1,0 +1,84 @@
+{
+  "identifier": "cpansa-libwww-perl-2017-01",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "libwww-perl"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2017-11-06",
+                    "kind": "advisory",
+                    "version": "6.27"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "6.27"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      },
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "LWP"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2017-11-06",
+                    "kind": "advisory",
+                    "version": "6.27"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "6.27"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      }
+    ],
+    "aliases": [],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026"
+    },
+    "details": "LWP::Protocol::file can open existent file from file:// scheme. However, current version of LWP uses open FILEHANDLE,EXPR and it has ability to execute arbitrary command",
+    "id": "CPANSA-libwww-perl-2017-01",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "2017-11-06T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "https://github.com/libwww-perl/libwww-perl/pull/270"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-libwww-perl-2026-8368.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-libwww-perl-2026-8368.json
@@ -1,0 +1,102 @@
+{
+  "identifier": "cpansa-libwww-perl-2026-8368",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "libwww-perl"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2026-05-12",
+                    "kind": "advisory",
+                    "version": "6.83"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "6.83"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      },
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "LWP"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2026-05-12",
+                    "kind": "advisory",
+                    "version": "6.83"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "6.83"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      }
+    ],
+    "aliases": [
+      "CVE-2026-8368"
+    ],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026"
+    },
+    "details": "LWP::UserAgent versions before 6.83 for Perl leak Authorization and Proxy-Authorization headers on cross-origin redirects.  On a 3xx response, the redirect handler strips only Host and Cookie before issuing the follow-up request. Caller-supplied Authorization and Proxy-Authorization headers are sent unchanged to the redirect target, including across scheme, host, or port changes.  A redirect to an attacker controlled host therefore discloses the caller's credentials to that host.",
+    "id": "CPANSA-libwww-perl-2026-8368",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "2026-05-12T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "https://github.com/libwww-perl/libwww-perl/commit/9c4aeb6f2dd32f2b7eaf2d7827cade31ea6cb2c6.patch"
+      },
+      {
+        "type": "WEB",
+        "url": "https://github.com/libwww-perl/libwww-perl/pull/284"
+      },
+      {
+        "type": "WEB",
+        "url": "https://github.com/libwww-perl/libwww-perl/pull/512"
+      },
+      {
+        "type": "WEB",
+        "url": "https://metacpan.org/release/OALDERS/libwww-perl-6.83/changes"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.openwall.com/lists/oss-security/2026/05/12/7"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-mojolicious-2021-01.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-mojolicious-2021-01.json
@@ -1,0 +1,60 @@
+{
+  "identifier": "cpansa-mojolicious-2021-01",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "Mojolicious"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2021-03-16",
+                    "kind": "advisory",
+                    "version": "9.11"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "9.11"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      }
+    ],
+    "aliases": [
+      "CVE-2021-47208"
+    ],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026"
+    },
+    "details": "A bug in format detection can potentially be exploited for a DoS attack.",
+    "id": "CPANSA-Mojolicious-2021-01",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "2021-03-16T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "https://github.com/mojolicious/mojo/issues/1736"
+      },
+      {
+        "type": "WEB",
+        "url": "https://github.com/mojolicious/mojo/commit/a0c4576ffb11c235088550de9ba7ac4196e1953c"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-mojolicious-2022-03.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-mojolicious-2022-03.json
@@ -1,0 +1,62 @@
+{
+  "identifier": "cpansa-mojolicious-2022-03",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "Mojolicious"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2022-12-10",
+                    "kind": "advisory",
+                    "version": "9.31"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "9.31"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      }
+    ],
+    "aliases": [],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026"
+    },
+    "details": "Mojo::DOM did not correctly parse <script> tags.",
+    "id": "CPANSA-Mojolicious-2022-03",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "2022-12-10T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "https://github.com/mojolicious/mojo/commit/6f195d85db6756022d3599f7d2634975688c9550"
+      },
+      {
+        "type": "WEB",
+        "url": "https://github.com/mojolicious/mojo/issues/2014"
+      },
+      {
+        "type": "WEB",
+        "url": "https://github.com/mojolicious/mojo/issues/2015"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-perl-2015-8608.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-perl-2015-8608.json
@@ -1,0 +1,73 @@
+{
+  "identifier": "cpansa-perl-2015-8608",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "perl"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2017-02-07",
+                    "kind": "advisory",
+                    "version": "5.022002"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "5.022002"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      }
+    ],
+    "aliases": [
+      "CVE-2015-8608"
+    ],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026",
+      "severity": "critical"
+    },
+    "details": "The VDir::MapPathA and VDir::MapPathW functions in Perl 5.22 allow remote attackers to cause a denial of service (out-of-bounds read) and possibly execute arbitrary code via a crafted (1) drive letter or (2) pInName argument.",
+    "id": "CPANSA-perl-2015-8608",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "2017-02-07T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "https://rt.perl.org/Public/Bug/Display.html?id=126755"
+      },
+      {
+        "type": "WEB",
+        "url": "https://github.com/Perl/perl5/issues/15067"
+      },
+      {
+        "type": "WEB",
+        "url": "https://packetstormsecurity.com/files/136649/Perl-5.22-VDir-MapPathA-W-Out-Of-Bounds-Reads-Buffer-Over-Reads.html"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.oracle.com/technetwork/security-advisory/cpujul2017-3236622.html"
+      },
+      {
+        "type": "WEB",
+        "url": "https://www.oracle.com/security-alerts/cpujul2020.html"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-perl-2016-6185.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-perl-2016-6185.json
@@ -1,0 +1,113 @@
+{
+  "identifier": "cpansa-perl-2016-6185",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "perl"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2016-08-02",
+                    "kind": "advisory",
+                    "version": "5.024000"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "5.022000"
+              },
+              {
+                "fixed": "5.024000"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      }
+    ],
+    "aliases": [
+      "CVE-2016-6185"
+    ],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026",
+      "severity": "high"
+    },
+    "details": "The XSLoader::load method in XSLoader in Perl does not properly locate .so files when called in a string eval, which might allow local users to execute arbitrary code via a Trojan horse library under the current working directory.",
+    "id": "CPANSA-perl-2016-6185",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "2016-08-02T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/5RFDMASVZLFZYBB2GNTZXU6I76E4NA4V/"
+      },
+      {
+        "type": "WEB",
+        "url": "https://github.com/Perl/perl5/commit/08e3451d7b3b714ad63a27f1b9c2a23ee75d15ee"
+      },
+      {
+        "type": "WEB",
+        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PRIPTDA6XINBVEJXI2NGLKVEINBREHTN/"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.openwall.com/lists/oss-security/2016/07/07/1"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.openwall.com/lists/oss-security/2016/07/08/5"
+      },
+      {
+        "type": "WEB",
+        "url": "https://rt.cpan.org/Public/Bug/Display.html?id=115808"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.debian.org/security/2016/dsa-3628"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.securitytracker.com/id/1036260"
+      },
+      {
+        "type": "WEB",
+        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ITYZJXQH24X2F2LAOQEQAC5KXLYJTJ76/"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.oracle.com/technetwork/topics/security/bulletinjul2016-3090568.html"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.securityfocus.com/bid/91685"
+      },
+      {
+        "type": "WEB",
+        "url": "https://security.gentoo.org/glsa/201701-75"
+      },
+      {
+        "type": "WEB",
+        "url": "https://usn.ubuntu.com/3625-2/"
+      },
+      {
+        "type": "WEB",
+        "url": "https://usn.ubuntu.com/3625-1/"
+      },
+      {
+        "type": "WEB",
+        "url": "https://github.com/Perl/perl5/blob/blead/pod/perl5260delta.pod"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-perl-2026-57432.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-perl-2026-57432.json
@@ -1,0 +1,86 @@
+{
+  "identifier": "cpansa-perl-2026-57432",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "perl"
+        },
+        "ranges": [
+          {
+            "database_specific": {
+              "anchore": {
+                "fixes": [
+                  {
+                    "date": "2026-07-13",
+                    "kind": "advisory",
+                    "version": "5.040005"
+                  },
+                  {
+                    "date": "2026-07-13",
+                    "kind": "advisory",
+                    "version": "5.042003"
+                  },
+                  {
+                    "date": "2026-07-13",
+                    "kind": "advisory",
+                    "version": "5.043011"
+                  }
+                ]
+              }
+            },
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "5.040005"
+              },
+              {
+                "introduced": "5.042000"
+              },
+              {
+                "fixed": "5.042003"
+              },
+              {
+                "introduced": "5.043001"
+              },
+              {
+                "fixed": "5.043011"
+              }
+            ],
+            "type": "ECOSYSTEM"
+          }
+        ]
+      }
+    ],
+    "aliases": [
+      "CVE-2026-57432"
+    ],
+    "database_specific": {
+      "cpansa_commit": "9d31c332f0ada976973c71b35385c0c2bc46fd83",
+      "cpansa_generated": "Mon Aug  3 11:45:47 2026"
+    },
+    "details": "Perl versions through 5.43.10 have an integer overflow in S_measure_struct leading to an out-of-bounds heap read in pack and unpack.  S_measure_struct adds each item's size times its repeat count to a running total with no overflow check, so a large repeat count in a pack or unpack template wraps the signed SSize_t total negative. The @, X, and x position codes then guard their moves with a signed length comparison that passes when the length is negative, advancing the buffer pointer out of bounds.  A template derived from untrusted input can read heap memory past the buffer and return it to the caller.",
+    "id": "CPANSA-perl-2026-57432",
+    "modified": "2026-08-03T11:45:47Z",
+    "published": "2026-07-13T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "https://github.com/Perl/perl5/commit/40754edc72dd3e513d758153c0e2f0215897740e.patch"
+      },
+      {
+        "type": "WEB",
+        "url": "https://github.com/Perl/perl5/commit/5f7eb6bbbe0510964e3fb1d6bb691e5445913e55.patch"
+      },
+      {
+        "type": "WEB",
+        "url": "http://www.openwall.com/lists/oss-security/2026/07/13/6"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-urxvt-bgdsl-2022-4170.json
+++ b/grype/matcher/stock/testdata/cpansa/cpan/results/cpansa-urxvt-bgdsl-2022-4170.json
@@ -1,0 +1,37 @@
+{
+  "identifier": "cpansa-urxvt-bgdsl-2022-4170",
+  "item": {
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "CPAN",
+          "name": "urxvt-bgdsl"
+        },
+        "ranges": []
+      }
+    ],
+    "aliases": [
+      "CVE-2022-4170"
+    ],
+    "database_specific": {
+      "cpansa_commit": "2089ff7201b44e5e462742a5baaa080ba003d257",
+      "cpansa_generated": "Sun Jul 26 06:23:50 2026"
+    },
+    "details": "The rxvt-unicode package is vulnerable to a remote code execution, in the Perl background extension, when an attacker can control the data written to the user's terminal and certain options are set.",
+    "id": "CPANSA-urxvt-bgdsl-2022-4170",
+    "modified": "2026-07-26T06:23:50Z",
+    "published": "2022-12-09T00:00:00Z",
+    "references": [
+      {
+        "type": "WEB",
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2151597"
+      },
+      {
+        "type": "WEB",
+        "url": "https://www.openwall.com/lists/oss-security/2022/12/05/1"
+      }
+    ],
+    "schema_version": "1.6.1"
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/osv/schema-1.6.1.json"
+}

--- a/grype/matcher/stock/testdata/cpansa/nvd/metadata.json
+++ b/grype/matcher/stock/testdata/cpansa/nvd/metadata.json
@@ -1,0 +1,19 @@
+{
+  "provider": "nvd",
+  "version": 2,
+  "processor": "vunnel@0.59.0",
+  "schema": {
+    "version": "1.0.3",
+    "url": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/provider-workspace-state/schema-1.0.3.json"
+  },
+  "urls": [
+    "https://services.nvd.nist.gov/rest/json/cves/2.0"
+  ],
+  "timestamp": "2026-08-03T00:00:00Z",
+  "listing": {
+    "path": "results/listing.xxh64",
+    "digest": "0000000000000000",
+    "algorithm": "xxh64"
+  },
+  "store": "flat-file"
+}

--- a/grype/matcher/stock/testdata/cpansa/nvd/results/2026/cve-2026-57432.json
+++ b/grype/matcher/stock/testdata/cpansa/nvd/results/2026/cve-2026-57432.json
@@ -1,0 +1,176 @@
+{
+  "identifier": "2026/cve-2026-57432",
+  "item": {
+    "cve": {
+      "affected": [
+        {
+          "affectedData": [
+            {
+              "collectionURL": "https://cpan.org/modules",
+              "defaultStatus": "unaffected",
+              "packageName": "perl",
+              "product": "perl",
+              "programFiles": [
+                "pp_pack.c"
+              ],
+              "programRoutines": [
+                {
+                  "name": "S_measure_struct"
+                }
+              ],
+              "repo": "https://github.com/Perl/perl5",
+              "vendor": "SHAY",
+              "versions": [
+                {
+                  "lessThanOrEqual": "5.43.10",
+                  "status": "affected",
+                  "version": "0",
+                  "versionType": "custom"
+                }
+              ]
+            }
+          ],
+          "source": "9b29abf9-4ab0-4765-b253-1875cd9b441e"
+        }
+      ],
+      "configurations": [
+        {
+          "nodes": [
+            {
+              "cpeMatch": [
+                {
+                  "criteria": "cpe:2.3:a:perl:perl:*:*:*:*:*:*:*:*",
+                  "matchCriteriaId": "8122F8D4-DD5A-4167-AB6A-BA1323CC4349",
+                  "versionEndIncluding": "5.43.10",
+                  "vulnerable": true
+                }
+              ],
+              "negate": false,
+              "operator": "OR"
+            }
+          ]
+        }
+      ],
+      "cveTags": [],
+      "descriptions": [
+        {
+          "lang": "en",
+          "value": "Perl versions through 5.43.10 have an integer overflow in S_measure_struct leading to an out-of-bounds heap read in pack and unpack.\n\nS_measure_struct adds each item's size times its repeat count to a running total with no overflow check, so a large repeat count in a pack or unpack template wraps the signed SSize_t total negative. The @, X, and x position codes then guard their moves with a signed length comparison that passes when the length is negative, advancing the buffer pointer out of bounds.\n\nA template derived from untrusted input can read heap memory past the buffer and return it to the caller."
+        }
+      ],
+      "id": "CVE-2026-57432",
+      "lastModified": "2026-07-14T18:04:48.367",
+      "metrics": {
+        "cvssMetricV31": [
+          {
+            "cvssData": {
+              "attackComplexity": "LOW",
+              "attackVector": "LOCAL",
+              "availabilityImpact": "HIGH",
+              "baseScore": 8.4,
+              "baseSeverity": "HIGH",
+              "confidentialityImpact": "HIGH",
+              "integrityImpact": "HIGH",
+              "privilegesRequired": "NONE",
+              "scope": "UNCHANGED",
+              "userInteraction": "NONE",
+              "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "version": "3.1"
+            },
+            "exploitabilityScore": 2.5,
+            "impactScore": 5.9,
+            "source": "nvd@nist.gov",
+            "type": "Primary"
+          },
+          {
+            "cvssData": {
+              "attackComplexity": "LOW",
+              "attackVector": "LOCAL",
+              "availabilityImpact": "HIGH",
+              "baseScore": 8.4,
+              "baseSeverity": "HIGH",
+              "confidentialityImpact": "HIGH",
+              "integrityImpact": "HIGH",
+              "privilegesRequired": "NONE",
+              "scope": "UNCHANGED",
+              "userInteraction": "NONE",
+              "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "version": "3.1"
+            },
+            "exploitabilityScore": 2.5,
+            "impactScore": 5.9,
+            "source": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+            "type": "Secondary"
+          }
+        ],
+        "ssvcV203": [
+          {
+            "source": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+            "ssvcData": {
+              "id": "CVE-2026-57432",
+              "options": [
+                {
+                  "exploitation": "none"
+                },
+                {
+                  "automatable": "no"
+                },
+                {
+                  "technicalImpact": "total"
+                }
+              ],
+              "role": "CISA Coordinator",
+              "timestamp": "2026-07-14T13:34:38.894921Z",
+              "version": "2.0.3"
+            }
+          }
+        ]
+      },
+      "published": "2026-07-13T17:17:55.670",
+      "references": [
+        {
+          "source": "9b29abf9-4ab0-4765-b253-1875cd9b441e",
+          "tags": [
+            "Patch"
+          ],
+          "url": "https://github.com/Perl/perl5/commit/40754edc72dd3e513d758153c0e2f0215897740e.patch"
+        },
+        {
+          "source": "9b29abf9-4ab0-4765-b253-1875cd9b441e",
+          "tags": [
+            "Patch"
+          ],
+          "url": "https://github.com/Perl/perl5/commit/5f7eb6bbbe0510964e3fb1d6bb691e5445913e55.patch"
+        },
+        {
+          "source": "af854a3a-2127-422b-91ae-364da2661108",
+          "tags": [
+            "Mailing List",
+            "Patch",
+            "Third Party Advisory"
+          ],
+          "url": "http://www.openwall.com/lists/oss-security/2026/07/13/6"
+        }
+      ],
+      "sourceIdentifier": "9b29abf9-4ab0-4765-b253-1875cd9b441e",
+      "vulnStatus": "Analyzed",
+      "weaknesses": [
+        {
+          "description": [
+            {
+              "lang": "en",
+              "value": "CWE-125"
+            },
+            {
+              "lang": "en",
+              "value": "CWE-190"
+            }
+          ],
+          "source": "9b29abf9-4ab0-4765-b253-1875cd9b441e",
+          "type": "Secondary"
+        }
+      ]
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/nvd/schema-1.0.1.json"
+}

--- a/grype/pkg/version_format.go
+++ b/grype/pkg/version_format.go
@@ -29,6 +29,13 @@ func VersionFormat(p Package) version.Format {
 		return version.GolangFormat
 	case syftPkg.AlpmPkg:
 		return version.PacmanFormat
+	// TODO: use syftPkg.CpanPkg once the syft release carrying it is vendored
+	case syftPkg.Type("cpan"):
+		// without this a cpan package falls through to UnknownFormat and the comparison runs
+		// under fuzzy rules, which is where perl versions go wrong: the package side is what
+		// picks the comparator, so `5.22.1` never resolves against a range written `5.022000`
+		// even though the range itself is tagged cpan.
+		return version.CpanFormat
 	}
 
 	if isJvmPackage(p) {

--- a/grype/pkg/version_format_test.go
+++ b/grype/pkg/version_format_test.go
@@ -50,6 +50,16 @@ func TestVersionFormat(t *testing.T) {
 			format: version.PacmanFormat,
 		},
 		{
+			// the package side is what selects the comparator, so falling through to
+			// UnknownFormat here would compare perl versions under fuzzy rules
+			name: "cpan (perl)",
+			p: Package{
+				// TODO: use syftPkg.CpanPkg once the syft release carrying it is vendored
+				Type: syftPkg.Type("cpan"),
+			},
+			format: version.CpanFormat,
+		},
+		{
 			name: "jvm by metadata",
 			p: Package{
 				Metadata: JavaVMInstallationMetadata{},

--- a/internal/dbtest/README.md
+++ b/internal/dbtest/README.md
@@ -196,7 +196,7 @@ For ignore filters, `Ignores().SelectRelatedPackageIgnore(reason, vulnID)` selec
 The assertion API is a **façade** over `match.Match` and `vulnerability.Vulnerability`. The whole point is to let grype refactor those internal types without touching tests. Two consequences:
 
 - **There is no `Match()` accessor on `SingleFindingAssertion` and there should never be one.** `FindingsAssertion.Matches()` exists as a deprecated escape hatch and is not used anywhere — leave it that way.
-- **When a test needs a new assertion, add a focused helper.** That is the documented extension story. `HasFix`, `HasAdvisories`, `InNamespace`, `SelectMatches.WithDetailType`, `SelectDetailBy{Distro,CPE,Ecosystem}`, `SelectRelatedPackageIgnores` were all added this way. Hypothetical future helpers: `HasSeverity`, `HasCVSSScore`, `HasRelatedVulnerabilities`, `HasFixAvailableDate`.
+- **When a test needs a new assertion, add a focused helper.** That is the documented extension story. `HasFix`, `HasAdvisories`, `HasRelatedVulnerabilities`, `InNamespace`, `SelectMatches.WithDetailType`, `SelectDetailBy{Distro,CPE,Ecosystem}`, `SelectRelatedPackageIgnores` were all added this way. Hypothetical future helpers: `HasSeverity`, `HasCVSSScore`, `HasFixAvailableDate`.
 
 If you find yourself reaching for raw struct fields, stop and add the helper. A 5-line addition to `assertions.go` is cheaper than a 50-test sweep next time the underlying struct moves.
 

--- a/internal/dbtest/assertions.go
+++ b/internal/dbtest/assertions.go
@@ -740,6 +740,21 @@ func (s *SingleFindingAssertion) HasAdvisories(ids ...string) *SingleFindingAsse
 	return s
 }
 
+// HasRelatedVulnerabilities asserts the match's vulnerability has exactly the
+// given related vulnerability IDs (order doesn't matter). This is how a record
+// keyed by a provider-specific id declares the CVE it is really about, so it is
+// the only way to show that two findings under different ids are the same
+// underlying vulnerability.
+func (s *SingleFindingAssertion) HasRelatedVulnerabilities(ids ...string) *SingleFindingAssertion {
+	s.t.Helper()
+	got := make([]string, 0, len(s.match.Vulnerability.RelatedVulnerabilities))
+	for _, r := range s.match.Vulnerability.RelatedVulnerabilities {
+		got = append(got, r.ID)
+	}
+	assert.ElementsMatch(s.t, ids, got, "unexpected related vulnerability IDs")
+	return s
+}
+
 // WithAdvisoryLink asserts the match carries an advisory with the given ID whose link is the
 // expected URL. Per-minor RHEL rows pin the RHSA that governs the host's minor (rolled
 // forward across gap minors), so this verifies the correct errata link surfaces for the host


### PR DESCRIPTION
End-to-end validation turned up four independent bugs. Three made cpan advisories match nothing, one made a single advisory match everything, and none of them failed loudly. **Two are not perl-specific and affect shipped ecosystems today.**

- `grype/pkg/version_format.go` had no `cpan` arm, so cpan packages fell through to `UnknownFormat` and were compared under fuzzy rules. The perl comparator was never reached, and `5.22.1` never resolved against a range written `5.022000`.
- OSV AND clauses were joined with a space instead of a comma. The range parser only splits on commas, so **every window with a non-zero `introduced` silently matched nothing**. This also hit chainguard `apk`.
- the clause regex in `EnforceSemVerConstraint` captured a trailing comma, doubling commas on input that was already comma-separated. **GHSA feeds ranges in exactly that shape**, so this surfaced as soon as the comma fix above landed.
- an affected package carrying no ranges was not skipped, only an advisory with no affected packages. The empty constraint was satisfied by every version, so one advisory matched all of `libwww-perl`.

Also adds matcher coverage that builds a real v6 database from CPANSA records and drives it from an actual syft SBOM, rather than from packages constructed in the test. That is what covers the seam between the two tools, where the distribution-vs-module naming and the interpreter's package type both live.

Two things left uncovered on purpose: the fixture database has no `nvd` provider, so the CPE path never fires and there is nothing to check deduplication against; and the fixture image ships perl 5.40.4, which no advisory in the fixture set covers, so the interpreter's own matching is covered separately from its identity.

Top of the grype stack. Builds on the CPANSA transformer.