### PR TITLE
feat(db/search): add alias aware grype db search flag

### DIFF
--- a/cmd/grype/cli/options/database_search_vulnerabilities.go
+++ b/cmd/grype/cli/options/database_search_vulnerabilities.go
@@ -13,6 +13,7 @@ import (
 type DBSearchVulnerabilities struct {
 	VulnerabilityIDs []string `yaml:"vulnerability-ids" json:"vulnerability-ids" mapstructure:"vulnerability-ids"`
 	UseVulnIDFlag    bool     `yaml:"-" json:"-" mapstructure:"-"`
+	IncludeAliases   bool     `yaml:"include-aliases" json:"include-aliases" mapstructure:"include-aliases"`
 
 	PublishedAfter string `yaml:"published-after" json:"published-after" mapstructure:"published-after"`
 	ModifiedAfter  string `yaml:"modified-after" json:"modified-after" mapstructure:"modified-after"`
@@ -27,6 +28,7 @@ func (c *DBSearchVulnerabilities) AddFlags(flags clio.FlagSet) {
 	if c.UseVulnIDFlag {
 		flags.StringArrayVarP(&c.VulnerabilityIDs, "vuln", "", "only show results for the given vulnerability ID")
 	}
+	flags.BoolVarP(&c.IncludeAliases, "include-aliases", "", "include vulnerability rows which are aliases to this vuln id")
 	flags.StringVarP(&c.PublishedAfter, "published-after", "", "only show vulnerabilities originally published after the given date (format: YYYY-MM-DD)")
 	flags.StringVarP(&c.ModifiedAfter, "modified-after", "", "only show vulnerabilities originally published or modified since the given date (format: YYYY-MM-DD)")
 	flags.StringArrayVarP(&c.Providers, "provider", "", "only show vulnerabilities from the given provider")
@@ -82,6 +84,7 @@ func (c *DBSearchVulnerabilities) PostLoad() error {
 			PublishedAfter: publishedAfter,
 			ModifiedAfter:  modifiedAfter,
 			Providers:      c.Providers,
+			IncludeAliases: c.IncludeAliases,
 		})
 	}
 

--- a/grype/db/v6/vulnerability_store.go
+++ b/grype/db/v6/vulnerability_store.go
@@ -350,16 +350,21 @@ func handleVulnerabilityOptions(base, parentQuery *gorm.DB, configs ...Vulnerabi
 	}
 
 	orConditions := base.Model(&VulnerabilityHandle{})
-	var includeAliasJoin bool
 	for _, config := range configs {
 		query := base.Model(&VulnerabilityHandle{})
 		if config.Name != "" {
+			names := []string{config.Name}
 			if config.IncludeAliases {
-				includeAliasJoin = true
-				query = query.Where("vulnerability_handles.name = ? collate nocase OR vulnerability_aliases.alias = ?  collate nocase", config.Name, config.Name)
-			} else {
-				query = query.Where("vulnerability_handles.name = ?  collate nocase", config.Name)
+				// Resolve aliases to concrete names up front so the predicate stays a same-table OR
+				// chain over vulnerability_handles.name, which SQLite serves with per-name index
+				// lookups. Matching aliases inline via a cross-table OR would defeat the name index.
+				aliases, err := resolveVulnerabilityAliases(base, config.Name)
+				if err != nil {
+					return nil, fmt.Errorf("unable to resolve aliases for vulnerability %q: %w", config.Name, err)
+				}
+				names = appendUniqueNames(names, aliases...)
 			}
+			query = query.Where(nameConditions(base, names))
 		}
 
 		if config.ID != 0 {
@@ -385,9 +390,55 @@ func handleVulnerabilityOptions(base, parentQuery *gorm.DB, configs ...Vulnerabi
 		orConditions = orConditions.Or(query)
 	}
 
-	if includeAliasJoin {
-		parentQuery = parentQuery.Joins("LEFT JOIN vulnerability_aliases ON vulnerability_aliases.name = vulnerability_handles.name collate nocase")
-	}
-
 	return parentQuery.Where(orConditions), nil
+}
+
+// resolveVulnerabilityAliases returns the vulnerability names that are aliases of the given name
+func resolveVulnerabilityAliases(db *gorm.DB, name string) ([]string, error) {
+	var names []string
+	// The input may sit in either column, so look both ways and return the value from the other
+	// column; UNION merges and de-duplicates. Each branch is a point lookup on its own NOCASE index.
+	err := db.Raw(
+		`SELECT name FROM vulnerability_aliases WHERE alias = ? COLLATE NOCASE
+UNION
+SELECT alias FROM vulnerability_aliases WHERE name = ? COLLATE NOCASE`,
+		name, name,
+	).Scan(&names).Error
+	if err != nil {
+		return nil, err
+	}
+	return names, nil
+}
+
+// nameConditions builds a grouped, case-insensitive OR predicate over vulnerability_handles.name.
+// A same-table OR chain lets SQLite use a MULTI-INDEX OR plan (one name-index lookup per value).
+func nameConditions(base *gorm.DB, names []string) *gorm.DB {
+	group := base.Model(&VulnerabilityHandle{})
+	// "IN (...)" is avoided: the name column's default collation is BINARY (only its index is
+	// NOCASE), so per-term "= ? collate nocase" is needed for case-insensitive, index-backed lookups.
+	for i, name := range names {
+		if i == 0 {
+			group = group.Where("vulnerability_handles.name = ? collate nocase", name)
+		} else {
+			group = group.Or("vulnerability_handles.name = ? collate nocase", name)
+		}
+	}
+	return group
+}
+
+// appendUniqueNames appends the additional names that are not already present, comparing
+// case-insensitively (vulnerability name matching is case-insensitive).
+func appendUniqueNames(existing []string, additional ...string) []string {
+	seen := strset.New()
+	out := existing
+	for _, n := range existing {
+		seen.Add(strings.ToLower(n))
+	}
+	for _, n := range additional {
+		if key := strings.ToLower(n); !seen.Has(key) {
+			seen.Add(key)
+			out = append(out, n)
+		}
+	}
+	return out
 }


### PR DESCRIPTION
### What

Adds an alias aware option to `grype db search`

### Why

With Chainguard OSV feed using CGAs, looking up a vulnerability in the database becomes harder since we have lookup individual CGAs rather than equivalent CVE. I added a flag to add optional use of aliases for db searches to make this easier:

```
✦ ❯ GRYPE_DB_CACHE_DIR=~/.cache/cg-grype/osv/db/ GRYPE_DB_AUTO_UPDATE=false ./bin/grype db search --vuln CVE-2019-1010022
VULNERABILITY     PACKAGE                              ECOSYSTEM  NAMESPACE                   VERSION CONSTRAINT
CVE-2019-1010022  cpe:2.3:a:gnu:glibc:*:*:*:*:*:*:*:*             nvd:cpe
CVE-2019-1010022  glibc                                apk        wolfi:distro:wolfi:rolling  < 0

✦ ❯ GRYPE_DB_CACHE_DIR=~/.cache/cg-grype/osv/db/ GRYPE_DB_AUTO_UPDATE=false ./bin/grype db search --vuln CVE-2019-1010022 --include-aliases
VULNERABILITY       PACKAGE                              ECOSYSTEM   NAMESPACE                             VERSION CONSTRAINT
CGA-8m4j-hg3f-5xv5  glibc                                Chainguard  chainguard:distro:chainguard:rolling  < 0
CGA-8m4j-hg3f-5xv5  glibc                                Wolfi       chainguard:distro:wolfi:rolling       < 0
CGA-8m9p-pp6f-hmvj  glibc                                Chainguard  chainguard:distro:chainguard:rolling  < 0
CGA-8m9p-pp6f-hmvj  glibc                                Wolfi       chainguard:distro:wolfi:rolling       < 0
CVE-2019-1010022    cpe:2.3:a:gnu:glibc:*:*:*:*:*:*:*:*              nvd:cpe
CVE-2019-1010022    glibc                                apk         wolfi:distro:wolfi:rolling            < 0
```

NOTE: above is run on local build of grype with custom db using chainguard osv feed

### Notes

Because of the way indexes are setup, I found that `grype db search --vuln <>` was incredibly slow but `grype db search --vuln <> --pkg <>` was _much_ faster. There a couple solutions to this. Firstly, a new index can be added for iterating over aliases without a pkg name. However, I implemented a code-only change to pull the aliases before querying the database.

If we prefer to add an index, this can be changed
