### PR TITLE
Add MegaLinter to README as another way to run Grype

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ curl -sSfL https://get.anchore.io/grype | sudo sh -s -- -b /usr/local/bin
 > [!TIP]
 > See [Installation docs](https://oss.anchore.com/docs/installation/grype/) for more ways to get Grype, including Homebrew, Docker, Chocolatey, MacPorts, and more!
 
+Grype also ships inside [MegaLinter](https://megalinter.io), an open-source linters aggregator for CI, which runs it against your repository out of the box (see the [Grype descriptor](https://megalinter.io/latest/descriptors/repository_grype/)).
+
 ## The basics
 
 Scan a container image or directory for vulnerabilities:


### PR DESCRIPTION
Hi! I maintain [MegaLinter](https://megalinter.io), an open-source linters aggregator for CI that bundles Grype and runs it on repositories out of the box ([descriptor page](https://megalinter.io/latest/descriptors/repository_grype/)).

This PR adds a short line in the Installation section of the README so Grype users know they can also get it through MegaLinter. Feel free to reword or move it if there's a better spot!