### PR TITLE
fix: buffer Enumerate channel to prevent goroutine leak on early exit

### DIFF
--- a/grype/match/matches.go
+++ b/grype/match/matches.go
@@ -94,7 +94,10 @@ func (r *Matches) Add(matches ...Match) {
 }
 
 func (r *Matches) Enumerate() <-chan Match {
-	channel := make(chan Match)
+	// Buffer the channel to the full match count so the producer goroutine
+	// never blocks, even when the consumer exits early (e.g. --fail-on
+	// short-circuits after finding a match at/above the threshold).
+	channel := make(chan Match, len(r.byFingerprint))
 	go func() {
 		defer close(channel)
 		for _, match := range r.byFingerprint {


### PR DESCRIPTION
## The bug

Matches.Enumerate() returned an unbuffered channel. hasSeverityAtOrAbove (called by FindMatchesContext whenever --fail-on is set) returns from inside the range loop as soon as it finds a match at/above the threshold. The producer goroutine then blocks forever, pinning the full Matches map.

## Fix

Buffer the channel to the match count so the producer never blocks.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>