### PR TITLE
add option to skip KEV, EPSS and CWE metadata enrichment for library callers

### DIFF
--- a/grype/db/v6/vulnerability_provider.go
+++ b/grype/db/v6/vulnerability_provider.go
@@ -28,7 +28,21 @@ var (
 	_ vulnerability.EOLChecker            = (*vulnerabilityProvider)(nil)
 )
 
-func NewVulnerabilityProvider(rdr Reader) vulnerability.Provider {
+// ProviderOption configures the vulnerability provider returned by NewVulnerabilityProvider.
+type ProviderOption func(*vulnerabilityProvider)
+
+// WithoutMetadataEnrichment skips the per-CVE KnownExploited, EPSS and CWE lookups when
+// building vulnerability metadata. Those three fields are left empty, which makes
+// Metadata.RiskScore zero (it derives from EPSS and KEV) and thins the table and CycloneDX
+// presenters. Severity, CVSS, description and URLs come from the vulnerability record and are
+// unchanged. For callers that consume only the match set and read none of those fields.
+func WithoutMetadataEnrichment() ProviderOption {
+	return func(vp *vulnerabilityProvider) {
+		vp.skipEnrichment = true
+	}
+}
+
+func NewVulnerabilityProvider(rdr Reader, opts ...ProviderOption) vulnerability.Provider {
 	// load the arch alias table once: it is small, static for the life of the DB, and read by
 	// every architecture qualifier at match time. An error (or a DB predating the table) leaves
 	// archAliases empty, which the architecture qualifier reads as "use the built-in defaults".
@@ -37,15 +51,20 @@ func NewVulnerabilityProvider(rdr Reader) vulnerability.Provider {
 		log.WithFields("error", err).Warn("unable to load architecture aliases from DB; falling back to built-in defaults")
 		archAliases = nil
 	}
-	return &vulnerabilityProvider{
+	vp := &vulnerabilityProvider{
 		reader:      rdr,
 		archAliases: archAliases,
 	}
+	for _, opt := range opts {
+		opt(vp)
+	}
+	return vp
 }
 
 type vulnerabilityProvider struct {
-	reader      Reader
-	archAliases map[string]string
+	reader         Reader
+	archAliases    map[string]string
+	skipEnrichment bool // see WithoutMetadataEnrichment
 }
 
 // Deprecated: vulnerability.Vulnerability objects now have metadata included
@@ -73,6 +92,10 @@ func (vp vulnerabilityProvider) VulnerabilityMetadata(ref vulnerability.Referenc
 }
 
 func (vp vulnerabilityProvider) getVulnerabilityMetadata(vuln *VulnerabilityHandle, namespace string) (*vulnerability.Metadata, error) {
+	if vp.skipEnrichment {
+		return newVulnerabilityMetadata(vuln, namespace, nil, nil, nil)
+	}
+
 	cves := getCVEs(vuln)
 
 	kevs, err := vp.fetchKnownExploited(cves)

--- a/grype/db/v6/vulnerability_provider_bench_test.go
+++ b/grype/db/v6/vulnerability_provider_bench_test.go
@@ -1,0 +1,168 @@
+package v6
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/anchore/grype/grype/distro"
+	"github.com/anchore/grype/grype/search"
+	"github.com/anchore/grype/grype/version"
+	"github.com/anchore/grype/grype/vulnerability"
+)
+
+// Synthetic DB for the enrichment benchmarks: benchPackages packages with benchVulnsPerPkg
+// vulnerabilities each, every vulnerability with one KEV row, one EPSS row and two CWE rows,
+// and a constraint that matches the queried version so every vulnerability is a match.
+const (
+	benchPackages    = 100
+	benchVulnsPerPkg = 20
+)
+
+var enrichmentCases = []struct {
+	name string
+	opts []ProviderOption
+}{
+	{name: "enrichment=on"},
+	{name: "enrichment=off", opts: []ProviderOption{WithoutMetadataEnrichment()}},
+}
+
+func benchPackageName(i int) string {
+	return fmt.Sprintf("pkg-%04d", i%benchPackages)
+}
+
+// buildBenchmarkDB writes the fixture to a temp dir and returns its path.
+func buildBenchmarkDB(b *testing.B) string {
+	b.Helper()
+	dir := b.TempDir()
+	w, err := NewWriter(Config{DBDirPath: dir})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	now := time.Now()
+	prov := &Provider{ID: "debian", Version: "1", Processor: "debian-processor", DateCaptured: &now, InputDigest: "bench"}
+	os := &OperatingSystem{Name: "debian", ReleaseID: "debian", MajorVersion: "12"}
+
+	for p := range benchPackages {
+		name := benchPackageName(p)
+		for v := range benchVulnsPerPkg {
+			cve := fmt.Sprintf("CVE-2024-%04d%03d", p, v)
+			vuln := &VulnerabilityHandle{
+				Name:       cve,
+				Status:     VulnerabilityActive,
+				ProviderID: prov.ID,
+				Provider:   prov,
+				BlobValue: &VulnerabilityBlob{
+					ID:          cve,
+					Description: cve + " description",
+					References:  []Reference{{URL: "https://security-tracker.debian.org/tracker/" + cve}},
+					Severities:  []Severity{{Scheme: SeveritySchemeCVSS, Value: "high"}},
+				},
+			}
+			if err := w.AddVulnerabilities(vuln); err != nil {
+				b.Fatal(err)
+			}
+			if err := w.AddAffectedPackages(&AffectedPackageHandle{
+				Vulnerability:   vuln,
+				OperatingSystem: os,
+				Package:         &Package{Ecosystem: "deb", Name: name},
+				BlobValue: &PackageBlob{
+					Ranges: []Range{{Version: Version{Type: "deb", Constraint: "< 99.0.0"}}},
+				},
+			}); err != nil {
+				b.Fatal(err)
+			}
+			if err := w.AddKnownExploitedVulnerabilities(&KnownExploitedVulnerabilityHandle{
+				Cve:       cve,
+				BlobValue: &KnownExploitedVulnerabilityBlob{Cve: cve, VendorProject: "bench", Product: name},
+			}); err != nil {
+				b.Fatal(err)
+			}
+			if err := w.AddEpss(&EpssHandle{Cve: cve, Epss: 0.5, Percentile: 0.9, Date: now}); err != nil {
+				b.Fatal(err)
+			}
+			if err := w.AddCWE(
+				&CWEHandle{CVE: cve, CWE: "CWE-79", Source: "nvd", Type: "primary"},
+				&CWEHandle{CVE: cve, CWE: "CWE-20", Source: "nvd", Type: "secondary"},
+			); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	if err := w.Close(); err != nil {
+		b.Fatal(err)
+	}
+	return dir
+}
+
+// BenchmarkFindVulnerabilities_MetadataEnrichment measures the matching path, which builds
+// metadata for every vulnerability a package search returns, with and without the per-CVE
+// KEV, EPSS and CWE lookups. One op is one package lookup returning benchVulnsPerPkg matches.
+//
+//	go test ./grype/db/v6/ -run '^$' -bench 'MetadataEnrichment' -benchmem -count 6 | tee bench.txt
+//	benchstat -col /enrichment bench.txt
+func BenchmarkFindVulnerabilities_MetadataEnrichment(b *testing.B) {
+	dir := buildBenchmarkDB(b)
+	d := distro.New(distro.Debian, "12", "")
+	v := version.New("1.0.0", version.DebFormat)
+
+	for _, tc := range enrichmentCases {
+		b.Run(tc.name, func(b *testing.B) {
+			provider := NewVulnerabilityProvider(setupReadOnlyTestStore(b, dir), tc.opts...)
+			defer provider.Close()
+			i := 0
+			for b.Loop() {
+				vulns, err := provider.FindVulnerabilities(search.ByDistro(*d), search.ByPackageName(benchPackageName(i)), search.ByVersion(*v))
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(vulns) != benchVulnsPerPkg {
+					b.Fatalf("expected %d matches, got %d", benchVulnsPerPkg, len(vulns))
+				}
+				i++
+			}
+		})
+	}
+}
+
+// BenchmarkVulnerabilityMetadata_MetadataEnrichment measures the deprecated per-reference
+// metadata lookup that the matcher's progress monitor still calls once per match. The
+// references carry Internal, as they do when the matcher calls it.
+func BenchmarkVulnerabilityMetadata_MetadataEnrichment(b *testing.B) {
+	dir := buildBenchmarkDB(b)
+	d := distro.New(distro.Debian, "12", "")
+	v := version.New("1.0.0", version.DebFormat)
+
+	seed := NewVulnerabilityProvider(setupReadOnlyTestStore(b, dir))
+	var refs []vulnerability.Reference
+	for p := range benchPackages {
+		vulns, err := seed.FindVulnerabilities(search.ByDistro(*d), search.ByPackageName(benchPackageName(p)), search.ByVersion(*v))
+		if err != nil {
+			b.Fatal(err)
+		}
+		for _, vuln := range vulns {
+			refs = append(refs, vuln.Reference)
+		}
+	}
+	if err := seed.Close(); err != nil {
+		b.Fatal(err)
+	}
+	if len(refs) == 0 {
+		b.Fatal("fixture produced no matches")
+	}
+
+	for _, tc := range enrichmentCases {
+		b.Run(tc.name, func(b *testing.B) {
+			provider := NewVulnerabilityProvider(setupReadOnlyTestStore(b, dir), tc.opts...)
+			defer provider.Close()
+			i := 0
+			for b.Loop() {
+				if _, err := provider.VulnerabilityMetadata(refs[i%len(refs)]); err != nil { //nolint:staticcheck // deprecated API is what the matcher calls
+					b.Fatal(err)
+				}
+				i++
+			}
+		})
+	}
+}

--- a/grype/db/v6/vulnerability_provider_enrichment_test.go
+++ b/grype/db/v6/vulnerability_provider_enrichment_test.go
@@ -1,0 +1,79 @@
+package v6
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/grype/grype/vulnerability"
+)
+
+func Test_WithoutMetadataEnrichment(t *testing.T) {
+	const cve = "CVE-2024-0001"
+	tmp := t.TempDir()
+
+	w, err := NewWriter(Config{DBDirPath: tmp})
+	require.NoError(t, err)
+
+	now := time.Now()
+	prov := &Provider{
+		ID:           "nvd",
+		Version:      "1",
+		Processor:    "nvd-processor",
+		DateCaptured: &now,
+		InputDigest:  "abc",
+	}
+	require.NoError(t, w.AddVulnerabilities(&VulnerabilityHandle{
+		Name:       cve,
+		Status:     VulnerabilityActive,
+		ProviderID: prov.ID,
+		Provider:   prov,
+		BlobValue: &VulnerabilityBlob{
+			ID:          cve,
+			Description: "a description",
+			References:  []Reference{{URL: "https://nvd.example/" + cve}},
+			Severities:  []Severity{{Scheme: SeveritySchemeCVSS, Value: "high"}},
+		},
+	}))
+	require.NoError(t, w.AddKnownExploitedVulnerabilities(&KnownExploitedVulnerabilityHandle{
+		Cve:       cve,
+		BlobValue: &KnownExploitedVulnerabilityBlob{Cve: cve, VendorProject: "acme"},
+	}))
+	require.NoError(t, w.AddEpss(&EpssHandle{Cve: cve, Epss: 0.5, Percentile: 0.9, Date: now}))
+	require.NoError(t, w.AddCWE(&CWEHandle{CVE: cve, CWE: "CWE-79", Source: "nvd", Type: "primary"}))
+	require.NoError(t, w.Close())
+
+	ref := vulnerability.Reference{ID: cve, Namespace: "nvd:cpe"}
+
+	enriched := NewVulnerabilityProvider(setupReadOnlyTestStore(t, tmp))
+	withEnrichment, err := enriched.VulnerabilityMetadata(ref) //nolint:staticcheck // deprecated API is the one under test
+	require.NoError(t, err)
+	require.NotNil(t, withEnrichment)
+
+	// sanity: the fixture really does carry every kind of enrichment
+	require.NotEmpty(t, withEnrichment.KnownExploited)
+	require.NotEmpty(t, withEnrichment.EPSS)
+	require.NotEmpty(t, withEnrichment.CWEs)
+
+	plain := NewVulnerabilityProvider(setupReadOnlyTestStore(t, tmp), WithoutMetadataEnrichment())
+	withoutEnrichment, err := plain.VulnerabilityMetadata(ref) //nolint:staticcheck // deprecated API is the one under test
+	require.NoError(t, err)
+	require.NotNil(t, withoutEnrichment)
+
+	// the enrichment fields are skipped...
+	assert.Empty(t, withoutEnrichment.KnownExploited)
+	assert.Empty(t, withoutEnrichment.EPSS)
+	assert.Empty(t, withoutEnrichment.CWEs)
+
+	// ...and nothing that comes from the vulnerability record itself changes
+	assert.Equal(t, withEnrichment.ID, withoutEnrichment.ID)
+	assert.Equal(t, withEnrichment.Namespace, withoutEnrichment.Namespace)
+	assert.Equal(t, withEnrichment.DataSource, withoutEnrichment.DataSource)
+	assert.Equal(t, withEnrichment.Severity, withoutEnrichment.Severity)
+	assert.NotEqual(t, toSeverityString(vulnerability.UnknownSeverity), withoutEnrichment.Severity)
+	assert.Equal(t, withEnrichment.Cvss, withoutEnrichment.Cvss)
+	assert.Equal(t, withEnrichment.Description, withoutEnrichment.Description)
+	assert.Equal(t, withEnrichment.URLs, withoutEnrichment.URLs)
+}

--- a/grype/load_vulnerability_db.go
+++ b/grype/load_vulnerability_db.go
@@ -10,7 +10,9 @@ import (
 	"github.com/anchore/grype/internal/log"
 )
 
-func LoadVulnerabilityDB(distCfg v6dist.Config, installCfg v6inst.Config, update bool) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+// LoadVulnerabilityDB installs or updates the database as configured and returns a provider
+// over it, with any ProviderOption values applied.
+func LoadVulnerabilityDB(distCfg v6dist.Config, installCfg v6inst.Config, update bool, opts ...v6.ProviderOption) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
 	client, err := v6dist.NewClient(distCfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create distribution client: %w", err)
@@ -45,5 +47,5 @@ func LoadVulnerabilityDB(distCfg v6dist.Config, installCfg v6inst.Config, update
 		return nil, nil, fmt.Errorf("unable to create db reader: %w", err)
 	}
 
-	return v6.NewVulnerabilityProvider(rdr), &s, nil
+	return v6.NewVulnerabilityProvider(rdr, opts...), &s, nil
 }


### PR DESCRIPTION
## Summary

Adds `v6.WithoutMetadataEnrichment()`, a `ProviderOption` for `v6.NewVulnerabilityProvider`, and threads options through `grype.LoadVulnerabilityDB`. With the option set, vulnerability metadata is built from the vulnerability record alone and the per-CVE known-exploited, EPSS and CWE lookups are skipped. The CLI is unchanged and keeps enrichment on.

## Motivation

- `getVulnerabilityMetadata` runs three queries per CVE in `getCVEs(vuln)`, which is the record's name, blob ID and every alias, so advisory records with several CVE aliases pay 3×N. It is called for every vulnerability a package search returns, cached only within that search (`processAffectedPackageHandles`, `processAffectedCPEHandles` and the ID search each build their own map), and again once per match by `updateVulnerabilityList` for the severity progress counters, with no cache at all.
- Library users that consume only the match set, meaning vulnerability IDs, fix state, fixed versions and severity, pay that cost for fields they never read.
- With the option set, `Metadata.KnownExploited`, `EPSS` and `CWEs` are empty. `Metadata.RiskScore()` derives from EPSS and KEV and so becomes zero, which affects the default `SortByRisk` ordering, and the table and CycloneDX presenters omit the EPSS and KEV fields. The doc comment says so. Severity, CVSS, description and URLs come from the vulnerability record and are unchanged.

## Benchmark

`BenchmarkFindVulnerabilities_MetadataEnrichment` and `BenchmarkVulnerabilityMetadata_MetadataEnrichment` in `grype/db/v6` build a synthetic DB (100 packages, 20 vulnerabilities each, every vulnerability with KEV, EPSS and two CWE rows, all matching) and compare the two paths.

    go test ./grype/db/v6/ -run '^$' -bench 'MetadataEnrichment' -benchmem -count 6 | tee bench.txt
    benchstat -col /enrichment bench.txt

benchstat, Apple M5 Pro, n=6:

                                          │      on       │              off               │
    FindVulnerabilities (1 pkg, 20 vulns)   8840.6µ ± 0%    447.8µ ± 2%   -94.93% (p=0.002)
      B/op                                  841.4Ki ± 0%   311.1Ki ± 0%   -63.03%
      allocs/op                             11.627k ± 0%    4.364k ± 0%   -62.47%
    VulnerabilityMetadata (1 ref)          424407.5n ± 0%    66.75n ± 2%   -99.98% (p=0.002)
      B/op                                  27102.0 ± 0%     216.0 ± 0%   -99.20%
      allocs/op                             364.000 ± 0%     2.000 ± 0%   -99.45%

The fixture isolates the enrichment cost: with trivial constraints and no CPE or ignore-rule work, enrichment is nearly all of the matching path here, which overstates its share of a real scan. The `VulnerabilityMetadata` references carry `Internal`, as they do when the matcher's progress monitor calls it, so with enrichment off that path needs no query at all.

## Changes

- `grype/db/v6/vulnerability_provider.go`: add `ProviderOption`, `WithoutMetadataEnrichment()`, and a variadic `opts` parameter on `NewVulnerabilityProvider`. When set, `getVulnerabilityMetadata` returns `newVulnerabilityMetadata(vuln, namespace, nil, nil, nil)`.
- `grype/load_vulnerability_db.go`: `LoadVulnerabilityDB(distCfg, installCfg, update, opts ...v6.ProviderOption)` passes options to the provider. Variadic, so existing callers compile unchanged.
- `grype/db/v6/vulnerability_provider_enrichment_test.go`: fixture with one CVE plus KEV, EPSS and CWE rows; asserts the default provider returns all three and the option returns none, with ID, namespace, data source, severity, CVSS, description and URLs equal between the two.
- `grype/db/v6/vulnerability_provider_bench_test.go`: the benchmark above.

No breaking changes. No CLI or documented behaviour changes.

## Type of change

- [x] New feature
- [x] Performance

## Checklist

- [x] Added unit tests covering the changed behaviour
- [x] Tested common scenarios for regressions: full `grype/db/v6` package tests, `go build ./...`, `go vet`, golangci-lint clean on the changed files
- [x] Commented code that is hard to understand
