### PR TITLE
fix(version): prevent panic on portage versions without digits

### DIFF
--- a/grype/version/portage_version.go
+++ b/grype/version/portage_version.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"errors"
 	"math/big"
 	"regexp"
 	"strings"
@@ -20,10 +21,19 @@ type portageVersion struct {
 	version string
 }
 
-func newPortageVersion(raw string) portageVersion {
+// errNoNumericComponent is returned for portage versions that versionRegexp cannot match at all.
+// Every portage version starts with a numeric component, so a value without one (e.g. "none")
+// has nothing for comparePortageVersions to work with.
+var errNoNumericComponent = errors.New("no numeric version component")
+
+func newPortageVersion(raw string) (portageVersion, error) {
+	if versionRegexp.FindStringSubmatch(raw) == nil {
+		return portageVersion{}, invalidFormatError(PortageFormat, raw, errNoNumericComponent)
+	}
+
 	return portageVersion{
 		version: raw,
-	}
+	}, nil
 }
 
 func (v portageVersion) Compare(other *Version) (int, error) {
@@ -31,7 +41,12 @@ func (v portageVersion) Compare(other *Version) (int, error) {
 		return -1, ErrNoVersionProvided
 	}
 
-	return v.compare(newPortageVersion(other.Raw)), nil
+	o, err := newPortageVersion(other.Raw)
+	if err != nil {
+		return 0, err
+	}
+
+	return v.compare(o), nil
 }
 
 // Compare returns 0 if v == v2, -1 if v < v2, and +1 if v > v2.

--- a/grype/version/portage_version_test.go
+++ b/grype/version/portage_version_test.go
@@ -296,3 +296,55 @@ func TestPortageVersion_Compare_EdgeCases(t *testing.T) {
 		})
 	}
 }
+
+func TestPortageVersion_WithoutNumericComponent(t *testing.T) {
+	// every portage version carries a numeric component, so versionRegexp finds nothing in
+	// values like these. that no-match result used to be indexed unconditionally, which
+	// panicked. the matcher recovers matcher panics into a fatal error, and the fatal path
+	// throws away every match collected so far, so one such package took down the whole scan
+	// instead of just being skipped.
+	nonNumeric := []string{"none", "latest", "rolling", "stable", "git", "N/A", "abc"}
+
+	for _, raw := range nonNumeric {
+		t.Run("package version "+raw, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				_, err := New(raw, PortageFormat).Compare(New("1.2.3", PortageFormat))
+				require.ErrorContains(t, err, "no numeric version component")
+			})
+		})
+
+		t.Run("compared-against version "+raw, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				_, err := New("1.2.3", PortageFormat).Compare(New(raw, PortageFormat))
+				require.ErrorContains(t, err, "no numeric version component")
+			})
+		})
+
+		t.Run("constraint check "+raw, func(t *testing.T) {
+			constraint, err := GetConstraint("< 1.2.3", PortageFormat)
+			require.NoError(t, err)
+
+			require.NotPanics(t, func() {
+				_, err := constraint.Satisfied(New(raw, PortageFormat))
+				require.Error(t, err)
+			})
+		})
+	}
+}
+
+func TestPortageVersion_NumericComponentStillAccepted(t *testing.T) {
+	// guards against the rejection above being tightened into something that turns away
+	// versions portage does accept. the check reuses versionRegexp unanchored, so anything
+	// that compared successfully before still does.
+	accepted := []string{"1", "1.2.3", "1.2.3-r1", "1.2.3_alpha1", "1.2.3b", "12.2", "a1"}
+
+	for _, raw := range accepted {
+		t.Run(raw, func(t *testing.T) {
+			_, err := newPortageVersion(raw)
+			require.NoError(t, err)
+
+			_, err = New(raw, PortageFormat).Compare(New("1.2.3", PortageFormat))
+			require.NoError(t, err)
+		})
+	}
+}

--- a/grype/version/version.go
+++ b/grype/version/version.go
@@ -71,7 +71,7 @@ func (v *Version) getComparator(format Format) (Comparator, error) {
 	case GemFormat:
 		comparator, err = newGemVersion(v.Raw)
 	case PortageFormat:
-		comparator = newPortageVersion(v.Raw)
+		comparator, err = newPortageVersion(v.Raw)
 	case JVMFormat:
 		comparator, err = newJvmVersion(v.Raw)
 	case PacmanFormat:


### PR DESCRIPTION
Portage version comparison panics on any version string with no digits in it.

`versionRegexp` needs a numeric component, so `FindStringSubmatch("none")` returns nil and `comparePortageVersions` indexes `match1[1]` without checking. On main this is `index out of range [1] with length 0` at portage_version.go:51. It happens on both sides of the comparison, the package version and the version being compared against.

What makes it worth fixing rather than leaving as a bad-input crash: `callMatcherSafely` turns a matcher panic into a fatal error, and `searchDBForMatches` returns an empty `match.Matches` when it sees one, so everything already collected is dropped. Running the default matchers over two portage packages against a mock provider, openssl with a real advisory plus one sibling package versioned `none`:

```
only openssl 1.1.1                matches=1  err=<nil>
openssl 1.1.1 + sibling "none"    matches=0  err=unable to find matches against vulnerability
                                  database: portage-matcher encountered a fatal error:
                                  runtime error: index out of range [1] with length 0
```

The openssl finding disappears and the scan fails. With this change both cases report the one match.

Reachability is narrow. Syft's portage cataloger cannot produce this, since `cpvRe` in parse_portage_contents.go requires `(\d+)` in the version group, so image and directory scans are fine. The path is grype ingesting package data it did not produce, so `grype sbom:...` with a portage package whose version has no digits.

## Approach

`newPortageVersion` now returns `(portageVersion, error)` the way apk, deb, rpm, pacman and the others already do, and the `PortageFormat` case in `getComparator` picks the error up. It was one of only two cases there ignoring one.

The check reuses the same unanchored `versionRegexp`, so nothing that compared successfully before is turned away. Only values that used to panic now return an error, which gets logged and the package skipped, matching how other malformed versions are already handled.

## Testing

Two tests added. The first covers `none`, `latest`, `rolling`, `stable`, `git`, `N/A` and `abc` on the package side, the compared-against side, and through a constraint check. It panics on main and passes with the change. The second pins versions that have to keep working (`1`, `1.2.3`, `1.2.3-r1`, `1.2.3_alpha1`, `1.2.3b`, `12.2`, `a1`) so the new rejection cannot be tightened into a regression.

`go test ./grype/version/...` passes. A full `go test ./...` before and after gives an identical set of 27 failing packages, all pre-existing failures on my Windows checkout (db, network, CLI and integration suites).

No linked issue, found while property-testing the version comparators for antisymmetry.
