### PR TITLE
docs: document full set of ignore rule fields in --ignore help

### DIFF
--- a/cmd/grype/cli/options/grype.go
+++ b/cmd/grype/cli/options/grype.go
@@ -203,8 +203,14 @@ This is the full set of supported rule fields:
     package:
       name: libcurl
       version: 1.5.1
+      language: javascript
       type: npm
       location: "/usr/local/lib/node_modules/**"
+      upstream-name: libcurl
+    namespace: nvd:cpe
+    match-type: exact-direct-match
+    include-aliases: true
+    reason: "not applicable in this environment"
 
 VEX fields apply when Grype reads vex data:
   - vex-status: not_affected


### PR DESCRIPTION
Closes #3663

The `--ignore` option help comment claims to enumerate the full set of
supported rule fields, but several fields that are part of the
`match.IgnoreRule` and `match.IgnoreRulePackage` structs are missing
from the example:

- Top-level: `include-aliases`, `reason`, `namespace`, `match-type`
- Under `package:`: `language`, `upstream-name`

This made it look like those fields are unsupported or undocumented,
even though Grype honors them when present in user config.

This change extends the example to list every supported field, with
indentation matching the YAML structure so the nesting under
`package:` is obvious.

### Verification

```
go test ./cmd/grype/cli/options/ -count=1 -short
go test ./grype/match/ -count=1 -short
go build ./cmd/grype/cli/options/
```

All pass.

Signed-off-by: Rylen Anil <rylen.anil@gmail.com>