### PR TITLE
fix: normalize apk package fallback versions for CPE matching

### DIFF
--- a/grype/matcher/internal/cpe.go
+++ b/grype/matcher/internal/cpe.go
@@ -47,15 +47,15 @@ func FindResultsByCPEs(vulnProvider vulnerability.Provider, p pkg.Package, upstr
 	}
 
 	for _, c := range p.CPEs {
-		// prefer the CPE version, but if npt specified use the package version
+		// prefer the CPE version, but if not specified use the package version
 		searchVersion := c.Attributes.Version
-
-		if p.Type == syftPkg.ApkPkg {
-			searchVersion = cpeversion.Alpine(searchVersion)
-		}
 
 		if searchVersion == wfn.NA || searchVersion == wfn.Any || isUnknownVersion(searchVersion) {
 			searchVersion = p.Version
+		}
+
+		if p.Type == syftPkg.ApkPkg {
+			searchVersion = cpeversion.Alpine(searchVersion)
 		}
 
 		if isUnknownVersion(searchVersion) {

--- a/grype/matcher/internal/cpe_test.go
+++ b/grype/matcher/internal/cpe_test.go
@@ -104,6 +104,24 @@ func newCPETestStore() vulnerability.Provider {
 			Constraint:  version.MustGetConstraint("< 4.7.7", version.UnknownFormat),
 			CPEs:        []cpe.CPE{cpe.Must("cpe:2.3:a:handlebarsjs:handlebars:*:*:*:*:*:node.js:*:*", "")},
 		},
+		{
+			Reference: vulnerability.Reference{
+				ID:        "CVE-2017-fake-9",
+				Namespace: "nvd:cpe",
+			},
+			PackageName: "openssl",
+			Constraint:  version.MustGetConstraint("<= 1.0.1f", version.ApkFormat),
+			CPEs:        []cpe.CPE{cpe.Must("cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*", "")},
+		},
+		{
+			Reference: vulnerability.Reference{
+				ID:        "CVE-2017-fake-10",
+				Namespace: "nvd:cpe",
+			},
+			PackageName: "openssl",
+			Constraint:  version.MustGetConstraint("< 1.0.1f", version.ApkFormat),
+			CPEs:        []cpe.CPE{cpe.Must("cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*", "")},
+		},
 	}...)
 }
 
@@ -210,6 +228,52 @@ func TestFindMatchesByPackageCPE(t *testing.T) {
 								CPEs:              []string{"cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*"},
 								VersionConstraint: "< 3.7.6 (gem)",
 								VulnerabilityID:   "CVE-2017-fake-1",
+							},
+							Matcher: matcher,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "fallback to apk package version normalizes build suffix",
+			p: pkg.Package{
+				CPEs: []cpe.CPE{
+					cpe.Must("cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*", ""),
+				},
+				Name:    "openssl",
+				Version: "1.0.1f-r2",
+				Type:    syftPkg.ApkPkg,
+			},
+			expected: []match.Match{
+				{
+					Vulnerability: vulnerability.Vulnerability{
+						Reference: vulnerability.Reference{ID: "CVE-2017-fake-9"},
+					},
+					Package: pkg.Package{
+						CPEs: []cpe.CPE{
+							cpe.Must("cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*", ""),
+						},
+						Name:    "openssl",
+						Version: "1.0.1f-r2",
+						Type:    syftPkg.ApkPkg,
+					},
+					Details: []match.Detail{
+						{
+							Type:       match.CPEMatch,
+							Confidence: 0.9,
+							SearchedBy: match.CPEParameters{
+								CPEs:      []string{"cpe:2.3:a:openssl:openssl:1.0.1f:*:*:*:*:*:*:*"},
+								Namespace: "nvd:cpe",
+								Package: match.PackageParameter{
+									Name:    "openssl",
+									Version: "1.0.1f-r2",
+								},
+							},
+							Found: match.CPEResult{
+								CPEs:              []string{"cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*"},
+								VersionConstraint: "<= 1.0.1f (apk)",
+								VulnerabilityID:   "CVE-2017-fake-9",
 							},
 							Matcher: matcher,
 						},


### PR DESCRIPTION
When a package CPE has an unspecified version (`*`, `-`, or `unknown`), `FindResultsByCPEs` falls back to `p.Version`. For APK packages, that fallback used the raw package version because `cpeversion.Alpine(...)` had already run.

This moves APK CPE-version normalization after the fallback and adds a regression for an unversioned OpenSSL CPE. The fixture also has a `< 1.0.1f` control record so the normalized `1.0.1f` search does not over-match.

Checked:
- `go test ./grype/matcher/internal -run 'TestFindMatchesByPackageCPE/fallback_to_apk_package_version_normalizes_build_suffix' -count=1`
- `go test -race ./grype/matcher/internal -run 'TestFindMatchesByPackageCPE/fallback_to_apk_package_version_normalizes_build_suffix' -count=5`
- `go test ./grype/matcher/internal ./grype/matcher/internal/result ./grype/matcher/apk -count=1`
- `go test ./grype/matcher/... -count=1`
- `make static-analysis`
- `git diff --check`