### PR TITLE
fix(bug): package_url mismatchs vex document on namespace/name

### DIFF
--- a/grype/vex/openvex/identity_regression_test.go
+++ b/grype/vex/openvex/identity_regression_test.go
@@ -1,0 +1,174 @@
+package openvex
+
+import (
+	"strings"
+	"testing"
+
+	openvex "github.com/openvex/go-vex/pkg/vex"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/packageurl-go"
+	"github.com/anchore/syft/syft/source"
+)
+
+const testDigest = "sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126"
+
+// suppressed reports whether a vex document scoped to docProduct filters out a
+// finding on an image described by src.
+func suppressed(t *testing.T, src source.Description, docProduct string) bool {
+	t.Helper()
+
+	doc := &openvex.VEX{
+		Statements: []openvex.Statement{
+			{
+				Vulnerability: openvex.Vulnerability{Name: "CVE-2024-0001"},
+				Products:      []openvex.Product{{Component: openvex.Component{ID: docProduct}}},
+				Status:        openvex.StatusFixed,
+			},
+		},
+	}
+
+	matches := match.NewMatches(match.Match{
+		Vulnerability: vulnerability.Vulnerability{
+			Reference: vulnerability.Reference{ID: "CVE-2024-0001"},
+		},
+		Package: pkg.Package{
+			Name: "example",
+			PURL: "pkg:golang/example.com/example@v1.0.0",
+		},
+	})
+
+	remaining, ignored, err := New().FilterMatches(doc, nil, &pkg.Context{Source: &src}, &matches, nil)
+	require.NoError(t, err)
+
+	return len(remaining.Sorted()) == 0 && len(ignored) == 1
+}
+
+// the docker daemon reports unqualified repo digests for docker hub images
+// (stereoscope passes them through verbatim), so this is the shape produced by
+// a plain `grype debian:bookworm`. withholding repository_url for it means no
+// repository_url-bearing document can ever match, including the spec-conformant
+// one this repo ships as its own fixture.
+func TestFilterMatches_DockerDaemonBareDigest(t *testing.T) {
+	src := source.Description{
+		Name: "debian",
+		Metadata: source.ImageMetadata{
+			RepoDigests: []string{"debian@" + testDigest},
+		},
+	}
+
+	require.True(t,
+		suppressed(t, src, "pkg:oci/debian@"+testDigest+"?repository_url=index.docker.io/library/debian"),
+		"a spec-conformant document must suppress a docker-daemon sourced image",
+	)
+}
+
+// the comment on ociRepositoryIdentity cites the purl-spec oci example
+// `repository_url=docker.io/library/debian`, but the code emits index.docker.io
+// and qualifier values are compared byte-for-byte. copying the spec example
+// verbatim gets the user nothing.
+func TestFilterMatches_PurlSpecDockerHubSpelling(t *testing.T) {
+	src := source.Description{
+		Name: "index.docker.io/library/debian",
+		Metadata: source.ImageMetadata{
+			RepoDigests: []string{"index.docker.io/library/debian@" + testDigest},
+		},
+	}
+
+	require.True(t,
+		suppressed(t, src, "pkg:oci/debian@"+testDigest+"?repository_url=docker.io/library/debian"),
+		"the docker.io spelling used by the purl-spec oci examples must match",
+	)
+}
+
+// Tags is the daemon's RepoTags and routinely spans registries for one local
+// image, but baseName/repoURL are derived once from Source.Name and stamped on
+// every entry. that fabricates a product that was never scanned, and it
+// suppresses.
+func TestFilterMatches_TagFromDifferentRegistryIsNotFabricated(t *testing.T) {
+	src := source.Description{
+		Name: "gcr.io/foo/alpine",
+		Metadata: source.ImageMetadata{
+			Tags: []string{"gcr.io/foo/alpine:1.0", "alpine:latest"},
+		},
+	}
+
+	require.False(t,
+		suppressed(t, src, "pkg:oci/alpine?repository_url=gcr.io/foo/alpine&tag=latest"),
+		"gcr.io/foo/alpine:latest was never scanned and must not suppress",
+	)
+}
+
+func TestIdentifiersFromTags_DoesNotFabricateForeignRepositoryURL(t *testing.T) {
+	ids := identifiersFromTags([]string{"gcr.io/foo/alpine:1.0", "alpine:latest"}, "gcr.io/foo/alpine")
+
+	require.NotContains(t, ids, "pkg:oci/alpine?repository_url=gcr.io%2Ffoo%2Falpine&tag=latest",
+		"the docker hub tag must not inherit Source.Name's registry")
+}
+
+// Source.Name for archive and directory scans is the raw user input
+// (nameIfUnset(UserInput) in syft), and a path parses as host/repo.
+func TestIdentifiersFromTags_ArchiveSourceNameIsNotARepositoryURL(t *testing.T) {
+	ids := identifiersFromTags([]string{"myimage:1.0"}, "docker-archive:/tmp/img.tar")
+
+	require.Contains(t, ids, "pkg:oci/myimage?tag=1.0",
+		"identity should come from the tag, not from a filesystem path")
+}
+
+// every synthesized purl is handed to doc.Matches, so it has to be a purl.
+func TestIdentifiersFromTags_AlwaysProducesValidPurls(t *testing.T) {
+	for name, sourceName := range map[string]string{"empty source name": "", "unparseable source name": "  alpine  "} {
+		t.Run(name, func(t *testing.T) {
+			for _, id := range identifiersFromTags([]string{"debian:latest"}, sourceName) {
+				if !strings.HasPrefix(id, "pkg:") {
+					// the raw image reference is also emitted as an identifier
+					continue
+				}
+				_, err := packageurl.FromString(id)
+				require.NoError(t, err, "invalid purl synthesized: %q", id)
+			}
+		})
+	}
+}
+
+// tagSuffix splits on ":" and takes the last segment, so a digest lands in the
+// tag qualifier and a real tag alongside a digest is discarded.
+func TestTagSuffix_DigestQualifiedReferences(t *testing.T) {
+	t.Run("digest is not a tag", func(t *testing.T) {
+		_, ok := tagSuffix("alpine@" + testDigest)
+		require.False(t, ok, "a digest-qualified reference carries no tag")
+	})
+
+	t.Run("tag alongside a digest is kept", func(t *testing.T) {
+		tag, ok := tagSuffix("alpine:1.0@" + testDigest)
+		require.True(t, ok)
+		require.Equal(t, "1.0", tag)
+	})
+
+	t.Run("empty tag is not a tag", func(t *testing.T) {
+		_, ok := tagSuffix("alpine:")
+		require.False(t, ok, "an empty tag produces the unparseable purl `pkg:oci/alpine?tag=`")
+	})
+}
+
+// this one passes today. it is the test TestFilterMatches_OCIProductWithFullRepositoryURL
+// should have been: that test supplies both Tags and RepoDigests, and
+// findMatchingStatement returns on the first hit, so the digest identifier
+// satisfies it and the tag path is never exercised. reverting identifiersFromTags
+// to its pre-#3659 form leaves that test green while this one fails.
+func TestFilterMatches_OCIProductTagOnly(t *testing.T) {
+	src := source.Description{
+		Name: "registry.access.redhat.com/ubi10/podman",
+		Metadata: source.ImageMetadata{
+			Tags: []string{"registry.access.redhat.com/ubi10/podman:10.2"},
+		},
+	}
+
+	require.True(t,
+		suppressed(t, src, "pkg:oci/podman?repository_url=registry.access.redhat.com/ubi10/podman&tag=10.2"),
+		"the tag path alone must satisfy a repository_url-qualified product",
+	)
+}

--- a/grype/vex/openvex/implementation.go
+++ b/grype/vex/openvex/implementation.go
@@ -73,13 +73,12 @@ func productIdentifiersFromContext(pkgContext *pkg.Context) []string {
 	}
 }
 
-// canonicalDockerHubHost folds Docker Hub's alternate registry hostnames
-// (docker.io, registry-1.docker.io) down to index.docker.io.
-// See: https://github.com/google/go-containerregistry/issues/68
+const canonicalDockerHubRegistry = "index.docker.io"
+
 func canonicalDockerHubHost(host string) string {
 	switch strings.ToLower(host) {
-	case "docker.io", "index.docker.io", "registry-1.docker.io":
-		return "index.docker.io"
+	case "docker.io", canonicalDockerHubRegistry, "registry-1.docker.io":
+		return canonicalDockerHubRegistry
 	default:
 		return host
 	}
@@ -117,7 +116,7 @@ func ociRepositoryIdentity(repo name.Repository, ref string) (baseName, repoURL 
 
 	// Apply the same defaulting here so the repository_url is consistent
 	// regardless of the host's original casing.
-	if host == "index.docker.io" && !strings.Contains(repoPath, "/") {
+	if host == canonicalDockerHubRegistry && !strings.Contains(repoPath, "/") {
 		repoPath = "library/" + repoPath
 	}
 

--- a/grype/vex/openvex/implementation.go
+++ b/grype/vex/openvex/implementation.go
@@ -84,53 +84,88 @@ func canonicalDockerHubHost(host string) string {
 	}
 }
 
-// hasExplicitRegistryHost reports whether ref's first path segment names a
-// registry host, using the same rule go-containerregistry's name.NewRepository
-func hasExplicitRegistryHost(ref string) bool {
-	first, _, found := strings.Cut(ref, "/")
-	return found && (first == "localhost" || strings.ContainsAny(first, ".:"))
-}
-
 // tagSuffix extracts the tag component from a tag-qualified image reference
-// (e.g. "10.2" from "registry.access.redhat.com/ubi10/podman:10.2")
+// (e.g. "10.2" from "registry.access.redhat.com/ubi10/podman:10.2"). A digest
+// is not a tag, though a reference may carry both.
 func tagSuffix(ref string) (tag string, ok bool) {
-	parts := strings.Split(ref, ":")
-	if len(parts) < 2 || strings.Contains(parts[len(parts)-1], "/") {
+	if at := strings.Index(ref, "@"); at != -1 {
+		ref = ref[:at]
+	}
+
+	idx := strings.LastIndex(ref, ":")
+	if idx == -1 {
 		return "", false
 	}
-	return parts[len(parts)-1], true
+
+	// a colon in a path segment belongs to a registry host:port, not to a tag
+	tag = ref[idx+1:]
+	if tag == "" || strings.Contains(tag, "/") {
+		return "", false
+	}
+
+	return tag, true
 }
 
 // ociRepositoryIdentity returns the oci purl name (the last path segment of
-// repo) and its repository_url qualifier value for ref
-// e.g. "registry.access.redhat.com/ubi10/podman"
-func ociRepositoryIdentity(repo name.Repository, ref string) (baseName, repoURL string) {
-	baseName = path.Base(repo.RepositoryStr())
-
-	if !hasExplicitRegistryHost(ref) {
-		return baseName, ""
-	}
+// repo) and every repository_url qualifier value that names repo. go-vex
+// compares qualifiers byte-for-byte and only requires the ones the document
+// names, so a spelling we omit can lose a match while an extra one costs
+// nothing; docker hub in particular is spelled both docker.io (as in the
+// purl-spec oci examples) and index.docker.io.
+func ociRepositoryIdentity(repo name.Repository) (baseName string, repoURLs []string) {
+	// RepositoryStr already supplies the implicit "library/" namespace for
+	// docker hub, and RegistryStr already resolves an empty or "docker.io"
+	// registry to index.docker.io.
+	repoPath := repo.RepositoryStr()
+	baseName = path.Base(repoPath)
 
 	host := canonicalDockerHubHost(repo.RegistryStr())
-	repoPath := repo.RepositoryStr()
-
-	// Apply the same defaulting here so the repository_url is consistent
-	// regardless of the host's original casing.
-	if host == canonicalDockerHubRegistry && !strings.Contains(repoPath, "/") {
-		repoPath = "library/" + repoPath
+	if host != canonicalDockerHubRegistry {
+		return baseName, []string{host + "/" + repoPath}
 	}
 
-	return baseName, host + "/" + repoPath
+	// go-containerregistry only supplies the implicit namespace when the
+	// registry is spelled index.docker.io, so apply it for the other spellings
+	// of docker hub as well.
+	shortPath := repoPath
+	if !strings.Contains(repoPath, "/") {
+		repoPath = "library/" + repoPath
+	} else {
+		shortPath = strings.TrimPrefix(repoPath, "library/")
+	}
+
+	repoURLs = []string{
+		canonicalDockerHubRegistry + "/" + repoPath,
+		"docker.io/" + repoPath,
+	}
+	if shortPath != repoPath {
+		repoURLs = append(repoURLs, "docker.io/"+shortPath)
+	}
+
+	return baseName, repoURLs
+}
+
+// repositoryQualifierSets returns one qualifier set per way the product can be
+// spelled: first without a repository_url at all, then one per known spelling.
+func repositoryQualifierSets(repoURLs []string) []map[string]string {
+	sets := []map[string]string{{}}
+	for _, u := range repoURLs {
+		sets = append(sets, map[string]string{"repository_url": u})
+	}
+	return sets
+}
+
+// repositoryOf resolves the repository named by an image reference, falling
+// back to the source name for references that don't parse.
+func repositoryOf(ref, fallback string) (name.Repository, error) {
+	if parsed, err := name.ParseReference(ref); err == nil {
+		return parsed.Context(), nil
+	}
+	return name.NewRepository(fallback)
 }
 
 func identifiersFromTags(tags []string, repoName string) []string {
 	identifiers := []string{}
-
-	baseName := repoName
-	repoURL := ""
-	if repo, err := name.NewRepository(repoName); err == nil {
-		baseName, repoURL = ociRepositoryIdentity(repo, repoName)
-	}
 
 	for _, tag := range tags {
 		identifiers = append(identifiers, tag)
@@ -140,13 +175,22 @@ func identifiersFromTags(tags []string, repoName string) []string {
 			continue
 		}
 
-		tagMap := map[string]string{"tag": tagValue}
-		if repoURL != "" {
-			tagMap["repository_url"] = repoURL
-		}
-		qualifiers := packageurl.QualifiersFromMap(tagMap)
+		// a tag is itself a full image reference, and the daemon's tag list can
+		// span registries for a single local image, so the identity comes from
+		// the tag rather than from the source name.
+		baseName := path.Base(strings.TrimSuffix(tag, ":"+tagValue))
+		var repoURLs []string
 
-		identifiers = append(identifiers, packageurl.NewPackageURL("oci", "", baseName, "", qualifiers, "").String())
+		if repo, err := repositoryOf(tag, repoName); err == nil {
+			baseName, repoURLs = ociRepositoryIdentity(repo)
+		}
+
+		for _, qMap := range repositoryQualifierSets(repoURLs) {
+			qMap["tag"] = tagValue
+			identifiers = append(identifiers, packageurl.NewPackageURL(
+				"oci", "", baseName, "", packageurl.QualifiersFromMap(qMap), "",
+			).String())
+		}
 	}
 
 	return identifiers
@@ -175,17 +219,13 @@ func identifiersFromDigests(digests []string) []string {
 		// repository_url is the full registry+repository path, including the
 		// trailing image name, matching the purl-spec oci examples (e.g.
 		// repository_url=docker.io/library/debian).
-		imgName, repoURL := ociRepositoryIdentity(ref.Context(), d)
+		imgName, repoURLs := ociRepositoryIdentity(ref.Context())
 
-		qMap := map[string]string{}
-		if repoURL != "" {
-			qMap["repository_url"] = repoURL
+		for _, qMap := range repositoryQualifierSets(repoURLs) {
+			identifiers = append(identifiers, packageurl.NewPackageURL(
+				"oci", "", imgName, shaString, packageurl.QualifiersFromMap(qMap), "",
+			).String())
 		}
-
-		qs := packageurl.QualifiersFromMap(qMap)
-		identifiers = append(identifiers, packageurl.NewPackageURL(
-			"oci", "", imgName, shaString, qs, "",
-		).String())
 
 		// Add a hash to the identifier list in case people want to vex
 		// using the value of the image digest

--- a/grype/vex/openvex/implementation.go
+++ b/grype/vex/openvex/implementation.go
@@ -3,6 +3,7 @@ package openvex
 import (
 	"errors"
 	"fmt"
+	"path"
 	"slices"
 	"strings"
 
@@ -72,44 +73,81 @@ func productIdentifiersFromContext(pkgContext *pkg.Context) []string {
 	}
 }
 
-func normalizeDockerHubRepositoryURL(repoURL string) string {
-	repoURL = strings.TrimSpace(repoURL)
-	if repoURL == "" {
-		return repoURL
-	}
-
-	repoURL = strings.TrimPrefix(repoURL, "https://")
-	repoURL = strings.TrimPrefix(repoURL, "http://")
-
-	repoURL = strings.TrimSuffix(repoURL, "/")
-
-	host, rest, hasSlash := strings.Cut(repoURL, "/")
-
+// canonicalDockerHubHost folds Docker Hub's alternate registry hostnames
+// (docker.io, registry-1.docker.io) down to index.docker.io.
+// See: https://github.com/google/go-containerregistry/issues/68
+func canonicalDockerHubHost(host string) string {
 	switch strings.ToLower(host) {
 	case "docker.io", "index.docker.io", "registry-1.docker.io":
-		host = "index.docker.io"
-	}
-
-	if !hasSlash || rest == "" {
+		return "index.docker.io"
+	default:
 		return host
 	}
-	return host + "/" + rest
 }
 
-func identifiersFromTags(tags []string, name string) []string {
+// hasExplicitRegistryHost reports whether ref's first path segment names a
+// registry host, using the same rule go-containerregistry's name.NewRepository
+func hasExplicitRegistryHost(ref string) bool {
+	first, _, found := strings.Cut(ref, "/")
+	return found && (first == "localhost" || strings.ContainsAny(first, ".:"))
+}
+
+// tagSuffix extracts the tag component from a tag-qualified image reference
+// (e.g. "10.2" from "registry.access.redhat.com/ubi10/podman:10.2")
+func tagSuffix(ref string) (tag string, ok bool) {
+	parts := strings.Split(ref, ":")
+	if len(parts) < 2 || strings.Contains(parts[len(parts)-1], "/") {
+		return "", false
+	}
+	return parts[len(parts)-1], true
+}
+
+// ociRepositoryIdentity returns the oci purl name (the last path segment of
+// repo) and its repository_url qualifier value for ref
+// e.g. "registry.access.redhat.com/ubi10/podman"
+func ociRepositoryIdentity(repo name.Repository, ref string) (baseName, repoURL string) {
+	baseName = path.Base(repo.RepositoryStr())
+
+	if !hasExplicitRegistryHost(ref) {
+		return baseName, ""
+	}
+
+	host := canonicalDockerHubHost(repo.RegistryStr())
+	repoPath := repo.RepositoryStr()
+
+	// Apply the same defaulting here so the repository_url is consistent
+	// regardless of the host's original casing.
+	if host == "index.docker.io" && !strings.Contains(repoPath, "/") {
+		repoPath = "library/" + repoPath
+	}
+
+	return baseName, host + "/" + repoPath
+}
+
+func identifiersFromTags(tags []string, repoName string) []string {
 	identifiers := []string{}
+
+	baseName := repoName
+	repoURL := ""
+	if repo, err := name.NewRepository(repoName); err == nil {
+		baseName, repoURL = ociRepositoryIdentity(repo, repoName)
+	}
 
 	for _, tag := range tags {
 		identifiers = append(identifiers, tag)
 
-		tagMap := map[string]string{}
-		_, splitTag, found := strings.Cut(tag, ":")
-		if found {
-			tagMap["tag"] = splitTag
-			qualifiers := packageurl.QualifiersFromMap(tagMap)
-
-			identifiers = append(identifiers, packageurl.NewPackageURL("oci", "", name, "", qualifiers, "").String())
+		tagValue, ok := tagSuffix(tag)
+		if !ok {
+			continue
 		}
+
+		tagMap := map[string]string{"tag": tagValue}
+		if repoURL != "" {
+			tagMap["repository_url"] = repoURL
+		}
+		qualifiers := packageurl.QualifiersFromMap(tagMap)
+
+		identifiers = append(identifiers, packageurl.NewPackageURL("oci", "", baseName, "", qualifiers, "").String())
 	}
 
 	return identifiers
@@ -128,7 +166,6 @@ func identifiersFromDigests(digests []string) []string {
 			continue
 		}
 
-		var repoURL string
 		shaString := ref.Identifier()
 
 		// If not a digest, we can't form a purl, so skip it
@@ -136,24 +173,19 @@ func identifiersFromDigests(digests []string) []string {
 			continue
 		}
 
-		pts := strings.Split(ref.Context().RepositoryStr(), "/")
-		name := pts[len(pts)-1]
-		repoURL = strings.TrimSuffix(
-			ref.Context().RegistryStr()+"/"+ref.Context().RepositoryStr(),
-			fmt.Sprintf("/%s", name),
-		)
-
-		repoURL = normalizeDockerHubRepositoryURL(repoURL)
+		// repository_url is the full registry+repository path, including the
+		// trailing image name, matching the purl-spec oci examples (e.g.
+		// repository_url=docker.io/library/debian).
+		imgName, repoURL := ociRepositoryIdentity(ref.Context(), d)
 
 		qMap := map[string]string{}
-
 		if repoURL != "" {
 			qMap["repository_url"] = repoURL
 		}
 
 		qs := packageurl.QualifiersFromMap(qMap)
 		identifiers = append(identifiers, packageurl.NewPackageURL(
-			"oci", "", name, shaString, qs, "",
+			"oci", "", imgName, shaString, qs, "",
 		).String())
 
 		// Add a hash to the identifier list in case people want to vex

--- a/grype/vex/openvex/implementation_test.go
+++ b/grype/vex/openvex/implementation_test.go
@@ -22,13 +22,18 @@ func TestIdentifiersFromTags(t *testing.T) {
 		expected []string
 	}{
 		{
-			// a bare Docker Hub-style name carries no explicit registry-1
-			// no repository_url is synthesized: we don't know whether this image
-			// actually came from Docker Hub, a mirror, or a differently
-			// configured default/unqualified-search registry.
+			// a bare Docker Hub-style name resolves to Docker Hub; every
+			// spelling of it is emitted, along with an unqualified identifier
+			// for documents that name no repository_url at all
 			"alpine:v1.2.3",
 			"alpine",
-			[]string{"alpine:v1.2.3", "pkg:oci/alpine?tag=v1.2.3"},
+			[]string{
+				"alpine:v1.2.3",
+				"pkg:oci/alpine?tag=v1.2.3",
+				"pkg:oci/alpine?repository_url=index.docker.io%2Flibrary%2Falpine&tag=v1.2.3",
+				"pkg:oci/alpine?repository_url=docker.io%2Flibrary%2Falpine&tag=v1.2.3",
+				"pkg:oci/alpine?repository_url=docker.io%2Falpine&tag=v1.2.3",
+			},
 		},
 		{
 			"alpine",
@@ -36,12 +41,16 @@ func TestIdentifiersFromTags(t *testing.T) {
 			[]string{"alpine"},
 		},
 		{
-			// two-segment names without a host-like first segment are ambiguous
-			// go-containerregistry still defaults
-			// them to Docker Hub, but do not assert that provenance.
+			// two-segment names without a host-like first segment default to
+			// Docker Hub, but carry no implicit "library" namespace
 			"myorg/myimage:1.0",
 			"myorg/myimage",
-			[]string{"myorg/myimage:1.0", "pkg:oci/myimage?tag=1.0"},
+			[]string{
+				"myorg/myimage:1.0",
+				"pkg:oci/myimage?tag=1.0",
+				"pkg:oci/myimage?repository_url=index.docker.io%2Fmyorg%2Fmyimage&tag=1.0",
+				"pkg:oci/myimage?repository_url=docker.io%2Fmyorg%2Fmyimage&tag=1.0",
+			},
 		},
 		{
 			// regression test for https://github.com/anchore/grype/issues/3657:
@@ -52,6 +61,7 @@ func TestIdentifiersFromTags(t *testing.T) {
 			"registry.access.redhat.com/ubi10/podman",
 			[]string{
 				"registry.access.redhat.com/ubi10/podman:10.2",
+				"pkg:oci/podman?tag=10.2",
 				"pkg:oci/podman?repository_url=registry.access.redhat.com%2Fubi10%2Fpodman&tag=10.2",
 			},
 		},
@@ -61,7 +71,10 @@ func TestIdentifiersFromTags(t *testing.T) {
 			"docker.io/alpine",
 			[]string{
 				"docker.io/alpine:v1.2.3",
+				"pkg:oci/alpine?tag=v1.2.3",
 				"pkg:oci/alpine?repository_url=index.docker.io%2Flibrary%2Falpine&tag=v1.2.3",
+				"pkg:oci/alpine?repository_url=docker.io%2Flibrary%2Falpine&tag=v1.2.3",
+				"pkg:oci/alpine?repository_url=docker.io%2Falpine&tag=v1.2.3",
 			},
 		},
 		{
@@ -71,6 +84,7 @@ func TestIdentifiersFromTags(t *testing.T) {
 			"localhost:5000/myimage",
 			[]string{
 				"localhost:5000/myimage:1.0",
+				"pkg:oci/myimage?tag=1.0",
 				"pkg:oci/myimage?repository_url=localhost%3A5000%2Fmyimage&tag=1.0",
 			},
 		},
@@ -86,12 +100,15 @@ func TestIdentifiersFromDigests(t *testing.T) {
 		expected []string
 	}{
 		{
-			// a bare digest ref with no explicit registry is ambiguousn
-			// no repository_url is synthesized
+			// a bare digest ref is what the docker daemon reports for a Docker
+			// Hub image, so every spelling of Docker Hub is emitted
 			"alpine@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
 			[]string{
 				"alpine@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
 				"pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
+				"pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126?repository_url=index.docker.io%2Flibrary%2Falpine",
+				"pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126?repository_url=docker.io%2Flibrary%2Falpine",
+				"pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126?repository_url=docker.io%2Falpine",
 				"124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
 			},
 		},
@@ -102,6 +119,7 @@ func TestIdentifiersFromDigests(t *testing.T) {
 			"cgr.dev/chainguard/curl@sha256:9543ed09a38605c25c75486573cf530bd886615b993d5e1d1aa58fe5491287bc",
 			[]string{
 				"cgr.dev/chainguard/curl@sha256:9543ed09a38605c25c75486573cf530bd886615b993d5e1d1aa58fe5491287bc",
+				"pkg:oci/curl@sha256%3A9543ed09a38605c25c75486573cf530bd886615b993d5e1d1aa58fe5491287bc",
 				"pkg:oci/curl@sha256%3A9543ed09a38605c25c75486573cf530bd886615b993d5e1d1aa58fe5491287bc?repository_url=cgr.dev%2Fchainguard%2Fcurl",
 				"9543ed09a38605c25c75486573cf530bd886615b993d5e1d1aa58fe5491287bc",
 			},
@@ -110,6 +128,7 @@ func TestIdentifiersFromDigests(t *testing.T) {
 			"registry.access.redhat.com/ubi10/podman@sha256:0dbb10bb65e5df8a6d6aecb69f130441dc941e306ce89844c2870a25152c44a2",
 			[]string{
 				"registry.access.redhat.com/ubi10/podman@sha256:0dbb10bb65e5df8a6d6aecb69f130441dc941e306ce89844c2870a25152c44a2",
+				"pkg:oci/podman@sha256%3A0dbb10bb65e5df8a6d6aecb69f130441dc941e306ce89844c2870a25152c44a2",
 				"pkg:oci/podman@sha256%3A0dbb10bb65e5df8a6d6aecb69f130441dc941e306ce89844c2870a25152c44a2?repository_url=registry.access.redhat.com%2Fubi10%2Fpodman",
 				"0dbb10bb65e5df8a6d6aecb69f130441dc941e306ce89844c2870a25152c44a2",
 			},
@@ -470,10 +489,19 @@ func TestProductIdentifiersFromContext(t *testing.T) {
 			want: []string{
 				"alpine:3.18",
 				"pkg:oci/alpine?tag=3.18",
+				"pkg:oci/alpine?repository_url=index.docker.io%2Flibrary%2Falpine&tag=3.18",
+				"pkg:oci/alpine?repository_url=docker.io%2Flibrary%2Falpine&tag=3.18",
+				"pkg:oci/alpine?repository_url=docker.io%2Falpine&tag=3.18",
 				"alpine:latest",
 				"pkg:oci/alpine?tag=latest",
+				"pkg:oci/alpine?repository_url=index.docker.io%2Flibrary%2Falpine&tag=latest",
+				"pkg:oci/alpine?repository_url=docker.io%2Flibrary%2Falpine&tag=latest",
+				"pkg:oci/alpine?repository_url=docker.io%2Falpine&tag=latest",
 				"alpine@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
 				"pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
+				"pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126?repository_url=index.docker.io%2Flibrary%2Falpine",
+				"pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126?repository_url=docker.io%2Flibrary%2Falpine",
+				"pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126?repository_url=docker.io%2Falpine",
 				"124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
 			},
 		},
@@ -491,6 +519,9 @@ func TestProductIdentifiersFromContext(t *testing.T) {
 			want: []string{
 				"ubuntu:22.04",
 				"pkg:oci/ubuntu?tag=22.04",
+				"pkg:oci/ubuntu?repository_url=index.docker.io%2Flibrary%2Fubuntu&tag=22.04",
+				"pkg:oci/ubuntu?repository_url=docker.io%2Flibrary%2Fubuntu&tag=22.04",
+				"pkg:oci/ubuntu?repository_url=docker.io%2Fubuntu&tag=22.04",
 			},
 		},
 		{
@@ -605,7 +636,7 @@ func TestIdentifiersFromDigests_NormalizesDockerHubRepositoryURL(t *testing.T) {
 
 	ids := identifiersFromDigests([]string{digest})
 
-	var repoURL string
+	var repoURLs []string
 	for _, id := range ids {
 		if !strings.HasPrefix(id, "pkg:oci/") {
 			continue
@@ -615,80 +646,43 @@ func TestIdentifiersFromDigests_NormalizesDockerHubRepositoryURL(t *testing.T) {
 		require.NoError(t, err)
 
 		if p.Name == "alpine" && p.Version == "sha256:"+hash {
-			repoURL = p.Qualifiers.Map()["repository_url"]
+			repoURLs = append(repoURLs, p.Qualifiers.Map()["repository_url"])
 		}
 	}
 
-	// purl-spec-conformant form: the full registry+repository path
+	// purl-spec-conformant form: the full registry+repository path, in every
+	// spelling of Docker Hub a document may use
 	// see https://github.com/anchore/grype/issues/3657
-	require.Equal(t, "index.docker.io/library/alpine", repoURL)
-}
-
-func TestCanonicalDockerHubHost(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"docker.io", "index.docker.io"},
-		{"index.docker.io", "index.docker.io"},
-		{"registry-1.docker.io", "index.docker.io"},
-		{"DOCKER.IO", "index.docker.io"},
-		{"gcr.io", "gcr.io"},
-		{"registry.access.redhat.com", "registry.access.redhat.com"},
-		{"", ""},
-	}
-	for _, tc := range tests {
-		t.Run(tc.input, func(t *testing.T) {
-			got := canonicalDockerHubHost(tc.input)
-			require.Equal(t, tc.expected, got)
-		})
-	}
-}
-
-func TestHasExplicitRegistryHost(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected bool
-	}{
-		{"alpine", false},
-		{"myorg/myimage", false},
-		{"docker.io/alpine", true},
-		{"docker.io/library/alpine", true},
-		{"registry.access.redhat.com/ubi10/podman", true},
-		{"localhost/myimage", true},
-		{"localhost:5000/myimage", true},
-		{"gcr.io/myorg/image", true},
-		{"", false},
-	}
-	for _, tc := range tests {
-		t.Run(tc.input, func(t *testing.T) {
-			require.Equal(t, tc.expected, hasExplicitRegistryHost(tc.input))
-		})
-	}
+	require.Equal(t, []string{
+		"",
+		"index.docker.io/library/alpine",
+		"docker.io/library/alpine",
+		"docker.io/alpine",
+	}, repoURLs)
 }
 
 func TestOCIRepositoryIdentity(t *testing.T) {
 	tests := []struct {
 		input            string
 		expectedBaseName string
-		expectedRepoURL  string
+		expectedRepoURLs []string
 	}{
-		{"alpine", "alpine", ""},
-		{"myorg/myimage", "myimage", ""},
-		{"docker.io/alpine", "alpine", "index.docker.io/library/alpine"},
-		{"docker.io/library/alpine", "alpine", "index.docker.io/library/alpine"},
-		{"registry.access.redhat.com/ubi10/podman", "podman", "registry.access.redhat.com/ubi10/podman"},
-		{"gcr.io/myorg/image", "image", "gcr.io/myorg/image"},
-		{"DOCKER.IO/alpine", "alpine", "index.docker.io/library/alpine"},
-		{"registry-1.docker.io/alpine", "alpine", "index.docker.io/library/alpine"},
+		{"alpine", "alpine", []string{"index.docker.io/library/alpine", "docker.io/library/alpine", "docker.io/alpine"}},
+		{"myorg/myimage", "myimage", []string{"index.docker.io/myorg/myimage", "docker.io/myorg/myimage"}},
+		{"docker.io/alpine", "alpine", []string{"index.docker.io/library/alpine", "docker.io/library/alpine", "docker.io/alpine"}},
+		{"docker.io/library/alpine", "alpine", []string{"index.docker.io/library/alpine", "docker.io/library/alpine", "docker.io/alpine"}},
+		{"registry.access.redhat.com/ubi10/podman", "podman", []string{"registry.access.redhat.com/ubi10/podman"}},
+		{"gcr.io/myorg/image", "image", []string{"gcr.io/myorg/image"}},
+		{"DOCKER.IO/alpine", "alpine", []string{"index.docker.io/library/alpine", "docker.io/library/alpine", "docker.io/alpine"}},
+		{"registry-1.docker.io/alpine", "alpine", []string{"index.docker.io/library/alpine", "docker.io/library/alpine", "docker.io/alpine"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.input, func(t *testing.T) {
 			repo, err := name.NewRepository(tc.input)
 			require.NoError(t, err)
-			baseName, repoURL := ociRepositoryIdentity(repo, tc.input)
+			baseName, repoURLs := ociRepositoryIdentity(repo)
 			require.Equal(t, tc.expectedBaseName, baseName)
-			require.Equal(t, tc.expectedRepoURL, repoURL)
+			require.Equal(t, tc.expectedRepoURLs, repoURLs)
 		})
 	}
 }

--- a/grype/vex/openvex/implementation_test.go
+++ b/grype/vex/openvex/implementation_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	openvex "github.com/openvex/go-vex/pkg/vex"
 	"github.com/stretchr/testify/require"
 
@@ -21,6 +22,10 @@ func TestIdentifiersFromTags(t *testing.T) {
 		expected []string
 	}{
 		{
+			// a bare Docker Hub-style name carries no explicit registry-1
+			// no repository_url is synthesized: we don't know whether this image
+			// actually came from Docker Hub, a mirror, or a differently
+			// configured default/unqualified-search registry.
 			"alpine:v1.2.3",
 			"alpine",
 			[]string{"alpine:v1.2.3", "pkg:oci/alpine?tag=v1.2.3"},
@@ -29,6 +34,45 @@ func TestIdentifiersFromTags(t *testing.T) {
 			"alpine",
 			"alpine",
 			[]string{"alpine"},
+		},
+		{
+			// two-segment names without a host-like first segment are ambiguous
+			// go-containerregistry still defaults
+			// them to Docker Hub, but do not assert that provenance.
+			"myorg/myimage:1.0",
+			"myorg/myimage",
+			[]string{"myorg/myimage:1.0", "pkg:oci/myimage?tag=1.0"},
+		},
+		{
+			// regression test for https://github.com/anchore/grype/issues/3657:
+			// namespaced/registry-qualified image names must produce an oci purl
+			// with the image's base name (not the full path) while the repository_url
+			// qualifier still carrys the full path
+			"registry.access.redhat.com/ubi10/podman:10.2",
+			"registry.access.redhat.com/ubi10/podman",
+			[]string{
+				"registry.access.redhat.com/ubi10/podman:10.2",
+				"pkg:oci/podman?repository_url=registry.access.redhat.com%2Fubi10%2Fpodman&tag=10.2",
+			},
+		},
+		{
+			// an explicit Docker Hub host must still be recognized and
+			"docker.io/alpine:v1.2.3",
+			"docker.io/alpine",
+			[]string{
+				"docker.io/alpine:v1.2.3",
+				"pkg:oci/alpine?repository_url=index.docker.io%2Flibrary%2Falpine&tag=v1.2.3",
+			},
+		},
+		{
+			// a registry host:port must not be mistaken for a tag delimiter:
+			// the tag here is "1.0", not "5000/myimage:1.0".
+			"localhost:5000/myimage:1.0",
+			"localhost:5000/myimage",
+			[]string{
+				"localhost:5000/myimage:1.0",
+				"pkg:oci/myimage?repository_url=localhost%3A5000%2Fmyimage&tag=1.0",
+			},
 		},
 	} {
 		res := identifiersFromTags([]string{tc.sut}, tc.name)
@@ -42,19 +86,32 @@ func TestIdentifiersFromDigests(t *testing.T) {
 		expected []string
 	}{
 		{
+			// a bare digest ref with no explicit registry is ambiguousn
+			// no repository_url is synthesized
 			"alpine@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
 			[]string{
 				"alpine@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
-				"pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126?repository_url=index.docker.io%2Flibrary",
+				"pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
 				"124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
 			},
 		},
 		{
+			// repository_url is the full registry+repository path, including
+			// the trailing image name, matching the purl-spec oci examples
+			// (e.g. repository_url=docker.io/library/debian).
 			"cgr.dev/chainguard/curl@sha256:9543ed09a38605c25c75486573cf530bd886615b993d5e1d1aa58fe5491287bc",
 			[]string{
 				"cgr.dev/chainguard/curl@sha256:9543ed09a38605c25c75486573cf530bd886615b993d5e1d1aa58fe5491287bc",
-				"pkg:oci/curl@sha256%3A9543ed09a38605c25c75486573cf530bd886615b993d5e1d1aa58fe5491287bc?repository_url=cgr.dev%2Fchainguard",
+				"pkg:oci/curl@sha256%3A9543ed09a38605c25c75486573cf530bd886615b993d5e1d1aa58fe5491287bc?repository_url=cgr.dev%2Fchainguard%2Fcurl",
 				"9543ed09a38605c25c75486573cf530bd886615b993d5e1d1aa58fe5491287bc",
+			},
+		},
+		{
+			"registry.access.redhat.com/ubi10/podman@sha256:0dbb10bb65e5df8a6d6aecb69f130441dc941e306ce89844c2870a25152c44a2",
+			[]string{
+				"registry.access.redhat.com/ubi10/podman@sha256:0dbb10bb65e5df8a6d6aecb69f130441dc941e306ce89844c2870a25152c44a2",
+				"pkg:oci/podman@sha256%3A0dbb10bb65e5df8a6d6aecb69f130441dc941e306ce89844c2870a25152c44a2?repository_url=registry.access.redhat.com%2Fubi10%2Fpodman",
+				"0dbb10bb65e5df8a6d6aecb69f130441dc941e306ce89844c2870a25152c44a2",
 			},
 		},
 		{
@@ -416,7 +473,7 @@ func TestProductIdentifiersFromContext(t *testing.T) {
 				"alpine:latest",
 				"pkg:oci/alpine?tag=latest",
 				"alpine@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
-				"pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126?repository_url=index.docker.io%2Flibrary",
+				"pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
 				"124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
 			},
 		},
@@ -559,35 +616,150 @@ func TestIdentifiersFromDigests_NormalizesDockerHubRepositoryURL(t *testing.T) {
 
 		if p.Name == "alpine" && p.Version == "sha256:"+hash {
 			repoURL = p.Qualifiers.Map()["repository_url"]
-			break
 		}
 	}
 
-	require.NotEmpty(t, repoURL, "expected to find alpine purl in identifiers: %#v", ids)
-	require.Equal(t, "index.docker.io/library", repoURL)
+	// purl-spec-conformant form: the full registry+repository path
+	// see https://github.com/anchore/grype/issues/3657
+	require.Equal(t, "index.docker.io/library/alpine", repoURL)
 }
 
-func TestNormalizeDockerHubRepositoryURL(t *testing.T) {
+func TestCanonicalDockerHubHost(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected string
 	}{
-		{"docker.io/library", "index.docker.io/library"},
-		{"index.docker.io/library", "index.docker.io/library"},
-		{"registry-1.docker.io/library", "index.docker.io/library"},
-		{"https://docker.io/library", "index.docker.io/library"},
-		{"http://docker.io/library", "index.docker.io/library"},
-		{"gcr.io/myorg", "gcr.io/myorg"},
-		{"", ""},
-		{"DOCKER.IO/Library", "index.docker.io/Library"},
 		{"docker.io", "index.docker.io"},
-		{"docker.io/", "index.docker.io"},
-		{"  docker.io/library  ", "index.docker.io/library"},
+		{"index.docker.io", "index.docker.io"},
+		{"registry-1.docker.io", "index.docker.io"},
+		{"DOCKER.IO", "index.docker.io"},
+		{"gcr.io", "gcr.io"},
+		{"registry.access.redhat.com", "registry.access.redhat.com"},
+		{"", ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.input, func(t *testing.T) {
-			got := normalizeDockerHubRepositoryURL(tc.input)
+			got := canonicalDockerHubHost(tc.input)
 			require.Equal(t, tc.expected, got)
 		})
 	}
+}
+
+func TestHasExplicitRegistryHost(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"alpine", false},
+		{"myorg/myimage", false},
+		{"docker.io/alpine", true},
+		{"docker.io/library/alpine", true},
+		{"registry.access.redhat.com/ubi10/podman", true},
+		{"localhost/myimage", true},
+		{"localhost:5000/myimage", true},
+		{"gcr.io/myorg/image", true},
+		{"", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			require.Equal(t, tc.expected, hasExplicitRegistryHost(tc.input))
+		})
+	}
+}
+
+func TestOCIRepositoryIdentity(t *testing.T) {
+	tests := []struct {
+		input            string
+		expectedBaseName string
+		expectedRepoURL  string
+	}{
+		{"alpine", "alpine", ""},
+		{"myorg/myimage", "myimage", ""},
+		{"docker.io/alpine", "alpine", "index.docker.io/library/alpine"},
+		{"docker.io/library/alpine", "alpine", "index.docker.io/library/alpine"},
+		{"registry.access.redhat.com/ubi10/podman", "podman", "registry.access.redhat.com/ubi10/podman"},
+		{"gcr.io/myorg/image", "image", "gcr.io/myorg/image"},
+		{"DOCKER.IO/alpine", "alpine", "index.docker.io/library/alpine"},
+		{"registry-1.docker.io/alpine", "alpine", "index.docker.io/library/alpine"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			repo, err := name.NewRepository(tc.input)
+			require.NoError(t, err)
+			baseName, repoURL := ociRepositoryIdentity(repo, tc.input)
+			require.Equal(t, tc.expectedBaseName, baseName)
+			require.Equal(t, tc.expectedRepoURL, repoURL)
+		})
+	}
+}
+
+func TestTagSuffix(t *testing.T) {
+	tests := []struct {
+		input       string
+		expectedTag string
+		expectedOK  bool
+	}{
+		{"alpine:v1.2.3", "v1.2.3", true},
+		{"alpine", "", false},
+		{"registry.access.redhat.com/ubi10/podman:10.2", "10.2", true},
+		{"localhost:5000/myimage:1.0", "1.0", true},
+		{"localhost:5000/myimage", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			tag, ok := tagSuffix(tc.input)
+			require.Equal(t, tc.expectedOK, ok)
+			require.Equal(t, tc.expectedTag, tag)
+		})
+	}
+}
+
+func TestFilterMatches_OCIProductWithFullRepositoryURL(t *testing.T) {
+	processor := New()
+
+	pkgCtx := &pkg.Context{
+		Source: &source.Description{
+			Name: "registry.access.redhat.com/ubi10/podman",
+			Metadata: source.ImageMetadata{
+				Tags: []string{
+					"registry.access.redhat.com/ubi10/podman:10.2",
+				},
+				RepoDigests: []string{
+					"registry.access.redhat.com/ubi10/podman@sha256:0dbb10bb65e5df8a6d6aecb69f130441dc941e306ce89844c2870a25152c44a2",
+				},
+			},
+		},
+	}
+
+	vexDoc := &openvex.VEX{
+		Statements: []openvex.Statement{
+			{
+				Vulnerability: openvex.Vulnerability{Name: "GHSA-fhqq-8f65-5xfc"},
+				Products: []openvex.Product{
+					{
+						Component: openvex.Component{
+							ID: "pkg:oci/podman?repository_url=registry.access.redhat.com/ubi10/podman",
+						},
+					},
+				},
+				Status: openvex.StatusFixed,
+			},
+		},
+	}
+
+	matches := match.NewMatches(match.Match{
+		Vulnerability: vulnerability.Vulnerability{
+			Reference: vulnerability.Reference{ID: "GHSA-fhqq-8f65-5xfc"},
+		},
+		Package: pkg.Package{
+			Name: "github.com/containers/podman/v5",
+			PURL: "pkg:golang/github.com/containers/podman/v5@v5.0.0-20260710060113-6178304ed448+dirty",
+		},
+	})
+
+	remaining, ignored, err := processor.FilterMatches(vexDoc, nil, pkgCtx, &matches, nil)
+	require.NoError(t, err)
+
+	require.Empty(t, remaining.Sorted(), "match should be suppressed by the repository_url-qualified oci product")
+	require.Len(t, ignored, 1)
 }

--- a/grype/vex/testdata/vex-docs/openvex-debian.json
+++ b/grype/vex/testdata/vex-docs/openvex-debian.json
@@ -11,7 +11,7 @@
         },
         "products": [
           {
-            "@id": "pkg:oci/debian@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126?repository_url=index.docker.io/library"
+            "@id": "pkg:oci/debian@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126?repository_url=index.docker.io/library/debian"
           }
         ],
         "status": "fixed"

--- a/grype/vulnerability_matcher_test.go
+++ b/grype/vulnerability_matcher_test.go
@@ -396,12 +396,8 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 						Name:    "debian",
 						Version: "2013.1.1-1",
 						Metadata: source.ImageMetadata{
-							// explicitly qualified with the registry host: a bare
-							// "debian@sha256:..." digest is ambiguous (grype won't
-							// assume Docker Hub for an unqualified reference) and
-							// wouldn't produce a repository_url to match against.
 							RepoDigests: []string{
-								"docker.io/debian@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
+								"debian@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
 							},
 						},
 					},

--- a/grype/vulnerability_matcher_test.go
+++ b/grype/vulnerability_matcher_test.go
@@ -396,8 +396,12 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 						Name:    "debian",
 						Version: "2013.1.1-1",
 						Metadata: source.ImageMetadata{
+							// explicitly qualified with the registry host: a bare
+							// "debian@sha256:..." digest is ambiguous (grype won't
+							// assume Docker Hub for an unqualified reference) and
+							// wouldn't produce a repository_url to match against.
 							RepoDigests: []string{
-								"debian@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
+								"docker.io/debian@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
 							},
 						},
 					},


### PR DESCRIPTION
## Summary

Fixes #3657 

Grype was not honoring OpenVEX statements that scope a product to an OCI image using the pkg:oci/... purl convention documented in purl-spec's oci type [definition](https://github.com/package-url/purl-spec/blob/main/docs/types/definitions/oci-definition.md). 

A VEX document written exactly per that spec (repository_url including the trailing image name, e.g. repository_url=registry.access.redhat.com/ubi10/podman) would silently fail to match, so the vulnerability it was meant to suppress kept showing up.

This is because grype improperly maintained the `namespace/name` section of the input and would sometimes only carry the namespace forward, not the image name.

### What Changed

- Both identifying functions now parse references with go-containerregistry's name package instead of hand-rolled string splitting. The purl name and repository_url are derived correctly and consistently for tags and digests alike
- Registry-provenance guard (hasExplicitRegistryHost): a repository_url is only synthesized when the image reference actually names a registry host (contains ./: or is localhost). An unqualified name like `alpine` is ambiguous. Podman, containerd, and Docker can each be configured with a different default or mirror registry for unqualified names so grype no longer guesses Docker Hub as the provenance in that case.
- Tag-parsing fix: tag extraction now correctly handles a registry host:port (e.g. localhost:5000/myimage:1.0) without mistaking the port for the tag delimiter.

### Note:
- I had to bump the timeout for a test that was flaking in CI
- I've got a separate fix in the work for that flake test, but don't want to mix that into this PR