### PR TITLE
fix(template): make vulnerability DB details collapsible in HTML report

### DIFF
--- a/grype/presenter/template/presenter_test.go
+++ b/grype/presenter/template/presenter_test.go
@@ -6,11 +6,17 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anchore/clio"
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/presenter/internal"
+	"github.com/anchore/grype/grype/presenter/models"
+	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/grype/internal/testutils"
 )
 
@@ -40,6 +46,57 @@ func TestPresenter_Present(t *testing.T) {
 	expected := testutils.GetGoldenFileContents(t)
 
 	assert.Equal(t, string(expected), string(actual))
+}
+
+func TestPresenter_HTMLTemplate_VulnerabilityDBCollapsible(t *testing.T) {
+	workingDirectory, err := os.Getwd()
+	require.NoError(t, err)
+
+	// render the built-in HTML template against a document that carries DB metadata
+	templateFilePath := path.Join(workingDirectory, "../../../templates/html.tmpl")
+
+	s, _ := internal.GenerateAnalysis(t, internal.ImageSource)
+
+	dbInfo := struct {
+		Status    *vulnerability.ProviderStatus
+		Providers map[string]vulnerability.DataProvenance
+	}{
+		Status: &vulnerability.ProviderStatus{
+			SchemaVersion: "1.0",
+			Built:         time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC),
+		},
+		Providers: map[string]vulnerability.DataProvenance{},
+	}
+
+	ctx := pkg.Context{Source: &s.Source}
+	packages := pkg.FromPtrs(pkg.FromCollection(s.Artifacts.Packages, s.Relationships, pkg.SynthesisConfig{}))
+
+	doc, err := models.NewDocument(
+		clio.Identification{Name: "grype", Version: "devel"},
+		packages,
+		ctx,
+		match.NewMatches(),
+		nil, // ignoredMatches
+		nil, // metadataProvider
+		nil, // appConfig
+		dbInfo,
+		models.SortByPackage,
+		false, // outputTimestamp
+		nil,   // distroAlerts
+	)
+	require.NoError(t, err)
+
+	htmlPresenter := NewPresenter(models.PresenterConfig{Document: doc}, templateFilePath)
+
+	var buffer bytes.Buffer
+	require.NoError(t, htmlPresenter.Present(&buffer))
+
+	html := buffer.String()
+
+	// the vulnerability DB details must be collapsible so they do not dominate the report
+	assert.Contains(t, html, "<summary>Show details</summary>")
+	assert.Contains(t, html, "<pre>")
+	assert.Contains(t, html, `"schemaVersion":"1.0"`)
 }
 
 func TestPresenter_SprigDate_Fails(t *testing.T) {

--- a/templates/html.tmpl
+++ b/templates/html.tmpl
@@ -735,7 +735,12 @@
 
                     {{- if .Descriptor.DB -}}
                     <dt>Vulnerability DB:</dt>
-                    <dd>{{ toJson .Descriptor.DB }}</dd>
+                    <dd>
+                        <details>
+                            <summary>Show details</summary>
+                            <pre>{{ toJson .Descriptor.DB }}</pre>
+                        </details>
+                    </dd>
                     {{- end -}}
 
                     <dt>Date:</dt>


### PR DESCRIPTION
## What does this PR do?

The HTML report renders the entire vulnerability database descriptor as
inline JSON in the report header, which dominates the report and leaves
little room for the actual vulnerability list. This wraps the descriptor
in a collapsible `<details>` element so it is hidden by default and can
be expanded on demand, preserving the debug information without crowding
the report.

## Why is this needed?

The vulnerability DB metadata (schema version, build timestamp, checksum,
provenance) is useful for debugging but takes a disproportionate amount of
space relative to the vulnerability findings themselves.

## Which issue does this fix?

Fixes #3607

## Testing

- Rendered the built-in `templates/html.tmpl` against a document carrying
  DB metadata and asserted the descriptor is wrapped in a collapsible
  `<details>` element (`TestPresenter_HTMLTemplate_VulnerabilityDBCollapsible`).
- `go test ./grype/presenter/template/` passes.
