### PR TITLE
Keep the namespace on Go module PURLs in the OpenVEX transformer

### DIFF
--- a/grype/db/v6/build/transformers/openvex/transform.go
+++ b/grype/db/v6/build/transformers/openvex/transform.go
@@ -158,7 +158,13 @@ func packageNameFromPURL(purl *packageurl.PackageURL) string {
 	switch purl.Type {
 	case packageurl.TypeMaven:
 		return purl.Namespace + ":" + purl.Name
-	case packageurl.TypeNPM:
+	case packageurl.TypeNPM, packageurl.TypeGolang:
+		// For Go the namespace is not metadata, it is the leading part of the
+		// module path: pkg:golang/github.com/gin-gonic/gin splits into
+		// Namespace="github.com/gin-gonic" and Name="gin", and the module is
+		// only identified by the two joined. Dropping it would file the
+		// statement under "gin". A module with no namespace, such as
+		// pkg:golang/stdlib, is returned unchanged by the check above.
 		return purl.Namespace + "/" + purl.Name
 	}
 	return purl.Name

--- a/grype/db/v6/build/transformers/openvex/transform_test.go
+++ b/grype/db/v6/build/transformers/openvex/transform_test.go
@@ -8,6 +8,8 @@ import (
 	govex "github.com/openvex/go-vex/pkg/vex"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anchore/packageurl-go"
+
 	"github.com/anchore/grype/grype/db/internal/provider/unmarshal"
 	"github.com/anchore/grype/grype/db/provider"
 	db "github.com/anchore/grype/grype/db/v6"
@@ -618,6 +620,70 @@ func Test_GetPackageHandles(t *testing.T) {
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("GetPackages() mismatch (-want +got):\n%s", diff)
 			}
+		})
+	}
+}
+
+func Test_packageNameFromPURL(t *testing.T) {
+	tests := []struct {
+		name string
+		purl string
+		want string
+	}{
+		{
+			// A Go module is identified by its full path; the namespace is the
+			// leading part of it rather than metadata, so dropping it filed the
+			// statement under a different package than the advisory and matcher
+			// paths use.
+			name: "golang module keeps its namespace",
+			purl: "pkg:golang/github.com/gin-gonic/gin@v1.9.0",
+			want: "github.com/gin-gonic/gin",
+		},
+		{
+			name: "golang module on a vanity host",
+			purl: "pkg:golang/k8s.io/client-go@v0.29.0",
+			want: "k8s.io/client-go",
+		},
+		{
+			name: "golang module with a version suffix in the name",
+			purl: "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+			want: "gopkg.in/yaml.v3",
+		},
+		{
+			name: "golang module with no namespace is unchanged",
+			purl: "pkg:golang/stdlib@1.21.0",
+			want: "stdlib",
+		},
+		{
+			name: "maven keeps the groupId separator",
+			purl: "pkg:maven/org.apache.commons/commons-lang3@3.12.0",
+			want: "org.apache.commons:commons-lang3",
+		},
+		{
+			name: "npm scoped name is rejoined",
+			purl: "pkg:npm/%40angular/core@17.0.0",
+			want: "@angular/core",
+		},
+		{
+			// An ecosystem whose namespace is metadata rather than identity is
+			// left alone, so this change does not widen beyond Go.
+			name: "namespace that is not part of the name is dropped",
+			purl: "pkg:deb/debian/curl@7.50.3-1",
+			want: "curl",
+		},
+		{
+			name: "flat ecosystem is unchanged",
+			purl: "pkg:pypi/urllib3@1.26.16",
+			want: "urllib3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			purl, err := packageurl.FromString(tt.purl)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.want, packageNameFromPURL(&purl))
 		})
 	}
 }


### PR DESCRIPTION
Fixes #3680.

`packageNameFromPURL` rebuilds Maven and npm names from the purl namespace and falls through to `purl.Name` otherwise, so a Go module lost its path. The reproduction in the issue holds on `main`:

```
expected: "github.com/gin-gonic/gin"
actual  : "gin"
```

Go belongs with npm rather than in the fallthrough because its namespace is not metadata, it is the leading part of the module path. Checking how the purl library actually splits these before assuming:

```
pkg:golang/github.com/gin-gonic/gin@v1.9.0   ns="github.com/gin-gonic"  name="gin"
pkg:golang/k8s.io/client-go@v0.29.0          ns="k8s.io"                name="client-go"
pkg:golang/gopkg.in/yaml.v3@v3.0.1           ns="gopkg.in"              name="yaml.v3"
pkg:golang/stdlib@1.21.0                     ns=""                      name="stdlib"
```

so `Namespace + "/" + Name` reconstructs the module path, and `stdlib` returns early on the existing empty-namespace check and is untouched.

The comment above that switch already anticipates this ("Callers can extend this switch as more VEX providers come online for additional ecosystems"), so I extended the existing `TypeNPM` case rather than adding a separate branch that would do the same join.

## Tests

`Test_packageNameFromPURL` is a table covering the four Go shapes above plus four guards that the change does not widen: Maven still uses `:`, npm scoped names still rejoin, `pkg:deb/debian/curl` still drops a namespace that genuinely is metadata, and a flat ecosystem is unchanged. The Go cases fail on `main` with the actual/expected pair above.

`go build ./...`, `go vet`, `gofmt` and `go test ./grype/db/v6/build/...` are clean.

I have taken only #3680 here. #3682 covers the handle-level consequence in `getPackageHandle`, and I did not want to fold two issues into one PR; happy to follow up on it once you are happy with this, or to close it as covered if you consider the name fix sufficient.
