### PR TITLE
fix: keep the PURL namespace when searching the db by package URL

### DIFF
--- a/cmd/grype/cli/options/database_search_packages.go
+++ b/cmd/grype/cli/options/database_search_packages.go
@@ -62,7 +62,9 @@ func (o *DBSearchPackages) PostLoad() error {
 				log.Warnf("ignoring version and qualifiers for package URL %q", purl)
 			}
 
-			o.PkgSpecs = append(o.PkgSpecs, &v6.PackageSpecifier{Name: purl.Name, Ecosystem: purl.Type})
+			name := packageNameFromPURL(purl)
+
+			o.PkgSpecs = append(o.PkgSpecs, &v6.PackageSpecifier{Name: name, Ecosystem: purl.Type})
 			o.CPESpecs = append(o.CPESpecs, &v6.PackageSpecifier{CPE: &cpe.Attributes{Part: "a", Product: purl.Name, TargetSW: purl.Type}})
 
 		default:
@@ -81,4 +83,31 @@ func (o *DBSearchPackages) PostLoad() error {
 	}
 
 	return nil
+}
+
+// packageNameFromPURL builds the package name the DB is keyed by from a parsed
+// package URL. For most ecosystems the PURL name is only the last segment, and
+// dropping the namespace searches for the wrong thing entirely: the Go module
+// "github.com/gin-gonic/gin" arrives as namespace "github.com/gin-gonic" plus
+// name "gin", and searching for "gin" alone finds nothing.
+//
+// How the two are joined is ecosystem-specific, so this only rejoins the types
+// whose convention is known. A namespace that is not part of the package
+// identity, such as the distro on an rpm or deb PURL, is left out.
+func packageNameFromPURL(purl packageurl.PackageURL) string {
+	if purl.Namespace == "" {
+		return purl.Name
+	}
+
+	switch purl.Type {
+	case packageurl.TypeMaven:
+		// Maven coordinates are "<group>:<artifact>", matching how the Java
+		// name resolver builds them (grype/db/v6/name/java.go).
+		return fmt.Sprintf("%s:%s", purl.Namespace, purl.Name)
+	case packageurl.TypeGolang, packageurl.TypeNPM, packageurl.TypeComposer,
+		packageurl.TypeGithub, packageurl.TypeBitbucket, packageurl.TypeSwift:
+		return fmt.Sprintf("%s/%s", purl.Namespace, purl.Name)
+	}
+
+	return purl.Name
 }

--- a/cmd/grype/cli/options/database_search_packages_test.go
+++ b/cmd/grype/cli/options/database_search_packages_test.go
@@ -43,6 +43,58 @@ func TestDBSearchPackagesPostLoad(t *testing.T) {
 			},
 		},
 		{
+			// the module path is split across namespace and name, and searching
+			// for "gin" alone finds nothing
+			name: "golang PURL keeps the full module path",
+			input: DBSearchPackages{
+				Packages: []string{"pkg:golang/github.com/gin-gonic/gin@v1.9.0"},
+			},
+			expectedPkg: v6.PackageSpecifiers{
+				{Name: "github.com/gin-gonic/gin", Ecosystem: "golang"},
+			},
+			expectedCPE: v6.PackageSpecifiers{
+				{CPE: &cpe.Attributes{Part: "a", Product: "gin", TargetSW: "golang"}},
+			},
+		},
+		{
+			name: "scoped npm PURL keeps the scope",
+			input: DBSearchPackages{
+				Packages: []string{"pkg:npm/%40types/node@20.0.0"},
+			},
+			expectedPkg: v6.PackageSpecifiers{
+				{Name: "@types/node", Ecosystem: "npm"},
+			},
+			expectedCPE: v6.PackageSpecifiers{
+				{CPE: &cpe.Attributes{Part: "a", Product: "node", TargetSW: "npm"}},
+			},
+		},
+		{
+			// maven joins on a colon, matching grype/db/v6/name/java.go
+			name: "maven PURL keeps the group",
+			input: DBSearchPackages{
+				Packages: []string{"pkg:maven/org.apache.commons/commons-lang3@3.12.0"},
+			},
+			expectedPkg: v6.PackageSpecifiers{
+				{Name: "org.apache.commons:commons-lang3", Ecosystem: "maven"},
+			},
+			expectedCPE: v6.PackageSpecifiers{
+				{CPE: &cpe.Attributes{Part: "a", Product: "commons-lang3", TargetSW: "maven"}},
+			},
+		},
+		{
+			// the namespace on an rpm PURL is the distro, not part of the name
+			name: "rpm PURL leaves the distro namespace out",
+			input: DBSearchPackages{
+				Packages: []string{"pkg:rpm/redhat/openssl@1.1.1k"},
+			},
+			expectedPkg: v6.PackageSpecifiers{
+				{Name: "openssl", Ecosystem: "rpm"},
+			},
+			expectedCPE: v6.PackageSpecifiers{
+				{CPE: &cpe.Attributes{Part: "a", Product: "openssl", TargetSW: "rpm"}},
+			},
+		},
+		{
 			name: "plain package name",
 			input: DBSearchPackages{
 				Packages: []string{"package-name"},


### PR DESCRIPTION
Closes #3508.

`DBSearchPackages.PostLoad` used `purl.Name` on its own and dropped `purl.Namespace`. A Go module arrives split across the two, so the search in the issue:

```
grype db search --pkg "pkg:golang/github.com/gin-gonic/gin@v1.9.0"
DEBUG searching for affected packages os=any pkg=package(name=gin, ecosystem=golang)
No results found
```

looked for `gin`, not `github.com/gin-gonic/gin`.

The reason I didn't just concatenate is that the join is ecosystem-specific and getting it wrong makes things worse elsewhere:

- maven joins on a colon, so `pkg:maven/org.apache.commons/commons-lang3` is `org.apache.commons:commons-lang3`. Took that from `grype/db/v6/name/java.go` rather than inventing it.
- golang, npm, composer, github, bitbucket and swift join on a slash. This also fixes scoped npm, where `pkg:npm/%40types/node` was searching for `node`.
- on an rpm or deb PURL the namespace is the distro, not part of the package name, so those keep using the name alone.

Anything else falls through to the old behaviour, since guessing at a convention I can't point to seemed worse than leaving it.

The CPE specifier still uses the bare `purl.Name` as the product. CPE products aren't namespaced, and `cpe:2.3:a:*:github.com/gin-gonic/gin:*` wouldn't match anything.

Added four cases to `TestDBSearchPackagesPostLoad`. Against the unpatched file the golang, npm and maven ones fail and the rpm one passes, which is the shape I wanted — the rpm case is there to catch a fix that over-corrects.

```
go test ./cmd/grype/cli/options/ -run TestDBSearchPackagesPostLoad
ok  github.com/anchore/grype/cmd/grype/cli/options  0.026s
```
