### PR TITLE
test: assert the --by-cve merge survivor is not order-dependent

### DIFF
--- a/grype/vulnerability_matcher_test.go
+++ b/grype/vulnerability_matcher_test.go
@@ -1958,6 +1958,14 @@ func TestVulnerabilityMatcher_FindMatches_normalizeByCVEIsDeterministic(t *testi
 
 		got := describe(matches)
 
+		// Guard the index below, and assert the collapse while we are here: --by-cve
+		// exists to merge the two aliased records into a single match, so any other
+		// count is a regression in its own right. Without this an empty result panics
+		// with "index out of range", and a panic aborts every remaining test in the
+		// package instead of naming what actually broke.
+		require.Len(t, got, 1,
+			"run %d: expected the two aliased records to collapse into one match, got %v", i, got)
+
 		// Assert the contract, not merely that the runs agree with each other.
 		// "All runs equal" is a weaker check than it looks: with both halves of the
 		// fix reverted this fixture still produced 25 identical runs about one time

--- a/grype/vulnerability_matcher_test.go
+++ b/grype/vulnerability_matcher_test.go
@@ -2,6 +2,7 @@ package grype
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -1872,5 +1873,105 @@ func TestVulnerabilityMatcher_EOLDistroPackages(t *testing.T) {
 				assert.ElementsMatch(t, tt.expectedEOLPackages, actualNames)
 			}
 		})
+	}
+}
+
+func TestVulnerabilityMatcher_FindMatches_normalizeByCVEIsDeterministic(t *testing.T) {
+	// When two advisory records describe the same package and alias to the same CVE,
+	// --by-cve collapses them into one match. Only one of the two records can survive,
+	// and the surviving record is what supplies the emitted namespace, dataSource,
+	// severity and description -- normalizeByCVE rewrites Vulnerability.ID and
+	// Vulnerability.Namespace, but the metadata blob those fields are presented from
+	// belongs to whichever record won the merge.
+	//
+	// So "which record wins" is user-visible, and it must not depend on Go map
+	// iteration order. TestMatch_Merge_isOrderIndependent covers Match.Merge in
+	// isolation; this covers the --by-cve path that reaches it, which no test
+	// currently does. The one case that exercises that path end to end
+	// ("normalize by cve") compares with cmpopts.IgnoreFields on
+	// vulnerability.Reference "Internal", and Internal is precisely where the
+	// conflicting metadata lives -- so it cannot see a regression here.
+	//
+	// The fixture needs nothing new: testVulnerabilities() already carries
+	// GHSA-2014-fake-3 (github:language:ruby, severity medium) aliasing
+	// CVE-2014-fake-3 (nvd:cpe, severity critical) for activerecord.
+	vp := mock.VulnerabilityProvider(testVulnerabilities()...)
+
+	cp, err := cpe.New("cpe:2.3:*:activerecord:activerecord:*:*:*:*:*:rails:*:*", "")
+	require.NoError(t, err)
+
+	activerecordPkg := pkg.Package{
+		ID:       pkg.ID(uuid.NewString()),
+		Name:     "activerecord",
+		Version:  "3.7.5",
+		CPEs:     []cpe.CPE{cp},
+		Type:     syftPkg.GemPkg,
+		Language: syftPkg.Ruby,
+	}
+
+	m := &VulnerabilityMatcher{
+		VulnerabilityProvider: vp,
+		Matchers: matcher.NewDefaultMatchers(
+			matcher.Config{
+				Ruby: ruby.MatcherConfig{
+					UseCPEs: true,
+				},
+			},
+		),
+		NormalizeByCVE: true,
+	}
+
+	// Reduce each run to the fields the issue reports as varying, so a failure names
+	// what drifted rather than dumping two match sets. The mock provider populates
+	// only Severity on the metadata blob today; namespace and dataSource are carried
+	// here because they are the other fields the issue reports drifting, and they
+	// would start discriminating for free if the fixture ever fills them in.
+	describe := func(matches *match.Matches) []string {
+		var out []string
+		for _, mt := range matches.Sorted() {
+			severity, namespace, dataSource := "", "", ""
+			if md, ok := mt.Vulnerability.Internal.(vulnerability.Metadata); ok {
+				severity, namespace, dataSource = md.Severity, md.Namespace, md.DataSource
+			}
+			out = append(out, fmt.Sprintf(
+				"id=%s ns=%s pkg=%s | surviving record: severity=%s namespace=%s dataSource=%s fix=%v",
+				mt.Vulnerability.ID, mt.Vulnerability.Namespace, mt.Vulnerability.PackageName,
+				severity, namespace, dataSource, mt.Vulnerability.Fix.Versions,
+			))
+		}
+		return out
+	}
+
+	// Go randomizes the start offset of every map range, so repeating the call in one
+	// process is enough to surface an order-dependent survivor. Reverting either half
+	// of the fix on its own does not reproduce it -- swapping matches.Sorted() back to
+	// matches.Enumerate() leaves the result stable because Match.Merge still selects by
+	// authority. With both reverted, 30 runs of this fixture split 27/3 between the two
+	// severities, so a single call would pass most of the time; the repetition is what
+	// makes the guard reliable.
+	const runs = 25
+
+	var first []string
+	for i := 0; i < runs; i++ {
+		matches, _, err := m.FindMatches([]pkg.Package{activerecordPkg}, pkg.Context{})
+		require.NoError(t, err)
+
+		got := describe(matches)
+
+		// Assert the contract, not merely that the runs agree with each other.
+		// "All runs equal" is a weaker check than it looks: with both halves of the
+		// fix reverted this fixture still produced 25 identical runs about one time
+		// in five, because a single process reuses one map layout. Naming the record
+		// that must win removes that luck -- the ecosystem advisory outranks the CPE
+		// match, so its metadata is the one that has to survive the merge.
+		require.Contains(t, got[0], "severity=medium",
+			"run %d: the ecosystem advisory must win the merge; a CPE-matched record "+
+				"supplying the metadata means merge authority stopped deciding it", i)
+
+		if i == 0 {
+			first = got
+			continue
+		}
+		require.Equal(t, first, got, "run %d produced a different surviving record than run 0", i)
 	}
 }


### PR DESCRIPTION
Follow-up to #3630, which you closed noting that a test for `--by-cve` determinism would be welcome if one added verification beyond what already landed. This is that test.

### What was and wasn't already covered

`TestMatch_Merge_isOrderIndependent` and `...ForThreeRecords` (added in #3634) pin `Match.Merge` in isolation, and they do the job there. Nothing covered the `--by-cve` path that reaches it.

The one case that exercises that path end to end, `TestVulnerabilityMatcher_FindMatches/"normalize by cve"`, compares with:

```go
cmpopts.IgnoreFields(vulnerability.Reference{}, "Internal"),
```

`Internal` is where the fixture's two records carry their conflicting severities — `medium` on `GHSA-2014-fake-3`, `critical` on `CVE-2014-fake-3`. So that case cannot observe which record survived the merge, which is the thing #3630 was about.

### What this asserts

That the ecosystem advisory outranks the CPE match and its metadata is what survives, on every one of 25 runs. No new fixture: `testVulnerabilities()` already carries the aliasing pair for `activerecord`.

It asserts the contract rather than only that repeated runs agree with each other. That distinction turned out to matter more than I expected — see below.

### Verified by mutation

| tree | result |
| --- | --- |
| unmodified | passes 8/8 |
| `compareRecordAuthority` neutered to always tie, sort intact | **fails 12/12** |
| `matches.Sorted()` reverted to `matches.Enumerate()`, authority intact | still passes |

That third row is the interesting one: reverting the enumeration change alone does not reproduce the symptom, because `Match.Merge` still selects by authority. The merge rule is the load-bearing half of the fix, and it is what this test guards.

An earlier draft asserted only "all 25 runs agree". With merge authority reverted, that version still passed about one run in five — a single process reuses one map layout, so agreement is not as strong a signal as it looks. Naming the record that must win removes the luck.

### One thing I left alone

On an authority tie, `Merge` keeps the receiver (`match.go:55-58` swaps only when the comparison is negative), and `Metadata` is not among the compared fields — `compareRecordAuthority` looks at `Details.rank()`, then `PackageName`, `Status`, `Unaffected`. Where two records tie on all of those but differ in metadata, the survivor still follows arrival order.

I could not reach that state through the `--by-cve` path with the current fixtures, so it may be unreachable in practice, and a test for it would fail today rather than guard anything. Is that tie intended to be resolved by arrival order, or is it just a case that hasn't come up?
