### PR TITLE
fix: don't reorder a match's fix versions while sorting

### DIFF
--- a/grype/match/sort.go
+++ b/grype/match/sort.go
@@ -1,6 +1,7 @@
 package match
 
 import (
+	"slices"
 	"sort"
 	"strings"
 )
@@ -22,12 +23,8 @@ func (m ByElements) Less(i, j int) bool {
 				if m[i].Package.Type == m[j].Package.Type {
 					// this is an approximate ordering, but is not accurate in terms of semver and other version formats
 					// but stability is what is important here, not the accuracy of the sort.
-					fixVersions1 := m[i].Vulnerability.Fix.Versions
-					fixVersions2 := m[j].Vulnerability.Fix.Versions
-					sort.Strings(fixVersions1)
-					sort.Strings(fixVersions2)
-					fixStr1 := strings.Join(fixVersions1, ",")
-					fixStr2 := strings.Join(fixVersions2, ",")
+					fixStr1 := sortedFixVersions(m[i].Vulnerability.Fix.Versions)
+					fixStr2 := sortedFixVersions(m[j].Vulnerability.Fix.Versions)
 
 					if fixStr1 == fixStr2 {
 						loc1 := m[i].Package.Locations.ToSlice()
@@ -57,4 +54,20 @@ func (m ByElements) Less(i, j int) bool {
 // Swap swaps the elements with indexes i and j.
 func (m ByElements) Swap(i, j int) {
 	m[i], m[j] = m[j], m[i]
+}
+
+// sortedFixVersions renders fix versions in a stable order for comparison.
+//
+// This deliberately works on a copy. The slice belongs to the Match being compared, and the
+// presenters emit Fix.Versions in the order the match holds them, so sorting it in place here would
+// let a comparison rewrite what a caller later reads back from its own match.
+func sortedFixVersions(versions []string) string {
+	if len(versions) < 2 {
+		return strings.Join(versions, ",")
+	}
+
+	sorted := slices.Clone(versions)
+	slices.Sort(sorted)
+
+	return strings.Join(sorted, ",")
 }

--- a/grype/match/sort_test.go
+++ b/grype/match/sort_test.go
@@ -1,0 +1,55 @@
+package match
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+// TestByElements_ComparisonDoesNotMutateMatches pins that comparing two matches leaves both of them as
+// they were. Less only reaches the fix-versions comparison when the vulnerability ID, package name,
+// version and type all tie, so the fixtures tie on exactly those and differ in namespace (which Less
+// does not consult) and in the order their fix versions are listed in.
+func TestByElements_ComparisonDoesNotMutateMatches(t *testing.T) {
+	pkgID := pkg.ID(uuid.NewString())
+	newMatch := func(namespace string, fixVersions []string) Match {
+		return Match{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{ID: "CVE-2020-0001", Namespace: namespace},
+				Fix:       vulnerability.Fix{Versions: fixVersions},
+			},
+			Package: pkg.Package{ID: pkgID, Name: "package-a", Version: "1.0.0", Type: syftPkg.NpmPkg},
+			Details: Details{{Type: ExactDirectMatch, Matcher: StockMatcher}},
+		}
+	}
+
+	t.Run("Less leaves both operands' fix versions in their original order", func(t *testing.T) {
+		first := newMatch("nvd:cpe", []string{"2.0.0", "1.0.0"})
+		second := newMatch("github:language:javascript", []string{"3.0.0", "1.0.0"})
+
+		ByElements([]Match{first, second}).Less(0, 1)
+
+		assert.Equal(t, []string{"2.0.0", "1.0.0"}, first.Vulnerability.Fix.Versions)
+		assert.Equal(t, []string{"3.0.0", "1.0.0"}, second.Vulnerability.Fix.Versions)
+	})
+
+	t.Run("Sorted returns matches with their fix versions in their original order", func(t *testing.T) {
+		matches := NewMatches(
+			newMatch("nvd:cpe", []string{"2.0.0", "1.0.0"}),
+			newMatch("github:language:javascript", []string{"3.0.0", "1.0.0"}),
+		)
+
+		byNamespace := map[string][]string{}
+		for _, m := range matches.Sorted() {
+			byNamespace[m.Vulnerability.Namespace] = m.Vulnerability.Fix.Versions
+		}
+
+		assert.Equal(t, []string{"2.0.0", "1.0.0"}, byNamespace["nvd:cpe"], "fix versions were reordered by sorting")
+		assert.Equal(t, []string{"3.0.0", "1.0.0"}, byNamespace["github:language:javascript"], "fix versions were reordered by sorting")
+	})
+}


### PR DESCRIPTION
`ByElements.Less` sorts both matches' `Fix.Versions` in place before joining them for comparison:

```go
fixVersions1 := m[i].Vulnerability.Fix.Versions
fixVersions2 := m[j].Vulnerability.Fix.Versions
sort.Strings(fixVersions1)
sort.Strings(fixVersions2)
```

The local variables copy only the slice header, so `sort.Strings` reorders the slice each `Match` actually holds.

### What this causes

`Less` only reaches that comparison when two matches tie on vulnerability ID, package name, version and type, so the effect is confined to findings that collide there. For those, `Sorted()` hands back matches whose `Fix.Versions` are in sorted rather than stored order, and the presenters emit them as they find them (`grype/presenter/cyclonedx/vulnerability.go:206` iterates the slice directly). A comparison function rewriting its operands is the underlying problem; the reordered output is how it shows.

`Sorted()` is called per matcher in `searchDBForMatches`, so this is on the normal scan path rather than test-only.

### Change

Compare a sorted copy instead of sorting in place. The ordering `Less` produces is unchanged — it still compares the sorted, comma-joined versions — only the mutation goes away.

The test pins that both operands keep their original version order through a `Less` call and through `Sorted()`. Both subtests fail on unpatched `main` and pass with the change.

### History

As first opened, this PR also described three consequences through `Fingerprint`, which at the time joined `Fix.Versions`: a `Less` call changing a match's fingerprint, `byFingerprint` keys drifting from their values after `Sorted()`, and deduplication depending on a prior sort. #3634 removed the fix versions from `Fingerprint`, so none of those is reachable any more and the tests that pinned them passed on unpatched `main`. Rebased and cut back to the mutation that still discriminates.

Found while looking at #3630, but independent of it — different file, different mechanism, and it stands on its own.

### Verification

`go test ./grype/match/...` and `go vet` pass on the rebased head. Reverting `sort.go` to `main` makes both subtests fail. `golangci-lint` panics on package load with the toolchain here (Go 1.26.5), so CI is the better judge of lint.
