### PR TITLE
fix(search): skip unparseable fix versions instead of reporting as fixed

### DIFF
--- a/grype/search/version_constraint.go
+++ b/grype/search/version_constraint.go
@@ -74,6 +74,7 @@ func ByFixedVersion(v version.Version) vulnerability.Criteria {
 				cmp, e := v.Compare(version.New(fixVersion, v.Format))
 				if e != nil {
 					err = e
+					continue
 				}
 				if cmp >= 0 {
 					// installed version is greater than or equal to the fix version, so is considered fixed


### PR DESCRIPTION
## The bug

In `ByFixedVersion`, when `Version.Compare` returned an error, the `cmp` value was `0`, making `cmp >= 0` true — so the vulnerability was reported as **fixed** with a misleading message, even though the comparison never succeeded. One malformed fix version in an advisory record polluted EUS/ESM match resolution.

## Fix

Skip the unparseable version and continue to the next fix version in the list.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>