### PR TITLE
fix: make --by-cve merge pick a stable record

### DIFF
--- a/grype/match/matches.go
+++ b/grype/match/matches.go
@@ -98,13 +98,21 @@ func (r *Matches) addOrMerge(newMatch Match, newFp Fingerprint) {
 
 	if existingMatch, exists := r.byFingerprint[newFp]; exists {
 		// case A
-		if err := existingMatch.Merge(newMatch); err != nil {
-			log.WithFields("original", existingMatch.String(), "new", newMatch.String(), "error", err).Warn("unable to merge matches")
-			// at least capture the additional details
-			existingMatch.Details = append(existingMatch.Details, newMatch.Details...)
+		// Merge keeps the receiver's vulnerability metadata, and matches are not always added in a
+		// deterministic order (Matches.Enumerate ranges over a map), so pick the survivor explicitly
+		// rather than letting it fall out of arrival order.
+		keep, absorb := existingMatch, newMatch
+		if prefersVulnerabilityOf(newMatch, existingMatch) {
+			keep, absorb = newMatch, existingMatch
 		}
 
-		r.byFingerprint[newFp] = existingMatch
+		if err := keep.Merge(absorb); err != nil {
+			log.WithFields("original", keep.String(), "new", absorb.String(), "error", err).Warn("unable to merge matches")
+			// at least capture the additional details
+			keep.Details = append(keep.Details, absorb.Details...)
+		}
+
+		r.byFingerprint[newFp] = keep
 	} else if existingFingerprints, exists := r.byCoreFingerprint[newFp.coreFingerprint]; exists {
 		// case B
 		if !r.mergeCoreMatches(newMatch, newFp, existingFingerprints) {
@@ -192,6 +200,54 @@ func (r *Matches) Sorted() []Match {
 // Count returns the total number of matches in a result
 func (r *Matches) Count() int {
 	return len(r.byFingerprint)
+}
+
+// prefersVulnerabilityOf reports whether candidate's vulnerability metadata should survive a merge
+// with incumbent, given that the two share a fingerprint.
+//
+// Sharing a fingerprint does not mean the two matches describe the same upstream record. Normalizing
+// by CVE rewrites an ecosystem record's ID and namespace to the CVE it aliases, which makes it collide
+// with the NVD record for that CVE and package. Only the identity is rewritten: the description, data
+// source, severity and fix data still describe the record the match was originally found in, so which
+// of the two survives is visible in the output.
+//
+// Prefer the record found by matching the package directly against an ecosystem advisory. Those records
+// carry curated fix data, while a record reached only by CPE describes the same CVE more loosely.
+func prefersVulnerabilityOf(candidate, incumbent Match) bool {
+	candidateRank, incumbentRank := vulnerabilityRank(candidate), vulnerabilityRank(incumbent)
+	if candidateRank != incumbentRank {
+		return candidateRank > incumbentRank
+	}
+
+	// equally ranked records still need a stable winner, otherwise the result depends on which of the
+	// two happened to be added first. A record whose metadata could not be resolved has no
+	// description or data source to contribute, so it loses to one that can be identified.
+	candidateSource, incumbentSource := vulnerabilitySource(candidate), vulnerabilitySource(incumbent)
+	if candidateSource == "" || incumbentSource == "" {
+		return incumbentSource == "" && candidateSource != ""
+	}
+
+	return candidateSource < incumbentSource
+}
+
+// vulnerabilityRank orders matches by how directly the vulnerability record was tied to the package.
+func vulnerabilityRank(m Match) int {
+	switch {
+	case hasMatchType(m.Details, ExactDirectMatch):
+		return 2
+	case hasMatchType(m.Details, ExactIndirectMatch):
+		return 1
+	}
+	return 0
+}
+
+// vulnerabilitySource identifies the record a match's vulnerability metadata came from. Two matches
+// that share a fingerprint can still originate from different providers.
+func vulnerabilitySource(m Match) string {
+	if m.Vulnerability.Metadata == nil {
+		return ""
+	}
+	return m.Vulnerability.Metadata.Namespace + "|" + m.Vulnerability.Metadata.DataSource
 }
 
 func hasMatchType(details Details, ty Type) bool {

--- a/grype/match/matches_test.go
+++ b/grype/match/matches_test.go
@@ -702,3 +702,143 @@ func TestMatches_Add_Merge(t *testing.T) {
 		})
 	}
 }
+
+func TestMatches_MergeSurvivorIsIndependentOfAddOrder(t *testing.T) {
+	// Normalizing by CVE rewrites an ecosystem record's ID and namespace to the CVE it aliases, which
+	// makes it collide with the NVD record for the same CVE and package. Only the identity is rewritten,
+	// so the two matches share a fingerprint while still carrying the metadata and fix data of the
+	// records they were found in. Whichever survives the merge is what a caller sees.
+	p := pkg.Package{
+		ID:      pkg.ID(uuid.NewString()),
+		Name:    "stdlib",
+		Version: "go1.21.0",
+		Type:    syftPkg.GoModulePkg,
+	}
+
+	// both records report the same fix versions, which is what puts them on the exact-fingerprint
+	// merge path rather than the looser core-fingerprint one
+	fixVersions := []string{"1.21.9", "1.22.2"}
+
+	ecosystemMatch := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			Reference: vulnerability.Reference{ID: "CVE-2023-45288", Namespace: "nvd:cpe"},
+			Fix: vulnerability.Fix{
+				Versions:  fixVersions,
+				State:     vulnerability.FixStateFixed,
+				Available: []vulnerability.FixAvailable{{Version: "1.21.9", Kind: "advisory"}},
+			},
+			Metadata: &vulnerability.Metadata{
+				ID:         "CVE-2023-45288",
+				Namespace:  "govulndb:language:go",
+				DataSource: "https://go.dev/issue/65051",
+			},
+			RelatedVulnerabilities: []vulnerability.Reference{
+				{ID: "GO-2024-2687", Namespace: "govulndb:language:go"},
+			},
+		},
+		Package: p,
+		Details: Details{{Type: ExactDirectMatch, Matcher: GoModuleMatcher, Confidence: 1}},
+	}
+
+	nvdMatch := Match{
+		Vulnerability: vulnerability.Vulnerability{
+			Reference: vulnerability.Reference{ID: "CVE-2023-45288", Namespace: "nvd:cpe"},
+			Fix: vulnerability.Fix{
+				Versions:  fixVersions,
+				State:     vulnerability.FixStateFixed,
+				Available: []vulnerability.FixAvailable{{Version: "1.21.9", Kind: "first-observed"}},
+			},
+			Metadata: &vulnerability.Metadata{
+				ID:         "CVE-2023-45288",
+				Namespace:  "nvd:cpe",
+				DataSource: "https://nvd.nist.gov/vuln/detail/CVE-2023-45288",
+			},
+		},
+		Package: p,
+		Details: Details{{Type: CPEMatch, Matcher: GoModuleMatcher, Confidence: 0.9}},
+	}
+
+	require.Equal(t, ecosystemMatch.Fingerprint(), nvdMatch.Fingerprint(),
+		"test requires both matches to collide on the exact fingerprint")
+
+	tests := []struct {
+		name  string
+		added []Match
+	}{
+		{name: "ecosystem record added first", added: []Match{ecosystemMatch, nvdMatch}},
+		{name: "nvd record added first", added: []Match{nvdMatch, ecosystemMatch}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := NewMatches(tt.added...)
+			require.Equal(t, 1, matches.Count(), "expected the two records to merge into one match")
+
+			actual := matches.Sorted()[0]
+
+			require.NotNil(t, actual.Vulnerability.Metadata)
+			assert.Equal(t, "https://go.dev/issue/65051", actual.Vulnerability.Metadata.DataSource)
+			assert.Equal(t, "govulndb:language:go", actual.Vulnerability.Metadata.Namespace)
+			require.Len(t, actual.Vulnerability.Fix.Available, 1)
+			assert.Equal(t, "advisory", actual.Vulnerability.Fix.Available[0].Kind)
+
+			// the merge should still union what both records contributed
+			assert.ElementsMatch(t, []Type{ExactDirectMatch, CPEMatch}, actual.Details.Types())
+			assert.Equal(t,
+				[]vulnerability.Reference{{ID: "GO-2024-2687", Namespace: "govulndb:language:go"}},
+				actual.Vulnerability.RelatedVulnerabilities)
+		})
+	}
+}
+
+func TestMatches_MergeKeepsTheIdentifiableRecord(t *testing.T) {
+	// the provider leaves Vulnerability.Metadata nil when it cannot resolve metadata for a record, so
+	// an equally-ranked record with no metadata must not displace one that has it
+	p := pkg.Package{
+		ID:      pkg.ID(uuid.NewString()),
+		Name:    "stdlib",
+		Version: "go1.21.0",
+		Type:    syftPkg.GoModulePkg,
+	}
+	newMatch := func(metadata *vulnerability.Metadata) Match {
+		return Match{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{ID: "CVE-2023-45288", Namespace: "nvd:cpe"},
+				Fix:       vulnerability.Fix{Versions: []string{"1.21.9"}},
+				Metadata:  metadata,
+			},
+			Package: p,
+			Details: Details{{Type: CPEMatch, Matcher: GoModuleMatcher, Confidence: 0.9}},
+		}
+	}
+
+	identified := newMatch(&vulnerability.Metadata{
+		ID:         "CVE-2023-45288",
+		Namespace:  "nvd:cpe",
+		DataSource: "https://nvd.nist.gov/vuln/detail/CVE-2023-45288",
+	})
+	unidentified := newMatch(nil)
+
+	require.Equal(t, identified.Fingerprint(), unidentified.Fingerprint(),
+		"test requires both matches to collide on the exact fingerprint")
+
+	tests := []struct {
+		name  string
+		added []Match
+	}{
+		{name: "identified record added first", added: []Match{identified, unidentified}},
+		{name: "unidentified record added first", added: []Match{unidentified, identified}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := NewMatches(tt.added...)
+			require.Equal(t, 1, matches.Count())
+
+			actual := matches.Sorted()[0]
+
+			require.NotNil(t, actual.Vulnerability.Metadata, "the record with metadata should have survived")
+			assert.Equal(t, "https://nvd.nist.gov/vuln/detail/CVE-2023-45288", actual.Vulnerability.Metadata.DataSource)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3630.

`--by-cve` collapses several advisory records for one CVE and package into a single match, but which record's metadata survived changed between identical runs.

`normalizeByCVE` rewrites an ecosystem record's `ID` and `Namespace` to the CVE it aliases and nothing else — `Reference.Internal`, `Vulnerability.Metadata` and `Vulnerability.Fix` still describe the record the match was found in. When that rewritten record reports the same fix versions as the NVD record for the same CVE and package, the two collide on the full `Fingerprint` (which includes the joined `Fix.Versions`), so `addOrMerge` takes case A. `Match.Merge` unions `RelatedVulnerabilities`, `Details` and `CPEs` and leaves the receiver's remaining `Vulnerability` fields alone, and the receiver is whichever match was added first — which, for the normalization loop at `grype/vulnerability_matcher.go:156`, is Go's randomized map order, because `Matches.Enumerate` ranges over `byFingerprint`.

### Change

Pick the survivor explicitly in case A rather than letting it fall out of arrival order, preferring the record matched directly against an ecosystem advisory over one reached only by CPE.

Records that rank equally fall back to a stable comparison of the record they came from. A record whose metadata could not be resolved loses to one that can be identified, since `getCachedMetadata` failing leaves `Vulnerability.Metadata` nil (`grype/db/v6/vulnerability_provider.go:501-506`) and such a record has no description or data source to contribute.

Preferring the direct match is not only for stability. In the reproduction below, every `fix.available` entry on the ecosystem records carries `kind: advisory` with real advisory dates (140 entries), while every entry on the NVD records carries `kind: first-observed` (171 entries) — so when the NVD record won the coin flip, the curated fix metadata was what got dropped.

This is deliberately the second of the two directions raised in #3630. The narrower alternative — iterating a sorted fingerprint list — is also stable, but the survivor then becomes whichever fingerprint sorts first, which for CVE-vs-GHSA/GO is consistently the NVD record. Happy to switch to that if it is preferred; it is a small change from here.

### Verification

Built from this branch and from `main` at `970b4d10`, against the same database (v6.1.9, built 2026-08-05, confirmed identical across runs via `descriptor.db.status`), scanning a one-component SBOM matched through both a purl and a CPE. Comparing runs on `vulnerability.{namespace,dataSource,description,fix,urls,severity,relatedVulnerabilities}`:

| | before | after |
|---|---|---|
| distinct outputs from 20 runs | 20 | **1** |
| run pairs identical in content | 0 / 190 | **190 / 190** |
| findings whose content varies | 65 / 83 | **0 / 83** |

The finding set itself was already stable before and is unchanged after; the surviving record is now consistently the ecosystem one (`https://go.dev/issue/65051`, `kind: advisory`), and both match details are still unioned onto it.

### Tests

`TestMatches_MergeSurvivorIsIndependentOfAddOrder` in `grype/match/matches_test.go` builds the colliding pair directly — same fingerprint, different metadata and fix provenance — and adds them in both orders, asserting the same record wins each time. It is not a scan-twice-and-compare test, so it cannot pass by luck: on `main` the `nvd record added first` case fails deterministically.

`grype/match`, `grype`, `grype/presenter/models` and `cmd/grype/cli/...` pass. I could not get a clean signal from the full suite locally on Windows — a number of matcher and db packages fail there on `t.TempDir()` cleanup ("The process cannot access the file because it is being used by another process") and on `internal/dbtest` fixture tooling, identically with and without this change, and `make static-analysis` fails at `go mod tidy -diff` on a clean checkout too. Those all look environmental rather than related to this change, but CI is the better judge.
