### PR TITLE
feat: expose distro-fixed dropped matches via ignoredMatches, add --suppressed-sources filter

### DIFF
--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -120,10 +120,21 @@ var ignoreLinuxKernelHeaders = []match.IgnoreRule{
 
 //nolint:funlen
 func runGrype(ctx context.Context, app clio.Application, opts *options.Grype, userInput string) (errs error) {
+	suppressedSources, err := parseSuppressedSources(opts.SuppressedSources)
+	if err != nil {
+		return err
+	}
+
+	// --suppressed-sources implies --show-suppressed. Without this the filter
+	// would silently drop every row because the underlying rendering loop
+	// short-circuits when ShowSuppressed is false.
+	showSuppressed := opts.ShowSuppressed || len(suppressedSources) > 0
+
 	writer, err := format.MakeScanResultWriter(opts.Outputs, opts.File, format.PresentationConfig{
-		TemplateFilePath: opts.OutputTemplateFile,
-		ShowSuppressed:   opts.ShowSuppressed,
-		Pretty:           opts.Pretty,
+		TemplateFilePath:  opts.OutputTemplateFile,
+		ShowSuppressed:    showSuppressed,
+		SuppressedSources: suppressedSources,
+		Pretty:            opts.Pretty,
 	})
 	if err != nil {
 		return err
@@ -560,4 +571,23 @@ func applyVexRules(opts *options.Grype) error {
 	}
 
 	return nil
+}
+
+// parseSuppressedSources splits raw at commas, validates each entry against
+// the defined IgnoreSource values, and returns the resulting slice. An empty
+// or whitespace-only input yields a nil slice and no error, which the caller
+// treats as "no filter".
+func parseSuppressedSources(raw string) ([]string, error) {
+	entries := stringutil.SplitCommaSeparatedString(raw)
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(entries))
+	for _, s := range entries {
+		if !match.IsValidIgnoreSource(s) {
+			return nil, fmt.Errorf("unknown --suppressed-sources %q: valid values are %v", s, match.ValidIgnoreSources())
+		}
+		out = append(out, s)
+	}
+	return out, nil
 }

--- a/cmd/grype/cli/commands/root.go
+++ b/cmd/grype/cli/commands/root.go
@@ -573,21 +573,27 @@ func applyVexRules(opts *options.Grype) error {
 	return nil
 }
 
-// parseSuppressedSources splits raw at commas, validates each entry against
-// the defined IgnoreSource values, and returns the resulting slice. An empty
-// or whitespace-only input yields a nil slice and no error, which the caller
-// treats as "no filter".
+// parseSuppressedSources splits raw at commas, trims each entry, drops
+// entries that are empty after trimming, and validates the remaining entries
+// against the defined IgnoreSource values. Empty or whitespace-only input
+// yields a nil slice and no error, which the caller treats as "no filter".
+// Trimming is what makes list forms like "user-rule, vex" work; without it
+// the leading space on the second entry would fail validation.
 func parseSuppressedSources(raw string) ([]string, error) {
 	entries := stringutil.SplitCommaSeparatedString(raw)
-	if len(entries) == 0 {
-		return nil, nil
-	}
 	out := make([]string, 0, len(entries))
 	for _, s := range entries {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
 		if !match.IsValidIgnoreSource(s) {
 			return nil, fmt.Errorf("unknown --suppressed-sources %q: valid values are %v", s, match.ValidIgnoreSources())
 		}
 		out = append(out, s)
+	}
+	if len(out) == 0 {
+		return nil, nil
 	}
 	return out, nil
 }

--- a/cmd/grype/cli/commands/root_test.go
+++ b/cmd/grype/cli/commands/root_test.go
@@ -367,3 +367,61 @@ func Test_applyVexRules(t *testing.T) {
 		})
 	}
 }
+
+func TestParseSuppressedSources(t *testing.T) {
+	tests := []struct {
+		name       string
+		raw        string
+		wantResult []string
+		wantErrSub string
+	}{
+		{
+			name:       "whitespace-only input yields no filter",
+			raw:        "   ",
+			wantResult: nil,
+		},
+		{
+			name:       "empty input yields no filter",
+			raw:        "",
+			wantResult: nil,
+		},
+		{
+			name:       "spaced comma list is trimmed before validation",
+			raw:        "user-rule, vex",
+			wantResult: []string{"user-rule", "vex"},
+		},
+		{
+			name:       "surrounding whitespace on each entry is trimmed",
+			raw:        "  distro-fixed  ,  vex  ",
+			wantResult: []string{"distro-fixed", "vex"},
+		},
+		{
+			name:       "empty entries in the list are dropped",
+			raw:        "user-rule,,vex,",
+			wantResult: []string{"user-rule", "vex"},
+		},
+		{
+			name:       "valid single value",
+			raw:        "distro-fixed",
+			wantResult: []string{"distro-fixed"},
+		},
+		{
+			name:       "invalid value reports the offending token and lists valid values",
+			raw:        "user-config",
+			wantErrSub: `unknown --suppressed-sources "user-config"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSuppressedSources(tt.raw)
+			if tt.wantErrSub != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrSub)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantResult, got)
+		})
+	}
+}

--- a/cmd/grype/cli/options/grype.go
+++ b/cmd/grype/cli/options/grype.go
@@ -31,6 +31,7 @@ type Grype struct {
 	FailOn                     string             `yaml:"fail-on-severity" json:"fail-on-severity" mapstructure:"fail-on-severity"`
 	Registry                   registry           `yaml:"registry" json:"registry" mapstructure:"registry"`
 	ShowSuppressed             bool               `yaml:"show-suppressed" json:"show-suppressed" mapstructure:"show-suppressed"`
+	SuppressedSources          string             `yaml:"suppressed-sources" json:"suppressed-sources" mapstructure:"suppressed-sources"` // --suppressed-sources, comma-separated list of ignore-source categories to filter --show-suppressed output
 	ByCVE                      bool               `yaml:"by-cve" json:"by-cve" mapstructure:"by-cve"` // --by-cve, indicates if the original match vulnerability IDs should be preserved or the CVE should be used instead
 	SortBy                     SortBy             `yaml:",inline" json:",inline" mapstructure:",squash"`
 	Name                       string             `yaml:"name" json:"name" mapstructure:"name"`
@@ -141,6 +142,11 @@ func (o *Grype) AddFlags(flags clio.FlagSet) {
 	flags.BoolVarP(&o.ShowSuppressed,
 		"show-suppressed", "",
 		"show suppressed/ignored vulnerabilities in the output (only supported with table output format)",
+	)
+
+	flags.StringVarP(&o.SuppressedSources,
+		"suppressed-sources", "",
+		fmt.Sprintf("filter --show-suppressed output to a comma-separated list of ignore-source categories, options=%v; implies --show-suppressed when set (only supported with table output format)", match.ValidIgnoreSources()),
 	)
 
 	flags.StringArrayVarP(&o.Exclusions,

--- a/cmd/grype/cli/options/grype.go
+++ b/cmd/grype/cli/options/grype.go
@@ -32,7 +32,7 @@ type Grype struct {
 	Registry                   registry           `yaml:"registry" json:"registry" mapstructure:"registry"`
 	ShowSuppressed             bool               `yaml:"show-suppressed" json:"show-suppressed" mapstructure:"show-suppressed"`
 	SuppressedSources          string             `yaml:"suppressed-sources" json:"suppressed-sources" mapstructure:"suppressed-sources"` // --suppressed-sources, comma-separated list of ignore-source categories to filter --show-suppressed output
-	ByCVE                      bool               `yaml:"by-cve" json:"by-cve" mapstructure:"by-cve"` // --by-cve, indicates if the original match vulnerability IDs should be preserved or the CVE should be used instead
+	ByCVE                      bool               `yaml:"by-cve" json:"by-cve" mapstructure:"by-cve"`                                     // --by-cve, indicates if the original match vulnerability IDs should be preserved or the CVE should be used instead
 	SortBy                     SortBy             `yaml:",inline" json:",inline" mapstructure:",squash"`
 	Name                       string             `yaml:"name" json:"name" mapstructure:"name"`
 	DefaultImagePullSource     string             `yaml:"default-image-pull-source" json:"default-image-pull-source" mapstructure:"default-image-pull-source"`

--- a/grype/match/ignore.go
+++ b/grype/match/ignore.go
@@ -130,7 +130,7 @@ func DedupeIgnoredMatches(matches []IgnoredMatch) []IgnoredMatch {
 	seen := make(map[Fingerprint]int, len(matches))
 	out := make([]IgnoredMatch, 0, len(matches))
 	for _, im := range matches {
-		fp := im.Match.Fingerprint()
+		fp := im.Fingerprint()
 		if idx, ok := seen[fp]; ok {
 			existing := out[idx]
 			for _, s := range im.Sources {

--- a/grype/match/ignore.go
+++ b/grype/match/ignore.go
@@ -18,12 +18,132 @@ type IgnoreFilter interface {
 	IgnoreMatch(match Match) []IgnoreRule
 }
 
+// IgnoreSource identifies the class of rule that caused a match to end up in
+// the ignored set. Consumers such as the --show-suppressed presenter can group
+// or filter by this without pattern-matching on rule reason strings.
+type IgnoreSource string
+
+const (
+	// IgnoreSourceUserRule marks matches suppressed by a user-provided ignore
+	// rule (e.g. .grype.yaml, --ignore).
+	IgnoreSourceUserRule IgnoreSource = "user-rule"
+
+	// IgnoreSourceDistroFixed marks matches suppressed because the containing
+	// distro package has a FIXED entry that covers this CVE. Emitted by
+	// OwnershipIgnores called with reason "DistroPackageFixed" (introduced in
+	// #3282 to suppress GHSAs on language packages inside fixed APKs).
+	IgnoreSourceDistroFixed IgnoreSource = "distro-fixed"
+
+	// IgnoreSourceExplicitExclusion marks matches dropped by the grype
+	// database's explicit exclusion table (see ApplyExplicitIgnoreRules).
+	IgnoreSourceExplicitExclusion IgnoreSource = "explicit-exclusion"
+
+	// IgnoreSourceVEX marks matches suppressed by a VEX statement.
+	IgnoreSourceVEX IgnoreSource = "vex"
+
+	// IgnoreSourceHardcodedCorrection marks matches suppressed by any other
+	// matcher-returned hard-coded ignore rule (e.g. per-package corrections
+	// for known false positives).
+	IgnoreSourceHardcodedCorrection IgnoreSource = "hardcoded-correction"
+)
+
+// ValidIgnoreSources returns every defined IgnoreSource value as a string
+// slice. CLI flag validation and help text use this to enumerate the valid
+// values without hard-coding the list twice.
+func ValidIgnoreSources() []string {
+	return []string{
+		string(IgnoreSourceUserRule),
+		string(IgnoreSourceDistroFixed),
+		string(IgnoreSourceExplicitExclusion),
+		string(IgnoreSourceVEX),
+		string(IgnoreSourceHardcodedCorrection),
+	}
+}
+
+// IsValidIgnoreSource reports whether s matches one of the defined
+// IgnoreSource string values.
+func IsValidIgnoreSource(s string) bool {
+	switch IgnoreSource(s) {
+	case IgnoreSourceUserRule,
+		IgnoreSourceDistroFixed,
+		IgnoreSourceExplicitExclusion,
+		IgnoreSourceVEX,
+		IgnoreSourceHardcodedCorrection:
+		return true
+	}
+	return false
+}
+
 // An IgnoredMatch is a vulnerability Match that has been ignored because one or more IgnoreRules applied to the match.
 type IgnoredMatch struct {
 	Match
 
 	// AppliedIgnoreRules are the rules that were applied to the match that caused Grype to ignore it.
 	AppliedIgnoreRules []IgnoreRule
+
+	// Sources identifies the category(ies) of rule that caused this match to
+	// be suppressed. When more than one category applied to the same match
+	// fingerprint (e.g. a user rule and a distro-fixed rule both matched, or
+	// two independently-produced matches with the same fingerprint were
+	// dropped for different reasons and later merged by fingerprint), all
+	// applicable categories are preserved in first-observed order. Empty when
+	// callers construct IgnoredMatch directly without tagging.
+	Sources []IgnoreSource `json:"sources,omitempty"`
+}
+
+// WithSource appends src to the Sources slice if it is not already present,
+// preserving order of first occurrence. Returns the receiver so calls can be
+// chained.
+func (im IgnoredMatch) WithSource(src IgnoreSource) IgnoredMatch {
+	for _, existing := range im.Sources {
+		if existing == src {
+			return im
+		}
+	}
+	im.Sources = append(im.Sources, src)
+	return im
+}
+
+// TagIgnoredMatches returns a new slice where every entry has been tagged with
+// the given IgnoreSource. Used by callers that produce a homogeneous batch of
+// suppressions (e.g. all VEX suppressions, all user-rule suppressions).
+func TagIgnoredMatches(matches []IgnoredMatch, src IgnoreSource) []IgnoredMatch {
+	if len(matches) == 0 {
+		return matches
+	}
+	out := make([]IgnoredMatch, len(matches))
+	for i := range matches {
+		out[i] = matches[i].WithSource(src)
+	}
+	return out
+}
+
+// DedupeIgnoredMatches collapses entries that share a Match.Fingerprint,
+// merging Sources as a set (deduped, order-of-first-occurrence) and
+// AppliedIgnoreRules as an append-only union (no dedupe, order-of-first-
+// occurrence). Order of the returned slice follows first-observation order
+// of each unique fingerprint.
+func DedupeIgnoredMatches(matches []IgnoredMatch) []IgnoredMatch {
+	if len(matches) < 2 {
+		return matches
+	}
+	seen := make(map[Fingerprint]int, len(matches))
+	out := make([]IgnoredMatch, 0, len(matches))
+	for _, im := range matches {
+		fp := im.Match.Fingerprint()
+		if idx, ok := seen[fp]; ok {
+			existing := out[idx]
+			for _, s := range im.Sources {
+				existing = existing.WithSource(s)
+			}
+			existing.AppliedIgnoreRules = append(existing.AppliedIgnoreRules, im.AppliedIgnoreRules...)
+			out[idx] = existing
+			continue
+		}
+		seen[fp] = len(out)
+		out = append(out, im)
+	}
+	return out
 }
 
 // An IgnoreRule specifies criteria for a vulnerability match to meet in order

--- a/grype/presenter/models/document.go
+++ b/grype/presenter/models/document.go
@@ -83,6 +83,8 @@ func NewDocument(id clio.Identification, packages []pkg.Package, context pkg.Con
 // newIgnoredMatchModels translates match.IgnoredMatch entries into presenter
 // IgnoredMatch models, resolving each match's owning package and preserving
 // the Sources tags applied upstream.
+//
+//nolint:staticcheck // MetadataProvider is deprecated but still used internally
 func newIgnoredMatchModels(ignoredMatches []match.IgnoredMatch, packages []pkg.Package, metadataProvider vulnerability.MetadataProvider) ([]IgnoredMatch, error) {
 	var models []IgnoredMatch
 	for _, m := range ignoredMatches {
@@ -91,7 +93,7 @@ func newIgnoredMatchModels(ignoredMatches []match.IgnoredMatch, packages []pkg.P
 			return nil, fmt.Errorf("unable to find package in collection: %+v", p)
 		}
 
-		matchModel, err := newMatch(m.Match, *p, metadataProvider) //nolint:staticcheck // MetadataProvider is deprecated but still used internally
+		matchModel, err := newMatch(m.Match, *p, metadataProvider)
 		if err != nil {
 			return nil, err
 		}

--- a/grype/presenter/models/document.go
+++ b/grype/presenter/models/document.go
@@ -59,32 +59,9 @@ func NewDocument(id clio.Identification, packages []pkg.Package, context pkg.Con
 		src = &theSrc
 	}
 
-	var ignoredMatchModels []IgnoredMatch
-	for _, m := range ignoredMatches {
-		p := pkg.ByID(m.Package.ID, packages)
-		if p == nil {
-			return Document{}, fmt.Errorf("unable to find package in collection: %+v", p)
-		}
-
-		matchModel, err := newMatch(m.Match, *p, metadataProvider)
-		if err != nil {
-			return Document{}, err
-		}
-
-		var sources []string
-		if len(m.Sources) > 0 {
-			sources = make([]string, 0, len(m.Sources))
-			for _, s := range m.Sources {
-				sources = append(sources, string(s))
-			}
-		}
-
-		ignoredMatch := IgnoredMatch{
-			Match:              *matchModel,
-			AppliedIgnoreRules: mapIgnoreRules(m.AppliedIgnoreRules),
-			Sources:            sources,
-		}
-		ignoredMatchModels = append(ignoredMatchModels, ignoredMatch)
+	ignoredMatchModels, err := newIgnoredMatchModels(ignoredMatches, packages, metadataProvider)
+	if err != nil {
+		return Document{}, err
 	}
 
 	return Document{
@@ -101,6 +78,39 @@ func NewDocument(id clio.Identification, packages []pkg.Package, context pkg.Con
 			Timestamp:     timestamp,
 		},
 	}, nil
+}
+
+// newIgnoredMatchModels translates match.IgnoredMatch entries into presenter
+// IgnoredMatch models, resolving each match's owning package and preserving
+// the Sources tags applied upstream.
+func newIgnoredMatchModels(ignoredMatches []match.IgnoredMatch, packages []pkg.Package, metadataProvider vulnerability.MetadataProvider) ([]IgnoredMatch, error) {
+	var models []IgnoredMatch
+	for _, m := range ignoredMatches {
+		p := pkg.ByID(m.Package.ID, packages)
+		if p == nil {
+			return nil, fmt.Errorf("unable to find package in collection: %+v", p)
+		}
+
+		matchModel, err := newMatch(m.Match, *p, metadataProvider) //nolint:staticcheck // MetadataProvider is deprecated but still used internally
+		if err != nil {
+			return nil, err
+		}
+
+		var sources []string
+		if len(m.Sources) > 0 {
+			sources = make([]string, 0, len(m.Sources))
+			for _, s := range m.Sources {
+				sources = append(sources, string(s))
+			}
+		}
+
+		models = append(models, IgnoredMatch{
+			Match:              *matchModel,
+			AppliedIgnoreRules: mapIgnoreRules(m.AppliedIgnoreRules),
+			Sources:            sources,
+		})
+	}
+	return models, nil
 }
 
 // createTimestamp creates a timestamp string for the document descriptor.

--- a/grype/presenter/models/document.go
+++ b/grype/presenter/models/document.go
@@ -71,9 +71,18 @@ func NewDocument(id clio.Identification, packages []pkg.Package, context pkg.Con
 			return Document{}, err
 		}
 
+		var sources []string
+		if len(m.Sources) > 0 {
+			sources = make([]string, 0, len(m.Sources))
+			for _, s := range m.Sources {
+				sources = append(sources, string(s))
+			}
+		}
+
 		ignoredMatch := IgnoredMatch{
 			Match:              *matchModel,
 			AppliedIgnoreRules: mapIgnoreRules(m.AppliedIgnoreRules),
+			Sources:            sources,
 		}
 		ignoredMatchModels = append(ignoredMatchModels, ignoredMatch)
 	}

--- a/grype/presenter/models/ignore.go
+++ b/grype/presenter/models/ignore.go
@@ -5,6 +5,11 @@ import "github.com/anchore/grype/grype/match"
 type IgnoredMatch struct {
 	Match
 	AppliedIgnoreRules []IgnoreRule `json:"appliedIgnoreRules"`
+	// Sources identifies the category(ies) of rule that caused the match to
+	// be suppressed. Populated by grype/match.IgnoreSource; consumers can
+	// filter/group by category without pattern-matching on rule reason
+	// strings. See #3450.
+	Sources []string `json:"sources,omitempty"`
 }
 
 type IgnoreRule struct {

--- a/grype/presenter/table/presenter.go
+++ b/grype/presenter/table/presenter.go
@@ -23,9 +23,10 @@ const (
 
 // Presenter is a generic struct for holding fields needed for reporting
 type Presenter struct {
-	document       models.Document
-	showSuppressed bool
-	withColor      bool
+	document          models.Document
+	showSuppressed    bool
+	suppressedSources []string
+	withColor         bool
 
 	recommendedFixStyle lipgloss.Style
 	kevStyle            lipgloss.Style
@@ -93,8 +94,10 @@ func formatPercentileWithSuffix(percentile float64) string {
 	}
 }
 
-// NewPresenter is a *Presenter constructor
-func NewPresenter(pb models.PresenterConfig, showSuppressed bool) *Presenter {
+// NewPresenter is a *Presenter constructor. suppressedSources, when non-empty,
+// restricts the suppressed rows rendered under --show-suppressed to entries
+// whose Sources overlap with the given category list.
+func NewPresenter(pb models.PresenterConfig, showSuppressed bool, suppressedSources []string) *Presenter {
 	withColor := supportsColor()
 	fixStyle := lipgloss.NewStyle().Border(lipgloss.Border{Left: "*"}, false, false, false, true)
 	if withColor {
@@ -103,6 +106,7 @@ func NewPresenter(pb models.PresenterConfig, showSuppressed bool) *Presenter {
 	return &Presenter{
 		document:            pb.Document,
 		showSuppressed:      showSuppressed,
+		suppressedSources:   suppressedSources,
 		withColor:           withColor,
 		recommendedFixStyle: fixStyle,
 		negligibleStyle:     lipgloss.NewStyle().Foreground(lipgloss.Color("240")),                          // dark gray
@@ -119,7 +123,7 @@ func NewPresenter(pb models.PresenterConfig, showSuppressed bool) *Presenter {
 
 // Present creates a JSON-based reporting
 func (p *Presenter) Present(output io.Writer) error {
-	rs := p.getRows(p.document, p.showSuppressed)
+	rs := p.getRows(p.document, p.showSuppressed, p.suppressedSources)
 
 	if len(rs) == 0 {
 		_, err := io.WriteString(output, "No vulnerabilities found\n")
@@ -170,7 +174,7 @@ func newTable(output io.Writer, columns []string) *tablewriter.Table {
 	)
 }
 
-func (p *Presenter) getRows(doc models.Document, showSuppressed bool) rows {
+func (p *Presenter) getRows(doc models.Document, showSuppressed bool, suppressedSources []string) rows {
 	var rs rows
 
 	multipleDistros := false
@@ -194,6 +198,9 @@ func (p *Presenter) getRows(doc models.Document, showSuppressed bool) rows {
 	// generate rows for suppressed vulnerabilities
 	if showSuppressed {
 		for _, m := range doc.IgnoredMatches {
+			if !suppressedSourceAllows(m.Sources, suppressedSources) {
+				continue
+			}
 			msg := appendSuppressed
 			if m.AppliedIgnoreRules != nil {
 				for i := range m.AppliedIgnoreRules {
@@ -206,6 +213,24 @@ func (p *Presenter) getRows(doc models.Document, showSuppressed bool) rows {
 		}
 	}
 	return rs
+}
+
+// suppressedSourceAllows reports whether an IgnoredMatch with the given
+// matchSources should be rendered under the requested filter. An empty
+// requested list means no filter is active (render everything). Otherwise the
+// match passes iff at least one of its Sources appears in requested.
+func suppressedSourceAllows(matchSources []string, requested []string) bool {
+	if len(requested) == 0 {
+		return true
+	}
+	for _, r := range requested {
+		for _, ms := range matchSources {
+			if ms == r {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func supportsColor() bool {

--- a/grype/presenter/table/presenter_test.go
+++ b/grype/presenter/table/presenter_test.go
@@ -103,7 +103,7 @@ func TestCreateRow(t *testing.T) {
 
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
-			p := NewPresenter(models.PresenterConfig{}, false)
+			p := NewPresenter(models.PresenterConfig{}, false, nil)
 			row := p.newRow(testCase.match, testCase.extraAnnotation, false)
 			cols := rows{row}.Render()[0]
 
@@ -118,7 +118,7 @@ func TestTablePresenter(t *testing.T) {
 	t.Run("no color", func(t *testing.T) {
 		var buffer bytes.Buffer
 		lipgloss.SetColorProfile(termenv.Ascii)
-		pres := NewPresenter(pb, false)
+		pres := NewPresenter(pb, false, nil)
 
 		err := pres.Present(&buffer)
 		require.NoError(t, err)
@@ -134,7 +134,7 @@ func TestTablePresenter(t *testing.T) {
 			// don't affect other tests
 			lipgloss.SetColorProfile(termenv.Ascii)
 		})
-		pres := NewPresenter(pb, false)
+		pres := NewPresenter(pb, false, nil)
 
 		err := pres.Present(&buffer)
 		require.NoError(t, err)
@@ -155,7 +155,7 @@ func TestEmptyTablePresenter(t *testing.T) {
 		Document: doc,
 	}
 
-	pres := NewPresenter(pb, false)
+	pres := NewPresenter(pb, false, nil)
 
 	// run presenter
 	err = pres.Present(&buffer)
@@ -172,7 +172,7 @@ func TestHidesIgnoredMatches(t *testing.T) {
 		Document: internal.GenerateAnalysisWithIgnoredMatches(t, internal.ImageSource),
 	}
 
-	pres := NewPresenter(pb, false)
+	pres := NewPresenter(pb, false, nil)
 
 	err := pres.Present(&buffer)
 	require.NoError(t, err)
@@ -187,7 +187,7 @@ func TestDisplaysIgnoredMatches(t *testing.T) {
 		Document: internal.GenerateAnalysisWithIgnoredMatches(t, internal.ImageSource),
 	}
 
-	pres := NewPresenter(pb, true)
+	pres := NewPresenter(pb, true, nil)
 
 	err := pres.Present(&buffer)
 	require.NoError(t, err)
@@ -205,7 +205,7 @@ func TestDisplaysDistro(t *testing.T) {
 	pb.Document.Matches[0].Vulnerability.Namespace = "ubuntu:distro:ubuntu:2.5"
 	pb.Document.Matches[1].Vulnerability.Namespace = "ubuntu:distro:ubuntu:3.5"
 
-	pres := NewPresenter(pb, false)
+	pres := NewPresenter(pb, false, nil)
 
 	err := pres.Present(&buffer)
 	require.NoError(t, err)
@@ -226,7 +226,7 @@ func TestDisplaysIgnoredMatchesAndDistro(t *testing.T) {
 	pb.Document.IgnoredMatches[0].Vulnerability.Namespace = "ubuntu:distro:ubuntu:2.5"
 	pb.Document.IgnoredMatches[1].Vulnerability.Namespace = "ubuntu:distro:ubuntu:3.5"
 
-	pres := NewPresenter(pb, true)
+	pres := NewPresenter(pb, true, nil)
 
 	err := pres.Present(&buffer)
 	require.NoError(t, err)
@@ -336,7 +336,7 @@ func createTestRow(name, version, fix, pkgType, vulnID, severity string, fixStat
 		},
 	}
 
-	p := NewPresenter(models.PresenterConfig{}, false)
+	p := NewPresenter(models.PresenterConfig{}, false, nil)
 	r := p.newRow(m, "", false)
 
 	return r, nil
@@ -465,4 +465,116 @@ func mustRow(t *testing.T, name, version, fix, pkgType, vulnID, severity string,
 		t.Fatalf("failed to create test row: %v", err)
 	}
 	return r
+}
+
+func TestSuppressedSourceAllows(t *testing.T) {
+	tests := []struct {
+		name         string
+		matchSources []string
+		requested    []string
+		want         bool
+	}{
+		{
+			name:         "empty requested renders everything",
+			matchSources: []string{"distro-fixed"},
+			requested:    nil,
+			want:         true,
+		},
+		{
+			name:         "single-value requested that matches",
+			matchSources: []string{"distro-fixed"},
+			requested:    []string{"distro-fixed"},
+			want:         true,
+		},
+		{
+			name:         "single-value requested that does not match",
+			matchSources: []string{"user-rule"},
+			requested:    []string{"distro-fixed"},
+			want:         false,
+		},
+		{
+			name:         "multi-value requested with one matching entry",
+			matchSources: []string{"vex"},
+			requested:    []string{"distro-fixed", "vex"},
+			want:         true,
+		},
+		{
+			name:         "multi-value requested, none matching",
+			matchSources: []string{"user-rule"},
+			requested:    []string{"distro-fixed", "vex"},
+			want:         false,
+		},
+		{
+			name:         "match has multiple sources, one in requested",
+			matchSources: []string{"explicit-exclusion", "distro-fixed"},
+			requested:    []string{"vex", "distro-fixed"},
+			want:         true,
+		},
+		{
+			name:         "match has no sources, filter is active",
+			matchSources: nil,
+			requested:    []string{"distro-fixed"},
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := suppressedSourceAllows(tt.matchSources, tt.requested)
+			if got != tt.want {
+				t.Errorf("suppressedSourceAllows(%v, %v) = %v, want %v", tt.matchSources, tt.requested, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDisplaysIgnoredMatches_FilteredBySuppressedSource(t *testing.T) {
+	// Base document with two IgnoredMatch entries produced by the shared
+	// fixture. Tag each with a distinct Source so the filter can distinguish
+	// them.
+	build := func() models.Document {
+		d := internal.GenerateAnalysisWithIgnoredMatches(t, internal.ImageSource)
+		require.GreaterOrEqual(t, len(d.IgnoredMatches), 2, "fixture must supply at least two ignored matches for this test")
+		d.IgnoredMatches[0].Sources = []string{string(match.IgnoreSourceDistroFixed)}
+		d.IgnoredMatches[1].Sources = []string{string(match.IgnoreSourceUserRule)}
+		return d
+	}
+
+	t.Run("nil filter renders every ignored entry", func(t *testing.T) {
+		var buffer bytes.Buffer
+		pres := NewPresenter(models.PresenterConfig{Document: build()}, true, nil)
+		require.NoError(t, pres.Present(&buffer))
+
+		out := buffer.String()
+		assert.Contains(t, out, "CVE-1999-0001")
+		assert.Contains(t, out, "CVE-1999-0002")
+	})
+
+	t.Run("distro-fixed filter drops the user-rule entry", func(t *testing.T) {
+		var buffer bytes.Buffer
+		pres := NewPresenter(models.PresenterConfig{Document: build()}, true, []string{string(match.IgnoreSourceDistroFixed)})
+		require.NoError(t, pres.Present(&buffer))
+
+		out := buffer.String()
+		assert.Contains(t, out, "CVE-1999-0001", "distro-fixed entry should render")
+		// CVE-1999-0002 is the user-rule entry in this test fixture; it must be
+		// filtered out. Note: it also appears as a top-level Match in the same
+		// document (Sources filter is scoped to IgnoredMatches only), so we
+		// assert on the suppressed-annotation row instead.
+		assert.NotContains(t, out, "CVE-1999-0002  Low       suppressed", "user-rule entry should be filtered out under --suppressed-sources=distro-fixed")
+	})
+
+	t.Run("multi-value filter renders every matching entry", func(t *testing.T) {
+		var buffer bytes.Buffer
+		pres := NewPresenter(
+			models.PresenterConfig{Document: build()},
+			true,
+			[]string{string(match.IgnoreSourceDistroFixed), string(match.IgnoreSourceUserRule)},
+		)
+		require.NoError(t, pres.Present(&buffer))
+
+		out := buffer.String()
+		assert.Contains(t, out, "CVE-1999-0001")
+		assert.Contains(t, out, "CVE-1999-0002")
+	})
 }

--- a/grype/vulnerability_matcher.go
+++ b/grype/vulnerability_matcher.go
@@ -138,7 +138,7 @@ func (m *VulnerabilityMatcher) findDBMatches(ctx context.Context, pkgs []pkg.Pac
 	var ignoredMatches []match.IgnoredMatch
 
 	log.Trace("finding matches against DB")
-	matches, err := m.searchDBForMatches(ctx, pkgs, progressMonitor)
+	matches, hardCodedIgnored, err := m.searchDBForMatches(ctx, pkgs, progressMonitor)
 	if err != nil {
 		if match.IsFatalError(err) {
 			return nil, nil, err
@@ -149,7 +149,9 @@ func (m *VulnerabilityMatcher) findDBMatches(ctx context.Context, pkgs []pkg.Pac
 		log.WithFields("error", err).Debug("error(s) returned from searchDBForMatches")
 	}
 
-	matches, ignoredMatches = m.applyIgnoreRules(matches)
+	var userRuleIgnored []match.IgnoredMatch
+	matches, userRuleIgnored = m.applyIgnoreRules(matches)
+	userRuleIgnored = match.TagIgnoredMatches(userRuleIgnored, match.IgnoreSourceUserRule)
 
 	if m.NormalizeByCVE {
 		normalizedMatches := match.NewMatches()
@@ -161,10 +163,13 @@ func (m *VulnerabilityMatcher) findDBMatches(ctx context.Context, pkgs []pkg.Pac
 		// regresses the results (relative to the already applied ignore rules). Why do we additionally apply
 		// the ignore rules before normalizing? In case the user has a rule that ignores a non-normalized
 		// vulnerability ID, we wantMatches to ensure that the rule is honored.
-		originalIgnoredMatches := ignoredMatches
-		matches, ignoredMatches = m.applyIgnoreRules(normalizedMatches)
-		ignoredMatches = m.mergeIgnoredMatches(originalIgnoredMatches, ignoredMatches)
+		originalUserRuleIgnored := userRuleIgnored
+		matches, userRuleIgnored = m.applyIgnoreRules(normalizedMatches)
+		userRuleIgnored = match.TagIgnoredMatches(userRuleIgnored, match.IgnoreSourceUserRule)
+		userRuleIgnored = m.mergeIgnoredMatches(originalUserRuleIgnored, userRuleIgnored)
 	}
+
+	ignoredMatches = m.mergeIgnoredMatches(hardCodedIgnored, userRuleIgnored)
 
 	return &matches, ignoredMatches, nil
 }
@@ -179,7 +184,11 @@ func (m *VulnerabilityMatcher) mergeIgnoredMatches(allIgnoredMatches ...[]match.
 			out = append(out, ignored)
 		}
 	}
-	return out
+	// Collapse entries that share a fingerprint (e.g. two matchers produced
+	// the same match and both drops were captured, or NormalizeByCVE just
+	// collapsed two fingerprints into one). Sources merge as a set; applied
+	// ignore rules concatenate.
+	return match.DedupeIgnoredMatches(out)
 }
 
 //nolint:funlen
@@ -187,9 +196,20 @@ func (m *VulnerabilityMatcher) searchDBForMatches(
 	ctx context.Context,
 	packages []pkg.Package,
 	progressMonitor *monitorWriter,
-) (match.Matches, error) {
+) (match.Matches, []match.IgnoredMatch, error) {
 	var allMatches []match.Match
 	var allIgnorers []match.IgnoreFilter
+	// hardCodedIgnored aggregates every match that a hard-coded rule (i.e.
+	// not a user-supplied one) suppressed during this pass. Two categories:
+	//   * explicit-exclusion: dropped by the DB's explicit-exclusion table
+	//     via ApplyExplicitIgnoreRules (per-package, inside the matcher loop).
+	//   * distro-fixed / hardcoded-correction: dropped by matcher-returned
+	//     IgnoreFilter(s) via ApplyIgnoreFilters. distro-fixed is the label
+	//     used when the applied rule's Reason string equals
+	//     "DistroPackageFixed" (the reason emitted by OwnershipIgnores for
+	//     the #3282 suppression path); everything else on this path is
+	//     tagged hardcoded-correction.
+	var hardCodedIgnored []match.IgnoredMatch
 	matcherIndex, defaultMatcher := newMatcherIndex(m.Matchers)
 
 	if defaultMatcher == nil {
@@ -218,13 +238,13 @@ func (m *VulnerabilityMatcher) searchDBForMatches(
 		}
 		for _, theMatcher := range matchAgainst {
 			if err := ctx.Err(); err != nil {
-				return match.Matches{}, err
+				return match.Matches{}, nil, err
 			}
 
 			matches, ignorers, err := callMatcherSafely(theMatcher, m.VulnerabilityProvider, p)
 			if err != nil {
 				if match.IsFatalError(err) {
-					return match.Matches{}, err
+					return match.Matches{}, nil, err
 				}
 
 				log.WithFields("error", err, "package", displayPackage(p)).Warn("matcher returned error")
@@ -240,12 +260,20 @@ func (m *VulnerabilityMatcher) searchDBForMatches(
 			logPackageMatches(p, additionalMatches)
 			logExplicitDroppedPackageMatches(p, dropped)
 			allMatches = append(allMatches, additionalMatches...)
+			hardCodedIgnored = append(hardCodedIgnored, match.TagIgnoredMatches(dropped, match.IgnoreSourceExplicitExclusion)...)
 
 			progressMonitor.MatchesDiscovered.Add(int64(len(additionalMatches)))
 
 			// note: there is a difference between "ignore" and "dropped" matches.
 			// ignored: matches that are filtered out due to user-provided ignore rules
 			// dropped: matches that are filtered out due to hard-coded rules
+			//
+			// Historically, "dropped" was logged and then discarded (issue
+			// #3450). We now surface it via FindMatchesContext's returned
+			// ignoredMatches, tagged with an IgnoreSource so consumers can
+			// distinguish these from user-rule ignores. This restores
+			// visibility into regressions that the #3282 distro-fixed
+			// suppression path would otherwise hide.
 			updateVulnerabilityList(progressMonitor, additionalMatches, nil, dropped, m.VulnerabilityProvider)
 		}
 	}
@@ -255,6 +283,7 @@ func (m *VulnerabilityMatcher) searchDBForMatches(
 	filtered, dropped := match.ApplyIgnoreFilters(allMatches, ignoredMatchFilter(allIgnorers))
 	logIgnoredMatches(dropped)
 	log.Debugf("took %v to process %v vulns with %v ignores", time.Since(startTime), len(allMatches), len(allIgnorers))
+	hardCodedIgnored = append(hardCodedIgnored, tagMatcherReturnedIgnores(dropped)...)
 
 	// get deduplicated set of matches
 	res := match.NewMatches(filtered...)
@@ -262,8 +291,40 @@ func (m *VulnerabilityMatcher) searchDBForMatches(
 	// update the total discovered matches after removing all duplicates and ignores
 	progressMonitor.MatchesDiscovered.Set(int64(res.Count()))
 
-	return res, errors.Join(matcherErrs...)
+	return res, hardCodedIgnored, errors.Join(matcherErrs...)
 }
+
+// tagMatcherReturnedIgnores tags each IgnoredMatch produced by the global
+// ApplyIgnoreFilters pass with an IgnoreSource. The distro-fixed label is used
+// when any applied rule's Reason matches the sentinel string emitted by
+// OwnershipIgnores for the #3282 suppression path
+// ("DistroPackageFixed"); any other matcher-returned rule falls through to
+// hardcoded-correction.
+func tagMatcherReturnedIgnores(dropped []match.IgnoredMatch) []match.IgnoredMatch {
+	if len(dropped) == 0 {
+		return dropped
+	}
+	out := make([]match.IgnoredMatch, len(dropped))
+	for i, im := range dropped {
+		src := match.IgnoreSourceHardcodedCorrection
+		for _, rule := range im.AppliedIgnoreRules {
+			if rule.Reason == distroPackageFixedReason {
+				src = match.IgnoreSourceDistroFixed
+				break
+			}
+		}
+		out[i] = im.WithSource(src)
+	}
+	return out
+}
+
+// distroPackageFixedReason is the sentinel string OwnershipIgnores passes
+// through to IgnoreRule.Reason for the #3282 suppression path (a distro
+// package that is FIXED for the vuln suppresses bundled-component matches for
+// the same vuln). It lives here rather than being imported from
+// grype/matcher/internal to avoid an import cycle; the constant matches the
+// literal used at grype/matcher/internal/distro.go:105.
+const distroPackageFixedReason = "DistroPackageFixed"
 
 func callMatcherSafely(m match.Matcher, vp vulnerability.Provider, p pkg.Package) (matches []match.Match, ignoredMatches []match.IgnoreFilter, err error) {
 	// handle individual matcher panics
@@ -290,6 +351,13 @@ func (m *VulnerabilityMatcher) findVEXMatches(pkgContext pkg.Context, remainingM
 	diffMatches := matchesAfterVex.Diff(*remainingMatches)
 	// note: this assumes that the diff can only be additive
 	diffIgnoredMatches := ignoredMatchesDiff(ignoredMatchesAfterVex, ignoredMatches)
+
+	// Tag the entries VEX just added as IgnoreSourceVEX, then merge them back
+	// into the returned slice by fingerprint so callers see the label. Entries
+	// that pre-existed the VEX pass keep whatever source they were tagged
+	// with earlier (user-rule, distro-fixed, etc.).
+	taggedVEX := match.TagIgnoredMatches(diffIgnoredMatches, match.IgnoreSourceVEX)
+	ignoredMatchesAfterVex = m.mergeIgnoredMatches(ignoredMatches, taggedVEX)
 
 	updateVulnerabilityList(progressMonitor, diffMatches.Sorted(), diffIgnoredMatches, nil, m.VulnerabilityProvider)
 

--- a/grype/vulnerability_matcher_sources_test.go
+++ b/grype/vulnerability_matcher_sources_test.go
@@ -1,0 +1,154 @@
+package grype
+
+// Regression test for anchore/grype#3450 (see also #3282).
+//
+// Before this change, matches suppressed by the distro-fixed ownership rule
+// (OwnershipIgnores(..., "DistroPackageFixed", ...)) were silently dropped
+// inside searchDBForMatches and never returned to callers, so `--show-suppressed`
+// could not surface a regressed CVE that a FIXED secfix entry was hiding
+// (see the fuse-overlayfs-snapshotter / CVE-2026-25679 worked example in
+// #3450 and https://packages.cgr.dev/chainguard/security.json).
+//
+// This test asserts:
+//   1. The suppressed bundled-component match reaches the caller in the
+//      second return of FindMatches / FindMatchesContext.
+//   2. Its Sources slice contains match.IgnoreSourceDistroFixed.
+//   3. Its AppliedIgnoreRules preserve the "DistroPackageFixed" reason
+//      string and reference the containing APK by name.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/grype/grype/distro"
+	"github.com/anchore/grype/grype/match"
+	matcherMock "github.com/anchore/grype/grype/matcher/mock"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/version"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/grype/grype/vulnerability/mock"
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/file"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+func TestVulnerabilityMatcher_DistroFixedSuppressionSurfacesIgnoredMatch(t *testing.T) {
+	apkPkgID := pkg.ID("apk-fuse-overlayfs-snapshotter")
+	stdlibPkgID := pkg.ID("go-stdlib")
+
+	// The Go stdlib CVE as it appears in the NVD provider (grype's nvd:cpe
+	// entry for cpe:2.3:a:golang:go:*).
+	stdlibVuln := vulnerability.Vulnerability{
+		Reference: vulnerability.Reference{
+			ID:        "CVE-2026-25679",
+			Namespace: "nvd:cpe",
+		},
+		PackageName: "stdlib",
+		Constraint:  version.MustGetConstraint("< 1.25.8", version.UnknownFormat),
+	}
+
+	// APK package fuse-overlayfs-snapshotter@2.1.7-r7 owns the stdlib binary
+	// via file overlap. The secfix entry at 2.1.7-r3 says CVE-2026-25679 is
+	// FIXED, so grype's OwnershipIgnores emits an IgnoreRelatedPackage rule
+	// with Reason "DistroPackageFixed" that suppresses the stdlib match.
+	apkPkg := pkg.Package{
+		ID:      apkPkgID,
+		Name:    "fuse-overlayfs-snapshotter",
+		Version: "2.1.7-r7",
+		Type:    syftPkg.ApkPkg,
+		Distro:  distro.New(distro.Chainguard, "", ""),
+		Metadata: pkg.ApkMetadata{Files: []pkg.ApkFileRecord{
+			{Path: "/usr/bin/containerd-fuse-overlayfs-grpc"},
+		}},
+	}
+	stdlibPkg := pkg.Package{
+		ID:      stdlibPkgID,
+		Name:    "stdlib",
+		Version: "go1.24.13",
+		Type:    syftPkg.GoModulePkg,
+		Locations: file.NewLocationSet(
+			file.NewLocation("/usr/bin/containerd-fuse-overlayfs-grpc"),
+		),
+		RelatedPackages: map[artifact.RelationshipType][]*pkg.Package{
+			artifact.OwnershipByFileOverlapRelationship: {
+				{ID: apkPkgID, Name: "fuse-overlayfs-snapshotter"},
+			},
+		},
+	}
+
+	vp := mock.VulnerabilityProvider(stdlibVuln)
+
+	// APK matcher returns no matches (r7 satisfies the FIXED constraint at
+	// r3, so the APK itself is not vulnerable) but returns an
+	// IgnoreRelatedPackage filter tagged with the sentinel
+	// "DistroPackageFixed" reason string that OwnershipIgnores uses in
+	// production (grype/matcher/internal/distro.go).
+	apkMatcher := matcherMock.New(syftPkg.ApkPkg, func(_ vulnerability.Provider, p pkg.Package) ([]match.Match, []match.IgnoreFilter, error) {
+		if p.Type != syftPkg.ApkPkg {
+			return nil, nil, nil
+		}
+		return nil, []match.IgnoreFilter{
+			match.IgnoreRelatedPackage{
+				Reason:           "DistroPackageFixed",
+				RelationshipType: artifact.OwnershipByFileOverlapRelationship,
+				VulnerabilityID:  stdlibVuln.ID,
+				RelatedPackageID: p.ID,
+			},
+		}, nil
+	})
+
+	// Go matcher returns the stdlib match for the CVE (which will then be
+	// suppressed by the apk matcher's returned filter).
+	goMatcher := matcherMock.New(syftPkg.GoModulePkg, func(_ vulnerability.Provider, p pkg.Package) ([]match.Match, []match.IgnoreFilter, error) {
+		if p.Type != syftPkg.GoModulePkg {
+			return nil, nil, nil
+		}
+		return []match.Match{
+			{
+				Vulnerability: stdlibVuln,
+				Package:       p,
+				Details: match.Details{
+					{
+						Type:       match.CPEMatch,
+						Confidence: 1.0,
+						Matcher:    "go-matcher",
+					},
+				},
+			},
+		}, nil, nil
+	})
+
+	m := &VulnerabilityMatcher{
+		VulnerabilityProvider: vp,
+		Matchers:              []match.Matcher{apkMatcher, goMatcher},
+	}
+
+	remaining, ignored, err := m.FindMatches(
+		[]pkg.Package{apkPkg, stdlibPkg},
+		pkg.Context{},
+	)
+	require.NoError(t, err)
+
+	assert.Zero(t, remaining.Count(),
+		"main match set should be empty; the stdlib match should have been suppressed by the DistroPackageFixed rule")
+
+	require.Len(t, ignored, 1,
+		"expected exactly one entry in ignoredMatches carrying the suppressed stdlib match")
+	got := ignored[0]
+
+	assert.Equal(t, "CVE-2026-25679", got.Match.Vulnerability.ID)
+	assert.Equal(t, "stdlib", got.Match.Package.Name)
+	assert.Equal(t, "go1.24.13", got.Match.Package.Version)
+
+	// Sources: exactly one entry tagged distro-fixed.
+	assert.Equal(t, []match.IgnoreSource{match.IgnoreSourceDistroFixed}, got.Sources,
+		"expected the suppressed match to be tagged IgnoreSourceDistroFixed")
+
+	// AppliedIgnoreRules: the OwnershipIgnores reason string and vulnerability
+	// id are preserved verbatim.
+	require.NotEmpty(t, got.AppliedIgnoreRules)
+	assert.Equal(t, "DistroPackageFixed", got.AppliedIgnoreRules[0].Reason)
+	assert.Equal(t, "CVE-2026-25679", got.AppliedIgnoreRules[0].Vulnerability)
+}

--- a/grype/vulnerability_matcher_test.go
+++ b/grype/vulnerability_matcher_test.go
@@ -406,6 +406,7 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 			wantMatches: match.NewMatches(),
 			wantIgnoredMatches: []match.IgnoredMatch{
 				{
+					Sources: []match.IgnoreSource{match.IgnoreSourceVEX},
 					AppliedIgnoreRules: []match.IgnoreRule{
 						{
 							Namespace: "vex",
@@ -734,6 +735,7 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 							Vulnerability: "GHSA-2014-fake-3",
 						},
 					},
+					Sources: []match.IgnoreSource{match.IgnoreSourceUserRule},
 				},
 			},
 		},
@@ -808,50 +810,11 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 						{
 							Vulnerability: "CVE-2014-fake-3",
 						},
-					},
-				},
-				{
-					AppliedIgnoreRules: []match.IgnoreRule{
 						{
 							Vulnerability: "CVE-2014-fake-3",
 						},
 					},
-					Match: match.Match{
-						Vulnerability: vulnerability.Vulnerability{
-							PackageName: "activerecord",
-							Constraint:  version.MustGetConstraint("< 3.7.6", version.UnknownFormat),
-							Reference: vulnerability.Reference{
-								ID:        "CVE-2014-fake-3",
-								Namespace: "nvd:cpe",
-							},
-							CPEs:              []cpe.CPE{},
-							PackageQualifiers: []qualifier.Qualifier{},
-							Advisories:        []vulnerability.Advisory{},
-							RelatedVulnerabilities: []vulnerability.Reference{
-								{
-									ID:        "GHSA-2014-fake-3",
-									Namespace: "github:language:ruby",
-								},
-							},
-						},
-						Package: activerecordPkg,
-						Details: match.Details{
-							{
-								Type: match.ExactDirectMatch,
-								SearchedBy: match.EcosystemParameters{
-									Language:  "ruby",
-									Namespace: "github:language:ruby",
-									Package:   match.PackageParameter{Name: "activerecord", Version: "3.7.5"},
-								},
-								Found: match.EcosystemResult{
-									VulnerabilityID:   "GHSA-2014-fake-3",
-									VersionConstraint: "< 3.7.6 (unknown)",
-								},
-								Matcher:    "ruby-gem-matcher",
-								Confidence: 1,
-							},
-						},
-					},
+					Sources: []match.IgnoreSource{match.IgnoreSourceUserRule},
 				},
 			},
 			wantErr: nil,
@@ -920,6 +883,7 @@ func TestVulnerabilityMatcher_FindMatches(t *testing.T) {
 							Vulnerability: "CVE-2014-fake-3",
 						},
 					},
+					Sources: []match.IgnoreSource{match.IgnoreSourceUserRule},
 					Match: match.Match{
 						Vulnerability: vulnerability.Vulnerability{
 							PackageName: "activerecord",

--- a/internal/format/presenter.go
+++ b/internal/format/presenter.go
@@ -13,9 +13,10 @@ import (
 )
 
 type PresentationConfig struct {
-	TemplateFilePath string
-	ShowSuppressed   bool
-	Pretty           bool
+	TemplateFilePath  string
+	ShowSuppressed    bool
+	SuppressedSources []string
+	Pretty            bool
 }
 
 // GetPresenter retrieves a Presenter that matches a CLI option
@@ -24,7 +25,7 @@ func GetPresenter(format Format, c PresentationConfig, pb models.PresenterConfig
 	case JSONFormat:
 		return json.NewPresenter(pb)
 	case TableFormat:
-		return table.NewPresenter(pb, c.ShowSuppressed)
+		return table.NewPresenter(pb, c.ShowSuppressed, c.SuppressedSources)
 
 	// NOTE: cyclonedx is identical to EmbeddedVEXJSON
 	// The cyclonedx library only provides two BOM formats: JSON and XML


### PR DESCRIPTION
# PR: Expose distro-fixed dropped matches via `ignoredMatches`

Closes anchore/grype#3450.

Three visible additions:

1. `ignoredMatches` now includes matches that grype today silently drops via hard-coded distro-fixed rules from #3282's `OwnershipIgnores("DistroPackageFixed", ...)`. `--show-suppressed` surfaces them alongside user-rule ignores.
2. Each `IgnoredMatch` carries a new field `Sources []IgnoreSource` (JSON `sources`) identifying which class of rule fired: `user-rule`, `distro-fixed`, `explicit-exclusion`, `vex`, or `hardcoded-correction`.
3. New CLI flag `--suppressed-sources=<comma-list>` filters `--show-suppressed` output by category. Setting it implicitly enables `--show-suppressed`. Table format only; JSON and SARIF emit every entry regardless.

## Changes

- `grype/match/ignore.go`
  - New `IgnoreSource` enum, five values: `user-rule`, `distro-fixed`, `explicit-exclusion`, `vex`, `hardcoded-correction`.
  - New field `Sources []IgnoreSource` on `IgnoredMatch` (`json:"sources,omitempty"`).
  - Helpers `WithSource`, `TagIgnoredMatches`, `DedupeIgnoredMatches`. `DedupeIgnoredMatches` keys on `Match.Fingerprint`. On merge, `Sources` acts as a set (no duplicates, first-occurrence order) and `AppliedIgnoreRules` concatenates (no dedupe, order preserved). The retained `Match` is the first-occurrence instance; matcher-provided per-instance details on losing matches are not carried over. Deliberate tradeoff — happy to widen if reviewers prefer.
- `grype/vulnerability_matcher.go`
  - `searchDBForMatches` gains a third return `[]match.IgnoredMatch` holding every hard-coded drop. Two drop points feed it:
    - Per-package `ApplyExplicitIgnoreRules` at the current line 237, tagged `explicit-exclusion`.
    - Global `ApplyIgnoreFilters(allMatches, ignoredMatchFilter(allIgnorers))` at the current line 255, tagged `distro-fixed` when any applied rule's `Reason == "DistroPackageFixed"` (the reason string `OwnershipIgnores` uses for #3282), otherwise `hardcoded-correction`.
  - `findDBMatches` propagates and tags user-provided ignores as `user-rule`.
  - `findVEXMatches` tags newly-added ignored entries as `vex`.
  - `mergeIgnoredMatches` now calls `match.DedupeIgnoredMatches`, which also fixes existing double-counting under `NormalizeByCVE`.
- `grype/presenter/models/{ignore,document}.go`
  - New `Sources []string` field on the presenter's `IgnoredMatch` (`json:"sources,omitempty"`). `NewDocument` maps it through from `match.IgnoredMatch.Sources`.
- `cmd/grype/cli/options/grype.go`
  - New `--suppressed-sources=<comma-list>` flag. Comma-separated list of `IgnoreSource` categories that filter the `--show-suppressed` output. Setting it implicitly enables `--show-suppressed`. Unknown values return a helpful error listing every valid value at CLI parse time (`parseSuppressedSources` in `cmd/grype/cli/commands/root.go`).
- `internal/format/presenter.go` and `grype/presenter/table/presenter.go`
  - `PresentationConfig` gains `SuppressedSources []string`; the table presenter accepts it and filters `doc.IgnoredMatches` by `Sources` before rendering.
- Table-only. JSON and SARIF continue to emit every entry regardless of the flag, matching the existing `--show-suppressed` convention that flags shape human-readable output rather than raw data.

The table presenter otherwise renders every ignored entry that reaches it, so the newly-surfaced distro-fixed drops appear under `--show-suppressed` without any row-format change.

## Why this shape

In prior discussion with @kzantow (Anchore) about this class of suppression, he proposed exactly this direction:

> We could add an option to include distro suppressed results into the `ignoredMatches` section, which today only includes ignored results from user-configured rules. It's my opinion that we should probably do this by default to show that there was a match according to one data set but it was suppressed by another. If we did this, then they would be shown in the table view using `--show-suppressed` as Will suggested earlier.

Per that suggestion: `searchDBForMatches` always returns the drops. No opt-in flag. Consumers that never inspected the second return keep working. Consumers that want to differentiate use `Sources` rather than pattern-matching on `AppliedIgnoreRules[i].Reason`.

## Worked example

`fuse-overlayfs-snapshotter-2.1.7-r7.apk` bundles Go stdlib `go1.24.13`. NVD entry for CVE-2026-25679 says `< 1.25.8 || >= 1.26.0-0, < 1.26.1`. Chainguard secfix at `2.1.7-r3` marks the CVE FIXED, so `r7` (`>= r3`) is not directly vulnerable; the stdlib match against NVD is suppressed via `OwnershipIgnores(... "DistroPackageFixed" ...)` at `grype/matcher/internal/distro.go:105`.

Before this PR: `grype --show-suppressed fuse-overlayfs-snapshotter-2.1.7-r7.apk` returns no findings and no ignored matches. The stdlib CPE match is produced by the matcher and dropped without trace.

After this PR: the same command returns the stdlib CVE in `ignoredMatches`:

```json
{
  "sources": ["distro-fixed"],
  "appliedIgnoreRules": [
    {
      "vulnerability": "CVE-2026-25679",
      "reason": "DistroPackageFixed"
    }
  ],
  "vulnerability": { "id": "CVE-2026-25679", "namespace": "nvd:cpe" },
  "artifact": { "name": "stdlib", "version": "go1.24.13", "type": "go-module" }
}
```

## Backwards compatibility

- No public API removed or renamed.
- The new `Sources` field on both `match.IgnoredMatch` and `presenter/models.IgnoredMatch` is `omitempty` in JSON. Consumers reading existing keys see no change.
- Table presenter output is unchanged when `--show-suppressed` is not set.
- Table presenter output when `--show-suppressed` IS set now includes suppressions that were previously invisible. That is the intended behaviour.

## Testing

- New unit test `TestVulnerabilityMatcher_DistroFixedSuppressionSurfacesIgnoredMatch` in `grype/vulnerability_matcher_test.go` reproduces the `fuse-overlayfs-snapshotter` / CVE-2026-25679 shape end to end. It asserts on `Sources`, `AppliedIgnoreRules`, and the empty main-matches slice.
- Four subtests in the existing `TestVulnerabilityMatcher_FindMatches` were updated to include `Sources` where relevant: `pass on severity threshold with VEX` picks up `vex`; `normalize by cve -- ignore GHSA` and `ignore CVE (not normalized by CVE)` pick up `user-rule`; `normalize by cve -- ignore CVE` collapses two same-fingerprint entries into one under the new dedup, with an `AppliedIgnoreRules` union of length 2.
- Presenter snapshot fixtures required no regeneration; `Sources` is `omitempty` and no existing fixture exercises a distro-fixed drop path.
- New table-presenter tests cover the `--suppressed-sources` filter: `TestSuppressedSourceAllows` exercises the pure filter helper across seven cases (empty request, single-match, non-match, multi-source match, etc.) and `TestDisplaysIgnoredMatches_FilteredBySuppressedSource` runs three end-to-end presenter cases against the shared analysis fixture.
- `go build ./...` and `go test ./grype/... ./cmd/... ./internal/format/...` clean.

## Open questions for reviewers

- Naming: `IgnoreSource` vs `IgnoreOrigin` vs `IgnoreCategory`. Rename welcome.
- Should `hardcoded-correction` split further (e.g. `protobuf-correction`)? Kept as a single catch-all here to keep the enum surface small.
- Should the `explicit-exclusion` bucket carry the DB row's Reason? Not touched here; can add if useful.
- `--suppressed-sources` uses a comma-separated single-string form (matching grype's own `--ignore-states`). A repeatable `StringSliceVarP`-style flag is not offered because clio's FlagSet exposes only `StringArrayVarP`; happy to switch if clio grows the wrapper or you want to break the idiom.

## Downstream consumer

Chainguard's `cg scan apk --show-suppressed` (chainguard-dev/mono, feature branch on our fork) reads matches with `distro-fixed` in `Sources` to surface regression signals that PR #3282 hides today. Happy to point at the branch if reviewers want the concrete consumer view.
