### PR TITLE
fix(db): preserve http.Client timeout when applying user agent

### DIFF
--- a/grype/db/v6/distribution/client.go
+++ b/grype/db/v6/distribution/client.go
@@ -210,7 +210,12 @@ func withClientTimeout(timeout time.Duration) func(*http.Client) {
 
 func withUserAgent(id clio.Identification) func(*http.Client) {
 	return func(c *http.Client) {
-		*(c) = *newHTTPClientWithDefaultUserAgent(c.Transport, fmt.Sprintf("%s %s", id.Name, id.Version))
+		// note: this must only mutate c.Transport (not replace c itself), otherwise any
+		// fields already set on c by earlier post-processors (e.g. withClientTimeout) are lost
+		c.Transport = roundTripperWithUserAgent{
+			transport: c.Transport,
+			userAgent: fmt.Sprintf("%s %s", id.Name, id.Version),
+		}
 	}
 }
 
@@ -276,15 +281,6 @@ func isSupersededBy(current *v6.Description, candidate v6.Description) bool {
 
 	log.Debugf("existing database is already up to date")
 	return false
-}
-
-func newHTTPClientWithDefaultUserAgent(baseTransport http.RoundTripper, userAgent string) *http.Client {
-	return &http.Client{
-		Transport: roundTripperWithUserAgent{
-			transport: baseTransport,
-			userAgent: userAgent,
-		},
-	}
 }
 
 type roundTripperWithUserAgent struct {

--- a/grype/db/v6/distribution/client_test.go
+++ b/grype/db/v6/distribution/client_test.go
@@ -3,6 +3,8 @@ package distribution
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"testing"
 	"time"
@@ -13,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wagoodman/go-progress"
 
+	"github.com/anchore/clio"
 	db "github.com/anchore/grype/grype/db/v6"
 	"github.com/anchore/grype/internal/schemaver"
 )
@@ -299,6 +302,29 @@ func TestClient_IsUpdateAvailable(t *testing.T) {
 			assert.Equal(t, tt.archive, archive)
 		})
 	}
+}
+
+func Test_defaultHTTPClient_preservesTimeoutAfterUserAgent(t *testing.T) {
+	// regression test: withUserAgent used to replace the entire http.Client (losing any
+	// fields set by earlier post-processors, notably c.Timeout from withClientTimeout),
+	// which meant the configured CheckTimeout/UpdateTimeout was silently ignored and a
+	// stalled request could hang indefinitely instead of timing out as configured.
+	c, err := defaultHTTPClient(afero.NewMemMapFs(), "", withClientTimeout(30*time.Second), withUserAgent(clio.Identification{Name: "grype", Version: "1.2.3"}))
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Second, c.Timeout, "client timeout must survive being wrapped with a user agent")
+
+	// also verify the user agent is still applied via the wrapped transport
+	var gotUserAgent string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserAgent = r.Header.Get("User-Agent")
+	}))
+	defer server.Close()
+
+	resp, err := c.Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, "grype 1.2.3", gotUserAgent)
 }
 
 func TestDatabaseDescription_IsSupersededBy(t *testing.T) {


### PR DESCRIPTION
Motivation:
There is a report of a database update check that hung for 1h40m
even though the HTTP client is configured with a 30s CheckTimeout
(300s UpdateTimeout). The client is built in defaultHTTPClient() by
chaining post-processors, including withClientTimeout (sets
c.Timeout) followed by withUserAgent.

The old withUserAgent implementation replaced the entire
*http.Client via `*(c) = *newHTTPClientWithDefaultUserAgent(...)`,
constructing a brand new http.Client{} literal that never sets
Timeout (defaults to 0, meaning no timeout). This silently
discarded whatever Timeout had just been set by withClientTimeout,
so any client built through this path effectively never times out
via http.Client.Timeout. This is a plausible root cause for the
reported multi-hour hang: a stalled/unresponsive server with no
client-side timeout in effect.

Approach:
Change withUserAgent to mutate only c.Transport (wrapping the
existing transport in roundTripperWithUserAgent) instead of
replacing the whole client struct, so fields set by other
post-processors (Timeout, and anything set in the future) survive
regardless of post-processor order. Removed the now-unused
newHTTPClientWithDefaultUserAgent helper.

Validation:
- Wrote a temporary repro test asserting c.Timeout == 30s after
  applying withClientTimeout(30s) then withUserAgent(...) via
  defaultHTTPClient; against the old code it failed with
  c.Timeout == 0s, confirming the clobbering mechanism.
- Replaced it with a permanent regression test,
  Test_defaultHTTPClient_preservesTimeoutAfterUserAgent, which
  additionally spins up an httptest.Server to confirm the
  User-Agent header is still applied correctly through the
  wrapped transport. It passes against the fix.
- Ran: go build ./...  (succeeds)
- Ran: go test ./grype/db/v6/distribution/...  (all tests pass,
  including the new regression test)

This was not validated against a live stalled server reproducing
the original 1h40m hang, since the failure is reported as
infrequent and hard to reproduce on demand. This fix addresses a
concretely demonstrable defect in the client construction code
(the timeout being silently reset to zero) found via code review,
not a live-traffic reproduction of the reported incident.

Report: https://github.com/anchore/grype/issues/2910
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #2910