### PR TITLE
Added JUnit template for Azure DevOps

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -11,6 +11,7 @@ Current templates:
 ├── README.md
 ├── html.tmpl
 ├── junit.tmpl
+├── junit-azure-devops.tmpl
 ├── csv.tmpl
 └── table.tmpl
 </pre>

--- a/templates/junit-azure-devops.tmpl
+++ b/templates/junit-azure-devops.tmpl
@@ -2,18 +2,18 @@
 <testsuites name="grype-vulnerability-scan">
     <testsuite name="grype-vulnerability-scan" tests="{{ len .Matches }}" failures="{{ len .Matches }}" errors="0" skipped="0">
         {{- range .Matches }}
-        <testcase classname="{{ .Artifact.Name }}" name="{{ .Vulnerability.ID }} ({{ .Vulnerability.Severity }})" time="0">
-            <failure message="{{ .Vulnerability.ID }}: Vulnerability discovered in package {{ .Artifact.Name }}" type="{{ .Vulnerability.Severity }}">
-Package: {{ .Artifact.Name }}
-Version: {{ .Artifact.Version }}
-Type: {{ .Artifact.Type }}
-Vulnerability: {{ .Vulnerability.ID }}
-Severity: {{ .Vulnerability.Severity }}
-Link: {{ .Vulnerability.DataSource }}
+        <testcase classname="{{ .Artifact.Name | xml }}" name="{{ .Vulnerability.ID | xml }} ({{ .Vulnerability.Severity | xml }})" time="0">
+            <failure message="{{ .Vulnerability.ID | xml }}: Vulnerability discovered in package {{ .Artifact.Name | xml }}" type="{{ .Vulnerability.Severity | xml }}">
+Package: {{ .Artifact.Name | xml }}
+Version: {{ .Artifact.Version | xml }}
+Type: {{ .Artifact.Type | xml }}
+Vulnerability: {{ .Vulnerability.ID | xml }}
+Severity: {{ .Vulnerability.Severity | xml }}
+Link: {{ .Vulnerability.DataSource | xml }}
 Fix Version: {{ if .Vulnerability.Fix.Versions }}{{ join ", " .Vulnerability.Fix.Versions }}{{ else }}None{{ end }}
 
 Description:
-{{ .Vulnerability.Description }}
+{{ .Vulnerability.Description | xml }}
             </failure>
         </testcase>
         {{- end }}

--- a/templates/junit-azure-devops.tmpl
+++ b/templates/junit-azure-devops.tmpl
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="grype-vulnerability-scan">
+    <testsuite name="grype-vulnerability-scan" tests="{{ len .Matches }}" failures="{{ len .Matches }}" errors="0" skipped="0">
+        {{- range .Matches }}
+        <testcase classname="{{ .Artifact.Name }}" name="{{ .Vulnerability.ID }} ({{ .Vulnerability.Severity }})" time="0">
+            <failure message="{{ .Vulnerability.ID }}: Vulnerability discovered in package {{ .Artifact.Name }}" type="{{ .Vulnerability.Severity }}">
+Package: {{ .Artifact.Name }}
+Version: {{ .Artifact.Version }}
+Type: {{ .Artifact.Type }}
+Vulnerability: {{ .Vulnerability.ID }}
+Severity: {{ .Vulnerability.Severity }}
+Link: {{ .Vulnerability.DataSource }}
+Fix Version: {{ if .Vulnerability.Fix.Versions }}{{ join ", " .Vulnerability.Fix.Versions }}{{ else }}None{{ end }}
+
+Description:
+{{ .Vulnerability.Description }}
+            </failure>
+        </testcase>
+        {{- end }}
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
fixes #3626 

This PR adds a new helper template, templates/junit-azure-devops.tmpl, which produces JUnit XML output tailored for Azure DevOps

The context is in the relevant issue tagged.