### PR TITLE
fix(match): skip packages with an empty version like the "unknown" sentinel

### DIFF
--- a/grype/matcher/internal/distro.go
+++ b/grype/matcher/internal/distro.go
@@ -27,7 +27,7 @@ func MatchPackageByDistro(provider vulnerability.Provider, searchPkg pkg.Package
 		return nil, nil, nil
 	}
 
-	if isUnknownVersion(searchPkg.Version) {
+	if isMissingVersion(searchPkg.Version) {
 		log.WithFields("package", searchPkg.Name).Trace("skipping package with unknown version")
 		return nil, nil, nil
 	}
@@ -95,4 +95,16 @@ func matchPackage(searchPkg pkg.Package, catalogPkg *pkg.Package) pkg.Package {
 
 func isUnknownVersion(v string) bool {
 	return strings.ToLower(v) == "unknown"
+}
+
+// isMissingVersion reports whether a package carries no usable version for
+// range comparison. Both an empty string and the literal "unknown" sentinel
+// mean "we don't know the version". Range-based matchers must skip these
+// packages: OnlyVulnerableVersions treats a blank version as "match every
+// disclosure", so without this guard an unversioned package (e.g. a component
+// imported from an SBOM that omits its version) would report every CVE ever
+// recorded for its name. The rpm matcher's own isUnknownVersion already treats
+// both forms this way.
+func isMissingVersion(v string) bool {
+	return v == "" || isUnknownVersion(v)
 }

--- a/grype/matcher/internal/distro_test.go
+++ b/grype/matcher/internal/distro_test.go
@@ -103,6 +103,29 @@ func TestFindMatchesByPackageDistro(t *testing.T) {
 	assert.Empty(t, actual)
 }
 
+func TestMatchPackageByDistroSkipsMissingVersion(t *testing.T) {
+	store := newMockProviderByDistro()
+
+	// a package that reaches the matcher without a version (for example a
+	// component imported from an SBOM that omits its version) has nothing to
+	// compare against the affected ranges. It must be skipped like the
+	// "unknown" sentinel is, not matched against every disclosure for the name.
+	for _, blank := range []string{"", "unknown", "UNKNOWN"} {
+		p := pkg.Package{
+			ID:      pkg.ID(uuid.NewString()),
+			Name:    "neutron",
+			Version: blank,
+			Type:    syftPkg.DebPkg,
+		}
+		p.Distro = distro.New(distro.Debian, "8", "")
+
+		actual, ignored, err := MatchPackageByDistro(store, p, nil, match.PythonMatcher, nil)
+		require.NoError(t, err)
+		require.Empty(t, ignored)
+		assert.Emptyf(t, actual, "expected no matches for blank version %q", blank)
+	}
+}
+
 func TestMatchPackageByDistroWithIgnoreRules(t *testing.T) {
 	ownedFiles := pkg.ApkMetadata{Files: []pkg.ApkFileRecord{
 		{Path: "/usr/lib/python3/dist-packages/requests"},

--- a/grype/matcher/internal/language.go
+++ b/grype/matcher/internal/language.go
@@ -14,7 +14,7 @@ import (
 )
 
 func MatchPackageByLanguage(store vulnerability.Provider, p pkg.Package, matcherType match.MatcherType) ([]match.Match, []match.IgnoreFilter, error) {
-	if isUnknownVersion(p.Version) {
+	if isMissingVersion(p.Version) {
 		log.WithFields("package", p.Name).Trace("skipping package with unknown version")
 		return nil, nil, nil
 	}
@@ -56,7 +56,7 @@ func MatchPackageByLanguage(store vulnerability.Provider, p pkg.Package, matcher
 }
 
 func MatchPackageByEcosystemPackageName(vp vulnerability.Provider, p pkg.Package, packageName string, matcherType match.MatcherType) ([]match.Match, []match.IgnoreFilter, error) {
-	if isUnknownVersion(p.Version) {
+	if isMissingVersion(p.Version) {
 		log.WithFields("package", p.Name).Trace("skipping package with unknown version")
 		return nil, nil, nil
 	}

--- a/grype/matcher/internal/language_test.go
+++ b/grype/matcher/internal/language_test.go
@@ -101,6 +101,28 @@ func expectedMatchRuby(p pkg.Package, constraint string) []match.Match {
 	}
 }
 
+func TestMatchPackageByLanguageSkipsMissingVersion(t *testing.T) {
+	store := newMockProviderRuby()
+
+	// activerecord carries two disclosures in the mock feed. Without a version
+	// to compare, OnlyVulnerableVersions would report both of them (and, with a
+	// real feed, every historical CVE for the name). A versionless package must
+	// be skipped, consistent with the "unknown" sentinel and the rpm matcher.
+	for _, blank := range []string{"", "unknown"} {
+		p := pkg.Package{
+			ID:       pkg.ID(uuid.NewString()),
+			Name:     "activerecord",
+			Version:  blank,
+			Language: syftPkg.Ruby,
+			Type:     syftPkg.GemPkg,
+		}
+
+		actual, _, err := MatchPackageByLanguage(store, p, match.RubyGemMatcher)
+		require.NoError(t, err)
+		assert.Emptyf(t, actual, "expected no matches for blank version %q", blank)
+	}
+}
+
 func TestFindMatchesByPackageRuby(t *testing.T) {
 	cases := []struct {
 		p           pkg.Package


### PR DESCRIPTION
`isUnknownVersion` in the shared matcher helpers only recognizes the literal `"unknown"` string, so a package that reaches the distro or language matcher with an empty version slips past the skip guard. `OnlyVulnerableVersions` then sees a blank version and returns a match-everything predicate ("if no version is provided, match everything"), so the package gets every disclosure recorded for its name reported as a match.

That path is reachable from an imported SBOM whose component omits a version (e.g. `grype sbom:./bom.json`), or any provider that leaves the version blank. The effect is a flood of false positives: an `activerecord` gem with no version comes back matched against every activerecord CVE in the feed, regardless of the affected ranges.

The rpm matcher already handles this — its own `isUnknownVersion` is `v == "" || strings.ToLower(v) == "unknown"`. And per #2863 the intended default for versionless packages is to *not* surface vulnerabilities (surfacing them is a requested opt-in, not the current behavior). This change brings the distro and language matchers in line: an empty version is treated the same as `unknown`, so the package is skipped.

The CPE matcher is left as-is on purpose. It supports versionless matching by design — `MatchPackageByCPEs` has explicit empty-version test cases and `filterCPEsByVersion` has a "do not filter on empty version" case — so it keeps calling `isUnknownVersion` directly.

## Test

`TestMatchPackageByDistroSkipsMissingVersion` and `TestMatchPackageByLanguageSkipsMissingVersion` cover both the empty and `unknown` forms. Both fail before this change (the empty-version package produces matches) and pass after.
