### PR TITLE
docs: document all supported ignore rule fields (namespace, match-type, reason, include-aliases)

### DIFF
--- a/cmd/grype/cli/options/grype.go
+++ b/cmd/grype/cli/options/grype.go
@@ -196,17 +196,23 @@ when using template as the output type, you must also provide a value for 'outpu
 	descriptions.Add(&o.Pretty, `pretty-print output`)
 	descriptions.Add(&o.FailOn, `upon scanning, if a severity is found at or above the given severity then the return code will be 1
 default is unset which will skip this validation (options: negligible, low, medium, high, critical)`)
-	descriptions.Add(&o.Ignore, `A list of vulnerability ignore rules, one or more property may be specified and all matching vulnerabilities will be ignored.
-This is the full set of supported rule fields:
-  - vulnerability: CVE-2008-4318
-    fix-state: unknown
+	descriptions.Add(&o.Ignore, `a list of vulnerability ignore rules; a match must meet ALL criteria in a rule to be ignored.
+Full set of supported rule fields with examples:
+  - vulnerability: CVE-2008-4318        # match by vulnerability ID (required if no other criteria)
+    namespace: nvd                       # match by vulnerability namespace (e.g. nvd, github:language:go)
+    fix-state: unknown                   # ignore if fix state matches; options: unknown, fixed, not-fixed, wont-fix
+    match-type: exact-direct-match       # ignore by match type; options: exact-direct-match, exact-indirect-match, cpe-match
+    reason: "tolerated by policy"        # optional human-readable note (does not affect matching)
+    include-aliases: true                # also apply the vulnerability ID match to related/alias CVEs (default: false)
     package:
-      name: libcurl
-      version: 1.5.1
-      type: npm
-      location: "/usr/local/lib/node_modules/**"
+      name: libcurl                      # match by package name (supports regex)
+      version: 1.5.1                     # match by package version
+      type: npm                          # match by package type (e.g. rpm, deb, apk, gem, npm, …)
+      location: "/usr/local/lib/**"      # match by package file location glob
+      language: go                       # match by package language (e.g. go, java, python, …)
+      upstream-name: curl                # match by upstream package name (supports regex)
 
-VEX fields apply when Grype reads vex data:
+VEX fields apply when Grype reads VEX documents (--vex):
   - vex-status: not_affected
     vex-justification: vulnerable_code_not_present
 `)


### PR DESCRIPTION
Closes #3663

## Problem

The `ignore` rule in Grype's configuration supports more fields than are documented. The help text and configuration reference only listed:
- `vulnerability`
- `fix-state`
- `package.name`
- `package.version`
- `package.type`
- `package.location`

But `IgnoreRule` in `grype/match/ignore.go` also supports:
- `namespace` — filter by vulnerability namespace (e.g. `nvd`, `github:language:go`)
- `match-type` — filter by how the match was made (`exact-direct-match`, `exact-indirect-match`, `cpe-match`)
- `reason` — human-readable annotation (does not affect matching logic)
- `include-aliases` — extend vulnerability ID matching to alias/related CVEs

And `IgnoreRulePackage` also has undocumented fields:
- `package.language` — filter by package language (e.g. `go`, `java`, `python`)
- `package.upstream-name` — filter by upstream package name (supports regex)

## Fix

Updated the `DescribeFields` method in `cmd/grype/cli/options/grype.go`, which drives both the `--help` output and generated config documentation. The updated description now shows every supported field with inline comments explaining its purpose and valid values.

## Before

```
A list of vulnerability ignore rules, one or more property may be specified and all matching vulnerabilities will be ignored.
This is the full set of supported rule fields:
  - vulnerability: CVE-2008-4318
    fix-state: unknown
    package:
      name: libcurl
      version: 1.5.1
      type: npm
      location: "/usr/local/lib/node_modules/**"

VEX fields apply when Grype reads vex data:
  - vex-status: not_affected
    vex-justification: vulnerable_code_not_present
```

## After

```
a list of vulnerability ignore rules; a match must meet ALL criteria in a rule to be ignored.
Full set of supported rule fields with examples:
  - vulnerability: CVE-2008-4318        # match by vulnerability ID (required if no other criteria)
    namespace: nvd                       # match by vulnerability namespace (e.g. nvd, github:language:go)
    fix-state: unknown                   # ignore if fix state matches; options: unknown, fixed, not-fixed, wont-fix
    match-type: exact-direct-match       # ignore by match type; options: exact-direct-match, exact-indirect-match, cpe-match
    reason: "tolerated by policy"        # optional human-readable note (does not affect matching)
    include-aliases: true                # also apply the vulnerability ID match to related/alias CVEs (default: false)
    package:
      name: libcurl                      # match by package name (supports regex)
      version: 1.5.1                     # match by package version
      type: npm                          # match by package type (e.g. rpm, deb, apk, gem, npm, ...)
      location: "/usr/local/lib/**"      # match by package file location glob
      language: go                       # match by package language (e.g. go, java, python, ...)
      upstream-name: curl                # match by upstream package name (supports regex)

VEX fields apply when Grype reads VEX documents (--vex):
  - vex-status: not_affected
    vex-justification: vulnerable_code_not_present
```