### PR TITLE
fix: treat Amazon Linux's ALAS feed as comprehensive when deduplicati…

### DIFF
--- a/grype/pkg/package.go
+++ b/grype/pkg/package.go
@@ -284,11 +284,6 @@ func distroFeedIsComprehensive(dst *distro.Distro) bool {
 	if dst == nil {
 		return false
 	}
-	if dst.Type == distro.AmazonLinux {
-		// AmazonLinux shows "like rhel" but is not an rhel clone
-		// and does not have an exhaustive vulnerability feed.
-		return false
-	}
 	for _, d := range comprehensiveDistros {
 		if strings.EqualFold(string(d), dst.Name()) {
 			return true
@@ -305,7 +300,14 @@ func distroFeedIsComprehensive(dst *distro.Distro) bool {
 // computed by:
 // sqlite3 vulnerability.db 'select distinct namespace from vulnerability where fix_state in ("wont-fix", "not-fixed") order by namespace;' | cut -d ':' -f 1 | sort | uniq
 // then removing 'github'
+//
+// AmazonLinux was added separately (see https://github.com/anchore/grype/issues/3612):
+// the ALAS feed ingested by grype-db tracks both fixed and unfixed/pending-fix CVEs per
+// package (see https://explore.alas.aws.amazon.com), the same criterion used to derive
+// the rest of this list, but it was excluded by an explicit override that predates that
+// feed's current coverage.
 var comprehensiveDistros = []distro.Type{
+	distro.AmazonLinux,
 	distro.ArchLinux,
 	distro.Azure,
 	distro.Debian,

--- a/grype/pkg/package_test.go
+++ b/grype/pkg/package_test.go
@@ -1523,11 +1523,16 @@ func Test_RemovePackagesByOverlap(t *testing.T) {
 			expectedPackages: []string{"rpm:python3-rpm@4.14.3-26.el8"},
 		},
 		{
-			name: "amzn linux doesn't remove packages in this way",
+			// AmazonLinux's ALAS feed is comprehensive (tracks both fixed and unfixed CVEs per
+			// package, see https://github.com/anchore/grype/issues/3612), so this behaves the
+			// same as the "python bindings for system RPM install" case above: the language-level
+			// duplicate is removed rather than matched separately against the upstream PyPI
+			// version, which would misreport CVEs already backported by Amazon's RPM.
+			name: "amzn linux removes packages in this way, same as other comprehensive distros",
 			sbom: withLinuxRelease(catalogWithOverlaps(
 				[]string{"rpm:python3-rpm@4.14.3-26.el8", "python:rpm@4.14.3"},
 				[]string{"rpm:python3-rpm@4.14.3-26.el8 -> python:rpm@4.14.3"}), "amzn"),
-			expectedPackages: []string{"rpm:python3-rpm@4.14.3-26.el8", "python:rpm@4.14.3"},
+			expectedPackages: []string{"rpm:python3-rpm@4.14.3-26.el8"},
 		},
 		{
 			name: "remove overlapping package when parent version is prefix of child version",


### PR DESCRIPTION
…ng packages

distroFeedIsComprehensive() hardcoded Amazon Linux to false, which meant excludePackage() never suppressed the language-level duplicate that syft also reports for an RPM-repackaged Python library on Amazon Linux (once from the RPM db, once from egg-info/dist-info metadata). The suppression that every other comprehensive distro gets skipped Amazon Linux, so its language-level duplicate is matched against upstream PyPI/GHSA advisories using the plain upstream version string, which cannot reflect Amazon's RPM backporting -- producing a false-positive CVE for every backported package repackaged this way.

grype-db already ingests the ALAS feed, which -- like the distros in comprehensiveDistros -- tracks both fixed and unfixed/pending-fix CVEs per package (see https://explore.alas.aws.amazon.com), the same criterion the rest of the list was derived from. The AmazonLinux override predates that feed's current coverage.

Removed the override and added distro.AmazonLinux to comprehensiveDistros. Amazon Linux's ID_LIKE varies by release (AL2023 reports "fedora", AL2 reports "centos rhel fedora") and never matches any Type constant in the list via the existing IDLike fallback, so an explicit entry is required rather than relying on that fallback.

Updated the existing "amzn linux doesn't remove packages in this way" test case in Test_RemovePackagesByOverlap, which encoded the old (incorrect) behavior as expected, to assert the corrected behavior instead -- it now behaves the same as the RHEL case directly above it in the table. Confirmed the updated assertion fails against the unmodified code (reverting only package.go, keeping the test change) with a clear mismatch on the expected package list, and passes with the fix applied.

fixes #3612