### PR TITLE
fix(openvex): reconstruct full Go module path from namespace+name

### DIFF
--- a/grype/db/v6/build/transformers/openvex/transform.go
+++ b/grype/db/v6/build/transformers/openvex/transform.go
@@ -151,6 +151,13 @@ func getPackageHandle(product *govex.Product, vuln *unmarshal.OpenVEXVulnerabili
 // FixedIn name verbatim ("@scope/name"). Joining Namespace+"/"+Name
 // reproduces that string. Callers can extend this switch as more VEX
 // providers come online for additional ecosystems.
+//
+// Go modules are stored under their full module path by the go advisory
+// path ("github.com/gin-gonic/gin"), which lives split across the purl
+// namespace and name; joining them keeps the OpenVEX handle on the same
+// packages row the go matcher searches. Ecosystems whose namespace is
+// metadata rather than package identity (e.g. github archives) keep the
+// short name and are not listed here.
 func packageNameFromPURL(purl *packageurl.PackageURL) string {
 	if purl.Namespace == "" {
 		return purl.Name
@@ -159,6 +166,8 @@ func packageNameFromPURL(purl *packageurl.PackageURL) string {
 	case packageurl.TypeMaven:
 		return purl.Namespace + ":" + purl.Name
 	case packageurl.TypeNPM:
+		return purl.Namespace + "/" + purl.Name
+	case packageurl.TypeGolang:
 		return purl.Namespace + "/" + purl.Name
 	}
 	return purl.Name

--- a/grype/db/v6/build/transformers/openvex/transform_test.go
+++ b/grype/db/v6/build/transformers/openvex/transform_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/anchore/packageurl-go"
 	"github.com/google/go-cmp/cmp"
 	govex "github.com/openvex/go-vex/pkg/vex"
 	"github.com/stretchr/testify/require"
@@ -619,5 +620,16 @@ func Test_GetPackageHandles(t *testing.T) {
 				t.Errorf("GetPackages() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestGolangPURLKeepsNamespace(t *testing.T) {
+	purl, err := packageurl.FromString("pkg:golang/github.com/gin-gonic/gin@v1.9.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := packageNameFromPURL(&purl), "github.com/gin-gonic/gin"; got != want {
+		t.Fatalf("packageNameFromPURL() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
Closes #3680.

On current main, `packageNameFromPURL` returns the short name for Go packages (e.g. `"gin"` for `pkg:golang/github.com/gin-gonic/gin`) because only Maven and npm had explicit switch cases. That diverges from the go advisory transformer, which stores the full module path, and can put the OpenVEX handle on a different `packages` row.

Adds `TypeGolang` to the switch, mirroring the npm join. The focused regression now passes:

```text
$ go test ./grype/db/v6/build/transformers/openvex/ -run TestGolangPURLKeepsNamespace -count=1
ok  	github.com/anchore/grype/grype/db/v6/build/transformers/openvex	0.493s
```

The entire suite is green (0.486s locally).