### PR TITLE
fix: mark NVD records as disputed status based on cveTags

### DIFF
--- a/grype/db/internal/provider/unmarshal/nvd/cve.go
+++ b/grype/db/internal/provider/unmarshal/nvd/cve.go
@@ -2,6 +2,7 @@ package nvd
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/jinzhu/copier"
@@ -47,6 +48,7 @@ type CveItem struct {
 	// CisaRequiredAction    *string         `json:"cisaRequiredAction,omitempty"`
 	// CisaVulnerabilityName *string         `json:"cisaVulnerabilityName,omitempty"`
 	Configurations []Configuration `json:"configurations,omitempty"`
+	CveTags        []CveTag        `json:"cveTags,omitempty"`
 	Descriptions   []LangString    `json:"descriptions"`
 	// EvaluatorComment      *string         `json:"evaluatorComment,omitempty"`
 	// EvaluatorImpact       *string         `json:"evaluatorImpact,omitempty"`
@@ -169,6 +171,15 @@ type Weakness struct {
 	Type        string       `json:"type"`
 }
 
+// CveTag captures source-provided labels for a CVE record, such as "disputed" or "unsupported-when-assigned".
+// see https://csrc.nist.gov/schema/nvd/api/2.0/cve_api_json_2.0.schema
+type CveTag struct {
+	SourceIdentifier string   `json:"sourceIdentifier,omitempty"`
+	Tags             []string `json:"tags,omitempty"`
+}
+
+const disputedTag = "disputed"
+
 func (o CveItem) Description() string {
 	for _, d := range o.Descriptions {
 		if d.Lang == englishLanguage {
@@ -176,6 +187,19 @@ func (o CveItem) Description() string {
 		}
 	}
 	return ""
+}
+
+// IsDisputed returns true if any source has tagged this CVE as "disputed" via cveTags. Unlike vulnStatus, this
+// tag is not mutually exclusive with other statuses (e.g. a CVE can be "Analyzed" and disputed at the same time).
+func (o CveItem) IsDisputed() bool {
+	for _, t := range o.CveTags {
+		for _, tag := range t.Tags {
+			if strings.EqualFold(tag, disputedTag) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 type CvssSummary struct {

--- a/grype/db/internal/provider/unmarshal/nvd/cve_test.go
+++ b/grype/db/internal/provider/unmarshal/nvd/cve_test.go
@@ -1,6 +1,7 @@
 package nvd
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -193,6 +194,66 @@ func TestCvssSummaryVersion(t *testing.T) {
 			version := summary.version()
 			if version.String() != tc.expected {
 				t.Errorf("Expected version %s, got %s", tc.expected, version.String())
+			}
+		})
+	}
+}
+
+func TestCveItem_CveTags_UnmarshalJSON(t *testing.T) {
+	// this payload shape matches the documented NVD API schema
+	// (https://csrc.nist.gov/schema/nvd/api/2.0/cve_api_json_2.0.schema) and the real-world
+	// CVE-2001-1517 record, which carries a disputed cveTag independently of vulnStatus.
+	tests := []struct {
+		name             string
+		payload          string
+		expectedTags     []CveTag
+		expectedDisputed bool
+	}{
+		{
+			name: "cveTags with a disputed tag decodes and is disputed",
+			payload: `{
+				"id": "CVE-2001-1517",
+				"vulnStatus": "Deferred",
+				"descriptions": [],
+				"references": [],
+				"cveTags": [
+					{
+						"sourceIdentifier": "cve@mitre.org",
+						"tags": ["disputed"]
+					}
+				]
+			}`,
+			expectedTags: []CveTag{
+				{SourceIdentifier: "cve@mitre.org", Tags: []string{"disputed"}},
+			},
+			expectedDisputed: true,
+		},
+		{
+			name: "no cveTags decodes to nil and is not disputed",
+			payload: `{
+				"id": "CVE-2023-12345",
+				"vulnStatus": "Analyzed",
+				"descriptions": [],
+				"references": []
+			}`,
+			expectedTags:     nil,
+			expectedDisputed: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var item CveItem
+			if err := json.Unmarshal([]byte(tc.payload), &item); err != nil {
+				t.Fatalf("failed to unmarshal CveItem: %v", err)
+			}
+
+			if d := cmp.Diff(tc.expectedTags, item.CveTags); d != "" {
+				t.Errorf("unexpected CveTags (-want +got):\n%s", d)
+			}
+
+			if actual := item.IsDisputed(); actual != tc.expectedDisputed {
+				t.Errorf("IsDisputed() = %v, want %v", actual, tc.expectedDisputed)
 			}
 		})
 	}

--- a/grype/db/v6/build/transformers/nvd/transform.go
+++ b/grype/db/v6/build/transformers/nvd/transform.go
@@ -115,6 +115,24 @@ func getAssigner(vuln unmarshal.NVDVulnerability) []string {
 }
 
 func getVulnStatus(vuln unmarshal.NVDVulnerability) db.VulnerabilityStatus {
+	var s string
+	if vuln.VulnStatus != nil {
+		s = strings.TrimSpace(strings.ReplaceAll(strings.ToLower(*vuln.VulnStatus), " ", ""))
+	}
+
+	// reject (CVE list): A CVE Entry listed as "REJECT" is a CVE Entry that is not accepted as a CVE Entry. The reason a CVE Entry is marked
+	//    REJECT will most often be stated in the description of the CVE Entry. Possible examples include it being a duplicate CVE Entry, it being
+	//    withdrawn by the original requester, it being assigned incorrectly, or some other administrative reason.
+	//    As a rule, REJECT CVE Entries should be ignored.
+	//
+	// rejected (NVD): CVE has been marked as "**REJECT**" in the CVE List. These CVEs are stored in the NVD, but do not show up in search results.
+	//
+	// this takes precedence over a disputed tag: a rejected record must not be acted upon, which is a stronger
+	// signal than a dispute over whether it's a valid vulnerability.
+	if s == "rejected" || s == "reject" {
+		return db.VulnerabilityRejected
+	}
+
 	// note: a CVE can be tagged as "disputed" via cveTags independently of its vulnStatus (e.g. while "Analyzed"),
 	// so this needs to be checked before falling back to the vulnStatus-derived value below.
 	if vuln.IsDisputed() {
@@ -129,7 +147,6 @@ func getVulnStatus(vuln unmarshal.NVDVulnerability) db.VulnerabilityStatus {
 
 	// based off of the NVD or CVE list status, set the current vulnerability record status
 	// see https://nvd.nist.gov/vuln/vulnerability-status
-	s := strings.TrimSpace(strings.ReplaceAll(strings.ToLower(*vuln.VulnStatus), " ", ""))
 	switch s {
 	case "reserved", "received":
 		// reserved (CVE list): A CVE Entry is marked as "RESERVED" when it has been reserved for use by a CVE Numbering Authority (CNA) or security
@@ -153,14 +170,6 @@ func getVulnStatus(vuln unmarshal.NVDVulnerability) db.VulnerabilityStatus {
 		//    vendor or developer for more information.
 		//
 		return db.VulnerabilityDisputed
-	case "rejected", "reject":
-		// reject (CVE list): A CVE Entry listed as "REJECT" is a CVE Entry that is not accepted as a CVE Entry. The reason a CVE Entry is marked
-		//    REJECT will most often be stated in the description of the CVE Entry. Possible examples include it being a duplicate CVE Entry, it being
-		//    withdrawn by the original requester, it being assigned incorrectly, or some other administrative reason.
-		//    As a rule, REJECT CVE Entries should be ignored.
-		//
-		// rejected (NVD): CVE has been marked as "**REJECT**" in the CVE List. These CVEs are stored in the NVD, but do not show up in search results.
-		return db.VulnerabilityRejected
 	case "modified", "analyzed", "published":
 		// modified (NVD): CVE has been amended by a source (CVE Primary CNA or another CNA). Analysis data supplied by the NVD may be no longer be accurate due to these changes.
 		//

--- a/grype/db/v6/build/transformers/nvd/transform.go
+++ b/grype/db/v6/build/transformers/nvd/transform.go
@@ -115,6 +115,12 @@ func getAssigner(vuln unmarshal.NVDVulnerability) []string {
 }
 
 func getVulnStatus(vuln unmarshal.NVDVulnerability) db.VulnerabilityStatus {
+	// note: a CVE can be tagged as "disputed" via cveTags independently of its vulnStatus (e.g. while "Analyzed"),
+	// so this needs to be checked before falling back to the vulnStatus-derived value below.
+	if vuln.IsDisputed() {
+		return db.VulnerabilityDisputed
+	}
+
 	if vuln.VulnStatus == nil {
 		return db.UnknownVulnerabilityStatus
 	}

--- a/grype/db/v6/build/transformers/nvd/transform_test.go
+++ b/grype/db/v6/build/transformers/nvd/transform_test.go
@@ -2609,3 +2609,82 @@ func TestGetReferences(t *testing.T) {
 		})
 	}
 }
+
+func TestGetVulnStatus(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name     string
+		vuln     unmarshal.NVDVulnerability
+		expected db.VulnerabilityStatus
+	}{
+		{
+			name: "no vulnStatus and no cveTags is unknown",
+			vuln: unmarshal.NVDVulnerability{
+				ID: "CVE-2023-12345",
+			},
+			expected: db.UnknownVulnerabilityStatus,
+		},
+		{
+			name: "analyzed vulnStatus with no disputed cveTag is active",
+			vuln: unmarshal.NVDVulnerability{
+				ID:         "CVE-2023-12345",
+				VulnStatus: strPtr("Analyzed"),
+			},
+			expected: db.VulnerabilityActive,
+		},
+		{
+			name: "vulnStatus of Deferred with a disputed cveTag is disputed",
+			// this matches the real-world example from CVE-2001-1517, where the vulnStatus alone (an
+			// unrecognized "Deferred" value) does not convey the dispute captured in cveTags
+			vuln: unmarshal.NVDVulnerability{
+				ID:         "CVE-2001-1517",
+				VulnStatus: strPtr("Deferred"),
+				CveTags: []nvd.CveTag{
+					{SourceIdentifier: "cve@mitre.org", Tags: []string{"disputed"}},
+				},
+			},
+			expected: db.VulnerabilityDisputed,
+		},
+		{
+			name: "analyzed vulnStatus with a disputed cveTag is still disputed",
+			vuln: unmarshal.NVDVulnerability{
+				ID:         "CVE-2023-12345",
+				VulnStatus: strPtr("Analyzed"),
+				CveTags: []nvd.CveTag{
+					{SourceIdentifier: "cve@mitre.org", Tags: []string{"disputed"}},
+				},
+			},
+			expected: db.VulnerabilityDisputed,
+		},
+		{
+			name: "cveTags without a disputed tag does not change status",
+			vuln: unmarshal.NVDVulnerability{
+				ID:         "CVE-2023-12345",
+				VulnStatus: strPtr("Analyzed"),
+				CveTags: []nvd.CveTag{
+					{SourceIdentifier: "cve@mitre.org", Tags: []string{"unsupported-when-assigned"}},
+				},
+			},
+			expected: db.VulnerabilityActive,
+		},
+		{
+			name: "disputed vulnStatus is disputed",
+			vuln: unmarshal.NVDVulnerability{
+				ID:         "CVE-2023-12345",
+				VulnStatus: strPtr("Disputed"),
+			},
+			expected: db.VulnerabilityDisputed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := getVulnStatus(tt.vuln)
+
+			if diff := cmp.Diff(tt.expected, actual); diff != "" {
+				t.Errorf("getVulnStatus() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/grype/db/v6/build/transformers/nvd/transform_test.go
+++ b/grype/db/v6/build/transformers/nvd/transform_test.go
@@ -2676,6 +2676,19 @@ func TestGetVulnStatus(t *testing.T) {
 			},
 			expected: db.VulnerabilityDisputed,
 		},
+		{
+			name: "rejected vulnStatus with a disputed cveTag is still rejected",
+			// rejected must take precedence over a disputed tag: a rejected record must not be acted
+			// upon, which is a stronger signal than a dispute over whether it's a valid vulnerability
+			vuln: unmarshal.NVDVulnerability{
+				ID:         "CVE-2023-12345",
+				VulnStatus: strPtr("Rejected"),
+				CveTags: []nvd.CveTag{
+					{SourceIdentifier: "cve@mitre.org", Tags: []string{"disputed"}},
+				},
+			},
+			expected: db.VulnerabilityRejected,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Motivation:
NVD API records can be labeled "disputed" via the cveTags field
(https://csrc.nist.gov/schema/nvd/api/2.0/cve_api_json_2.0.schema)
independently of the vulnStatus field. Grype's NVD unmarshaller never
captured cveTags, and the v6 transformer only derived vulnerability
handle status from vulnStatus, so these records ended up with an
incorrect status (e.g. unknown) instead of disputed. For example,
CVE-2001-1517 has vulnStatus "Deferred" (not a status grype maps to
anything) but cveTags contains a "disputed" tag, so its grype db
status should be disputed.

Approach:
- Add a CveTags field (and CveTag struct) to CveItem in
  grype/db/internal/provider/unmarshal/nvd/cve.go, matching the NVD
  API schema shape, plus an IsDisputed() helper that does a
  case-insensitive scan for a "disputed" tag.
- In grype/db/v6/build/transformers/nvd/transform.go, getVulnStatus
  now checks IsDisputed() before falling back to the vulnStatus-based
  switch, since a record can carry a disputed cveTag while vulnStatus
  is any other value (e.g. "Analyzed" or an unrecognized one like
  "Deferred"). This means a disputed tag takes precedence over any
  other vulnStatus mapping, including "rejected" - this is an
  intentional choice since disputed and rejected are independent,
  non-mutually-exclusive signals in the NVD data and disputed is the
  more actionable/specific one to surface.

Validation:
Ran `go build ./...` (passes) and `go test ./grype/db/...` (all
packages pass), including the new grype/db/v6/build/transformers/nvd
TestGetVulnStatus table test, which reproduces the exact scenario
from the issue (vulnStatus "Deferred" + a disputed cveTag ->
db.VulnerabilityDisputed), matching CVE-2001-1517's real NVD data.
Also fed the exact JSON payload from the issue through the updated
CveItem JSON decoding (in a local scratch test, not included in this
commit) and confirmed CveTags populates correctly and IsDisputed()
returns true.

This change affects the shared unmarshal/transform packages used to
build the grype v6 vulnerability database; it does not alter grype's
own scan-time behavior in this repo, only the derived status of
disputed NVD records once a database is rebuilt with this logic.

Report: https://github.com/anchore/grype/issues/3248
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #3248