### PR TITLE
docs: point template authors at presenter models

### DIFF
--- a/cmd/grype/cli/options/grype.go
+++ b/cmd/grype/cli/options/grype.go
@@ -186,7 +186,9 @@ valid values are: registry, docker, podman`)
   - './out/**/*.json'
 same as --exclude`)
 	descriptions.Add(&o.File, `if using template output, you must provide a path to a Go template file
-see https://github.com/anchore/grype#using-templates for more information on template output
+see https://github.com/anchore/grype/blob/main/templates/README.md for template output guidance
+and https://github.com/anchore/grype/blob/main/grype/presenter/models for the presenter models
+(Go field names used by templates; not the -o json key casing)
 the default path to the template file is the current working directory
 output-template-file: .grype/html.tmpl
 

--- a/grype/presenter/models/document.go
+++ b/grype/presenter/models/document.go
@@ -13,7 +13,12 @@ import (
 	"github.com/anchore/grype/grype/vulnerability"
 )
 
-// Document represents the JSON document to be presented
+// Document is the top-level presenter model passed to all format presenters
+// (table, JSON, template, and others). Template authors should treat the
+// exported field names on this type and its nested types as the source of
+// truth for Go template field paths (for example .Matches, .Source).
+// JSON struct tags describe the -o json keys, which can differ in casing from
+// the Go field names used in templates.
 type Document struct {
 	Matches         []Match         `json:"matches"`
 	IgnoredMatches  []IgnoredMatch  `json:"ignoredMatches,omitempty"`
@@ -23,7 +28,7 @@ type Document struct {
 	Descriptor      descriptor      `json:"descriptor"`
 }
 
-// NewDocument creates and populates a new Document struct, representing the populated JSON document.
+// NewDocument creates and populates a new Document presenter model.
 //
 //nolint:staticcheck // MetadataProvider is deprecated but still used internally
 func NewDocument(id clio.Identification, packages []pkg.Package, context pkg.Context, matches match.Matches, ignoredMatches []match.IgnoredMatch, metadataProvider vulnerability.MetadataProvider, appConfig any, dbInfo any, strategy SortStrategy, outputTimestamp bool, distroAlerts *DistroAlertData) (Document, error) {

--- a/grype/presenter/models/match.go
+++ b/grype/presenter/models/match.go
@@ -11,7 +11,8 @@ import (
 	"github.com/anchore/grype/internal/log"
 )
 
-// Match is a single item for the JSON array reported
+// Match is a single vulnerability match in the presenter model (one element of Document.Matches).
+// Template authors should use the exported Go field names (Vulnerability, Artifact, and so on).
 type Match struct {
 	Vulnerability          Vulnerability           `json:"vulnerability"`
 	RelatedVulnerabilities []VulnerabilityMetadata `json:"relatedVulnerabilities"`

--- a/grype/presenter/models/package.go
+++ b/grype/presenter/models/package.go
@@ -7,7 +7,8 @@ import (
 	syftPkg "github.com/anchore/syft/syft/pkg"
 )
 
-// Package is meant to be only the fields that are needed when displaying a single pkg.Package object for the JSON presenter.
+// Package is the presenter view of a scanned package (Match.Artifact in templates).
+// Field names here are what template authors should use; json tags apply to -o json only.
 type Package struct {
 	ID           string              `json:"id"`
 	Name         string              `json:"name"`

--- a/templates/README.md
+++ b/templates/README.md
@@ -4,6 +4,18 @@ This folder contains a set of "helper" go templates you can use for your own rep
 
 Please feel free to extend and/or update the templates for your needs, be sure to contribute back into this folder any new templates!
 
+## Template data model
+
+Custom templates receive a [presenter `Document`](../grype/presenter/models/document.go) value. That type (and the nested types in [`grype/presenter/models`](../grype/presenter/models)) is the source of truth for field names and nesting.
+
+Use the **exported Go field names** in templates (for example `{{ .Matches }}`, `{{ .Vulnerability.Severity }}`, `{{ .Artifact.Name }}`). Do not rely on `grype -o json` key names for casing: JSON keys come from `json` struct tags and can differ from the Go identifiers templates must use.
+
+Example:
+
+```bash
+grype alpine:latest -o template -t ./templates/table.tmpl
+```
+
 Current templates:
 
 <pre>


### PR DESCRIPTION
## Summary
Point template authors at the presenter models instead of JSON output for field names.

- Document the presenter `Document` model in `templates/README.md`
- Clarify godoc on presenter model types so templates use Go field names
- Fix the broken `#using-templates` link in CLI option help

Fixes #333